### PR TITLE
Restore the sidebar on wide auto layouts

### DIFF
--- a/src/ui/lib/responsive.ts
+++ b/src/ui/lib/responsive.ts
@@ -55,6 +55,6 @@ export function resolveResponsiveLayout(requestedLayout: LayoutMode, viewportWid
   return {
     viewport,
     layout: "split",
-    showFilesPane: viewport === "full",
+    showFilesPane: true,
   };
 }

--- a/test/app-responsive.test.tsx
+++ b/test/app-responsive.test.tsx
@@ -142,10 +142,10 @@ describe("responsive shell", () => {
     expect(full).toContain("drag divider resize");
     expect(full).toContain("│");
 
-    expect(medium).not.toContain("Files");
+    expect(medium).toContain("M alpha.ts");
     expect(medium).not.toContain("Changeset summary");
     expect(medium).toContain("│");
-    expect(medium).not.toContain("drag divider resize");
+    expect(medium).toContain("drag divider resize");
 
     expect(tight).not.toContain("Files");
     expect(tight).not.toContain("Changeset summary");


### PR DESCRIPTION
## Summary
- restore the files sidebar for wide terminals whenever auto layout resolves to split view
- keep tight terminals in stacked single-pane mode
- update responsive coverage so 160-column terminals retain the sidebar and resize affordance

## Validation
- bun run typecheck
- bun test
- bun run test:tty-smoke