### PR TITLE
Auto-start the Hunk MCP daemon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ CLI input
 - All input sources normalize into one internal changeset model.
 - Pager mode has two paths: full diff UI for patch-like stdin, plain-text fallback for non-diff pager content.
 - View defaults are layered through built-ins, user config, repo `.hunk/config.toml`, command sections, pager sections, and CLI flags.
-- `hunk mcp serve` runs one loopback daemon that brokers agent commands to many live Hunk sessions. Keep it local-only and session-brokered rather than opening per-TUI ports.
+- `hunk mcp serve` runs one loopback daemon that brokers agent commands to many live Hunk sessions. Normal Hunk sessions should auto-start and register with that daemon when MCP is enabled. Keep it local-only and session-brokered rather than opening per-TUI ports.
 - Agent rationale is optional sidecar JSON matched onto files/hunks.
 - The order of `files` in the sidecar is intentional. Hunk uses that order for the sidebar and main review stream.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Takeaway:
 
 Hunk can run a local MCP daemon that brokers commands to live Hunk TUI sessions.
 
+Opening a normal Hunk review session now tries to register with the daemon automatically and will auto-start it on loopback when needed. You can still run the daemon explicitly:
+
 ```bash
 hunk mcp serve
 ```

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,5 +1,6 @@
 import type { AppliedCommentResult, HunkSessionRegistration, HunkSessionSnapshot, SessionClientMessage, SessionServerMessage } from "./types";
 import { HUNK_SESSION_SOCKET_PATH, resolveHunkMcpConfig } from "./config";
