### PR TITLE
perf: defer non-selected highlight loading until after first paint

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:bin": "bash ./scripts/build-bin.sh",
     "install:bin": "bash ./scripts/install-bin.sh",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "bench:highlight-prefetch": "bun run test/adjacent-highlight-prefetch-benchmark.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1,5 +1,5 @@
 import type { ScrollBoxRenderable } from "@opentui/core";
-import { useMemo, type RefObject } from "react";
+import { useCallback, useEffect, useMemo, useState, type RefObject } from "react";
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types";
 import type { VisibleAgentNote } from "../../lib/agentAnnotations";
 import type { AppTheme } from "../../themes";
@@ -53,6 +53,47 @@ export function DiffPane({
   onOpenAgentNotesAtHunk: (fileId: string, hunkIndex: number) => void;
   onSelectFile: (fileId: string) => void;
 }) {
+  const [prefetchAnchorKey, setPrefetchAnchorKey] = useState<string | null>(null);
+  const selectedHighlightKey = selectedFileId ? `${theme.appearance}:${selectedFileId}` : null;
+
+  useEffect(() => {
+    setPrefetchAnchorKey(null);
+  }, [selectedHighlightKey]);
+
+  // Hold background prefetches until the currently selected file has painted once.
+  const adjacentPrefetchFileIds = useMemo(() => {
+    if (!selectedHighlightKey || prefetchAnchorKey !== selectedHighlightKey || !selectedFileId) {
+      return new Set<string>();
+    }
+
+    const selectedIndex = files.findIndex((file) => file.id === selectedFileId);
+    if (selectedIndex < 0) {
+      return new Set<string>();
+    }
+
+    const next = new Set<string>();
+    const previousFile = files[selectedIndex - 1];
+    const nextFile = files[selectedIndex + 1];
+
+    if (previousFile) {
+      next.add(previousFile.id);
+    }
+
+    if (nextFile) {
+      next.add(nextFile.id);
+    }
+
+    return next;
+  }, [files, prefetchAnchorKey, selectedFileId, selectedHighlightKey]);
+
+  const handleSelectedHighlightReady = useCallback(() => {
+    if (!selectedHighlightKey) {
+      return;
+    }
+
+    setPrefetchAnchorKey((current) => current ?? selectedHighlightKey);
+  }, [selectedHighlightKey]);
+
   const visibleAgentNotesByFile = useMemo(() => {
     const next = new Map<string, VisibleAgentNote[]>();
 
@@ -112,6 +153,8 @@ export function DiffPane({
                 layout={layout}
                 selected={file.id === selectedFileId}
                 selectedHunkIndex={file.id === selectedFileId ? selectedHunkIndex : -1}
+                shouldLoadHighlight={file.id === selectedFileId || adjacentPrefetchFileIds.has(file.id)}
+                onHighlightReady={file.id === selectedFileId ? handleSelectedHighlightReady : undefined}
                 separatorWidth={separatorWidth}
                 showSeparator={index > 0}
                 showLineNumbers={showLineNumbers}

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -14,6 +14,8 @@ interface DiffSectionProps {
   layout: Exclude<LayoutMode, "auto">;
   selected: boolean;
   selectedHunkIndex: number;
+  shouldLoadHighlight: boolean;
+  onHighlightReady?: () => void;
   separatorWidth: number;
   showLineNumbers: boolean;
   showHunkHeaders: boolean;
@@ -35,6 +37,8 @@ function DiffSectionComponent({
   layout,
   selected,
   selectedHunkIndex,
+  shouldLoadHighlight,
+  onHighlightReady,
   separatorWidth,
   showLineNumbers,
   showHunkHeaders,
@@ -107,7 +111,9 @@ function DiffSectionComponent({
         visibleAgentNotes={visibleAgentNotes}
         onDismissAgentNote={onDismissAgentNote}
         onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+        onHighlightReady={onHighlightReady}
         selectedHunkIndex={selectedHunkIndex}
+        shouldLoadHighlight={shouldLoadHighlight}
         // The parent review stream owns scrolling across files.
         scrollable={false}
       />
@@ -125,6 +131,7 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
     previous.layout === next.layout &&
     previous.selected === next.selected &&
     previous.selectedHunkIndex === next.selectedHunkIndex &&
+    previous.shouldLoadHighlight === next.shouldLoadHighlight &&
     previous.separatorWidth === next.separatorWidth &&
     previous.showLineNumbers === next.showLineNumbers &&
     previous.showHunkHeaders === next.showHunkHeaders &&

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -866,6 +866,7 @@ export function PierreDiffView({
   layout,
   onDismissAgentNote,
   onOpenAgentNotesAtHunk,
+  onHighlightReady,
   showLineNumbers = true,
   showHunkHeaders = true,
   wrapLines = false,
@@ -873,6 +874,7 @@ export function PierreDiffView({
   visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
   width,
   selectedHunkIndex,
+  shouldLoadHighlight = true,
   scrollable = true,
 }: {
   annotatedHunkIndices?: Set<number>;
@@ -880,6 +882,7 @@ export function PierreDiffView({
   layout: Exclude<LayoutMode, "auto">;
   onDismissAgentNote?: (id: string) => void;
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
+  onHighlightReady?: () => void;
   showLineNumbers?: boolean;
   showHunkHeaders?: boolean;
   wrapLines?: boolean;
@@ -887,6 +890,7 @@ export function PierreDiffView({
   visibleAgentNotes?: VisibleAgentNote[];
   width: number;
   selectedHunkIndex: number;
+  shouldLoadHighlight?: boolean;
   scrollable?: boolean;
 }) {
   const [highlighted, setHighlighted] = useState<HighlightedDiffCode | null>(null);
@@ -895,9 +899,9 @@ export function PierreDiffView({
   const highlightPromiseRef = useRef(new Map<string, Promise<HighlightedDiffCode>>());
   const appearanceCacheKey = file ? `${theme.appearance}:${file.id}` : null;
 
-  // Start the async highlight request as soon as render knows which file/appearance is needed.
+  // Selected files load immediately; background prefetch can opt neighboring files in later.
   const pendingHighlight = useMemo(() => {
-    if (!file || !appearanceCacheKey || highlightedCacheRef.current.has(appearanceCacheKey)) {
+    if (!shouldLoadHighlight || !file || !appearanceCacheKey || highlightedCacheRef.current.has(appearanceCacheKey)) {
       return null;
     }
 
@@ -909,7 +913,7 @@ export function PierreDiffView({
     const pending = loadHighlightedDiff(file, theme.appearance);
     highlightPromiseRef.current.set(appearanceCacheKey, pending);
     return pending;
-  }, [appearanceCacheKey, file, theme.appearance]);
+  }, [appearanceCacheKey, file, shouldLoadHighlight, theme.appearance]);
 
   useLayoutEffect(() => {
     if (!file || !appearanceCacheKey) {
@@ -926,6 +930,10 @@ export function PierreDiffView({
     if (cached) {
       setHighlighted(cached);
       setHighlightedCacheKey(appearanceCacheKey);
+      return;
+    }
+
+    if (!shouldLoadHighlight) {
       return;
     }
 
@@ -961,7 +969,29 @@ export function PierreDiffView({
     return () => {
       cancelled = true;
     };
-  }, [appearanceCacheKey, file, highlightedCacheKey, pendingHighlight]);
+  }, [appearanceCacheKey, file, highlightedCacheKey, pendingHighlight, shouldLoadHighlight]);
+
+  // Prefer cached highlights during render so revisiting a file can paint immediately.
+  const resolvedHighlighted =
+    appearanceCacheKey && highlightedCacheKey === appearanceCacheKey
+      ? highlighted
+      : appearanceCacheKey
+        ? (highlightedCacheRef.current.get(appearanceCacheKey) ?? null)
+        : null;
+  const notifiedHighlightKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!onHighlightReady || !appearanceCacheKey || !resolvedHighlighted) {
+      return;
+    }
+
+    if (notifiedHighlightKeyRef.current === appearanceCacheKey) {
+      return;
+    }
+
+    notifiedHighlightKeyRef.current = appearanceCacheKey;
+    onHighlightReady();
+  }, [appearanceCacheKey, onHighlightReady, resolvedHighlighted]);
 
   if (!file) {
     return (
@@ -979,13 +1009,6 @@ export function PierreDiffView({
     );
   }
 
-  // Prefer cached highlights during render so revisiting a file can paint immediately.
-  const resolvedHighlighted =
-    appearanceCacheKey && highlightedCacheKey === appearanceCacheKey
-      ? highlighted
-      : appearanceCacheKey
-        ? (highlightedCacheRef.current.get(appearanceCacheKey) ?? null)
-        : null;
   const rows = useMemo(
     () => (layout === "split" ? buildSplitRows(file, resolvedHighlighted, theme) : buildStackRows(file, resolvedHighlighted, theme)),
     [file, layout, resolvedHighlighted, theme],

--- a/test/adjacent-highlight-prefetch-benchmark.ts
+++ b/test/adjacent-highlight-prefetch-benchmark.ts
@@ -1,0 +1,156 @@
+// Measure both first selected-file highlighting and how ready the next file is
+// once low-priority adjacent prefetch has had a chance to start.
+import { performance } from "perf_hooks";
+import React from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { parseDiffFromFile } from "@pierre/diffs";
+import { act } from "react";
+import { App } from "../src/ui/App";
+import type { AppBootstrap, DiffFile } from "../src/core/types";
+
+function createDiffFile(index: number, marker: string): DiffFile {
+  const path = `src/example${index}.ts`;
+  const before = [
+    `export const ${marker} = ${index};`,
+    `export function keep${index}(value: number) { return value + ${index}; }`,
+    `export const tail${index} = true;`,
+    "",
+  ].join("\n");
+
+  const after = [
+    `export const ${marker} = ${index + 1};`,
+    `export function keep${index}(value: number) { return value * ${index + 1}; }`,
+    `export const tail${index} = true;`,
+    "",
+  ].join("\n");
+
+  const metadata = parseDiffFromFile(
+    {
+      name: path,
+      contents: before,
+      cacheKey: `prefetch:${index}:before`,
+    },
+    {
+      name: path,
+      contents: after,
+      cacheKey: `prefetch:${index}:after`,
+    },
+    { context: 3 },
+    true,
+  );
+
+  return {
+    id: `prefetch:${index}`,
+    path,
+    patch: "",
+    language: "typescript",
+    stats: { additions: 2, deletions: 2 },
+    metadata,
+    agent: null,
+  };
+}
+
+function createBootstrap(): AppBootstrap {
+  return {
+    input: {
+      kind: "git",
+      staged: false,
+      options: {
+        mode: "auto",
+      },
+    },
+    changeset: {
+      id: "changeset:prefetch-benchmark",
+      sourceLabel: "repo",
+      title: "repo working tree",
+      files: [
+        createDiffFile(1, "alphaMarker"),
+        createDiffFile(2, "betaMarker"),
+        createDiffFile(3, "gammaMarker"),
+        createDiffFile(4, "deltaMarker"),
+      ],
+    },
+    initialMode: "split",
+    initialTheme: "midnight",
+  };
+}
+
+function frameHasHighlightedMarker(
+  frame: { lines: Array<{ spans: Array<{ text: string; fg?: unknown; bg?: unknown }> }> },
+  marker: string,
+) {
+  return frame.lines.some((line) => {
+    const text = line.spans.map((span) => span.text).join("");
+
+    if (!text.includes(marker)) {
+      return false;
+    }
+
+    // Plain fallback rendering tends to collapse the whole code cell into one span,
+    // while highlighted output keeps token-level segmentation around the marker.
+    return line.spans.some((span) => span.text.includes(marker) && span.text.trim().length < text.trim().length);
+  });
+}
+
+const setup = await testRender(React.createElement(App, { bootstrap: createBootstrap() }), { width: 240, height: 24 });
+const start = performance.now();
+let iterations = 0;
+let selectedStartupMs = 0;
+let adjacentReadyBeforeMove = false;
+
+try {
+  while (iterations < 400) {
+    iterations += 1;
+    await act(async () => {
+      await setup.renderOnce();
+      await Bun.sleep(0);
+    });
+
+    const frame = setup.captureSpans();
+    if (frameHasHighlightedMarker(frame, "alphaMarker")) {
+      selectedStartupMs = performance.now() - start;
+      adjacentReadyBeforeMove = frameHasHighlightedMarker(frame, "betaMarker");
+      break;
+    }
+  }
+
+  await act(async () => {
+    await setup.renderOnce();
+    await Bun.sleep(0);
+    await setup.renderOnce();
+    await Bun.sleep(0);
+  });
+
+  const moveStart = performance.now();
+
+  await act(async () => {
+    setup.mockInput.pressArrow("down");
+    await setup.renderOnce();
+    await Bun.sleep(0);
+  });
+
+  let nextFileReadyMs = 0;
+  while (iterations < 800) {
+    iterations += 1;
+    await act(async () => {
+      await setup.renderOnce();
+      await Bun.sleep(0);
+    });
+
+    const frame = setup.captureSpans();
+    if (frameHasHighlightedMarker(frame, "betaMarker")) {
+      nextFileReadyMs = performance.now() - moveStart;
+      break;
+    }
+  }
+
+  console.log(`METRIC selected_startup_ms=${selectedStartupMs.toFixed(2)}`);
+  console.log(`METRIC next_file_ready_ms=${nextFileReadyMs.toFixed(2)}`);
+  console.log(`METRIC adjacent_ready_before_move=${adjacentReadyBeforeMove ? 1 : 0}`);
+  console.log(`METRIC files=4`);
+  console.log(`METRIC iterations=${iterations}`);
+} finally {
+  await act(async () => {
+    setup.renderer.destroy();
+  });
+}


### PR DESCRIPTION
## Summary
- load syntax highlighting immediately for the selected file only
- start adjacent-file prefetch only after the selected file has painted once
- add a benchmark for selected-file startup and next-file readiness

## Why
The review stream mounts many file sections at once. Previously that meant non-selected files also kicked off highlight work during startup. This branch defers that background work until the first selected file has rendered highlighted content, then prefetches just the immediate neighbors so navigation still feels instant.

## Benchmarks
- Existing app-startup highlight benchmark pre-change sample on this branch: `724.93ms`
- Post-change samples: `447.78ms`, `403.35ms`, `389.39ms`
- New adjacent-prefetch benchmark:
  - `selected_startup_ms=22.33`
  - `next_file_ready_ms=8.08`
  - `adjacent_ready_before_move=1`

## Validation
- bun run typecheck
- bun test
- bun run bench:highlight-prefetch
- bun run test/app-syntax-highlight-startup-benchmark.ts
