### PR TITLE
Use a supported Intel macOS runner for prebuilt release builds

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -32,7 +32,7 @@ jobs:
           - package_name: hunkdiff-linux-x64
             runner: ubuntu-latest
           - package_name: hunkdiff-darwin-x64
-            runner: macos-13
+            runner: macos-15-intel
           - package_name: hunkdiff-darwin-arm64
             runner: macos-14
     steps:


### PR DESCRIPTION
## Summary
- switch the darwin x64 prebuilt release job from `macos-13` to `macos-15-intel`

## Why
The first beta dry-run of the new prebuilt release workflow failed immediately because the runner label backing the Intel macOS build was unavailable in this GitHub setup:

- `Build hunkdiff-darwin-x64`
- error: `The configuration 'macos-13-us-default' is not supported`

That prevented the workflow from reaching the staging and dry-run publish steps.

## Validation
- inspected the failed run `23382936831`
- confirmed the only failing matrix leg was the Intel macOS runner selection

Once this merges, rerun the beta workflow dry-run with:
- `publish = false`
- `npm_tag = beta`
