### PR TITLE
feat: render compact floating agent note popovers

### DIFF
--- a/src/ui/components/panes/AgentCard.tsx
+++ b/src/ui/components/panes/AgentCard.tsx
@@ -1,9 +1,12 @@
+import { buildAgentPopoverContent } from "../../lib/agentPopover";
+import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
-import { fitText } from "../../lib/text";
 
-/** Render one inline agent note card beside the diff rows it explains. */
+/** Render one framed floating agent note popover. */
 export function AgentCard({
   locationLabel,
+  noteCount = 1,
+  noteIndex = 0,
   rationale,
   onClose,
   summary,
@@ -11,22 +14,37 @@ export function AgentCard({
   width,
 }: {
   locationLabel: string;
+  noteCount?: number;
+  noteIndex?: number;
   rationale?: string;
   onClose?: () => void;
   summary: string;
   theme: AppTheme;
   width: number;
 }) {
+  const popover = buildAgentPopoverContent({
+    summary,
+    rationale,
+    locationLabel,
+    noteIndex,
+    noteCount,
+    width,
+  });
+  const titleWidth = Math.max(1, popover.innerWidth - (onClose ? 4 : 0));
+
   return (
     <box
       style={{
         width,
+        height: popover.height,
         border: true,
-        borderColor: theme.accentMuted,
-        backgroundColor: theme.panelAlt,
-        padding: 1,
+        borderColor: theme.accent,
+        backgroundColor: theme.panel,
+        paddingLeft: 1,
+        paddingRight: 1,
+        paddingTop: 0,
+        paddingBottom: 0,
         flexDirection: "column",
-        gap: 1,
       }}
     >
       <box
@@ -35,17 +53,42 @@ export function AgentCard({
           height: 1,
           flexDirection: "row",
           justifyContent: "space-between",
+          backgroundColor: theme.panel,
         }}
       >
-        <text fg={theme.accent}>{fitText(locationLabel, Math.max(1, width - (onClose ? 6 : 2)))}</text>
+        <text fg={theme.accent}>{padText(fitText(popover.title, titleWidth), titleWidth)}</text>
         {onClose ? (
-          <box onMouseUp={onClose}>
+          <box onMouseUp={onClose} style={{ backgroundColor: theme.panel }}>
             <text fg={theme.muted}>[x]</text>
           </box>
         ) : null}
       </box>
-      <text fg={theme.text}>{summary}</text>
-      {rationale ? <text fg={theme.muted}>{rationale}</text> : null}
+
+      {popover.summaryLines.map((line, index) => (
+        <box key={`summary:${index}`} style={{ width: "100%", height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.text}>{padText(line, popover.innerWidth)}</text>
+        </box>
+      ))}
+
+      {popover.rationaleLines.length > 0 ? (
+        <>
+          <box style={{ width: "100%", height: 1, backgroundColor: theme.panel }}>
+            <text fg={theme.text}>{" ".repeat(popover.innerWidth)}</text>
+          </box>
+          {popover.rationaleLines.map((line, index) => (
+            <box key={`rationale:${index}`} style={{ width: "100%", height: 1, backgroundColor: theme.panel }}>
+              <text fg={theme.muted}>{padText(line, popover.innerWidth)}</text>
+            </box>
+          ))}
+        </>
+      ) : null}
+
+      <box style={{ width: "100%", height: 1, backgroundColor: theme.panel }}>
+        <text fg={theme.text}>{" ".repeat(popover.innerWidth)}</text>
+      </box>
+      <box style={{ width: "100%", height: 1, backgroundColor: theme.panel }}>
+        <text fg={theme.muted}>{padText(popover.footer, popover.innerWidth)}</text>
+      </box>
     </box>
   );
 }

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1,7 +1,9 @@
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type RefObject } from "react";
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types";
-import type { VisibleAgentNote } from "../../lib/agentAnnotations";
+import { AgentCard } from "./AgentCard";
+import { annotationLocationLabel, type VisibleAgentNote } from "../../lib/agentAnnotations";
+import { buildAgentPopoverContent, resolveAgentPopoverPlacement } from "../../lib/agentPopover";
 import { estimateDiffBodyRows, estimateHunkAnchorRow } from "../../lib/sectionHeights";
 import { diffHunkId, diffSectionId } from "../../lib/ids";
 import type { AppTheme } from "../../themes";
@@ -9,6 +11,24 @@ import { DiffSection } from "./DiffSection";
 import { DiffSectionPlaceholder } from "./DiffSectionPlaceholder";
 
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
+
+function maxLineNumber(file: DiffFile) {
+  return Math.max(file.metadata.additionLines.length, file.metadata.deletionLines.length, 0);
+}
+
+function noteAnchorColumn(
+  file: DiffFile,
+  layout: Exclude<LayoutMode, "auto">,
+  width: number,
+  showLineNumbers: boolean,
+  note: VisibleAgentNote,
+) {
+  if (layout === "split") {
+    return note.annotation.oldRange && !note.annotation.newRange ? 1 : Math.max(2, Math.floor(width * 0.58));
+  }
+
+  return showLineNumbers ? Math.max(2, String(maxLineNumber(file)).length + 4) : 2;
+}
 
 /** Render the main multi-file review stream. */
 export function DiffPane({
@@ -144,6 +164,65 @@ export function DiffPane({
     () => files.map((file) => estimateDiffBodyRows(file, layout, showHunkHeaders)),
     [files, layout, showHunkHeaders],
   );
+  const selectedOverlayNote = useMemo(() => {
+    if (!selectedFileId) {
+      return null;
+    }
+
+    const selectedFileIndex = files.findIndex((file) => file.id === selectedFileId);
+    if (selectedFileIndex < 0) {
+      return null;
+    }
+
+    const selectedFile = files[selectedFileIndex]!;
+    const visibleNotes = visibleAgentNotesByFile.get(selectedFileId) ?? EMPTY_VISIBLE_AGENT_NOTES;
+    const note = visibleNotes[0];
+    if (!note) {
+      return null;
+    }
+
+    let sectionTop = 0;
+    for (let index = 0; index < selectedFileIndex; index += 1) {
+      sectionTop += (index > 0 ? 1 : 0) + 1 + (estimatedBodyHeights[index] ?? 0);
+    }
+
+    sectionTop += (selectedFileIndex > 0 ? 1 : 0) + 1;
+    const anchorRowTop = sectionTop + estimateHunkAnchorRow(selectedFile, layout, showHunkHeaders, selectedHunkIndex);
+    const anchorColumn = noteAnchorColumn(selectedFile, layout, diffContentWidth, showLineNumbers, note);
+    const noteWidth = Math.min(Math.max(34, Math.floor(diffContentWidth * 0.42)), Math.max(12, diffContentWidth - 2));
+    const locationLabel = annotationLocationLabel(selectedFile, note.annotation);
+    const popover = buildAgentPopoverContent({
+      summary: note.annotation.summary,
+      rationale: note.annotation.rationale,
+      locationLabel,
+      noteIndex: 0,
+      noteCount: visibleNotes.length,
+      width: noteWidth,
+    });
+
+    const contentHeight = files.reduce(
+      (total, file, index) => total + (index > 0 ? 1 : 0) + 1 + (estimatedBodyHeights[index] ?? 0),
+      0,
+    );
+    const placement = resolveAgentPopoverPlacement({
+      anchorColumn,
+      anchorRowTop,
+      anchorRowHeight: 1,
+      contentHeight,
+      noteHeight: popover.height,
+      noteWidth,
+      viewportWidth: diffContentWidth,
+    });
+
+    return {
+      note,
+      noteCount: visibleNotes.length,
+      noteWidth,
+      left: placement.left,
+      top: placement.top,
+      locationLabel,
+    };
+  }, [diffContentWidth, estimatedBodyHeights, files, layout, selectedFileId, selectedHunkIndex, showHunkHeaders, showLineNumbers, visibleAgentNotesByFile]);
 
   const visibleViewportFileIds = useMemo(() => {
     const overscanRows = 8;
@@ -267,7 +346,7 @@ export function DiffPane({
           verticalScrollbarOptions={{ visible: false }}
           horizontalScrollbarOptions={{ visible: false }}
         >
-          <box style={{ width: "100%", flexDirection: "column" }}>
+          <box style={{ width: "100%", flexDirection: "column", position: "relative", overflow: "visible" }}>
             {files.map((file, index) => {
               const shouldRenderSection = visibleWindowedFileIds?.has(file.id) ?? true;
               const shouldPrefetchVisibleHighlight =
@@ -295,7 +374,7 @@ export function DiffPane({
                   wrapLines={wrapLines}
                   theme={theme}
                   viewWidth={diffContentWidth}
-                  visibleAgentNotes={visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES}
+                  visibleAgentNotes={EMPTY_VISIBLE_AGENT_NOTES}
                   onDismissAgentNote={onDismissAgentNote}
                   onOpenAgentNotesAtHunk={(hunkIndex) => onOpenAgentNotesAtHunk(file.id, hunkIndex)}
                   onSelect={() => onSelectFile(file.id)}
@@ -314,6 +393,19 @@ export function DiffPane({
                 />
               );
             })}
+            {selectedFileId && selectedOverlayNote ? (
+              <box style={{ position: "absolute", top: selectedOverlayNote.top, left: selectedOverlayNote.left, zIndex: 20 }}>
+                <AgentCard
+                  locationLabel={selectedOverlayNote.locationLabel}
+                  noteCount={selectedOverlayNote.noteCount}
+                  rationale={selectedOverlayNote.note.annotation.rationale}
+                  summary={selectedOverlayNote.note.annotation.summary}
+                  theme={theme}
+                  width={selectedOverlayNote.noteWidth}
+                  onClose={() => onDismissAgentNote(selectedOverlayNote.note.id)}
+                />
+              </box>
+            ) : null}
           </box>
         </scrollbox>
       ) : (

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -62,6 +62,7 @@ function DiffSectionComponent({
         width: "100%",
         flexDirection: "column",
         backgroundColor: theme.panel,
+        overflow: "visible",
       }}
     >
       {showSeparator ? (

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState, type React
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../core/types";
 import { AgentCard } from "../components/panes/AgentCard";
 import { annotationLocationLabel, type VisibleAgentNote } from "../lib/agentAnnotations";
+import { buildAgentPopoverContent, resolveAgentPopoverPlacement } from "../lib/agentPopover";
 import { diffHunkId } from "../lib/ids";
 import type { AppTheme } from "../themes";
 import {
@@ -610,14 +611,8 @@ function rowMatchesNote(row: Extract<DiffRow, { type: "split-line" | "stack-line
   return anchor.side === "new" ? row.cell.newLineNumber === anchor.lineNumber : row.cell.oldLineNumber === anchor.lineNumber;
 }
 
-/** Attach visible notes to rows in the selected hunk, falling back to the first visible row when needed. */
-function buildAnchoredNotes(rows: DiffRow[], visibleAgentNotes: VisibleAgentNote[], selectedHunkIndex: number, showHunkHeaders: boolean) {
-  const anchoredNotes = new Map<string, VisibleAgentNote[]>();
-
-  if (visibleAgentNotes.length === 0 || selectedHunkIndex < 0) {
-    return anchoredNotes;
-  }
-
+/** Resolve the rendered row for the currently visible popover note. */
+function findNoteAnchorRow(rows: DiffRow[], note: VisibleAgentNote, selectedHunkIndex: number, showHunkHeaders: boolean) {
   const selectedHunkRows = rows.filter((row) => row.hunkIndex === selectedHunkIndex);
   const lineRows = selectedHunkRows.filter(
     (row): row is Extract<DiffRow, { type: "split-line" | "stack-line" }> => row.type === "split-line" || row.type === "stack-line",
@@ -625,64 +620,174 @@ function buildAnchoredNotes(rows: DiffRow[], visibleAgentNotes: VisibleAgentNote
   const headerRow = selectedHunkRows.find((row) => row.type === "hunk-header");
   const firstVisibleRow = showHunkHeaders ? headerRow ?? lineRows[0] : lineRows[0] ?? headerRow;
 
-  for (const note of visibleAgentNotes) {
-    const anchorRow = lineRows.find((row) => rowMatchesNote(row, note));
-    const targetKey = anchorRow?.key ?? firstVisibleRow?.key;
-    if (!targetKey) {
-      continue;
-    }
-
-    const current = anchoredNotes.get(targetKey) ?? [];
-    current.push(note);
-    anchoredNotes.set(targetKey, current);
-  }
-
-  return anchoredNotes;
+  return lineRows.find((row) => rowMatchesNote(row, note)) ?? firstVisibleRow;
 }
 
-/** Render the visible note cards anchored near their target rows. */
-function renderAnchoredNotes(
-  anchoredNotes: VisibleAgentNote[],
-  file: DiffFile,
+/** Measure how many terminal rows one rendered diff row occupies. */
+function measureRenderedRowHeight(
+  row: DiffRow,
   width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+  showHunkHeaders: boolean,
+  wrapLines: boolean,
   theme: AppTheme,
-  onDismissAgentNote?: (id: string) => void,
 ) {
-  if (anchoredNotes.length === 0) {
+  if (row.type === "hunk-header") {
+    return showHunkHeaders ? 1 : 0;
+  }
+
+  if (row.type === "collapsed") {
+    return 1;
+  }
+
+  if (row.type === "split-line") {
+    if (!wrapLines) {
+      return 1;
+    }
+
+    const markerWidth = 1;
+    const separatorWidth = 1;
+    const usableWidth = Math.max(0, width - markerWidth - separatorWidth);
+    const leftWidth = Math.max(0, markerWidth + Math.floor(usableWidth / 2));
+    const rightWidth = Math.max(0, separatorWidth + usableWidth - Math.floor(usableWidth / 2));
+    const leftLayout = buildWrappedSplitCell(row.left, leftWidth, lineNumberDigits, showLineNumbers, markerWidth, theme);
+    const rightLayout = buildWrappedSplitCell(row.right, rightWidth, lineNumberDigits, showLineNumbers, markerWidth, theme);
+
+    return Math.max(leftLayout.lines.length, rightLayout.lines.length);
+  }
+
+  if (row.type !== "stack-line") {
+    return 1;
+  }
+
+  if (!wrapLines) {
+    return 1;
+  }
+
+  const layout = buildWrappedStackCell(row.cell, width, lineNumberDigits, showLineNumbers, marker().length, theme);
+  return layout.lines.length;
+}
+
+/** Pick a horizontal anchor column for the floating note popover. */
+function noteAnchorColumn(
+  row: DiffRow,
+  note: VisibleAgentNote,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+) {
+  if (row.type === "split-line") {
+    const markerWidth = 1;
+    const separatorWidth = 1;
+    const usableWidth = Math.max(0, width - markerWidth - separatorWidth);
+    const leftWidth = Math.max(0, markerWidth + Math.floor(usableWidth / 2));
+    const anchor = noteAnchor(note.annotation);
+    return anchor?.side === "old" ? 1 : leftWidth + 1;
+  }
+
+  if (row.type === "stack-line") {
+    return showLineNumbers ? Math.max(2, lineNumberDigits + 4) : 2;
+  }
+
+  return 2;
+}
+
+interface SelectedOverlayNote {
+  anchorColumn: number;
+  anchorKey: string;
+  note: VisibleAgentNote;
+  noteCount: number;
+  noteIndex: number;
+}
+
+/** Resolve the single visible popover note for the selected hunk. */
+function buildSelectedOverlayNote(
+  rows: DiffRow[],
+  visibleAgentNotes: VisibleAgentNote[],
+  selectedHunkIndex: number,
+  showHunkHeaders: boolean,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+) {
+  if (visibleAgentNotes.length === 0 || selectedHunkIndex < 0) {
     return null;
   }
 
-  const noteWidth = Math.min(Math.max(28, Math.floor(width * 0.46)), Math.max(28, width - 6));
+  const note = visibleAgentNotes[0]!;
+  const anchorRow = findNoteAnchorRow(rows, note, selectedHunkIndex, showHunkHeaders);
+  if (!anchorRow) {
+    return null;
+  }
+
+  return {
+    anchorKey: anchorRow.key,
+    anchorColumn: noteAnchorColumn(anchorRow, note, width, lineNumberDigits, showLineNumbers),
+    note,
+    noteIndex: 0,
+    noteCount: visibleAgentNotes.length,
+  } satisfies SelectedOverlayNote;
+}
+
+/** Render the framed floating popover for the currently visible agent note. */
+function renderAgentPopover(
+  selectedOverlayNote: SelectedOverlayNote | null,
+  file: DiffFile,
+  width: number,
+  contentHeight: number,
+  rowMetrics: Map<string, { height: number; top: number }>,
+  theme: AppTheme,
+  onDismissAgentNote?: (id: string) => void,
+) {
+  if (!selectedOverlayNote) {
+    return null;
+  }
+
+  const noteWidth = Math.min(Math.max(34, Math.floor(width * 0.42)), Math.max(12, width - 2));
+  const locationLabel = annotationLocationLabel(file, selectedOverlayNote.note.annotation);
+  const popover = buildAgentPopoverContent({
+    summary: selectedOverlayNote.note.annotation.summary,
+    rationale: selectedOverlayNote.note.annotation.rationale,
+    locationLabel,
+    noteIndex: selectedOverlayNote.noteIndex,
+    noteCount: selectedOverlayNote.noteCount,
+    width: noteWidth,
+  });
+  const anchorMetric = rowMetrics.get(selectedOverlayNote.anchorKey);
+  if (!anchorMetric) {
+    return null;
+  }
+
+  const placement = resolveAgentPopoverPlacement({
+    anchorColumn: selectedOverlayNote.anchorColumn,
+    anchorRowTop: anchorMetric.top,
+    anchorRowHeight: anchorMetric.height,
+    contentHeight,
+    noteHeight: popover.height,
+    noteWidth,
+    viewportWidth: width,
+  });
 
   return (
-    <box
-      style={{
-        width: "100%",
-        flexDirection: "column",
-        gap: 1,
-        paddingRight: 2,
-        alignItems: "flex-end",
-      }}
-    >
-      {anchoredNotes.map((note) => (
-        <AgentCard
-          key={note.id}
-          locationLabel={annotationLocationLabel(file, note.annotation)}
-          rationale={note.annotation.rationale}
-          summary={note.annotation.summary}
-          theme={theme}
-          width={noteWidth}
-          onClose={onDismissAgentNote ? () => onDismissAgentNote(note.id) : undefined}
-        />
-      ))}
+    <box style={{ position: "absolute", top: placement.top, left: placement.left, zIndex: 20 }}>
+      <AgentCard
+        locationLabel={locationLabel}
+        noteCount={selectedOverlayNote.noteCount}
+        noteIndex={selectedOverlayNote.noteIndex}
+        rationale={selectedOverlayNote.note.annotation.rationale}
+        summary={selectedOverlayNote.note.annotation.summary}
+        theme={theme}
+        width={noteWidth}
+        onClose={onDismissAgentNote ? () => onDismissAgentNote(selectedOverlayNote.note.id) : undefined}
+      />
     </box>
   );
 }
 
-/** Render one diff row plus any visible note cards anchored to it. */
+/** Render one diff row. */
 function renderRow(
   row: DiffRow,
-  file: DiffFile,
   width: number,
   lineNumberDigits: number,
   showLineNumbers: boolean,
@@ -691,9 +796,7 @@ function renderRow(
   theme: AppTheme,
   selected: boolean,
   annotated: boolean,
-  anchoredNotes: VisibleAgentNote[],
   anchorId?: string,
-  onDismissAgentNote?: (id: string) => void,
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void,
 ) {
   let baseRow: ReactNode;
@@ -805,22 +908,11 @@ function renderRow(
     );
   }
 
-  // Most rows do not have note cards, so keep the common path as small as possible.
-  if (anchoredNotes.length === 0) {
-    return baseRow;
-  }
-
-  return (
-    <box style={{ width: "100%", flexDirection: "column" }}>
-      {baseRow}
-      {renderAnchoredNotes(anchoredNotes, file, width, theme, onDismissAgentNote)}
-    </box>
-  );
+  return baseRow;
 }
 
 interface DiffRowViewProps {
   row: DiffRow;
-  file: DiffFile;
   width: number;
   lineNumberDigits: number;
   showLineNumbers: boolean;
@@ -829,9 +921,7 @@ interface DiffRowViewProps {
   theme: AppTheme;
   selected: boolean;
   annotated: boolean;
-  anchoredNotes: VisibleAgentNote[];
   anchorId?: string;
-  onDismissAgentNote?: (id: string) => void;
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
 }
 
@@ -839,7 +929,6 @@ interface DiffRowViewProps {
 const DiffRowView = memo(
   function DiffRowViewComponent({
     row,
-    file,
     width,
     lineNumberDigits,
     showLineNumbers,
@@ -848,14 +937,11 @@ const DiffRowView = memo(
     theme,
     selected,
     annotated,
-    anchoredNotes,
     anchorId,
-    onDismissAgentNote,
     onOpenAgentNotesAtHunk,
   }: DiffRowViewProps) {
     return renderRow(
       row,
-      file,
       width,
       lineNumberDigits,
       showLineNumbers,
@@ -864,17 +950,13 @@ const DiffRowView = memo(
       theme,
       selected,
       annotated,
-      anchoredNotes,
       anchorId,
-      onDismissAgentNote,
       onOpenAgentNotesAtHunk,
     );
   },
   (previous, next) => {
-    // Row and anchored-note identity are intentionally stable across many navigation updates.
     return (
       previous.row === next.row &&
-      previous.file === next.file &&
       previous.width === next.width &&
       previous.lineNumberDigits === next.lineNumberDigits &&
       previous.showLineNumbers === next.showLineNumbers &&
@@ -883,13 +965,12 @@ const DiffRowView = memo(
       previous.theme === next.theme &&
       previous.selected === next.selected &&
       previous.annotated === next.annotated &&
-      previous.anchoredNotes === next.anchoredNotes &&
       previous.anchorId === next.anchorId
     );
   },
 );
 
-/** Render a file diff in split or stack mode, with optional inline agent notes. */
+/** Render a file diff in split or stack mode, with a floating agent-note popover overlay. */
 export function PierreDiffView({
   annotatedHunkIndices = EMPTY_ANNOTATED_HUNK_INDICES,
   file,
@@ -1041,10 +1122,6 @@ export function PierreDiffView({
     () => (layout === "split" ? buildSplitRows(file, resolvedHighlighted, theme) : buildStackRows(file, resolvedHighlighted, theme)),
     [file, layout, resolvedHighlighted, theme],
   );
-  const anchoredNotes = useMemo(
-    () => buildAnchoredNotes(rows, visibleAgentNotes, selectedHunkIndex, showHunkHeaders),
-    [rows, selectedHunkIndex, showHunkHeaders, visibleAgentNotes],
-  );
   const hunkAnchorIds = useMemo(() => {
     const anchors = new Map<string, string>();
     const seenHunks = new Set<number>();
@@ -1069,13 +1146,31 @@ export function PierreDiffView({
     return anchors;
   }, [rows, showHunkHeaders]);
   const lineNumberDigits = useMemo(() => String(findMaxLineNumber(file)).length, [file]);
+  const rowMetrics = useMemo(() => {
+    const metrics = new Map<string, { height: number; top: number }>();
+    let offset = 0;
+
+    for (const row of rows) {
+      const height = measureRenderedRowHeight(row, width, lineNumberDigits, showLineNumbers, showHunkHeaders, wrapLines, theme);
+      metrics.set(row.key, { top: offset, height });
+      offset += height;
+    }
+
+    return {
+      metrics,
+      contentHeight: offset,
+    };
+  }, [lineNumberDigits, rows, showHunkHeaders, showLineNumbers, theme, width, wrapLines]);
+  const selectedOverlayNote = useMemo(
+    () => buildSelectedOverlayNote(rows, visibleAgentNotes, selectedHunkIndex, showHunkHeaders, width, lineNumberDigits, showLineNumbers),
+    [lineNumberDigits, rows, selectedHunkIndex, showHunkHeaders, showLineNumbers, visibleAgentNotes, width],
+  );
   const content = (
     <box style={{ width: "100%", flexDirection: "column" }}>
       {rows.map((row) => (
         <DiffRowView
           key={row.key}
           row={row}
-          file={file}
           width={width}
           lineNumberDigits={lineNumberDigits}
           showLineNumbers={showLineNumbers}
@@ -1084,22 +1179,26 @@ export function PierreDiffView({
           theme={theme}
           selected={row.hunkIndex === selectedHunkIndex}
           annotated={row.type === "hunk-header" && annotatedHunkIndices.has(row.hunkIndex)}
-          anchoredNotes={anchoredNotes.get(row.key) ?? EMPTY_VISIBLE_AGENT_NOTES}
           anchorId={hunkAnchorIds.get(row.key)}
-          onDismissAgentNote={onDismissAgentNote}
           onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
         />
       ))}
     </box>
   );
+  const contentWithOverlay = (
+    <box style={{ width: "100%", position: "relative", overflow: "visible" }}>
+      {content}
+      {renderAgentPopover(selectedOverlayNote, file, width, rowMetrics.contentHeight, rowMetrics.metrics, theme, onDismissAgentNote)}
+    </box>
+  );
 
   if (!scrollable) {
-    return content;
+    return contentWithOverlay;
   }
 
   return (
     <scrollbox width="100%" height="100%" scrollY={true} viewportCulling={true} focused={false}>
-      {content}
+      {contentWithOverlay}
     </scrollbox>
   );
 }

--- a/src/ui/lib/agentPopover.ts
+++ b/src/ui/lib/agentPopover.ts
@@ -1,0 +1,116 @@
+import { fitText } from "./text";
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+/** Wrap plain text to a fixed terminal width, breaking long tokens when needed. */
+export function wrapText(text: string, width: number) {
+  if (width <= 0) {
+    return [""];
+  }
+
+  const normalized = text.trim().replace(/\s+/g, " ");
+  if (normalized.length === 0) {
+    return [""];
+  }
+
+  const words = normalized.split(" ");
+  const lines: string[] = [];
+  let current = "";
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      lines.push(current);
+      current = "";
+    }
+  };
+
+  for (const word of words) {
+    if (word.length > width) {
+      pushCurrent();
+      for (let offset = 0; offset < word.length; offset += width) {
+        lines.push(word.slice(offset, offset + width));
+      }
+      continue;
+    }
+
+    const next = current.length === 0 ? word : `${current} ${word}`;
+    if (next.length <= width) {
+      current = next;
+      continue;
+    }
+
+    pushCurrent();
+    current = word;
+  }
+
+  pushCurrent();
+  return lines.length > 0 ? lines : [""];
+}
+
+/** Build the framed agent-popover title shown in the card header. */
+export function agentPopoverTitle(noteIndex: number, noteCount: number) {
+  return noteCount > 1 ? `AI note ${noteIndex + 1}/${noteCount}` : "AI note";
+}
+
+/** Measure the content rows and total box height for one framed agent popover. */
+export function buildAgentPopoverContent({
+  locationLabel,
+  noteCount,
+  noteIndex,
+  rationale,
+  summary,
+  width,
+}: {
+  locationLabel: string;
+  noteCount: number;
+  noteIndex: number;
+  rationale?: string;
+  summary: string;
+  width: number;
+}) {
+  const innerWidth = Math.max(1, width - 4);
+  const summaryLines = wrapText(summary, innerWidth);
+  const rationaleLines = rationale ? wrapText(rationale, innerWidth) : [];
+  const footer = fitText(locationLabel, innerWidth);
+  const contentLineCount = 1 + summaryLines.length + (rationaleLines.length > 0 ? 1 + rationaleLines.length : 0) + 1 + 1;
+
+  return {
+    title: agentPopoverTitle(noteIndex, noteCount),
+    summaryLines,
+    rationaleLines,
+    footer,
+    height: contentLineCount + 2,
+    innerWidth,
+  };
+}
+
+/** Right-align the popover within the viewport while keeping its top edge anchored to the diff row. */
+export function resolveAgentPopoverPlacement({
+  anchorColumn,
+  anchorRowHeight,
+  anchorRowTop,
+  contentHeight,
+  noteHeight,
+  noteWidth,
+  viewportWidth,
+}: {
+  anchorColumn: number;
+  anchorRowHeight: number;
+  anchorRowTop: number;
+  contentHeight: number;
+  noteHeight: number;
+  noteWidth: number;
+  viewportWidth: number;
+}) {
+  const maxLeft = Math.max(1, viewportWidth - noteWidth);
+  const left = maxLeft;
+  const side: "right" | "left" = left >= anchorColumn ? "right" : "left";
+
+  const preferredTop = anchorRowTop + Math.max(0, Math.floor((anchorRowHeight - 1) / 2));
+  const maxTop = Math.max(0, contentHeight - noteHeight);
+  const top = clamp(preferredTop, 0, maxTop);
+
+  return { left, top, side };
+}

--- a/test/app-interactions.test.tsx
+++ b/test/app-interactions.test.tsx
@@ -259,12 +259,12 @@ describe("App interactions", () => {
       await flush(setup);
 
       const frame = setup.captureCharFrame();
+      expect(frame).toContain("AI note");
       expect(frame).toContain("Annotation for prefs.ts");
-      expect(frame).toContain("long wrapped line");
-      expect(frame).toContain("coverage");
+      expect(frame).toContain("Why prefs.ts changed");
       expect(frame).not.toContain("@@ -1,1 +1,2 @@");
       expect(frame).not.toContain("1 - export const message");
-      expect(frame).toContain("- export const message");
+      expect(frame).toContain("prefs.ts +2");
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/test/ui-components.test.tsx
+++ b/test/ui-components.test.tsx
@@ -8,6 +8,7 @@ import { resolveTheme } from "../src/ui/themes";
 const { App } = await import("../src/ui/App");
 const { HelpDialog } = await import("../src/ui/components/chrome/HelpDialog");
 const { FilesPane } = await import("../src/ui/components/panes/FilesPane");
+const { AgentCard } = await import("../src/ui/components/panes/AgentCard");
 const { DiffPane } = await import("../src/ui/components/panes/DiffPane");
 const { MenuDropdown } = await import("../src/ui/components/chrome/MenuDropdown");
 const { StatusBar } = await import("../src/ui/components/chrome/StatusBar");
@@ -236,6 +237,30 @@ describe("UI components", () => {
     expect(frame.indexOf("alpha.ts")).toBeLessThan(frame.indexOf("beta.ts"));
   });
 
+  test("AgentCard removes top and bottom padding while keeping the footer inside the frame", async () => {
+    const theme = resolveTheme("midnight", null);
+    const frame = await captureFrame(
+      <AgentCard
+        locationLabel="alpha.ts +2"
+        rationale="Why alpha.ts changed"
+        summary="Annotation for alpha.ts"
+        theme={theme}
+        width={34}
+        onClose={() => {}}
+      />,
+      40,
+      12,
+    );
+
+    const lines = frame.split("\n").slice(0, 8).map((line) => line.trimEnd());
+    expect(lines[0]).toBe("┌────────────────────────────────┐");
+    expect(lines[1]).toContain("AI note");
+    expect(lines[2]).toContain("Annotation for alpha.ts");
+    expect(lines[4]).toContain("Why alpha.ts changed");
+    expect(lines[6]).toContain("alpha.ts +2");
+    expect(lines[7]).toBe("└────────────────────────────────┘");
+  });
+
   test("DiffPane renders hunk notes with file and line labels only", async () => {
     const bootstrap = createBootstrap();
     const theme = resolveTheme("midnight", null);
@@ -266,6 +291,7 @@ describe("UI components", () => {
       18,
     );
 
+    expect(frame).toContain("AI note");
     expect(frame).toContain("alpha.ts +2");
     expect(frame).toContain("Annotation for alpha.ts");
     expect(frame).toContain("Why alpha.ts changed");
@@ -273,6 +299,60 @@ describe("UI components", () => {
     expect(frame).not.toContain("review");
     expect(frame).not.toContain("confidence");
     expect(frame).toContain("[x]");
+  });
+
+  test("DiffPane shows one framed popover at a time when a hunk has multiple notes", async () => {
+    const bootstrap = createBootstrap();
+    const theme = resolveTheme("midnight", null);
+    const file = bootstrap.changeset.files[0]!;
+    file.agent = {
+      ...file.agent!,
+      annotations: [
+        {
+          newRange: [2, 2],
+          summary: "First note",
+          rationale: "First rationale.",
+        },
+        {
+          newRange: [2, 2],
+          summary: "Second note",
+          rationale: "Second rationale.",
+        },
+      ],
+    };
+
+    const frame = await captureFrame(
+      <DiffPane
+        activeAnnotations={file.agent.annotations}
+        diffContentWidth={88}
+        dismissedAgentNoteIds={[]}
+        files={bootstrap.changeset.files}
+        headerLabelWidth={48}
+        headerStatsWidth={16}
+        layout="split"
+        scrollRef={createRef()}
+        selectedFileId="alpha"
+        selectedHunkIndex={0}
+        separatorWidth={84}
+        showAgentNotes={true}
+        showLineNumbers={true}
+        showHunkHeaders={true}
+        wrapLines={false}
+        theme={theme}
+        width={92}
+        onDismissAgentNote={() => {}}
+        onOpenAgentNotesAtHunk={() => {}}
+        onSelectFile={() => {}}
+      />,
+      96,
+      18,
+    );
+
+    expect(frame).toContain("AI note 1/2");
+    expect(frame).toContain("First note");
+    expect(frame).toContain("First rationale.");
+    expect(frame).not.toContain("Second note");
+    expect(frame).not.toContain("Second rationale.");
   });
 
   test("MenuDropdown renders checked items and key hints", async () => {
@@ -563,8 +643,10 @@ describe("UI components", () => {
     );
 
     expect(frame).not.toContain("@@ -1,1 +1,2 @@");
+    expect(frame).toContain("AI note");
     expect(frame).toContain("Ungrounded note");
-    expect(frame).toContain("Falls back to the first visible row.");
+    expect(frame).toContain("Falls back to the first visible");
+    expect(frame).toContain("row.");
     expect(frame).toContain("note-fallback.ts");
     expect(frame).toContain("1 - export const value = 1;");
   });

--- a/test/ui-lib.test.ts
+++ b/test/ui-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { parseDiffFromFile } from "@pierre/diffs";
 import type { DiffFile } from "../src/core/types";
 import { buildMenuSpecs, menuBoxHeight, menuWidth, nextMenuItemIndex, type MenuEntry } from "../src/ui/components/chrome/menu";
+import { buildAgentPopoverContent, resolveAgentPopoverPlacement, wrapText } from "../src/ui/lib/agentPopover";
 import { fitText, padText } from "../src/ui/lib/text";
 import { estimateDiffBodyRows } from "../src/ui/lib/sectionHeights";
 import { resizeSidebarWidth } from "../src/ui/lib/sidebar";
@@ -74,6 +75,49 @@ describe("ui helpers", () => {
     expect(fitText("hello", 4)).toBe("hel.");
     expect(padText("hello", 4)).toBe("hel.");
     expect(padText("ok", 4)).toBe("ok  ");
+  });
+
+  test("agent popover helpers wrap text and right-align the card within the viewport", () => {
+    expect(wrapText("alpha beta gamma", 8)).toEqual(["alpha", "beta", "gamma"]);
+    expect(wrapText("supercalifragilistic", 6)).toEqual(["superc", "alifra", "gilist", "ic"]);
+
+    const content = buildAgentPopoverContent({
+      summary: "Guard missing socket path",
+      rationale: "Prevents noisy reconnect errors during first launch.",
+      locationLabel: "startup.ts +43-44",
+      noteIndex: 0,
+      noteCount: 2,
+      width: 34,
+    });
+
+    expect(content.title).toBe("AI note 1/2");
+    expect(content.summaryLines.length).toBeGreaterThan(0);
+    expect(content.rationaleLines.length).toBeGreaterThan(0);
+    expect(content.height).toBe(9);
+
+    expect(
+      resolveAgentPopoverPlacement({
+        anchorColumn: 12,
+        anchorRowTop: 4,
+        anchorRowHeight: 1,
+        contentHeight: 20,
+        noteWidth: 18,
+        noteHeight: 7,
+        viewportWidth: 60,
+      }),
+    ).toMatchObject({ left: 42, top: 4, side: "right" });
+
+    expect(
+      resolveAgentPopoverPlacement({
+        anchorColumn: 48,
+        anchorRowTop: 16,
+        anchorRowHeight: 1,
+        contentHeight: 20,
+        noteWidth: 18,
+        noteHeight: 7,
+        viewportWidth: 60,
+      }),
+    ).toMatchObject({ left: 42, top: 13, side: "left" });
   });
 
   test("resizeSidebarWidth clamps drag updates into the allowed sidebar range", () => {


### PR DESCRIPTION
## Summary
- render selected hunk notes as floating popovers layered over the diff stream
- add shared popover sizing/placement helpers and right-align compact agent cards
- extend component, interaction, MCP, and TTY coverage for the new note behavior

## Testing
- bun run typecheck
- bun test
- bun run test:tty-smoke
- bun run install:bin