### PR TITLE
feat: harden MCP daemon lifecycle

### DIFF
--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,6 +1,11 @@
 import type { AppliedCommentResult, HunkSessionRegistration, HunkSessionSnapshot, SessionClientMessage, SessionServerMessage } from "./types";
 import { HUNK_SESSION_SOCKET_PATH, resolveHunkMcpConfig } from "./config";
-import { isHunkDaemonHealthy, launchHunkDaemon, waitForHunkDaemonHealth } from "./daemonLauncher";
+import { isHunkDaemonHealthy, isLoopbackPortReachable, launchHunkDaemon, waitForHunkDaemonHealth } from "./daemonLauncher";
+
+const DAEMON_LAUNCH_COOLDOWN_MS = 5_000;
+const DAEMON_STARTUP_TIMEOUT_MS = 3_000;
+const RECONNECT_DELAY_MS = 3_000;
+const HEARTBEAT_INTERVAL_MS = 10_000;
 
 export interface HunkAppBridge {
   applyComment: (message: Extract<SessionServerMessage, { command: "comment" }>) => Promise<AppliedCommentResult>;
@@ -12,9 +17,11 @@ export class HunkHostClient {
   private bridge: HunkAppBridge | null = null;
   private queuedMessages: SessionServerMessage[] = [];
   private reconnectTimer: Timer | null = null;
+  private heartbeatTimer: Timer | null = null;
   private stopped = false;
   private startupPromise: Promise<void> | null = null;
   private lastDaemonLaunchStartedAt = 0;
+  private lastConnectionWarning: string | null = null;
   private readonly config = resolveHunkMcpConfig();
 
   constructor(
@@ -31,9 +38,18 @@ export class HunkHostClient {
       return;
     }
 
-    this.startupPromise = this.ensureDaemonAndConnect().finally(() => {
-      this.startupPromise = null;
-    });
+    this.startupPromise = this.ensureDaemonAndConnect()
+      .catch((error) => {
+        if (this.stopped) {
+          return;
+        }
+
+        this.warnUnavailable(error);
+        this.scheduleReconnect();
+      })
+      .finally(() => {
+        this.startupPromise = null;
+      });
   }
 
   stop() {
@@ -43,6 +59,7 @@ export class HunkHostClient {
       this.reconnectTimer = null;
     }
 
+    this.stopHeartbeat();
     this.websocket?.close();
     this.websocket = null;
   }
@@ -54,19 +71,38 @@ export class HunkHostClient {
 
   private async ensureDaemonAvailable() {
     if (await isHunkDaemonHealthy(this.config)) {
+      this.lastConnectionWarning = null;
       return;
     }
 
-    const launchCooldownMs = 5_000;
-    if (Date.now() - this.lastDaemonLaunchStartedAt < launchCooldownMs) {
-      return;
+    const shouldLaunch = Date.now() - this.lastDaemonLaunchStartedAt >= DAEMON_LAUNCH_COOLDOWN_MS;
+    if (shouldLaunch) {
+      this.lastDaemonLaunchStartedAt = Date.now();
+      launchHunkDaemon();
     }
 
-    this.lastDaemonLaunchStartedAt = Date.now();
-    launchHunkDaemon();
-    await waitForHunkDaemonHealth({
+    const ready = await waitForHunkDaemonHealth({
       config: this.config,
+      timeoutMs: shouldLaunch ? DAEMON_STARTUP_TIMEOUT_MS : 1_500,
     });
+
+    if (ready) {
+      this.lastConnectionWarning = null;
+      return;
+    }
+
+    const portReachable = await isLoopbackPortReachable(this.config);
+    if (portReachable) {
+      throw new Error(
+        `Hunk MCP port ${this.config.host}:${this.config.port} is already in use by another process. ` +
+          `Stop the conflicting process or set HUNK_MCP_PORT to a different loopback port.`,
+      );
+    }
+
+    throw new Error(
+      `Timed out waiting for the Hunk MCP daemon on ${this.config.host}:${this.config.port}. ` +
+        `Hunk will retry in the background.`,
+    );
   }
 
   setBridge(bridge: HunkAppBridge | null) {
@@ -93,6 +129,8 @@ export class HunkHostClient {
 
     websocket.onopen = () => {
       this.lastDaemonLaunchStartedAt = 0;
+      this.lastConnectionWarning = null;
+      this.startHeartbeat();
       this.send({
         type: "register",
         registration: this.registration,
@@ -117,7 +155,11 @@ export class HunkHostClient {
     };
 
     websocket.onclose = () => {
-      this.websocket = null;
+      if (this.websocket === websocket) {
+        this.websocket = null;
+      }
+
+      this.stopHeartbeat();
       if (!this.stopped) {
         this.scheduleReconnect();
       }
@@ -128,16 +170,39 @@ export class HunkHostClient {
     };
   }
 
-  private scheduleReconnect() {
+  private scheduleReconnect(delayMs = RECONNECT_DELAY_MS) {
     if (this.reconnectTimer || this.stopped) {
       return;
     }
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
-      void this.ensureDaemonAndConnect();
-    }, 3_000);
+      this.start();
+    }, delayMs);
     this.reconnectTimer.unref?.();
+  }
+
+  private startHeartbeat() {
+    if (this.heartbeatTimer) {
+      return;
+    }
+
+    this.heartbeatTimer = setInterval(() => {
+      this.send({
+        type: "heartbeat",
+        sessionId: this.registration.sessionId,
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private stopHeartbeat() {
+    if (!this.heartbeatTimer) {
+      return;
+    }
+
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
   }
 
   private send(message: SessionClientMessage) {
@@ -183,5 +248,15 @@ export class HunkHostClient {
     for (const message of queued) {
       await this.handleServerMessage(message);
     }
+  }
+
+  private warnUnavailable(error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown Hunk MCP connection error.";
+    if (message === this.lastConnectionWarning) {
+      return;
+    }
+
+    this.lastConnectionWarning = message;
+    console.error(`[hunk:mcp] ${message}`);
   }
 }

--- a/src/mcp/daemonLauncher.ts
+++ b/src/mcp/daemonLauncher.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
+import { connect } from "node:net";
 import { resolveHunkMcpConfig, type ResolvedHunkMcpConfig } from "./config";
 
 const SCRIPT_ENTRYPOINT_PATTERN = /[\\/]|\.(?:[cm]?js|tsx?)$/;
@@ -43,6 +44,36 @@ export async function isHunkDaemonHealthy(config: ResolvedHunkMcpConfig = resolv
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/** Check whether some local process is already accepting TCP connections on the daemon port. */
+export function isLoopbackPortReachable(
+  config: Pick<ResolvedHunkMcpConfig, "host" | "port"> = resolveHunkMcpConfig(),
+  timeoutMs = 500,
+) {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const socket = connect({
+      host: config.host,
+      port: config.port,
+    });
+
+    const finish = (value: boolean) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      socket.destroy();
+      resolve(value);
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.unref?.();
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(false));
+    socket.once("error", () => finish(false));
+  });
 }
 
 /** Wait briefly for a just-launched daemon to become reachable on its health endpoint. */

--- a/src/mcp/daemonState.ts
+++ b/src/mcp/daemonState.ts
@@ -17,11 +17,16 @@ interface SessionEntry {
   snapshot: HunkSessionSnapshot;
   socket: DaemonSessionSocket;
   connectedAt: string;
+  lastSeenAt: string;
 }
 
 export interface SessionTargetSelector {
   sessionId?: string;
   repoRoot?: string;
+}
+
+function describeSessionChoices(sessions: ListedSession[]) {
+  return sessions.map((session) => `${session.sessionId} (${session.title})`).join(", ");
 }
 
 /** Resolve which live Hunk session one external command should target. */
@@ -42,7 +47,10 @@ export function resolveSessionTarget(sessions: ListedSession[], selector: Sessio
     }
 
     if (matches.length > 1) {
-      throw new Error(`Multiple active Hunk sessions match repoRoot ${selector.repoRoot}; specify sessionId instead.`);
+      throw new Error(
+        `Multiple active Hunk sessions match repoRoot ${selector.repoRoot}; specify sessionId instead. ` +
+          `Matches: ${describeSessionChoices(matches)}.`,
+      );
     }
 
     return matches[0]!;
@@ -53,10 +61,13 @@ export function resolveSessionTarget(sessions: ListedSession[], selector: Sessio
   }
 
   if (sessions.length === 0) {
-    throw new Error("No active Hunk sessions are registered with the daemon.");
+    throw new Error("No active Hunk sessions are registered with the daemon. Open Hunk and wait for it to connect.");
   }
 
-  throw new Error("Multiple active Hunk sessions are registered; specify sessionId or repoRoot.");
+  throw new Error(
+    `Multiple active Hunk sessions are registered; specify sessionId or repoRoot. ` +
+      `Sessions: ${describeSessionChoices(sessions)}.`,
+  );
 }
 
 /** Track registered Hunk sessions and route MCP commands onto the correct live TUI instance. */
@@ -87,6 +98,10 @@ export class HunkDaemonState {
     return resolveSessionTarget(this.listSessions(), selector);
   }
 
+  getPendingCommandCount() {
+    return this.pendingCommands.size;
+  }
+
   registerSession(socket: DaemonSessionSocket, registration: HunkSessionRegistration, snapshot: HunkSessionSnapshot) {
     const previousSessionId = this.sessionIdsBySocket.get(socket);
     if (previousSessionId && previousSessionId !== registration.sessionId) {
@@ -99,11 +114,13 @@ export class HunkDaemonState {
       this.rejectPendingCommandsForSession(registration.sessionId, new Error("Hunk session reconnected before the command completed."));
     }
 
+    const now = new Date().toISOString();
     this.sessions.set(registration.sessionId, {
       registration,
       snapshot,
       socket,
-      connectedAt: new Date().toISOString(),
+      connectedAt: now,
+      lastSeenAt: now,
     });
     this.sessionIdsBySocket.set(socket, registration.sessionId);
   }
@@ -117,6 +134,19 @@ export class HunkDaemonState {
     this.sessions.set(sessionId, {
       ...entry,
       snapshot,
+      lastSeenAt: new Date().toISOString(),
+    });
+  }
+
+  markSessionSeen(sessionId: string) {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) {
+      return;
+    }
+
+    this.sessions.set(sessionId, {
+      ...entry,
+      lastSeenAt: new Date().toISOString(),
     });
   }
 
@@ -126,9 +156,30 @@ export class HunkDaemonState {
       return;
     }
 
-    this.sessionIdsBySocket.delete(socket);
-    this.sessions.delete(sessionId);
-    this.rejectPendingCommandsForSession(sessionId, new Error("The targeted Hunk session disconnected."));
+    this.removeSession(sessionId, "The targeted Hunk session disconnected.");
+  }
+
+  pruneStaleSessions({
+    ttlMs,
+    now = Date.now(),
+  }: {
+    ttlMs: number;
+    now?: number;
+  }) {
+    let removed = 0;
+    const cutoff = now - ttlMs;
+
+    for (const [sessionId, entry] of this.sessions.entries()) {
+      const lastSeenAt = Date.parse(entry.lastSeenAt);
+      if (!Number.isFinite(lastSeenAt) || lastSeenAt > cutoff) {
+        continue;
+      }
+
+      this.removeSession(sessionId, "The targeted Hunk session became stale and was removed from the MCP daemon.");
+      removed += 1;
+    }
+
+    return removed;
   }
 
   async sendComment(input: CommentToolInput) {
@@ -159,14 +210,20 @@ export class HunkDaemonState {
         return;
       }
 
-      entry.socket.send(
-        JSON.stringify({
-          type: "command",
-          requestId,
-          command: "comment",
-          input,
-        }),
-      );
+      try {
+        entry.socket.send(
+          JSON.stringify({
+            type: "command",
+            requestId,
+            command: "comment",
+            input,
+          }),
+        );
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pendingCommands.delete(requestId);
+        reject(error instanceof Error ? error : new Error("The targeted Hunk session could not receive the command."));
+      }
     });
   }
 
@@ -185,6 +242,31 @@ export class HunkDaemonState {
     }
 
     pending.reject(new Error(message.error ?? "The Hunk session failed to handle the command."));
+  }
+
+  shutdown(error = new Error("The Hunk MCP daemon shut down.")) {
+    for (const [requestId, pending] of this.pendingCommands.entries()) {
+      clearTimeout(pending.timeout);
+      this.pendingCommands.delete(requestId);
+      pending.reject(error);
+    }
+
+    this.sessionIdsBySocket.clear();
+    this.sessions.clear();
+  }
+
+  private removeSession(sessionId: string, reason: string) {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) {
+      return;
+    }
+
+    this.sessions.delete(sessionId);
+    if (this.sessionIdsBySocket.get(entry.socket) === sessionId) {
+      this.sessionIdsBySocket.delete(entry.socket);
+    }
+
+    this.rejectPendingCommandsForSession(sessionId, new Error(reason));
   }
 
   private rejectPendingCommandsForSession(sessionId: string, error: Error) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,9 @@ import { HUNK_MCP_PATH, HUNK_SESSION_SOCKET_PATH, resolveHunkMcpConfig } from ".
 import { HunkDaemonState } from "./daemonState";
 import type { SessionClientMessage } from "./types";
 
+const STALE_SESSION_TTL_MS = 45_000;
+const STALE_SESSION_SWEEP_INTERVAL_MS = 15_000;
+
 interface McpTransportEntry {
   server: McpServer;
   transport: WebStandardStreamableHTTPServerTransport;
@@ -23,6 +26,23 @@ function textContent(text: string) {
       text,
     },
   ];
+}
+
+function formatDaemonServeError(error: unknown, host: string, port: number) {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  if (
+    normalized.includes("eaddrinuse")
+    || normalized.includes("address already in use")
+    || normalized.includes(`is port ${port} in use?`)
+  ) {
+    return new Error(
+      `Hunk MCP daemon could not bind ${host}:${port} because the port is already in use. ` +
+        `Stop the conflicting process or set HUNK_MCP_PORT to a different loopback port.`,
+    );
+  }
+
+  return new Error(`Failed to start the Hunk MCP daemon on ${host}:${port}: ${message}`);
 }
 
 function createHunkMcpServer(state: HunkDaemonState) {
@@ -121,116 +141,159 @@ export function serveHunkMcpServer() {
   const config = resolveHunkMcpConfig();
   const state = new HunkDaemonState();
   const transports = new Map<string, McpTransportEntry>();
+  const startedAt = Date.now();
+  let shuttingDown = false;
 
-  const server = Bun.serve<{ sessionId?: string }>({
-    hostname: config.host,
-    port: config.port,
-    fetch: async (request, bunServer) => {
-      const url = new URL(request.url);
+  const sweepTimer = setInterval(() => {
+    state.pruneStaleSessions({ ttlMs: STALE_SESSION_TTL_MS });
+  }, STALE_SESSION_SWEEP_INTERVAL_MS);
+  sweepTimer.unref?.();
 
-      if (url.pathname === "/health") {
-        return Response.json({
-          ok: true,
-          pid: process.pid,
-          transport: `${config.httpOrigin}${HUNK_MCP_PATH}`,
-          sessionSocket: `${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`,
-          sessions: state.listSessions().length,
-        });
-      }
+  let server: ReturnType<typeof Bun.serve<{ sessionId?: string }>>;
+  try {
+    server = Bun.serve<{ sessionId?: string }>({
+      hostname: config.host,
+      port: config.port,
+      fetch: async (request, bunServer) => {
+        const url = new URL(request.url);
 
-      if (url.pathname === HUNK_SESSION_SOCKET_PATH) {
-        if (bunServer.upgrade(request, { data: {} })) {
-          return undefined;
+        if (url.pathname === "/health") {
+          state.pruneStaleSessions({ ttlMs: STALE_SESSION_TTL_MS });
+          return Response.json({
+            ok: true,
+            pid: process.pid,
+            startedAt: new Date(startedAt).toISOString(),
+            uptimeMs: Date.now() - startedAt,
+            transport: `${config.httpOrigin}${HUNK_MCP_PATH}`,
+            sessionSocket: `${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`,
+            sessions: state.listSessions().length,
+            pendingCommands: state.getPendingCommandCount(),
+            staleSessionTtlMs: STALE_SESSION_TTL_MS,
+          });
         }
 
-        return new Response("Expected websocket upgrade.", { status: 426 });
-      }
+        if (url.pathname === HUNK_SESSION_SOCKET_PATH) {
+          if (bunServer.upgrade(request, { data: {} })) {
+            return undefined;
+          }
 
-      if (url.pathname !== HUNK_MCP_PATH) {
-        return new Response("Not found.", { status: 404 });
-      }
+          return new Response("Expected websocket upgrade.", { status: 426 });
+        }
 
-      const headerSessionId = request.headers.get("mcp-session-id") ?? undefined;
-      const parsedBody = request.method === "POST" ? await request.json() : undefined;
+        if (url.pathname !== HUNK_MCP_PATH) {
+          return new Response("Not found.", { status: 404 });
+        }
 
-      if (headerSessionId && transports.has(headerSessionId)) {
-        const entry = transports.get(headerSessionId)!;
-        return entry.transport.handleRequest(request, { parsedBody });
-      }
+        const headerSessionId = request.headers.get("mcp-session-id") ?? undefined;
+        const parsedBody = request.method === "POST" ? await request.json() : undefined;
 
-      if (!headerSessionId && request.method === "POST" && isInitializeRequest(parsedBody)) {
-        let transport: WebStandardStreamableHTTPServerTransport;
-        let transportEntry: McpTransportEntry;
+        if (headerSessionId && transports.has(headerSessionId)) {
+          const entry = transports.get(headerSessionId)!;
+          return entry.transport.handleRequest(request, { parsedBody });
+        }
 
-        transport = new WebStandardStreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          enableJsonResponse: true,
-          onsessioninitialized: (sessionId) => {
-            transports.set(sessionId, transportEntry);
+        if (!headerSessionId && request.method === "POST" && isInitializeRequest(parsedBody)) {
+          let transport: WebStandardStreamableHTTPServerTransport;
+          let transportEntry: McpTransportEntry;
+
+          transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableJsonResponse: true,
+            onsessioninitialized: (sessionId) => {
+              transports.set(sessionId, transportEntry);
+            },
+            onsessionclosed: (sessionId) => {
+              const entry = transports.get(sessionId);
+              if (entry) {
+                void entry.server.close();
+                transports.delete(sessionId);
+              }
+            },
+          });
+
+          const mcpServer = createHunkMcpServer(state);
+          transportEntry = {
+            server: mcpServer,
+            transport,
+          };
+
+          await mcpServer.connect(transport);
+          return transport.handleRequest(request, { parsedBody });
+        }
+
+        return Response.json(
+          {
+            jsonrpc: "2.0",
+            error: {
+              code: -32000,
+              message: "Bad Request: No valid MCP session id provided.",
+            },
+            id: null,
           },
-          onsessionclosed: (sessionId) => {
-            const entry = transports.get(sessionId);
-            if (entry) {
-              void entry.server.close();
-              transports.delete(sessionId);
-            }
+          {
+            status: 400,
           },
-        });
-
-        const mcpServer = createHunkMcpServer(state);
-        transportEntry = {
-          server: mcpServer,
-          transport,
-        };
-
-        await mcpServer.connect(transport);
-        return transport.handleRequest(request, { parsedBody });
-      }
-
-      return Response.json(
-        {
-          jsonrpc: "2.0",
-          error: {
-            code: -32000,
-            message: "Bad Request: No valid MCP session id provided.",
-          },
-          id: null,
-        },
-        {
-          status: 400,
-        },
-      );
-    },
-    websocket: {
-      message: (socket, message) => {
-        if (typeof message !== "string") {
-          return;
-        }
-
-        let parsed: SessionClientMessage;
-        try {
-          parsed = JSON.parse(message) as SessionClientMessage;
-        } catch {
-          return;
-        }
-
-        switch (parsed.type) {
-          case "register":
-            state.registerSession(socket, parsed.registration, parsed.snapshot);
-            break;
-          case "snapshot":
-            state.updateSnapshot(parsed.sessionId, parsed.snapshot);
-            break;
-          case "command-result":
-            state.handleCommandResult(parsed);
-            break;
-        }
+        );
       },
-      close: (socket) => {
-        state.unregisterSocket(socket);
+      websocket: {
+        message: (socket, message) => {
+          if (typeof message !== "string") {
+            return;
+          }
+
+          let parsed: SessionClientMessage;
+          try {
+            parsed = JSON.parse(message) as SessionClientMessage;
+          } catch {
+            return;
+          }
+
+          switch (parsed.type) {
+            case "register":
+              state.registerSession(socket, parsed.registration, parsed.snapshot);
+              break;
+            case "snapshot":
+              state.updateSnapshot(parsed.sessionId, parsed.snapshot);
+              break;
+            case "heartbeat":
+              state.markSessionSeen(parsed.sessionId);
+              break;
+            case "command-result":
+              state.handleCommandResult(parsed);
+              break;
+          }
+        },
+        close: (socket) => {
+          state.unregisterSocket(socket);
+        },
       },
-    },
-  });
+    });
+  } catch (error) {
+    clearInterval(sweepTimer);
+    throw formatDaemonServeError(error, config.host, config.port);
+  }
+
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    clearInterval(sweepTimer);
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+
+    state.shutdown();
+    for (const [sessionId, entry] of transports.entries()) {
+      void entry.server.close();
+      transports.delete(sessionId);
+    }
+
+    server.stop(true);
+  };
+
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
 
   console.log(`Hunk MCP daemon listening on ${config.httpOrigin}${HUNK_MCP_PATH}`);
   console.log(`Hunk session websocket listening on ${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`);

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -72,6 +72,10 @@ export type SessionClientMessage =
       snapshot: HunkSessionSnapshot;
     }
   | {
+      type: "heartbeat";
+      sessionId: string;
+    }
+  | {
       type: "command-result";
       requestId: string;
       ok: true;

--- a/test/daemon-launcher.test.ts
+++ b/test/daemon-launcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { resolveDaemonLaunchCommand } from "../src/mcp/daemonLauncher";
+import { createServer } from "node:net";
+import { isLoopbackPortReachable, resolveDaemonLaunchCommand } from "../src/mcp/daemonLauncher";
 
 describe("MCP daemon launcher", () => {
   test("reuses the current script entrypoint when Hunk is running from source or a JS wrapper", () => {
@@ -19,5 +20,24 @@ describe("MCP daemon launcher", () => {
       command: "/usr/local/bin/hunk",
       args: ["mcp", "serve"],
     });
+  });
+
+  test("detects whether some process is already listening on the daemon port", async () => {
+    const listener = createServer(() => undefined);
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = listener.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+
+    try {
+      await expect(isLoopbackPortReachable({ host: "127.0.0.1", port })).resolves.toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => listener.close(() => resolve()));
+    }
+
+    await expect(isLoopbackPortReachable({ host: "127.0.0.1", port })).resolves.toBe(false);
   });
 });

--- a/test/mcp-daemon.test.ts
+++ b/test/mcp-daemon.test.ts
@@ -34,7 +34,7 @@ function createListedSession(overrides: Partial<ListedSession> = {}): ListedSess
   };
 }
 
-function createRegistration(): HunkSessionRegistration {
+function createRegistration(overrides: Partial<HunkSessionRegistration> = {}): HunkSessionRegistration {
   return {
     sessionId: "session-1",
     pid: 123,
@@ -53,10 +53,11 @@ function createRegistration(): HunkSessionRegistration {
         hunkCount: 1,
       },
     ],
+    ...overrides,
   };
 }
 
-function createSnapshot(): HunkSessionSnapshot {
+function createSnapshot(overrides: Partial<HunkSessionSnapshot> = {}): HunkSessionSnapshot {
   return {
     selectedFileId: "file-1",
     selectedFilePath: "src/example.ts",
@@ -64,6 +65,7 @@ function createSnapshot(): HunkSessionSnapshot {
     showAgentNotes: false,
     liveCommentCount: 0,
     updatedAt: "2026-03-22T00:00:00.000Z",
+    ...overrides,
   };
 }
 
@@ -140,5 +142,83 @@ describe("Hunk MCP daemon state", () => {
     state.unregisterSocket(socket);
 
     await expect(pending).rejects.toThrow("disconnected");
+  });
+
+  test("rejects commands immediately when the live session socket cannot accept them", async () => {
+    const state = new HunkDaemonState();
+    const socket = {
+      send() {
+        throw new Error("socket closed");
+      },
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+
+    await expect(
+      state.sendComment({
+        sessionId: "session-1",
+        filePath: "src/example.ts",
+        side: "new",
+        line: 4,
+        summary: "Review note",
+      }),
+    ).rejects.toThrow("socket closed");
+    expect(state.getPendingCommandCount()).toBe(0);
+  });
+
+  test("prunes stale sessions and rejects their in-flight commands", async () => {
+    const state = new HunkDaemonState();
+    const sent: string[] = [];
+    const socket = {
+      send(data: string) {
+        sent.push(data);
+      },
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+    const pending = state.sendComment({
+      sessionId: "session-1",
+      filePath: "src/example.ts",
+      side: "new",
+      line: 4,
+      summary: "Review note",
+    });
+
+    expect(sent).toHaveLength(1);
+    const removed = state.pruneStaleSessions({
+      ttlMs: 1,
+      now: Date.now() + 10,
+    });
+
+    expect(removed).toBe(1);
+    expect(state.listSessions()).toHaveLength(0);
+    await expect(pending).rejects.toThrow("stale");
+  });
+
+  test("heartbeats keep an otherwise idle session from being pruned", () => {
+    const state = new HunkDaemonState();
+    const socket = {
+      send() {},
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+    const registeredAt = Date.now();
+
+    expect(
+      state.pruneStaleSessions({
+        ttlMs: 50,
+        now: registeredAt + 25,
+      }),
+    ).toBe(0);
+
+    state.markSessionSeen("session-1");
+
+    expect(
+      state.pruneStaleSessions({
+        ttlMs: 50,
+        now: Date.now() + 25,
+      }),
+    ).toBe(0);
+    expect(state.listSessions()).toHaveLength(1);
   });
 });

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:net";
+import { serveHunkMcpServer } from "../src/mcp/server";
+
+const originalHost = process.env.HUNK_MCP_HOST;
+const originalPort = process.env.HUNK_MCP_PORT;
+
+afterEach(() => {
+  if (originalHost === undefined) {
+    delete process.env.HUNK_MCP_HOST;
+  } else {
+    process.env.HUNK_MCP_HOST = originalHost;
+  }
+
+  if (originalPort === undefined) {
+    delete process.env.HUNK_MCP_PORT;
+  } else {
+    process.env.HUNK_MCP_PORT = originalPort;
+  }
+});
+
+describe("Hunk MCP server", () => {
+  test("reports a clear error when the daemon port is already in use", async () => {
+    const listener = createServer(() => undefined);
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = listener.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    try {
+      expect(() => serveHunkMcpServer()).toThrow("port is already in use");
+    } finally {
+      await new Promise<void>((resolve) => listener.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- harden daemon startup, shutdown, and reconnect behavior
- add heartbeat-driven stale-session cleanup and richer health output
- improve port-conflict and delivery-failure handling with regression tests

## Testing
- bun run typecheck
- bun test
- bun run test:tty-smoke