### PR TITLE
Support beta tags for prebuilt releases

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: false
         type: boolean
+      npm_tag:
+        description: npm dist-tag to publish under (for example latest or beta)
+        required: true
+        default: latest
+        type: string
   push:
     tags:
       - "v*"
@@ -95,7 +100,7 @@ jobs:
         run: bun run check:prebuilt-pack
 
       - name: Dry-run npm publish order
-        run: bun run publish:prebuilt:npm -- --dry-run
+        run: bun run publish:prebuilt:npm -- --dry-run --tag "${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}"
 
       - name: Upload staged npm release
         uses: actions/upload-artifact@v4
@@ -146,4 +151,4 @@ jobs:
       - name: Publish packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun run publish:prebuilt:npm
+        run: bun run publish:prebuilt:npm -- --tag "${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || 'latest' }}"

--- a/scripts/publish-prebuilt-npm.ts
+++ b/scripts/publish-prebuilt-npm.ts
@@ -10,8 +10,33 @@ type PackageJson = {
 };
 
 function parseArgs(argv: string[]) {
+  let dryRun = false;
+  let npmTag = "latest";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+
+    if (argument === "--tag") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error("Missing value for --tag");
+      }
+      npmTag = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
   return {
-    dryRun: argv.includes("--dry-run"),
+    dryRun,
+    npmTag,
   };
 }
 
@@ -26,7 +51,7 @@ function npmViewExists(name: string, version: string) {
   return proc.exitCode === 0;
 }
 
-function publishDirectory(directory: string, dryRun: boolean) {
+function publishDirectory(directory: string, dryRun: boolean, npmTag: string) {
   const packageJson = JSON.parse(readFileSync(path.join(directory, "package.json"), "utf8")) as PackageJson;
 
   if (npmViewExists(packageJson.name, packageJson.version)) {
@@ -38,7 +63,7 @@ function publishDirectory(directory: string, dryRun: boolean) {
     return;
   }
 
-  const args = ["publish", "--access", "public"];
+  const args = ["publish", "--access", "public", "--tag", npmTag];
   if (dryRun) {
     args.push("--dry-run");
   }
@@ -79,7 +104,11 @@ if (directories.length === 0) {
 }
 
 for (const directory of directories) {
-  publishDirectory(directory, options.dryRun);
+  publishDirectory(directory, options.dryRun, options.npmTag);
 }
 
-console.log(options.dryRun ? "Completed npm publish dry-run for staged prebuilt packages." : "Published staged prebuilt packages to npm.");
+console.log(
+  options.dryRun
+    ? `Completed npm publish dry-run for staged prebuilt packages with dist-tag \"${options.npmTag}\".`
+    : `Published staged prebuilt packages to npm with dist-tag \"${options.npmTag}\".`,
+);


### PR DESCRIPTION
## Summary
- add `--tag <dist-tag>` support to the prebuilt npm publish script
- thread a manual `npm_tag` input through the prebuilt release workflow
- keep tag-push releases defaulting to `latest`

## Why
PR #14 landed the actual prebuilt npm release workflow, but after merge we still needed a safe beta path so we can publish something like `0.3.0-beta.1` under npm's `beta` dist-tag before moving stable users off `latest`.

## What changed
- `scripts/publish-prebuilt-npm.ts`
  - parses `--tag <name>`
  - publishes with `npm publish --tag <name>`
  - reports the chosen dist-tag in dry-run / success output
- `.github/workflows/release-prebuilt-npm.yml`
  - adds `workflow_dispatch.inputs.npm_tag`
  - uses that tag for dry-run and publish steps on manual dispatch
  - still defaults tag pushes to `latest`

## Validation
- `bun run typecheck`
- `bun run build:prebuilt:artifact`
- `bun run stage:prebuilt:release`
- `bun run publish:prebuilt:npm -- --dry-run --tag beta`
