### PR TITLE
Add experimental MCP daemon for live Hunk sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ CLI input
 - All input sources normalize into one internal changeset model.
 - Pager mode has two paths: full diff UI for patch-like stdin, plain-text fallback for non-diff pager content.
 - View defaults are layered through built-ins, user config, repo `.hunk/config.toml`, command sections, pager sections, and CLI flags.
+- `hunk mcp serve` runs one loopback daemon that brokers agent commands to many live Hunk sessions. Keep it local-only and session-brokered rather than opening per-TUI ports.
 - Agent rationale is optional sidecar JSON matched onto files/hunks.
 - The order of `files` in the sidecar is intentional. Hunk uses that order for the sidebar and main review stream.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,28 @@ Takeaway:
 - `hunk patch [file|-]` — review a patch file or stdin
 - `hunk pager` — act as a Git pager wrapper, opening Hunk for diff-like stdin and falling back to plain text paging otherwise
 - `hunk difftool <left> <right> [path]` — integrate with Git difftool
+- `hunk mcp serve` — run the local MCP daemon for agent-to-diff communication
+
+## MCP daemon (experimental)
+
+Hunk can run a local MCP daemon that brokers commands to live Hunk TUI sessions.
+
+```bash
+hunk mcp serve
+```
+
+Current v1 scope:
+
+- local loopback daemon only
+- live session discovery via `list_sessions` / `get_session`
+- inline diff comments via `comment`
+- Linux-first implementation, designed to stay portable to macOS later
+
+Environment variables:
+
+- `HUNK_MCP_HOST` — bind host for the daemon and session clients, default `127.0.0.1`
+- `HUNK_MCP_PORT` — bind port for the daemon and session clients, default `47657`
+- `HUNK_MCP_DISABLE=1` — disable background session registration for one Hunk process
 
 ## Interaction
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "hunk",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@opentui/core": "^0.1.88",
         "@opentui/react": "^0.1.88",
         "@pierre/diffs": "^1.1.0",
@@ -13,6 +14,7 @@
         "diff": "^8.0.3",
         "parse-diff": "^0.11.1",
         "react": "^19.2.4",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -23,6 +25,8 @@
   },
   "packages": {
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
+
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
 
@@ -79,6 +83,8 @@
     "@jimp/types": ["@jimp/types@1.6.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg=="],
 
     "@jimp/utils": ["@jimp/utils@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "tinycolor2": "^1.6.0" } }, "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "@opentui/core": ["@opentui/core@0.1.88", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.88", "@opentui/core-darwin-x64": "0.1.88", "@opentui/core-linux-arm64": "0.1.88", "@opentui/core-linux-x64": "0.1.88", "@opentui/core-win32-arm64": "0.1.88", "@opentui/core-win32-x64": "0.1.88", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-eaDVZfAzZraddOIkgWSHMVkyaY0O20foYnPWKPQx1TY4t7G1oatIoan2zkytx67epW+4BZQ9vGib+61/uNM1MA=="],
 
@@ -160,6 +166,12 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
 
     "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
@@ -167,6 +179,8 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -186,6 +200,12 @@
 
     "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-zvnUl4EAsQbKsmZVu+lEJcH8axQ7MiCfqg2OmnHd6uw1THABmHaX0GbpKiHshdgadNN2Nf+4zDyTJB5YMcAdrA=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -196,7 +216,23 @@
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -204,35 +240,109 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
     "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
+    "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
 
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -246,7 +356,23 @@
 
     "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
 
@@ -262,9 +388,17 @@
 
     "parse-diff": ["parse-diff@0.11.1", "", {}, "sha512-Oq4j8LAOPOcssanQkIjxosjATBIEJhCxMCxPhMu+Ci4wdNmAEdx0O+a7gzbR2PyKXgKPvRLIN5g224+dJAsKHA=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
     "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
 
     "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "planck": ["planck@1.4.3", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-B+lHKhRSeg7vZOfEyEzyQVu7nx8JHcX3QgnAcHXrPW0j04XYKX5eXSiUrxH2Z5QR8OoqvjD6zKIaPMdMYAd0uA=="],
 
@@ -273,6 +407,14 @@
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -292,21 +434,47 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "stage-js": ["stage-js@1.0.1", "", {}, "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -318,9 +486,13 @@
 
     "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -336,13 +508,21 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
@@ -354,9 +534,45 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@jimp/plugin-blit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-circle/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-color/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-contain/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-cover/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-crop/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-displace/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-fisheye/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-flip/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-mask/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-print/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-quantize/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-resize/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-rotate/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-threshold/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@opentui/core/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@opentui/core": "^0.1.88",
     "@opentui/react": "^0.1.88",
     "@pierre/diffs": "^1.1.0",
@@ -69,7 +70,8 @@
     "commander": "^14.0.3",
     "diff": "^8.0.3",
     "parse-diff": "^0.11.1",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "zod": "^4.3.6"
   },
   "license": "MIT"
 }

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -49,6 +49,7 @@ function normalizeAnnotationFile(file: unknown): AgentFileContext {
       };
 
       return {
+        id: typeof item.id === "string" ? item.id : undefined,
         oldRange: normalizeRange(item.oldRange),
         newRange: normalizeRange(item.newRange),
         summary: item.summary,
@@ -58,6 +59,9 @@ function normalizeAnnotationFile(file: unknown): AgentFileContext {
           item.confidence === "low" || item.confidence === "medium" || item.confidence === "high"
             ? item.confidence
             : undefined,
+        source: typeof item.source === "string" ? item.source : undefined,
+        author: typeof item.author === "string" ? item.author : undefined,
+        createdAt: typeof item.createdAt === "string" ? item.createdAt : undefined,
       };
     }),
   };

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -84,6 +84,7 @@ function renderCliHelp() {
     "  hunk patch [file]                       review a patch file or stdin",
     "  hunk pager                              general Git pager wrapper with diff detection",
     "  hunk difftool <left> <right> [path]     review Git difftool file pairs",
+    "  hunk mcp serve                          run the local Hunk MCP daemon",
     "",
     "Options:",
     "  -h, --help                              show help",
@@ -98,6 +99,7 @@ function renderCliHelp() {
     "  hunk show abc123 -- README.md",
     "  hunk patch -",
     "  hunk pager",
+    "  hunk mcp serve",
     "",
   ].join("\n");
 }