+import { isHunkDaemonHealthy, launchHunkDaemon, waitForHunkDaemonHealth } from "./daemonLauncher";
 
 export interface HunkAppBridge {
   applyComment: (message: Extract<SessionServerMessage, { command: "comment" }>) => Promise<AppliedCommentResult>;
@@ -12,6 +13,8 @@ export class HunkHostClient {
   private queuedMessages: SessionServerMessage[] = [];
   private reconnectTimer: Timer | null = null;
   private stopped = false;
+  private startupPromise: Promise<void> | null = null;
+  private lastDaemonLaunchStartedAt = 0;
   private readonly config = resolveHunkMcpConfig();
 
   constructor(
@@ -24,7 +27,13 @@ export class HunkHostClient {
       return;
     }
 
-    this.connect();
+    if (this.startupPromise) {
+      return;
+    }
+
+    this.startupPromise = this.ensureDaemonAndConnect().finally(() => {
+      this.startupPromise = null;
+    });
   }
 
   stop() {
@@ -36,6 +45,28 @@ export class HunkHostClient {
 
     this.websocket?.close();
     this.websocket = null;
+  }
+
+  private async ensureDaemonAndConnect() {
+    await this.ensureDaemonAvailable();
+    this.connect();
+  }
+
+  private async ensureDaemonAvailable() {
+    if (await isHunkDaemonHealthy(this.config)) {
+      return;
+    }
+
+    const launchCooldownMs = 5_000;
+    if (Date.now() - this.lastDaemonLaunchStartedAt < launchCooldownMs) {
+      return;
+    }
+
+    this.lastDaemonLaunchStartedAt = Date.now();
+    launchHunkDaemon();
+    await waitForHunkDaemonHealth({
+      config: this.config,
+    });
   }
 
   setBridge(bridge: HunkAppBridge | null) {
@@ -61,6 +92,7 @@ export class HunkHostClient {
     this.websocket = websocket;
 
     websocket.onopen = () => {
+      this.lastDaemonLaunchStartedAt = 0;
       this.send({
         type: "register",
         registration: this.registration,
@@ -103,7 +135,7 @@ export class HunkHostClient {
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
-      this.connect();
+      void this.ensureDaemonAndConnect();
     }, 3_000);
     this.reconnectTimer.unref?.();
   }

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -3,8 +3,15 @@ export const DEFAULT_HUNK_MCP_PORT = 47657;
 export const HUNK_MCP_PATH = "/mcp";
 export const HUNK_SESSION_SOCKET_PATH = "/session";
 
+export interface ResolvedHunkMcpConfig {
+  host: string;
+  port: number;
+  httpOrigin: string;
+  wsOrigin: string;
+}
+
 /** Resolve the loopback host/port Hunk should use for the local MCP daemon. */
-export function resolveHunkMcpConfig(env: NodeJS.ProcessEnv = process.env) {
+export function resolveHunkMcpConfig(env: NodeJS.ProcessEnv = process.env): ResolvedHunkMcpConfig {
   const host = env.HUNK_MCP_HOST?.trim() || DEFAULT_HUNK_MCP_HOST;
   const parsedPort = Number.parseInt(env.HUNK_MCP_PORT ?? "", 10);
   const port = Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : DEFAULT_HUNK_MCP_PORT;

--- a/src/mcp/daemonLauncher.ts
+++ b/src/mcp/daemonLauncher.ts
@@ -1,0 +1,93 @@
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { resolveHunkMcpConfig, type ResolvedHunkMcpConfig } from "./config";
+
+const SCRIPT_ENTRYPOINT_PATTERN = /[\\/]|\.(?:[cm]?js|tsx?)$/;
+
+export interface DaemonLaunchCommand {
+  command: string;
+  args: string[];
+}
+
+/** Resolve how the current Hunk process should launch a sibling `hunk mcp serve` daemon. */
+export function resolveDaemonLaunchCommand(argv = process.argv, execPath = process.execPath): DaemonLaunchCommand {
+  const entrypoint = argv[1];
+
+  if (entrypoint && !entrypoint.startsWith("-") && SCRIPT_ENTRYPOINT_PATTERN.test(entrypoint)) {
+    return {
+      command: execPath,
+      args: [entrypoint, "mcp", "serve"],
+    };
+  }
+
+  return {
+    command: execPath,
+    args: ["mcp", "serve"],
+  };
+}
+
+/** Check whether the loopback Hunk daemon already answers health probes. */
+export async function isHunkDaemonHealthy(config: ResolvedHunkMcpConfig = resolveHunkMcpConfig(), timeoutMs = 500) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref?.();
+
+  try {
+    const response = await fetch(`${config.httpOrigin}/health`, {
+      signal: controller.signal,
+    });
+
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/** Wait briefly for a just-launched daemon to become reachable on its health endpoint. */
+export async function waitForHunkDaemonHealth({
+  config = resolveHunkMcpConfig(),
+  timeoutMs = 3_000,
+  intervalMs = 100,
+}: {
+  config?: ResolvedHunkMcpConfig;
+  timeoutMs?: number;
+  intervalMs?: number;
+}) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await isHunkDaemonHealthy(config)) {
+      return true;
+    }
+
+    await Bun.sleep(intervalMs);
+  }
+
+  return false;
+}
+
+/** Launch the Hunk daemon in the background without tying it to the current TTY session. */
+export function launchHunkDaemon({
+  cwd = process.cwd(),
+  env = process.env,
+  argv = process.argv,
+  execPath = process.execPath,
+}: {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  argv?: string[];
+  execPath?: string;
+} = {}): ChildProcess {
+  const command = resolveDaemonLaunchCommand(argv, execPath);
+  const child = spawn(command.command, command.args, {
+    cwd,
+    env,
+    detached: true,
+    stdio: "ignore",
+  });
+
+  child.unref();
+  return child;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -131,6 +131,7 @@ export function serveHunkMcpServer() {
       if (url.pathname === "/health") {
         return Response.json({
           ok: true,
+          pid: process.pid,
           transport: `${config.httpOrigin}${HUNK_MCP_PATH}`,
           sessionSocket: `${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`,
           sessions: state.listSessions().length,

--- a/test/daemon-launcher.test.ts
+++ b/test/daemon-launcher.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { resolveDaemonLaunchCommand } from "../src/mcp/daemonLauncher";
+
+describe("MCP daemon launcher", () => {
+  test("reuses the current script entrypoint when Hunk is running from source or a JS wrapper", () => {
+    expect(resolveDaemonLaunchCommand(["bun", "src/main.tsx", "diff"], "/usr/bin/bun")).toEqual({
+      command: "/usr/bin/bun",
+      args: ["src/main.tsx", "mcp", "serve"],
+    });
+
+    expect(resolveDaemonLaunchCommand(["node", "/app/bin/hunk.cjs", "diff"], "/usr/bin/node")).toEqual({
+      command: "/usr/bin/node",
+      args: ["/app/bin/hunk.cjs", "mcp", "serve"],
+    });
+  });
+
+  test("falls back to relaunching the current executable when no script entrypoint is present", () => {
+    expect(resolveDaemonLaunchCommand(["/usr/local/bin/hunk", "diff"], "/usr/local/bin/hunk")).toEqual({
+      command: "/usr/local/bin/hunk",
+      args: ["mcp", "serve"],
+    });
+  });
+});

--- a/test/mcp-e2e.test.ts
+++ b/test/mcp-e2e.test.ts
@@ -76,7 +76,7 @@ async function waitForHealth(port: number) {
         return null;
       }
 
-      return await response.json();
+      return (await response.json()) as { ok: boolean; pid: number; sessions: number };
     } catch {
       return null;
     }
@@ -88,24 +88,13 @@ afterEach(() => {
 });
 
 describe("MCP end-to-end", () => {
-  test("daemon comment calls reach a live Hunk TTY session and render inline notes", async () => {
+  test("a live Hunk session auto-starts the daemon and renders MCP comments inline", async () => {
     if (!ttyToolsAvailable) {
       return;
     }
 
     const fixture = createFixtureFiles();
     const port = 48000 + Math.floor(Math.random() * 1000);
-    const daemonProc = Bun.spawn(["bun", "run", sourceEntrypoint, "--", "mcp", "serve"], {
-      cwd: repoRoot,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-      env: {
-        ...process.env,
-        HUNK_MCP_PORT: String(port),
-      },
-    });
-
     const hunkCommand = [
       `(sleep 6; printf q) | timeout 8 script -q -f -e -c`,
       shellQuote(`bun run ${shellQuote(sourceEntrypoint)} diff ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`),
@@ -125,11 +114,14 @@ describe("MCP end-to-end", () => {
       },
     });
 
+    let daemonPid: number | null = null;
     let client: Client | null = null;
     let transport: StreamableHTTPClientTransport | null = null;
 
     try {
-      await waitForHealth(port);
+      const health = await waitForHealth(port);
+      daemonPid = health.pid;
+      expect(health.ok).toBe(true);
 
       client = new Client({ name: "mcp-e2e-test", version: "1.0.0" });
       transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`));
@@ -157,8 +149,8 @@ describe("MCP end-to-end", () => {
           filePath: "after.ts",
           side: "new",
           line: 2,
-          summary: "MCP e2e note",
-          rationale: "Injected from the automated MCP integration test.",
+          summary: "MCP autostart note",
+          rationale: "Injected after the Hunk session auto-started the local daemon.",
           author: "Pi",
           reveal: true,
         },
@@ -172,17 +164,23 @@ describe("MCP end-to-end", () => {
       expect([0, 124]).toContain(hunkExitCode);
 
       const transcript = stripTerminalControl(await Bun.file(fixture.transcript).text());
-      expect(transcript).toContain("MCP e2e note");
-      expect(transcript).toContain("Injected from the automated");
+      expect(transcript).toContain("MCP autostart note");
+      expect(transcript).toContain("Injected after the Hunk");
     } finally {
       if (transport) {
         await transport.close().catch(() => undefined);
       }
 
       hunkProc.kill();
-      daemonProc.kill();
       await hunkProc.exited.catch(() => undefined);
-      await daemonProc.exited.catch(() => undefined);
+
+      if (daemonPid) {
+        try {
+          process.kill(daemonPid, "SIGTERM");
+        } catch {
+          // Ignore daemons that already exited during cleanup.
+        }
+      }
     }
   }, 20_000);
 });

--- a/test/tty-render-smoke.test.ts
+++ b/test/tty-render-smoke.test.ts
@@ -128,6 +128,7 @@ async function runTtySmoke(options: { mode?: "split" | "stack"; pager?: boolean;
     env: {
       ...process.env,
       TERM: "xterm-256color",
+      HUNK_MCP_DISABLE: "1",
     },
   });
 
@@ -154,6 +155,7 @@ async function runStdinPagerSmoke(options?: { input?: string; inputCommand?: str
     env: {
       ...process.env,
       TERM: "xterm-256color",
+      HUNK_MCP_DISABLE: "1",
     },
   });
 


### PR DESCRIPTION
## Summary
- auto-start the local MCP daemon when a normal Hunk review session launches and the daemon is not already running
- add daemon launch resolution and health probing for source, wrapper, and executable entrypoints
- add unit and end-to-end coverage for daemon auto-start, and keep non-MCP TTY smoke tests isolated with `HUNK_MCP_DISABLE=1`

## Testing
- bun run typecheck
- bun test
- bun run test:tty-smoke
- manual tmux verification with one daemon + multiple Hunk instances routed through MCP comments