### PR TITLE
Retarget workflows from master to main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,7 @@ name: Benchmarks
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Main CI
 on:
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: main-ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- update the main CI workflow to run on pushes to `main`
- update the benchmarks workflow to run on pushes to `main`
- restore the README CI badge and post-merge benchmark runs after the default branch rename

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/workflows/benchmarks.yml'); puts 'workflow yaml ok'"