@@ -306,6 +308,44 @@ async function parseDifftoolCommand(tokens: string[], argv: string[]): Promise<P
   };
 }
 
+/** Parse `hunk mcp serve` as the local daemon entrypoint. */
+async function parseMcpCommand(tokens: string[]): Promise<ParsedCliInput> {
+  const [subcommand, ...rest] = tokens;
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    return {
+      kind: "help",
+      text: [
+        "Usage: hunk mcp serve",
+        "",
+        "Run the local Hunk MCP daemon and websocket session broker.",
+        "",
+        "Environment:",
+        "  HUNK_MCP_HOST   bind host (default 127.0.0.1)",
+        "  HUNK_MCP_PORT   bind port (default 47657)",
+      ].join("\n") + "\n",
+    };
+  }
+
+  if (subcommand !== "serve") {
+    throw new Error("Only `hunk mcp serve` is supported.");
+  }
+
+  if (rest.includes("--help") || rest.includes("-h")) {
+    return {
+      kind: "help",
+      text: [
+        "Usage: hunk mcp serve",
+        "",
+        "Run the local Hunk MCP daemon and websocket session broker.",
+      ].join("\n") + "\n",
+    };
+  }
+
+  return {
+    kind: "mcp-serve",
+  };
+}
+
 /** Parse `hunk stash show` as a full-UI stash review command. */
 async function parseStashCommand(tokens: string[], argv: string[]): Promise<ParsedCliInput> {
   const [subcommand, ...rest] = tokens;
@@ -373,6 +413,8 @@ export async function parseCli(argv: string[]): Promise<ParsedCliInput> {
       return parseDifftoolCommand(rest, argv);
     case "stash":
       return parseStashCommand(rest, argv);
+    case "mcp":
+      return parseMcpCommand(rest);
     default:
       throw new Error(`Unknown command: ${commandName}`);
   }

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -1,0 +1,44 @@
+import type { Hunk } from "@pierre/diffs";
+import type { DiffFile } from "./types";
+import type { CommentToolInput, DiffSide, LiveComment } from "../mcp/types";
+
+/** Compute the inclusive old/new line spans touched by one hunk. */
+export function hunkLineRange(hunk: Hunk) {
+  const newEnd = Math.max(hunk.additionStart, hunk.additionStart + Math.max(hunk.additionLines, 1) - 1);
+  const oldEnd = Math.max(hunk.deletionStart, hunk.deletionStart + Math.max(hunk.deletionLines, 1) - 1);
+
+  return {
+    oldRange: [hunk.deletionStart, oldEnd] as [number, number],
+    newRange: [hunk.additionStart, newEnd] as [number, number],
+  };
+}
+
+/** Find the diff file matching one current or previous path. */
+export function findDiffFileByPath(files: DiffFile[], filePath: string) {
+  return files.find((file) => file.path === filePath || file.previousPath === filePath);
+}
+
+/** Find the first hunk covering one requested side/line location. */
+export function findHunkIndexForLine(file: DiffFile, side: DiffSide, line: number) {
+  return file.metadata.hunks.findIndex((hunk) => {
+    const range = hunkLineRange(hunk);
+    const target = side === "new" ? range.newRange : range.oldRange;
+    return line >= target[0] && line <= target[1];
+  });
+}
+
+/** Convert one incoming MCP comment command into a live annotation. */
+export function buildLiveComment(input: CommentToolInput, commentId: string, createdAt: string): LiveComment {
+  return {
+    id: commentId,
+    source: "mcp",
+    author: input.author,
+    createdAt,
+    summary: input.summary,
+    rationale: input.rationale,
+    oldRange: input.side === "old" ? [input.line, input.line] : undefined,
+    newRange: input.side === "new" ? [input.line, input.line] : undefined,
+    tags: ["mcp"],
+    confidence: "high",
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -3,12 +3,16 @@ import type { FileDiffMetadata } from "@pierre/diffs";
 export type LayoutMode = "auto" | "split" | "stack";
 
 export interface AgentAnnotation {
+  id?: string;
   oldRange?: [number, number];
   newRange?: [number, number];
   summary: string;
   rationale?: string;
   tags?: string[];
   confidence?: "low" | "medium" | "high";
+  source?: string;
+  author?: string;
+  createdAt?: string;
 }
 
 export interface AgentFileContext {
@@ -76,6 +80,10 @@ export interface PagerCommandInput {
   options: CommonOptions;
 }
 
+export interface McpServeCommandInput {
+  kind: "mcp-serve";
+}
+
 export interface GitCommandInput {
   kind: "git";
   range?: string;
@@ -127,7 +135,7 @@ export type CliInput =
   | PatchCommandInput
   | DiffToolCommandInput;
 
-export type ParsedCliInput = CliInput | HelpCommandInput | PagerCommandInput;
+export type ParsedCliInput = CliInput | HelpCommandInput | PagerCommandInput | McpServeCommandInput;
 
 export interface AppBootstrap {
   input: CliInput;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,12 +9,24 @@ import { looksLikePatchInput, pagePlainText } from "./core/pager";
 import { shutdownSession } from "./core/shutdown";
 import { openControllingTerminal, resolveRuntimeCliInput, usesPipedPatchInput } from "./core/terminal";
 import { App } from "./ui/App";
+import { HunkHostClient } from "./mcp/client";
+import { serveHunkMcpServer } from "./mcp/server";
+import { createInitialSessionSnapshot, createSessionRegistration } from "./mcp/sessionRegistration";
 
 let parsedCliInput = await parseCli(process.argv);
 
 if (parsedCliInput.kind === "help") {
   process.stdout.write(parsedCliInput.text);
   process.exit(0);
+}
+
+if (parsedCliInput.kind === "mcp-serve") {
+  serveHunkMcpServer();
+  await new Promise<never>(() => {});
+}
+
+if (parsedCliInput.kind === "mcp-serve") {
+  throw new Error("Unreachable MCP daemon branch.");
 }
 
 if (parsedCliInput.kind === "pager") {
@@ -41,6 +53,8 @@ const configured = resolveConfiguredCliInput(runtimeCliInput);
 const cliInput = configured.input;
 const bootstrap = await loadAppBootstrap(cliInput);
 const controllingTerminal = usesPipedPatchInput(cliInput) ? openControllingTerminal() : null;
+const hostClient = new HunkHostClient(createSessionRegistration(bootstrap), createInitialSessionSnapshot(bootstrap));
+hostClient.start();
 
 const renderer = await createCliRenderer({
   stdin: controllingTerminal?.stdin,
@@ -62,6 +76,7 @@ function shutdown() {
   }
 
   shuttingDown = true;
+  hostClient.stop();
   shutdownSession({ root, renderer });
 }
 
@@ -69,6 +84,7 @@ function shutdown() {
 root.render(
   <App
     bootstrap={bootstrap}
+    hostClient={hostClient}
     onQuit={shutdown}
   />,
 );

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,155 @@
+import type { AppliedCommentResult, HunkSessionRegistration, HunkSessionSnapshot, SessionClientMessage, SessionServerMessage } from "./types";
+import { HUNK_SESSION_SOCKET_PATH, resolveHunkMcpConfig } from "./config";
+
+export interface HunkAppBridge {
+  applyComment: (message: Extract<SessionServerMessage, { command: "comment" }>) => Promise<AppliedCommentResult>;
+}
+
+/** Keep one running Hunk TUI session registered with the local MCP daemon. */
+export class HunkHostClient {
+  private websocket: WebSocket | null = null;
+  private bridge: HunkAppBridge | null = null;
+  private queuedMessages: SessionServerMessage[] = [];
+  private reconnectTimer: Timer | null = null;
+  private stopped = false;
+  private readonly config = resolveHunkMcpConfig();
+
+  constructor(
+    private readonly registration: HunkSessionRegistration,
+    private snapshot: HunkSessionSnapshot,
+  ) {}
+
+  start() {
+    if (process.env.HUNK_MCP_DISABLE === "1") {
+      return;
+    }
+
+    this.connect();
+  }
+
+  stop() {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    this.websocket?.close();
+    this.websocket = null;
+  }
+
+  setBridge(bridge: HunkAppBridge | null) {
+    this.bridge = bridge;
+    void this.flushQueuedMessages();
+  }
+
+  updateSnapshot(snapshot: HunkSessionSnapshot) {
+    this.snapshot = snapshot;
+    this.send({
+      type: "snapshot",
+      sessionId: this.registration.sessionId,
+      snapshot,
+    });
+  }
+
+  private connect() {
+    if (this.stopped || this.websocket) {
+      return;
+    }
+
+    const websocket = new WebSocket(`${this.config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`);
+    this.websocket = websocket;
+
+    websocket.onopen = () => {
+      this.send({
+        type: "register",
+        registration: this.registration,
+        snapshot: this.snapshot,
+      });
+      void this.flushQueuedMessages();
+    };
+
+    websocket.onmessage = (event) => {
+      if (typeof event.data !== "string") {
+        return;
+      }
+
+      let parsed: SessionServerMessage;
+      try {
+        parsed = JSON.parse(event.data) as SessionServerMessage;
+      } catch {
+        return;
+      }
+
+      void this.handleServerMessage(parsed);
+    };
+
+    websocket.onclose = () => {
+      this.websocket = null;
+      if (!this.stopped) {
+        this.scheduleReconnect();
+      }
+    };
+
+    websocket.onerror = () => {
+      websocket.close();
+    };
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer || this.stopped) {
+      return;
+    }
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, 3_000);
+    this.reconnectTimer.unref?.();
+  }
+
+  private send(message: SessionClientMessage) {
+    if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.websocket.send(JSON.stringify(message));
+  }
+
+  private async handleServerMessage(message: SessionServerMessage) {
+    if (!this.bridge) {
+      this.queuedMessages.push(message);
+      return;
+    }
+
+    try {
+      const result = await this.bridge.applyComment(message);
+      this.send({
+        type: "command-result",
+        requestId: message.requestId,
+        ok: true,
+        result,
+      });
+    } catch (error) {
+      this.send({
+        type: "command-result",
+        requestId: message.requestId,
+        ok: false,
+        error: error instanceof Error ? error.message : "Unknown Hunk session error.",
+      });
+    }
+  }
+
+  private async flushQueuedMessages() {
+    if (!this.bridge || this.queuedMessages.length === 0) {
+      return;
+    }
+
+    const queued = [...this.queuedMessages];
+    this.queuedMessages = [];
+
+    for (const message of queued) {
+      await this.handleServerMessage(message);
+    }
+  }
+}

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_HUNK_MCP_HOST = "127.0.0.1";
+export const DEFAULT_HUNK_MCP_PORT = 47657;
+export const HUNK_MCP_PATH = "/mcp";
+export const HUNK_SESSION_SOCKET_PATH = "/session";
+
+/** Resolve the loopback host/port Hunk should use for the local MCP daemon. */
+export function resolveHunkMcpConfig(env: NodeJS.ProcessEnv = process.env) {
+  const host = env.HUNK_MCP_HOST?.trim() || DEFAULT_HUNK_MCP_HOST;
+  const parsedPort = Number.parseInt(env.HUNK_MCP_PORT ?? "", 10);
+  const port = Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : DEFAULT_HUNK_MCP_PORT;
+
+  return {
+    host,
+    port,
+    httpOrigin: `http://${host}:${port}`,
+    wsOrigin: `ws://${host}:${port}`,
+  };
+}

--- a/src/mcp/daemonState.ts
+++ b/src/mcp/daemonState.ts
@@ -1,0 +1,201 @@
+import { randomUUID } from "node:crypto";
+import type { AppliedCommentResult, CommentToolInput, HunkSessionRegistration, HunkSessionSnapshot, ListedSession } from "./types";
+
+interface PendingCommand {
+  sessionId: string;
+  resolve: (result: AppliedCommentResult) => void;
+  reject: (error: Error) => void;
+  timeout: Timer;
+}
+
+export interface DaemonSessionSocket {
+  send(data: string): unknown;
+}
+
+interface SessionEntry {
+  registration: HunkSessionRegistration;
+  snapshot: HunkSessionSnapshot;
+  socket: DaemonSessionSocket;
+  connectedAt: string;
+}
+
+export interface SessionTargetSelector {
+  sessionId?: string;
+  repoRoot?: string;
+}
+
+/** Resolve which live Hunk session one external command should target. */
+export function resolveSessionTarget(sessions: ListedSession[], selector: SessionTargetSelector) {
+  if (selector.sessionId) {
+    const matched = sessions.find((session) => session.sessionId === selector.sessionId);
+    if (!matched) {
+      throw new Error(`No active Hunk session matches sessionId ${selector.sessionId}.`);
+    }
+
+    return matched;
+  }
+
+  if (selector.repoRoot) {
+    const matches = sessions.filter((session) => session.repoRoot === selector.repoRoot);
+    if (matches.length === 0) {
+      throw new Error(`No active Hunk session matches repoRoot ${selector.repoRoot}.`);
+    }
+
+    if (matches.length > 1) {
+      throw new Error(`Multiple active Hunk sessions match repoRoot ${selector.repoRoot}; specify sessionId instead.`);
+    }
+
+    return matches[0]!;
+  }
+
+  if (sessions.length === 1) {
+    return sessions[0]!;
+  }
+
+  if (sessions.length === 0) {
+    throw new Error("No active Hunk sessions are registered with the daemon.");
+  }
+
+  throw new Error("Multiple active Hunk sessions are registered; specify sessionId or repoRoot.");
+}
+
+/** Track registered Hunk sessions and route MCP commands onto the correct live TUI instance. */
+export class HunkDaemonState {
+  private sessions = new Map<string, SessionEntry>();
+  private sessionIdsBySocket = new Map<DaemonSessionSocket, string>();
+  private pendingCommands = new Map<string, PendingCommand>();
+
+  listSessions(): ListedSession[] {
+    return [...this.sessions.values()]
+      .map((entry) => ({
+        sessionId: entry.registration.sessionId,
+        pid: entry.registration.pid,
+        cwd: entry.registration.cwd,
+        repoRoot: entry.registration.repoRoot,
+        inputKind: entry.registration.inputKind,
+        title: entry.registration.title,
+        sourceLabel: entry.registration.sourceLabel,
+        launchedAt: entry.registration.launchedAt,
+        fileCount: entry.registration.files.length,
+        files: entry.registration.files,
+        snapshot: entry.snapshot,
+      }))
+      .sort((left, right) => right.snapshot.updatedAt.localeCompare(left.snapshot.updatedAt));
+  }
+
+  getSession(selector: SessionTargetSelector) {
+    return resolveSessionTarget(this.listSessions(), selector);
+  }
+
+  registerSession(socket: DaemonSessionSocket, registration: HunkSessionRegistration, snapshot: HunkSessionSnapshot) {
+    const previousSessionId = this.sessionIdsBySocket.get(socket);
+    if (previousSessionId && previousSessionId !== registration.sessionId) {
+      this.unregisterSocket(socket);
+    }
+
+    const existing = this.sessions.get(registration.sessionId);
+    if (existing && existing.socket !== socket) {
+      this.sessionIdsBySocket.delete(existing.socket);
+      this.rejectPendingCommandsForSession(registration.sessionId, new Error("Hunk session reconnected before the command completed."));
+    }
+
+    this.sessions.set(registration.sessionId, {
+      registration,
+      snapshot,
+      socket,
+      connectedAt: new Date().toISOString(),
+    });
+    this.sessionIdsBySocket.set(socket, registration.sessionId);
+  }
+
+  updateSnapshot(sessionId: string, snapshot: HunkSessionSnapshot) {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) {
+      return;
+    }
+
+    this.sessions.set(sessionId, {
+      ...entry,
+      snapshot,
+    });
+  }
+
+  unregisterSocket(socket: DaemonSessionSocket) {
+    const sessionId = this.sessionIdsBySocket.get(socket);
+    if (!sessionId) {
+      return;
+    }
+
+    this.sessionIdsBySocket.delete(socket);
+    this.sessions.delete(sessionId);
+    this.rejectPendingCommandsForSession(sessionId, new Error("The targeted Hunk session disconnected."));
+  }
+
+  async sendComment(input: CommentToolInput) {
+    const session = resolveSessionTarget(this.listSessions(), {
+      sessionId: input.sessionId,
+      repoRoot: input.repoRoot,
+    });
+    const requestId = randomUUID();
+
+    return new Promise<AppliedCommentResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingCommands.delete(requestId);
+        reject(new Error("Timed out waiting for the Hunk session to apply the comment."));
+      }, 15_000);
+
+      this.pendingCommands.set(requestId, {
+        sessionId: session.sessionId,
+        resolve,
+        reject,
+        timeout,
+      });
+
+      const entry = this.sessions.get(session.sessionId);
+      if (!entry) {
+        clearTimeout(timeout);
+        this.pendingCommands.delete(requestId);
+        reject(new Error("The targeted Hunk session is no longer connected."));
+        return;
+      }
+
+      entry.socket.send(
+        JSON.stringify({
+          type: "command",
+          requestId,
+          command: "comment",
+          input,
+        }),
+      );
+    });
+  }
+
+  handleCommandResult(message: { requestId: string; ok: boolean; result?: AppliedCommentResult; error?: string }) {
+    const pending = this.pendingCommands.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pendingCommands.delete(message.requestId);
+
+    if (message.ok && message.result) {
+      pending.resolve(message.result);
+      return;
+    }
+
+    pending.reject(new Error(message.error ?? "The Hunk session failed to handle the command."));
+  }
+
+  private rejectPendingCommandsForSession(sessionId: string, error: Error) {
+    for (const [requestId, pending] of this.pendingCommands.entries()) {
+      if (pending.sessionId !== sessionId) {
+        continue;
+      }
+
+      clearTimeout(pending.timeout);
+      this.pendingCommands.delete(requestId);
+      pending.reject(error);
+    }
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from "node:crypto";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import * as z from "zod/v4";
+import { HUNK_MCP_PATH, HUNK_SESSION_SOCKET_PATH, resolveHunkMcpConfig } from "./config";
+import { HunkDaemonState } from "./daemonState";
+import type { SessionClientMessage } from "./types";
+
+interface McpTransportEntry {
+  server: McpServer;
+  transport: WebStandardStreamableHTTPServerTransport;
+}
+
+function formatToolJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+function textContent(text: string) {
+  return [
+    {
+      type: "text" as const,
+      text,
+    },
+  ];
+}
+
+function createHunkMcpServer(state: HunkDaemonState) {
+  const server = new McpServer({
+    name: "hunk",
+    version: "0.1.0",
+  });
+
+  server.registerTool(
+    "list_sessions",
+    {
+      title: "List live Hunk sessions",
+      description: "List the live Hunk diff-review sessions currently registered with the local daemon.",
+    } as any,
+    (async () => {
+      const sessions = state.listSessions();
+
+      return {
+        content: textContent(formatToolJson({ sessions })),
+        structuredContent: {
+          sessions,
+        },
+      };
+    }) as any,
+  );
+
+  server.registerTool(
+    "get_session",
+    {
+      title: "Get one live Hunk session",
+      description: "Fetch details for one live Hunk session by session id or repo root.",
+      inputSchema: z.object({
+        sessionId: z.string().optional().describe("Explicit Hunk session id."),
+        repoRoot: z.string().optional().describe("Repo root fallback when exactly one session matches."),
+      }) as any,
+    } as any,
+    (async (input: { sessionId?: string; repoRoot?: string }) => {
+      const session = state.getSession({ sessionId: input.sessionId, repoRoot: input.repoRoot });
+
+      return {
+        content: textContent(formatToolJson(session)),
+        structuredContent: {
+          session,
+        },
+      };
+    }) as any,
+  );
+
+  server.registerTool(
+    "comment",
+    {
+      title: "Comment on a live Hunk diff",
+      description: "Attach an inline review note to a specific diff line in a live Hunk session.",
+      inputSchema: z.object({
+        sessionId: z.string().optional().describe("Explicit Hunk session id."),
+        repoRoot: z.string().optional().describe("Repo root fallback when exactly one session matches."),
+        filePath: z.string().describe("Diff file path as shown by Hunk."),
+        side: z.enum(["old", "new"]).describe("Which side of the diff the line belongs to."),
+        line: z.number().int().positive().describe("1-based diff line number on the chosen side."),
+        summary: z.string().min(1).describe("Short inline review note."),
+        rationale: z.string().optional().describe("Optional longer explanation shown in the note card."),
+        reveal: z.boolean().optional().describe("Whether Hunk should jump to and reveal the note. Defaults to true."),
+        author: z.string().optional().describe("Optional author label for the live comment."),
+      }) as any,
+    } as any,
+    (async (input: {
+      sessionId?: string;
+      repoRoot?: string;
+      filePath: string;
+      side: "old" | "new";
+      line: number;
+      summary: string;
+      rationale?: string;
+      reveal?: boolean;
+      author?: string;
+    }) => {
+      const result = await state.sendComment({
+        ...input,
+        reveal: input.reveal ?? true,
+      });
+
+      return {
+        content: textContent(formatToolJson(result)),
+        structuredContent: {
+          result,
+        },
+      };
+    }) as any,
+  );
+
+  return server;
+}
+
+/** Serve the local Hunk MCP daemon and websocket session broker. */
+export function serveHunkMcpServer() {
+  const config = resolveHunkMcpConfig();
+  const state = new HunkDaemonState();
+  const transports = new Map<string, McpTransportEntry>();
+
+  const server = Bun.serve<{ sessionId?: string }>({
+    hostname: config.host,
+    port: config.port,
+    fetch: async (request, bunServer) => {
+      const url = new URL(request.url);
+
+      if (url.pathname === "/health") {
+        return Response.json({
+          ok: true,
+          transport: `${config.httpOrigin}${HUNK_MCP_PATH}`,
+          sessionSocket: `${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`,
+          sessions: state.listSessions().length,
+        });
+      }
+
+      if (url.pathname === HUNK_SESSION_SOCKET_PATH) {
+        if (bunServer.upgrade(request, { data: {} })) {
+          return undefined;
+        }
+
+        return new Response("Expected websocket upgrade.", { status: 426 });
+      }
+
+      if (url.pathname !== HUNK_MCP_PATH) {
+        return new Response("Not found.", { status: 404 });
+      }
+
+      const headerSessionId = request.headers.get("mcp-session-id") ?? undefined;
+      const parsedBody = request.method === "POST" ? await request.json() : undefined;
+
+      if (headerSessionId && transports.has(headerSessionId)) {
+        const entry = transports.get(headerSessionId)!;
+        return entry.transport.handleRequest(request, { parsedBody });
+      }
+
+      if (!headerSessionId && request.method === "POST" && isInitializeRequest(parsedBody)) {
+        let transport: WebStandardStreamableHTTPServerTransport;
+        let transportEntry: McpTransportEntry;
+
+        transport = new WebStandardStreamableHTTPServerTransport({
+          sessionIdGenerator: () => randomUUID(),
+          enableJsonResponse: true,
+          onsessioninitialized: (sessionId) => {
+            transports.set(sessionId, transportEntry);
+          },
+          onsessionclosed: (sessionId) => {
+            const entry = transports.get(sessionId);
+            if (entry) {
+              void entry.server.close();
+              transports.delete(sessionId);
+            }
+          },
+        });
+
+        const mcpServer = createHunkMcpServer(state);
+        transportEntry = {
+          server: mcpServer,
+          transport,
+        };
+
+        await mcpServer.connect(transport);
+        return transport.handleRequest(request, { parsedBody });
+      }
+
+      return Response.json(
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Bad Request: No valid MCP session id provided.",
+          },
+          id: null,
+        },
+        {
+          status: 400,
+        },
+      );
+    },
+    websocket: {
+      message: (socket, message) => {
+        if (typeof message !== "string") {
+          return;
+        }
+
+        let parsed: SessionClientMessage;
+        try {
+          parsed = JSON.parse(message) as SessionClientMessage;
+        } catch {
+          return;
+        }
+
+        switch (parsed.type) {
+          case "register":
+            state.registerSession(socket, parsed.registration, parsed.snapshot);
+            break;
+          case "snapshot":
+            state.updateSnapshot(parsed.sessionId, parsed.snapshot);
+            break;
+          case "command-result":
+            state.handleCommandResult(parsed);
+            break;
+        }
+      },
+      close: (socket) => {
+        state.unregisterSocket(socket);
+      },
+    },
+  });
+
+  console.log(`Hunk MCP daemon listening on ${config.httpOrigin}${HUNK_MCP_PATH}`);
+  console.log(`Hunk session websocket listening on ${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`);
+
+  return server;
+}

--- a/src/mcp/sessionRegistration.ts
+++ b/src/mcp/sessionRegistration.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "node:crypto";
+import type { AppBootstrap } from "../core/types";
+import type { HunkSessionRegistration, HunkSessionSnapshot } from "./types";
+
+function inferRepoRoot(bootstrap: AppBootstrap) {
+  return bootstrap.input.kind === "git" || bootstrap.input.kind === "show" || bootstrap.input.kind === "stash-show"
+    ? bootstrap.changeset.sourceLabel
+    : undefined;
+}
+
+/** Build the daemon-facing metadata for one live Hunk TUI session. */
+export function createSessionRegistration(bootstrap: AppBootstrap): HunkSessionRegistration {
+  return {
+    sessionId: randomUUID(),
+    pid: process.pid,
+    cwd: process.cwd(),
+    repoRoot: inferRepoRoot(bootstrap),
+    inputKind: bootstrap.input.kind,
+    title: bootstrap.changeset.title,
+    sourceLabel: bootstrap.changeset.sourceLabel,
+    launchedAt: new Date().toISOString(),
+    files: bootstrap.changeset.files.map((file) => ({
+      id: file.id,
+      path: file.path,
+      previousPath: file.previousPath,
+      additions: file.stats.additions,
+      deletions: file.stats.deletions,
+      hunkCount: file.metadata.hunks.length,
+    })),
+  };
+}
+
+/** Start with an empty-but-valid snapshot until the UI reports its first selection. */
+export function createInitialSessionSnapshot(bootstrap: AppBootstrap): HunkSessionSnapshot {
+  return {
+    selectedFileId: bootstrap.changeset.files[0]?.id,
+    selectedFilePath: bootstrap.changeset.files[0]?.path,
+    selectedHunkIndex: 0,
+    showAgentNotes: bootstrap.initialShowAgentNotes ?? false,
+    liveCommentCount: 0,
+    updatedAt: new Date().toISOString(),
+  };
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,106 @@
+import type { AgentAnnotation, CliInput } from "../core/types";
+
+export type DiffSide = "old" | "new";
+
+export interface SessionFileSummary {
+  id: string;
+  path: string;
+  previousPath?: string;
+  additions: number;
+  deletions: number;
+  hunkCount: number;
+}
+
+export interface HunkSessionRegistration {
+  sessionId: string;
+  pid: number;
+  cwd: string;
+  repoRoot?: string;
+  inputKind: CliInput["kind"];
+  title: string;
+  sourceLabel: string;
+  launchedAt: string;
+  files: SessionFileSummary[];
+}
+
+export interface HunkSessionSnapshot {
+  selectedFileId?: string;
+  selectedFilePath?: string;
+  selectedHunkIndex: number;
+  showAgentNotes: boolean;
+  liveCommentCount: number;
+  updatedAt: string;
+}
+
+export interface CommentToolInput {
+  sessionId?: string;
+  repoRoot?: string;
+  filePath: string;
+  side: DiffSide;
+  line: number;
+  summary: string;
+  rationale?: string;
+  reveal?: boolean;
+  author?: string;
+}
+
+export interface LiveComment extends AgentAnnotation {
+  id: string;
+  source: "mcp";
+  author?: string;
+  createdAt: string;
+}
+
+export interface AppliedCommentResult {
+  commentId: string;
+  fileId: string;
+  filePath: string;
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+}
+
+export type SessionClientMessage =
+  | {
+      type: "register";
+      registration: HunkSessionRegistration;
+      snapshot: HunkSessionSnapshot;
+    }
+  | {
+      type: "snapshot";
+      sessionId: string;
+      snapshot: HunkSessionSnapshot;
+    }
+  | {
+      type: "command-result";
+      requestId: string;
+      ok: true;
+      result: AppliedCommentResult;
+    }
+  | {
+      type: "command-result";
+      requestId: string;
+      ok: false;
+      error: string;
+    };
+
+export type SessionServerMessage = {
+  type: "command";
+  requestId: string;
+  command: "comment";
+  input: CommentToolInput;
+};
+
+export interface ListedSession {
+  sessionId: string;
+  pid: number;
+  cwd: string;
+  repoRoot?: string;
+  inputKind: CliInput["kind"];
+  title: string;
+  sourceLabel: string;
+  launchedAt: string;
+  fileCount: number;
+  files: SessionFileSummary[];
+  snapshot: HunkSessionSnapshot;
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,6 @@
 import { MouseButton, type KeyEvent, type MouseEvent as TuiMouseEvent, type ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react";
-import { Suspense, lazy, startTransition, useDeferredValue, useEffect, useRef, useState } from "react";
+import { Suspense, lazy, startTransition, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type { AppBootstrap, LayoutMode } from "../core/types";
 import { MenuBar } from "./components/chrome/MenuBar";
 import { MENU_ORDER, buildMenuSpecs, menuWidth, nextMenuItemIndex, type MenuEntry, type MenuId } from "./components/chrome/menu";
@@ -14,6 +14,9 @@ import { buildHunkCursors, findNextHunkCursor } from "./lib/hunks";
 import { diffHunkId, diffSectionId, fileRowId } from "./lib/ids";
 import { resolveResponsiveLayout } from "./lib/responsive";
 import { resolveTheme, THEMES } from "./themes";
+import { HunkHostClient } from "../mcp/client";
+import type { LiveComment, SessionServerMessage } from "../mcp/types";
+import { buildLiveComment, findDiffFileByPath, findHunkIndexForLine } from "../core/liveComments";
 
 type FocusArea = "files" | "filter";
 
@@ -28,9 +31,11 @@ function clamp(value: number, min: number, max: number) {
 /** Orchestrate global app state, layout, navigation, and pane coordination. */
 export function App({
   bootstrap,
+  hostClient,
   onQuit = () => process.exit(0),
 }: {
   bootstrap: AppBootstrap;
+  hostClient?: HunkHostClient;
   onQuit?: () => void;
 }) {
   const FILES_MIN_WIDTH = 22;
@@ -61,12 +66,33 @@ export function App({
   const [dismissedAgentNoteIds, setDismissedAgentNoteIds] = useState<string[]>([]);
   const [selectedFileId, setSelectedFileId] = useState(bootstrap.changeset.files[0]?.id ?? "");
   const [selectedHunkIndex, setSelectedHunkIndex] = useState(0);
+  const [liveCommentsByFileId, setLiveCommentsByFileId] = useState<Record<string, LiveComment[]>>({});
   const deferredFilter = useDeferredValue(filter);
 
   const pagerMode = Boolean(bootstrap.input.options.pager);
   const activeTheme = resolveTheme(themeId, renderer.themeMode);
 
-  const filteredFiles = bootstrap.changeset.files.filter((file) => {
+  const allFiles = useMemo(
+    () =>
+      bootstrap.changeset.files.map((file) => {
+        const liveComments = liveCommentsByFileId[file.id];
+        if (!liveComments || liveComments.length === 0) {
+          return file;
+        }
+
+        return {
+          ...file,
+          agent: {
+            path: file.path,
+            summary: file.agent?.summary,
+            annotations: [...(file.agent?.annotations ?? []), ...liveComments],
+          },
+        };
+      }),
+    [bootstrap.changeset.files, liveCommentsByFileId],
+  );
+
+  const filteredFiles = allFiles.filter((file) => {
     if (!deferredFilter.trim()) {
       return true;
     }
@@ -75,10 +101,7 @@ export function App({
     return haystack.includes(deferredFilter.trim().toLowerCase());
   });
 
-  const selectedFile =
-    filteredFiles.find((file) => file.id === selectedFileId) ??
-    bootstrap.changeset.files.find((file) => file.id === selectedFileId) ??
-    filteredFiles[0];
+  const selectedFile = filteredFiles.find((file) => file.id === selectedFileId) ?? allFiles.find((file) => file.id === selectedFileId) ?? filteredFiles[0];
   const hunkCursors = buildHunkCursors(filteredFiles);
 
   const bodyPadding = pagerMode ? 0 : BODY_PADDING;
@@ -263,6 +286,71 @@ export function App({
     jumpToFile(fileId, hunkIndex);
     openAgentNotes();
   };
+
+  /** Apply one incoming daemon comment to the live review session and reveal it in the diff stream. */
+  const applyIncomingComment = useCallback(
+    async (message: Extract<SessionServerMessage, { command: "comment" }>) => {
+      const file = findDiffFileByPath(allFiles, message.input.filePath);
+      if (!file) {
+        throw new Error(`No visible diff file matches ${message.input.filePath}.`);
+      }
+
+      const hunkIndex = findHunkIndexForLine(file, message.input.side, message.input.line);
+      if (hunkIndex < 0) {
+        throw new Error(
+          `No ${message.input.side} diff hunk in ${message.input.filePath} covers line ${message.input.line}.`,
+        );
+      }
+
+      const commentId = `mcp:${message.requestId}`;
+      const liveComment = buildLiveComment(message.input, commentId, new Date().toISOString());
+
+      setLiveCommentsByFileId((current) => ({
+        ...current,
+        [file.id]: [...(current[file.id] ?? []), liveComment],
+      }));
+
+      if (message.input.reveal ?? true) {
+        jumpToFile(file.id, hunkIndex);
+        openAgentNotes();
+      }
+
+      return {
+        commentId,
+        fileId: file.id,
+        filePath: file.path,
+        hunkIndex,
+        side: message.input.side,
+        line: message.input.line,
+      };
+    },
+    [allFiles],
+  );
+
+  useEffect(() => {
+    if (!hostClient) {
+      return;
+    }
+
+    hostClient.setBridge({
+      applyComment: applyIncomingComment,
+    });
+
+    return () => {
+      hostClient.setBridge(null);
+    };
+  }, [applyIncomingComment, hostClient]);
+
+  useEffect(() => {
+    hostClient?.updateSnapshot({
+      selectedFileId: selectedFile?.id,
+      selectedFilePath: selectedFile?.path,
+      selectedHunkIndex,
+      showAgentNotes,
+      liveCommentCount: Object.values(liveCommentsByFileId).reduce((sum, notes) => sum + notes.length, 0),
+      updatedAt: new Date().toISOString(),
+    });
+  }, [hostClient, liveCommentsByFileId, selectedFile?.id, selectedFile?.path, selectedHunkIndex, showAgentNotes]);
 
   /** Leave the app through the shell-owned shutdown path. */
   const requestQuit = () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -135,6 +135,14 @@ describe("parseCli", () => {
     });
   });
 
+  test("parses the MCP daemon command", async () => {
+    const parsed = await parseCli(["bun", "hunk", "mcp", "serve"]);
+
+    expect(parsed).toEqual({
+      kind: "mcp-serve",
+    });
+  });
+
   test("parses stash show mode", async () => {
     const parsed = await parseCli(["bun", "hunk", "stash", "show", "stash@{1}"]);
 

--- a/test/help-output.test.ts
+++ b/test/help-output.test.ts
@@ -18,6 +18,7 @@ describe("CLI help output", () => {
     expect(stdout).toContain("hunk diff");
     expect(stdout).toContain("hunk show");
     expect(stdout).toContain("hunk pager");
+    expect(stdout).toContain("hunk mcp serve");
     expect(stdout).not.toContain("hunk git");
     expect(stdout).not.toContain("\u001b[?1049h");
   });

--- a/test/live-comments.test.ts
+++ b/test/live-comments.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { parseDiffFromFile } from "@pierre/diffs";
+import { buildLiveComment, findDiffFileByPath, findHunkIndexForLine, hunkLineRange } from "../src/core/liveComments";
+import type { DiffFile } from "../src/core/types";
+
+function createDiffFile(): DiffFile {
+  const metadata = parseDiffFromFile(
+    {
+      name: "src/example.ts",
+      contents: [
+        "export const alpha = 1;",
+        "export const keep = true;",
+        "export const beta = 1;",
+        "",
+      ].join("\n"),
+      cacheKey: "before",
+    },
+    {
+      name: "src/example.ts",
+      contents: [
+        "export const alpha = 2;",
+        "export const keep = true;",
+        "export const beta = 2;",
+        "export const gamma = true;",
+        "",
+      ].join("\n"),
+      cacheKey: "after",
+    },
+    { context: 3 },
+    true,
+  );
+
+  let additions = 0;
+  let deletions = 0;
+  for (const hunk of metadata.hunks) {
+    for (const content of hunk.hunkContent) {
+      if (content.type === "change") {
+        additions += content.additions;
+        deletions += content.deletions;
+      }
+    }
+  }
+
+  return {
+    id: "file:example",
+    path: "src/example.ts",
+    previousPath: "src/example-old.ts",
+    patch: "",
+    language: "typescript",
+    stats: { additions, deletions },
+    metadata,
+    agent: null,
+  };
+}
+
+describe("live comment helpers", () => {
+  test("finds a diff file by current or previous path", () => {
+    const file = createDiffFile();
+
+    expect(findDiffFileByPath([file], "src/example.ts")?.id).toBe(file.id);
+    expect(findDiffFileByPath([file], "src/example-old.ts")?.id).toBe(file.id);
+    expect(findDiffFileByPath([file], "missing.ts")).toBeUndefined();
+  });
+
+  test("maps old/new line numbers onto the covering hunk", () => {
+    const file = createDiffFile();
+
+    expect(findHunkIndexForLine(file, "old", 1)).toBe(0);
+    expect(findHunkIndexForLine(file, "new", 2)).toBe(0);
+    expect(findHunkIndexForLine(file, "new", 40)).toBe(-1);
+  });
+
+  test("builds a live MCP comment annotation", () => {
+    const comment = buildLiveComment(
+      {
+        filePath: "src/example.ts",
+        side: "new",
+        line: 4,
+        summary: "Note",
+        rationale: "Why this matters",
+        author: "Pi",
+      },
+      "comment-1",
+      "2026-03-22T00:00:00.000Z",
+    );
+
+    expect(comment).toMatchObject({
+      id: "comment-1",
+      source: "mcp",
+      author: "Pi",
+      summary: "Note",
+      rationale: "Why this matters",
+      newRange: [4, 4],
+      tags: ["mcp"],
+    });
+  });
+
+  test("computes inclusive single-line hunk ranges", () => {
+    const file = createDiffFile();
+    const range = hunkLineRange(file.metadata.hunks[0]!);
+
+    expect(range.oldRange[0]).toBeLessThanOrEqual(1);
+    expect(range.oldRange[1]).toBeGreaterThanOrEqual(2);
+    expect(range.newRange[0]).toBeLessThanOrEqual(1);
+    expect(range.newRange[1]).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/mcp-daemon.test.ts
+++ b/test/mcp-daemon.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { HunkDaemonState, resolveSessionTarget } from "../src/mcp/daemonState";
+import type { AppliedCommentResult, HunkSessionRegistration, HunkSessionSnapshot, ListedSession } from "../src/mcp/types";
+
+function createListedSession(overrides: Partial<ListedSession> = {}): ListedSession {
+  return {
+    sessionId: "session-1",
+    pid: 123,
+    cwd: "/repo",
+    repoRoot: "/repo",
+    inputKind: "git",
+    title: "repo working tree",
+    sourceLabel: "/repo",
+    launchedAt: "2026-03-22T00:00:00.000Z",
+    fileCount: 1,
+    files: [
+      {
+        id: "file-1",
+        path: "src/example.ts",
+        additions: 1,
+        deletions: 1,
+        hunkCount: 1,
+      },
+    ],
+    snapshot: {
+      selectedFileId: "file-1",
+      selectedFilePath: "src/example.ts",
+      selectedHunkIndex: 0,
+      showAgentNotes: false,
+      liveCommentCount: 0,
+      updatedAt: "2026-03-22T00:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function createRegistration(): HunkSessionRegistration {
+  return {
+    sessionId: "session-1",
+    pid: 123,
+    cwd: "/repo",
+    repoRoot: "/repo",
+    inputKind: "git",
+    title: "repo working tree",
+    sourceLabel: "/repo",
+    launchedAt: "2026-03-22T00:00:00.000Z",
+    files: [
+      {
+        id: "file-1",
+        path: "src/example.ts",
+        additions: 1,
+        deletions: 1,
+        hunkCount: 1,
+      },
+    ],
+  };
+}
+
+function createSnapshot(): HunkSessionSnapshot {
+  return {
+    selectedFileId: "file-1",
+    selectedFilePath: "src/example.ts",
+    selectedHunkIndex: 0,
+    showAgentNotes: false,
+    liveCommentCount: 0,
+    updatedAt: "2026-03-22T00:00:00.000Z",
+  };
+}
+
+describe("Hunk MCP daemon state", () => {
+  test("resolves one target session by session id, repo root, or sole-session fallback", () => {
+    const one = [createListedSession()];
+    const two = [createListedSession(), createListedSession({ sessionId: "session-2", snapshot: { ...createSnapshot(), updatedAt: "2026-03-22T00:00:01.000Z" } })];
+
+    expect(resolveSessionTarget(one, {}).sessionId).toBe("session-1");
+    expect(resolveSessionTarget(one, { repoRoot: "/repo" }).sessionId).toBe("session-1");
+    expect(resolveSessionTarget(two, { sessionId: "session-2" }).sessionId).toBe("session-2");
+    expect(() => resolveSessionTarget(two, {})).toThrow("specify sessionId or repoRoot");
+    expect(() => resolveSessionTarget(two, { repoRoot: "/repo" })).toThrow("specify sessionId instead");
+  });
+
+  test("routes a comment command to the live session and resolves the async result", async () => {
+    const state = new HunkDaemonState();
+    const sent: string[] = [];
+    const socket = {
+      send(data: string) {
+        sent.push(data);
+      },
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+
+    const pending = state.sendComment({
+      sessionId: "session-1",
+      filePath: "src/example.ts",
+      side: "new",
+      line: 4,
+      summary: "Review note",
+      reveal: true,
+    });
+
+    expect(sent).toHaveLength(1);
+    const outgoing = JSON.parse(sent[0]!) as {
+      requestId: string;
+    };
+
+    const result: AppliedCommentResult = {
+      commentId: "comment-1",
+      fileId: "file-1",
+      filePath: "src/example.ts",
+      hunkIndex: 0,
+      side: "new",
+      line: 4,
+    };
+
+    state.handleCommandResult({
+      requestId: outgoing.requestId,
+      ok: true,
+      result,
+    });
+
+    await expect(pending).resolves.toEqual(result);
+  });
+
+  test("rejects in-flight commands when the session disconnects", async () => {
+    const state = new HunkDaemonState();
+    const socket = {
+      send() {},
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+    const pending = state.sendComment({
+      sessionId: "session-1",
+      filePath: "src/example.ts",
+      side: "new",
+      line: 4,
+      summary: "Review note",
+    });
+
+    state.unregisterSocket(socket);
+
+    await expect(pending).rejects.toThrow("disconnected");
+  });
+});


### PR DESCRIPTION
## Summary
- add an experimental `hunk mcp serve` daemon on loopback for agent-to-diff communication
- register live Hunk TUI sessions over a websocket broker and expose MCP tools for session discovery and inline comments
- map incoming `comment` tool calls into the existing inline note UI, with docs and tests for the new flow

## Testing
- bun run typecheck
- bun test
- bun run test:tty-smoke
- manual tmux smoke test using `bun run src/main.tsx -- mcp serve` and `bun run src/main.tsx -- diff ...` from the repo source