### PR TITLE
Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # hunk
 
+<p align="center">
+  <a href="https://github.com/modem-dev/hunk/actions/workflows/ci.yml?branch=main"><img src="https://img.shields.io/github/actions/workflow/status/modem-dev/hunk/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI status"></a>
+  <a href="https://github.com/modem-dev/hunk/releases"><img src="https://img.shields.io/github/v/release/modem-dev/hunk?style=for-the-badge" alt="Latest release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
+</p>
+
 Hunk is a terminal diff viewer for reviewing agent-authored changesets with a desktop-style UI.
 
 - full-screen multi-file review stream


### PR DESCRIPTION
## Summary
- add centered README badges for CI status, latest release, and license
- match the standard OSS first-impression pattern near the top of the page

## Testing
- README change only