### PR TITLE
test: cover MCP port conflicts

### DIFF
--- a/test/mcp-client.test.ts
+++ b/test/mcp-client.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer } from "node:http";
+import { HunkHostClient } from "../src/mcp/client";
+import type { HunkSessionRegistration, HunkSessionSnapshot } from "../src/mcp/types";
+
+const originalHost = process.env.HUNK_MCP_HOST;
+const originalPort = process.env.HUNK_MCP_PORT;
+const originalDisable = process.env.HUNK_MCP_DISABLE;
+const originalConsoleError = console.error;
+
+function createRegistration(): HunkSessionRegistration {
+  return {
+    sessionId: "session-1",
+    pid: process.pid,
+    cwd: process.cwd(),
+    repoRoot: process.cwd(),
+    inputKind: "diff",
+    title: "before.ts ↔ after.ts",
+    sourceLabel: "before.ts -> after.ts",
+    launchedAt: "2026-03-22T00:00:00.000Z",
+    files: [
+      {
+        id: "file-1",
+        path: "after.ts",
+        additions: 1,
+        deletions: 1,
+        hunkCount: 1,
+      },
+    ],
+  };
+}
+
+function createSnapshot(): HunkSessionSnapshot {
+  return {
+    selectedFileId: "file-1",
+    selectedFilePath: "after.ts",
+    selectedHunkIndex: 0,
+    showAgentNotes: true,
+    liveCommentCount: 0,
+    updatedAt: "2026-03-22T00:00:00.000Z",
+  };
+}
+
+async function waitUntil(label: string, fn: () => boolean, timeoutMs = 5_000, intervalMs = 50) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (fn()) {
+      return;
+    }
+
+    await Bun.sleep(intervalMs);
+  }
+
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+afterEach(() => {
+  if (originalHost === undefined) {
+    delete process.env.HUNK_MCP_HOST;
+  } else {
+    process.env.HUNK_MCP_HOST = originalHost;
+  }
+
+  if (originalPort === undefined) {
+    delete process.env.HUNK_MCP_PORT;
+  } else {
+    process.env.HUNK_MCP_PORT = originalPort;
+  }
+
+  if (originalDisable === undefined) {
+    delete process.env.HUNK_MCP_DISABLE;
+  } else {
+    process.env.HUNK_MCP_DISABLE = originalDisable;
+  }
+
+  console.error = originalConsoleError;
+});
+
+describe("Hunk MCP client", () => {
+  test("logs one actionable warning when a non-Hunk listener owns the MCP port", async () => {
+    const conflictingListener = createServer((_request, response) => {
+      response.writeHead(404, { "content-type": "text/plain" });
+      response.end("not hunk");
+    });
+    await new Promise<void>((resolve, reject) => {
+      conflictingListener.once("error", reject);
+      conflictingListener.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = conflictingListener.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+    delete process.env.HUNK_MCP_DISABLE;
+
+    const messages: string[] = [];
+    console.error = (...args: unknown[]) => {
+      messages.push(args.map((value) => String(value)).join(" "));
+    };
+
+    const client = new HunkHostClient(createRegistration(), createSnapshot());
+
+    try {
+      client.start();
+      await waitUntil("initial MCP conflict warning", () => messages.length === 1);
+
+      client.start();
+      await Bun.sleep(2_000);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toContain(`[hunk:mcp] Hunk MCP port 127.0.0.1:${port} is already in use by another process.`);
+      expect(messages[0]).toContain("Stop the conflicting process or set HUNK_MCP_PORT to a different loopback port.");
+    } finally {
+      client.stop();
+      await new Promise<void>((resolve) => conflictingListener.close(() => resolve()));
+    }
+  }, 10_000);
+});

--- a/test/mcp-e2e.test.ts
+++ b/test/mcp-e2e.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -75,10 +76,22 @@ function createFixtureFiles(name: string, beforeLines: string[], afterLines: str
   return { dir, before, after, transcript, afterName };
 }
 
-function spawnHunkSession(fixture: FixtureFiles, port: number) {
+function spawnHunkSession(
+  fixture: FixtureFiles,
+  {
+    port,
+    quitAfterSeconds = 6,
+    timeoutSeconds = 8,
+  }: {
+    port: number;
+    quitAfterSeconds?: number;
+    timeoutSeconds?: number;
+  },
+) {
+  const innerCommand = `bun run ${shellQuote(sourceEntrypoint)} diff ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`;
   const hunkCommand = [
-    `(sleep 6; printf q) | timeout 8 script -q -f -e -c`,
-    shellQuote(`bun run ${shellQuote(sourceEntrypoint)} diff ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`),
+    `(sleep ${quitAfterSeconds}; printf q) | timeout ${timeoutSeconds} script -q -f -e -c`,
+    shellQuote(innerCommand),
     shellQuote(fixture.transcript),
   ].join(" ");
 
@@ -154,7 +167,7 @@ describe("MCP end-to-end", () => {
       ["export const alpha = 2;", "export const keep = true;", "export const gamma = true;"],
     );
     const port = 48000 + Math.floor(Math.random() * 1000);
-    const hunkProc = spawnHunkSession(fixture, port);
+    const hunkProc = spawnHunkSession(fixture, { port });
 
     let daemonPid: number | null = null;
     let transport: StreamableHTTPClientTransport | null = null;
@@ -232,8 +245,8 @@ describe("MCP end-to-end", () => {
       ["export const beta = 2;", "export const shared = true;", "export const onlyBeta = true;"],
     );
     const port = 49000 + Math.floor(Math.random() * 1000);
-    const hunkProcA = spawnHunkSession(fixtureA, port);
-    const hunkProcB = spawnHunkSession(fixtureB, port);
+    const hunkProcA = spawnHunkSession(fixtureA, { port });
+    const hunkProcB = spawnHunkSession(fixtureB, { port });
 
     let daemonPid: number | null = null;
     let transport: StreamableHTTPClientTransport | null = null;
@@ -315,6 +328,48 @@ describe("MCP end-to-end", () => {
           // Ignore daemons that already exited during cleanup.
         }
       }
+    }
+  }, 20_000);
+
+  test("a normal Hunk session still renders and exits cleanly when a non-Hunk listener owns the MCP port", async () => {
+    if (!ttyToolsAvailable) {
+      return;
+    }
+
+    const fixture = createFixtureFiles(
+      "conflict",
+      ["export const alpha = 1;", "export const keep = true;"],
+      ["export const alpha = 2;", "export const keep = true;", "export const gamma = true;"],
+    );
+
+    const port = 50000 + Math.floor(Math.random() * 1000);
+    const conflictingListener = createServer((_request, response) => {
+      response.writeHead(404, { "content-type": "text/plain" });
+      response.end("not hunk");
+    });
+    await new Promise<void>((resolve, reject) => {
+      conflictingListener.once("error", reject);
+      conflictingListener.listen(port, "127.0.0.1", () => resolve());
+    });
+
+    const hunkProc = spawnHunkSession(fixture, {
+      port,
+      quitAfterSeconds: 6,
+      timeoutSeconds: 8,
+    });
+
+    try {
+      const exitCode = await hunkProc.exited;
+      expect([0, 124]).toContain(exitCode);
+
+      const transcript = stripTerminalControl(await Bun.file(fixture.transcript).text());
+      expect(transcript).toContain("View  Navigate  Theme  Agent  Help");
+      expect(transcript).toContain(`${fixture.afterName}`);
+      expect(transcript).toContain("export const gamma = true;");
+    } finally {
+      hunkProc.kill();
+      await hunkProc.exited.catch(() => undefined);
+      await new Promise<void>((resolve) => conflictingListener.close(() => resolve()));
     }
   }, 20_000);
 });


### PR DESCRIPTION
## Summary
- add end-to-end coverage for running a normal Hunk session while a non-Hunk listener owns the MCP port
- add focused client coverage for the actionable conflict warning path
- verify the client does not spam duplicate warnings on repeated startup attempts

## Testing
- bun run typecheck
- bun test