### PR TITLE
Expand prebuilt helper edge coverage

### DIFF
--- a/scripts/prebuilt-package-helpers.ts
+++ b/scripts/prebuilt-package-helpers.ts
@@ -47,16 +47,16 @@ export function getPlatformPackageSpecByName(packageName: string) {
   return PLATFORM_PACKAGE_MATRIX.find((candidate) => candidate.packageName === packageName);
 }
 
-/** Return the Hunk package spec that matches the current machine. */
-export function getHostPlatformPackageSpec() {
-  const normalizedPlatform = normalizeHostPlatform(os.platform());
+/** Resolve the published package spec for a given Node platform/architecture pair. */
+export function getPlatformPackageSpecForHost(platform: NodeJS.Platform, arch: NodeJS.Architecture) {
+  const normalizedPlatform = normalizeHostPlatform(platform);
   if (!normalizedPlatform) {
-    throw new Error(`Unsupported host platform for prebuilt packaging: ${os.platform()}`);
+    throw new Error(`Unsupported host platform for prebuilt packaging: ${platform}`);
   }
 
-  const normalizedArch = normalizeHostArch(os.arch());
+  const normalizedArch = normalizeHostArch(arch);
   if (!normalizedArch) {
-    throw new Error(`Unsupported host architecture for prebuilt packaging: ${os.arch()}`);
+    throw new Error(`Unsupported host architecture for prebuilt packaging: ${arch}`);
   }
 
   const spec = PLATFORM_PACKAGE_MATRIX.find((candidate) => candidate.os === normalizedPlatform && candidate.cpu === normalizedArch);
@@ -65,6 +65,11 @@ export function getHostPlatformPackageSpec() {
   }
 
   return spec;
+}
+
+/** Return the Hunk package spec that matches the current machine. */
+export function getHostPlatformPackageSpec() {
+  return getPlatformPackageSpecForHost(os.platform(), os.arch());
 }
 
 /** Build the optional dependency map for the top-level hunkdiff package. */

--- a/test/prebuilt-package-helpers.test.ts
+++ b/test/prebuilt-package-helpers.test.ts
@@ -3,8 +3,13 @@ import {
   PLATFORM_PACKAGE_MATRIX,
   binaryFilenameForSpec,
   buildOptionalDependencyMap,
+  getHostPlatformPackageSpec,
   getPlatformPackageSpecByName,
+  getPlatformPackageSpecForHost,
+  normalizeHostArch,
+  normalizeHostPlatform,
   sortPlatformPackageSpecs,
+  type PlatformPackageSpec,
 } from "../scripts/prebuilt-package-helpers";
 
 describe("prebuilt package helpers", () => {
@@ -22,10 +27,48 @@ describe("prebuilt package helpers", () => {
     }
   });
 
+  test("binaryFilenameForSpec adds .exe for windows packages", () => {
+    const windowsSpec: PlatformPackageSpec = {
+      packageName: "hunkdiff-windows-x64",
+      os: "windows",
+      cpu: "x64",
+      binaryName: "hunk",
+      binaryRelativePath: "bin/hunk.exe",
+    };
+
+    expect(binaryFilenameForSpec(windowsSpec)).toBe("hunk.exe");
+  });
+
+  test("normalizeHostPlatform and normalizeHostArch reject unsupported values", () => {
+    expect(normalizeHostPlatform("linux")).toBe("linux");
+    expect(normalizeHostPlatform("win32")).toBe("windows");
+    expect(normalizeHostPlatform("freebsd" as NodeJS.Platform)).toBeUndefined();
+
+    expect(normalizeHostArch("x64")).toBe("x64");
+    expect(normalizeHostArch("arm64")).toBe("arm64");
+    expect(normalizeHostArch("ia32" as NodeJS.Architecture)).toBeUndefined();
+  });
+
   test("getPlatformPackageSpecByName returns known package specs", () => {
     expect(getPlatformPackageSpecByName("hunkdiff-linux-x64")?.cpu).toBe("x64");
     expect(getPlatformPackageSpecByName("hunkdiff-darwin-arm64")?.os).toBe("darwin");
     expect(getPlatformPackageSpecByName("hunkdiff-does-not-exist")).toBeUndefined();
+  });
+
+  test("getPlatformPackageSpecForHost resolves supported combinations and rejects unsupported ones", () => {
+    expect(getPlatformPackageSpecForHost("linux", "x64").packageName).toBe("hunkdiff-linux-x64");
+    expect(getPlatformPackageSpecForHost("darwin", "arm64").packageName).toBe("hunkdiff-darwin-arm64");
+    expect(() => getPlatformPackageSpecForHost("freebsd" as NodeJS.Platform, "x64")).toThrow(
+      "Unsupported host platform for prebuilt packaging: freebsd",
+    );
+    expect(() => getPlatformPackageSpecForHost("linux", "ia32" as NodeJS.Architecture)).toThrow(
+      "Unsupported host architecture for prebuilt packaging: ia32",
+    );
+    expect(() => getPlatformPackageSpecForHost("linux", "arm64")).toThrow("No published prebuilt package spec matches linux/arm64");
+  });
+
+  test("getHostPlatformPackageSpec resolves the current machine", () => {
+    expect(getHostPlatformPackageSpec()).toEqual(getPlatformPackageSpecForHost(process.platform, process.arch));
   });
 
   test("sortPlatformPackageSpecs keeps package publish order stable", () => {


### PR DESCRIPTION
## Summary
- add direct coverage for unsupported platform and architecture handling
- cover the Windows `.exe` binary naming branch
- extract parameterized host-spec resolution so edge cases are easy to test

## Testing
- bun test test/prebuilt-package-helpers.test.ts
- bun run typecheck
- bun test --coverage