### PR TITLE
Decouple sidebar from layout toggle

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -49,6 +49,7 @@ export function App({
   const [showLineNumbers, setShowLineNumbers] = useState(bootstrap.initialShowLineNumbers ?? true);
   const [wrapLines, setWrapLines] = useState(bootstrap.initialWrapLines ?? false);
   const [showHunkHeaders, setShowHunkHeaders] = useState(bootstrap.initialShowHunkHeaders ?? true);
+  const [sidebarVisible, setSidebarVisible] = useState(true);
   const [showHelp, setShowHelp] = useState(false);
   const [focusArea, setFocusArea] = useState<FocusArea>("files");
   const [activeMenuId, setActiveMenuId] = useState<MenuId | null>(null);
@@ -83,7 +84,7 @@ export function App({
   const bodyPadding = pagerMode ? 0 : BODY_PADDING;
   const bodyWidth = Math.max(0, terminal.width - bodyPadding);
   const responsiveLayout = resolveResponsiveLayout(layoutMode, terminal.width);
-  const showFilesPane = pagerMode ? false : responsiveLayout.showFilesPane;
+  const showFilesPane = pagerMode ? false : responsiveLayout.showFilesPane && sidebarVisible;
   const centerWidth = bodyWidth;
   const resolvedLayout = responsiveLayout.layout;
   const currentHunk = selectedFile?.metadata.hunks[selectedHunkIndex];
@@ -247,6 +248,11 @@ export function App({
     setWrapLines((current) => !current);
   };
 
+  /** Toggle sidebar visibility independently of layout mode. */
+  const toggleSidebar = () => {
+    setSidebarVisible((current) => !current);
+  };
+
   /** Toggle visibility of hunk metadata rows without changing the actual diff lines. */
   const toggleHunkHeaders = () => {
     setShowHunkHeaders((current) => !current);
@@ -352,6 +358,14 @@ export function App({
         hint: "0",
         checked: layoutMode === "auto",
         action: () => setLayoutMode("auto"),
+      },
+      { kind: "separator" },
+      {
+        kind: "item",
+        label: "Sidebar",
+        hint: "s",
+        checked: sidebarVisible,
+        action: toggleSidebar,
       },
       { kind: "separator" },
       {
@@ -674,6 +688,12 @@ export function App({
 
     if (key.name === "0") {
       setLayoutMode("auto");
+      closeMenu();
+      return;
+    }
+
+    if (key.name === "s") {
+      toggleSidebar();
       closeMenu();
       return;
     }

--- a/src/ui/components/chrome/StatusBar.tsx
+++ b/src/ui/components/chrome/StatusBar.tsx
@@ -25,7 +25,7 @@ export function StatusBar({
   if (canResizeDivider) {
     hintParts.push("drag divider resize");
   }
-  hintParts.push("space/b page", "/ filter", "[ ] hunk nav", "1 2 0 layout", "t theme", "a notes", "l lines", "w wrap", "m meta", "q quit");
+  hintParts.push("space/b page", "/ filter", "[ ] hunk nav", "1 2 0 layout", "s sidebar", "t theme", "a notes", "l lines", "w wrap", "m meta", "q quit");
 
   return (
     <box

--- a/src/ui/lib/responsive.ts
+++ b/src/ui/lib/responsive.ts
@@ -32,7 +32,7 @@ export function resolveResponsiveLayout(requestedLayout: LayoutMode, viewportWid
     return {
       viewport,
       layout: "split",
-      showFilesPane: false,
+      showFilesPane: viewport === "full",
     };
   }
 
@@ -40,7 +40,7 @@ export function resolveResponsiveLayout(requestedLayout: LayoutMode, viewportWid
     return {
       viewport,
       layout: "stack",
-      showFilesPane: false,
+      showFilesPane: viewport === "full",
     };
   }
 

--- a/test/app-interactions.test.tsx
+++ b/test/app-interactions.test.tsx
@@ -313,7 +313,6 @@ describe("App interactions", () => {
 
       frame = setup.captureCharFrame();
       expect(frame).not.toContain("Split view");
-      expect(frame).not.toContain("│");
       expect(frame).toContain("1   -  export const alpha = 1;");
     } finally {
       await act(async () => {

--- a/test/app-responsive.test.tsx
+++ b/test/app-responsive.test.tsx
@@ -162,10 +162,10 @@ describe("responsive shell", () => {
     expect(forcedSplit).toMatch(/▌.*▌/);
     expect(forcedSplit).not.toContain("drag divider resize");
 
-    expect(forcedStack).not.toContain("Files");
+    expect(forcedStack).toContain("M alpha.ts");
     expect(forcedStack).not.toContain("Changeset summary");
     expect(forcedStack).not.toMatch(/▌.*▌/);
-    expect(forcedStack).not.toContain("drag divider resize");
+    expect(forcedStack).toContain("drag divider resize");
   });
 
   test("pager mode stays responsive while hiding app chrome", async () => {


### PR DESCRIPTION
## Summary
- Layout toggles (`1`/`2`/`0`) now only change split/stack diff rendering — they no longer collapse the sidebar
- New `s` keybinding and View > Sidebar menu item to independently toggle the sidebar
- Sidebar visibility is based on terminal width (≥220 cols) and the new toggle, not layout mode

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (1 pre-existing unrelated failure)
- [ ] Smoke test: press `1`/`2` on a wide terminal and verify sidebar stays
- [ ] Smoke test: press `s` to toggle sidebar on/off

🤖 Generated with [Claude Code](https://claude.com/claude-code)