### PR TITLE
Refactor startup planning for direct tests

### DIFF
--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -1,0 +1,100 @@
+import { resolveConfiguredCliInput } from "./config";
+import { loadAppBootstrap } from "./loaders";
+import { looksLikePatchInput } from "./pager";
+import { openControllingTerminal, resolveRuntimeCliInput, usesPipedPatchInput, type ControllingTerminal } from "./terminal";
+import type { AppBootstrap, CliInput, ParsedCliInput } from "./types";
+import { parseCli } from "./cli";
+
+export type StartupPlan =
+  | {
+      kind: "help";
+      text: string;
+    }
+  | {
+      kind: "mcp-serve";
+    }
+  | {
+      kind: "plain-text-pager";
+      text: string;
+    }
+  | {
+      kind: "app";
+      bootstrap: AppBootstrap;
+      cliInput: CliInput;
+      controllingTerminal: ControllingTerminal | null;
+    };
+
+export interface StartupDeps {
+  parseCliImpl?: (argv: string[]) => Promise<ParsedCliInput>;
+  readStdinText?: () => Promise<string>;
+  looksLikePatchInputImpl?: (text: string) => boolean;
+  resolveRuntimeCliInputImpl?: typeof resolveRuntimeCliInput;
+  resolveConfiguredCliInputImpl?: typeof resolveConfiguredCliInput;
+  loadAppBootstrapImpl?: typeof loadAppBootstrap;
+  usesPipedPatchInputImpl?: typeof usesPipedPatchInput;
+  openControllingTerminalImpl?: typeof openControllingTerminal;
+}
+
+/** Normalize startup work so help, pager, and app-bootstrap paths can be tested directly. */
+export async function prepareStartupPlan(
+  argv: string[] = process.argv,
+  deps: StartupDeps = {},
+): Promise<StartupPlan> {
+  const parseCliImpl = deps.parseCliImpl ?? parseCli;
+  const readStdinText = deps.readStdinText ?? (() => new Response(Bun.stdin.stream()).text());
+  const looksLikePatchInputImpl = deps.looksLikePatchInputImpl ?? looksLikePatchInput;
+  const resolveRuntimeCliInputImpl = deps.resolveRuntimeCliInputImpl ?? resolveRuntimeCliInput;
+  const resolveConfiguredCliInputImpl = deps.resolveConfiguredCliInputImpl ?? resolveConfiguredCliInput;
+  const loadAppBootstrapImpl = deps.loadAppBootstrapImpl ?? loadAppBootstrap;
+  const usesPipedPatchInputImpl = deps.usesPipedPatchInputImpl ?? usesPipedPatchInput;
+  const openControllingTerminalImpl = deps.openControllingTerminalImpl ?? openControllingTerminal;
+
+  let parsedCliInput = await parseCliImpl(argv);
+
+  if (parsedCliInput.kind === "help") {
+    return {
+      kind: "help",
+      text: parsedCliInput.text,
+    };
+  }
+
+  if (parsedCliInput.kind === "mcp-serve") {
+    return {
+      kind: "mcp-serve",
+    };
+  }
+
+  if (parsedCliInput.kind === "pager") {
+    const stdinText = await readStdinText();
+
+    if (!looksLikePatchInputImpl(stdinText)) {
+      return {
+        kind: "plain-text-pager",
+        text: stdinText,
+      };
+    }
+
+    parsedCliInput = {
+      kind: "patch",
+      file: "-",
+      text: stdinText,
+      options: {
+        ...parsedCliInput.options,
+        pager: true,
+      },
+    };
+  }
+
+  const runtimeCliInput = resolveRuntimeCliInputImpl(parsedCliInput);
+  const configured = resolveConfiguredCliInputImpl(runtimeCliInput);
+  const cliInput = configured.input;
+  const bootstrap = await loadAppBootstrapImpl(cliInput);
+  const controllingTerminal = usesPipedPatchInputImpl(cliInput) ? openControllingTerminalImpl() : null;
+
+  return {
+    kind: "app",
+    bootstrap,
+    cliInput,
+    controllingTerminal,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,57 +2,36 @@
 
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
-import { parseCli } from "./core/cli";
-import { resolveConfiguredCliInput } from "./core/config";
-import { loadAppBootstrap } from "./core/loaders";
-import { looksLikePatchInput, pagePlainText } from "./core/pager";
+import { pagePlainText } from "./core/pager";
 import { shutdownSession } from "./core/shutdown";
-import { openControllingTerminal, resolveRuntimeCliInput, usesPipedPatchInput } from "./core/terminal";
+import { prepareStartupPlan } from "./core/startup";
 import { App } from "./ui/App";
 import { HunkHostClient } from "./mcp/client";
 import { serveHunkMcpServer } from "./mcp/server";
 import { createInitialSessionSnapshot, createSessionRegistration } from "./mcp/sessionRegistration";
 
-let parsedCliInput = await parseCli(process.argv);
+const startupPlan = await prepareStartupPlan();
 
-if (parsedCliInput.kind === "help") {
-  process.stdout.write(parsedCliInput.text);
+if (startupPlan.kind === "help") {
+  process.stdout.write(startupPlan.text);
   process.exit(0);
 }
 
-if (parsedCliInput.kind === "mcp-serve") {
+if (startupPlan.kind === "mcp-serve") {
   serveHunkMcpServer();
   await new Promise<never>(() => {});
 }
 
-if (parsedCliInput.kind === "mcp-serve") {
-  throw new Error("Unreachable MCP daemon branch.");
+if (startupPlan.kind === "plain-text-pager") {
+  await pagePlainText(startupPlan.text);
+  process.exit(0);
 }
 
-if (parsedCliInput.kind === "pager") {
-  const stdinText = await new Response(Bun.stdin.stream()).text();
-
-  if (!looksLikePatchInput(stdinText)) {
-    await pagePlainText(stdinText);
-    process.exit(0);
-  }
-
-  parsedCliInput = {
-    kind: "patch",
-    file: "-",
-    text: stdinText,
-    options: {
-      ...parsedCliInput.options,
-      pager: true,
-    },
-  };
+if (startupPlan.kind !== "app") {
+  throw new Error("Unreachable startup plan.");
 }
 
-const runtimeCliInput = resolveRuntimeCliInput(parsedCliInput);
-const configured = resolveConfiguredCliInput(runtimeCliInput);
-const cliInput = configured.input;
-const bootstrap = await loadAppBootstrap(cliInput);
-const controllingTerminal = usesPipedPatchInput(cliInput) ? openControllingTerminal() : null;
+const { bootstrap, cliInput, controllingTerminal } = startupPlan;
 const hostClient = new HunkHostClient(createSessionRegistration(bootstrap), createInitialSessionSnapshot(bootstrap));
 hostClient.start();
 

--- a/test/startup.test.ts
+++ b/test/startup.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { prepareStartupPlan } from "../src/core/startup";
+import type { AppBootstrap, CliInput, ParsedCliInput } from "../src/core/types";
+
+function createBootstrap(input: CliInput): AppBootstrap {
+  return {
+    input,
+    changeset: {
+      id: "changeset:startup",
+      sourceLabel: "repo",
+      title: "repo working tree",
+      files: [],
+    },
+    initialMode: input.options.mode ?? "auto",
+  };
+}
+
+describe("startup planning", () => {
+  test("returns help output without entering app startup", async () => {
+    let loaded = false;
+
+    const plan = await prepareStartupPlan(["bun", "hunk"], {
+      parseCliImpl: async () => ({ kind: "help", text: "Usage: hunk\n" }),
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({ kind: "help", text: "Usage: hunk\n" });
+    expect(loaded).toBe(false);
+  });
+
+  test("passes the MCP serve command through without app bootstrap work", async () => {
+    let loaded = false;
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "mcp", "serve"], {
+      parseCliImpl: async () => ({ kind: "mcp-serve" }),
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({ kind: "mcp-serve" });
+    expect(loaded).toBe(false);
+  });
+
+  test("routes non-diff pager stdin to the plain-text pager path", async () => {
+    let loaded = false;
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
+      parseCliImpl: async () => ({ kind: "pager", options: { theme: "paper" } }),
+      readStdinText: async () => "* main\n  feature/demo\n",
+      looksLikePatchInputImpl: () => false,
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({ kind: "plain-text-pager", text: "* main\n  feature/demo\n" });
+    expect(loaded).toBe(false);
+  });
+
+  test("normalizes diff-like pager stdin into patch app startup", async () => {
+    const seenInputs: CliInput[] = [];
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
+      parseCliImpl: async () => ({ kind: "pager", options: { theme: "paper" } }),
+      readStdinText: async () => "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n",
+      looksLikePatchInputImpl: () => true,
+      resolveRuntimeCliInputImpl(input) {
+        seenInputs.push(input);
+        return input;
+      },
+      resolveConfiguredCliInputImpl(input) {
+        seenInputs.push(input);
+        return { input } as never;
+      },
+      loadAppBootstrapImpl: async (input) => {
+        seenInputs.push(input);
+        return createBootstrap(input);
+      },
+      usesPipedPatchInputImpl: () => false,
+    });
+
+    expect(plan.kind).toBe("app");
+    if (plan.kind !== "app") {
+      throw new Error("Expected app startup plan.");
+    }
+
+    expect(plan.cliInput).toMatchObject({
+      kind: "patch",
+      file: "-",
+      text: "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n",
+      options: {
+        theme: "paper",
+        pager: true,
+      },
+    });
+    expect(seenInputs).toHaveLength(3);
+  });
+
+  test("opens the controlling terminal for piped patch startup", async () => {
+    const cliInput: CliInput = {
+      kind: "patch",
+      file: "-",
+      options: {
+        mode: "auto",
+        pager: true,
+      },
+    };
+    const controllingTerminal = { stdin: {} as never, stdout: {} as never, close: () => {} };
+    let opened = 0;
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "patch", "-"], {
+      parseCliImpl: async () => cliInput as ParsedCliInput,
+      resolveRuntimeCliInputImpl: (input) => input,
+      resolveConfiguredCliInputImpl: (input) => ({ input }) as never,
+      loadAppBootstrapImpl: async (input) => createBootstrap(input),
+      usesPipedPatchInputImpl: (input) => {
+        expect(input).toBe(cliInput);
+        return true;
+      },
+      openControllingTerminalImpl: () => {
+        opened += 1;
+        return controllingTerminal;
+      },
+    });
+
+    expect(plan).toMatchObject({
+      kind: "app",
+      cliInput,
+      controllingTerminal,
+    });
+    expect(opened).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- extract entrypoint branching into a dedicated startup planner
- keep `main.tsx` focused on side effects like pager output, renderer setup, and MCP daemon startup
- add direct tests for help, MCP daemon, plain-text pager, diff-like pager normalization, and controlling-terminal attachment

## Testing
- bun install --frozen-lockfile
- bun test test/startup.test.ts test/help-output.test.ts
- bun run typecheck
- bun test --coverage