### PR TITLE
test: cover malformed patches and daemon races

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -45,6 +45,14 @@ function normalizeAnnotationFile(file: unknown): AgentFileContext {
           throw new Error("Annotation ranges must be integer tuples.");
         }
 
+        if (start < 1 || end < 1) {
+          throw new Error("Annotation ranges must use positive 1-based line numbers.");
+        }
+
+        if (end < start) {
+          throw new Error("Annotation ranges must be ordered start..end tuples.");
+        }
+
         return [start, end] as [number, number];
       };
 

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -200,7 +200,21 @@ function normalizePatchChangeset(
   agentContext: AgentContext | null,
 ): Changeset {
   const normalizedPatchText = stripTerminalControl(patchText.replaceAll("\r\n", "\n"));
-  const parsedPatches = parsePatchFiles(normalizedPatchText, "patch", true);
+
+  let parsedPatches: ReturnType<typeof parsePatchFiles>;
+  try {
+    parsedPatches = parsePatchFiles(normalizedPatchText, "patch", true);
+  } catch {
+    return {
+      id: `changeset:${Date.now()}`,
+      sourceLabel,
+      title,
+      summary: normalizedPatchText.trim() || undefined,
+      agentSummary: agentContext?.summary,
+      files: [],
+    };
+  }
+
   const metadataFiles = parsedPatches.flatMap((entry) => entry.files);
   const chunks = splitPatchIntoFileChunks(normalizedPatchText);
 

--- a/test/agent.test.ts
+++ b/test/agent.test.ts
@@ -80,5 +80,39 @@ describe("agent context", () => {
     );
 
     await expect(loadAgentContext(invalidRangePath)).rejects.toThrow("Annotation ranges must be integer tuples.");
+
+    const negativeRangePath = join(dir, "negative-range.json");
+    writeFileSync(
+      negativeRangePath,
+      JSON.stringify({
+        version: 1,
+        files: [
+          {
+            path: "src/example.ts",
+            annotations: [{ summary: "Bad range", newRange: [0, 2] }],
+          },
+        ],
+      }),
+    );
+
+    await expect(loadAgentContext(negativeRangePath)).rejects.toThrow(
+      "Annotation ranges must use positive 1-based line numbers.",
+    );
+
+    const reversedRangePath = join(dir, "reversed-range.json");
+    writeFileSync(
+      reversedRangePath,
+      JSON.stringify({
+        version: 1,
+        files: [
+          {
+            path: "src/example.ts",
+            annotations: [{ summary: "Bad range", newRange: [4, 2] }],
+          },
+        ],
+      }),
+    );
+
+    await expect(loadAgentContext(reversedRangePath)).rejects.toThrow("Annotation ranges must be ordered start..end tuples.");
   });
 });

--- a/test/loaders.test.ts
+++ b/test/loaders.test.ts
@@ -277,6 +277,23 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.changeset.title).toContain("stash");
   });
 
+  test("treats malformed inline patch text as an empty review instead of throwing", async () => {
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: [
+        "\u001b]0;title\u0007not really a patch",
+        "--- separator only",
+        "@@ section heading",
+        "still plain text",
+      ].join("\n"),
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(0);
+    expect(bootstrap.changeset.title).toContain("Patch review");
+    expect(bootstrap.changeset.summary).toContain("not really a patch");
+  });
+
   test("loads colorized git patch files like the real pager stdin stream", async () => {
     const dir = mkdtempSync(join(tmpdir(), "hunk-patch-"));
     tempDirs.push(dir);

--- a/test/mcp-daemon.test.ts
+++ b/test/mcp-daemon.test.ts
@@ -217,6 +217,30 @@ describe("Hunk MCP daemon state", () => {
     await expect(pending).rejects.toThrow("disconnected");
   });
 
+  test("rejects in-flight commands when a session reconnects on a new socket", async () => {
+    const state = new HunkDaemonState();
+    const originalSocket = {
+      send() {},
+    };
+    const replacementSocket = {
+      send() {},
+    };
+
+    state.registerSession(originalSocket, createRegistration(), createSnapshot());
+    const pending = state.sendComment({
+      sessionId: "session-1",
+      filePath: "src/example.ts",
+      side: "new",
+      line: 4,
+      summary: "Review note",
+    });
+
+    state.registerSession(replacementSocket, createRegistration(), createSnapshot({ updatedAt: "2026-03-22T00:00:01.000Z" }));
+
+    await expect(pending).rejects.toThrow("reconnected before the command completed");
+    expect(state.listSessions()).toHaveLength(1);
+  });
+
   test("rejects commands immediately when the live session socket cannot accept them", async () => {
     const state = new HunkDaemonState();
     const socket = {

--- a/test/pager.test.ts
+++ b/test/pager.test.ts
@@ -39,10 +39,53 @@ describe("general pager detection", () => {
     expect(looksLikePatchInput(patch)).toBe(true);
   });
 
-  test("does not misclassify plain git pager text as a patch", () => {
-    const branchOutput = ["* main", "  feat/persist-view-config", "  release/0.1.0"].join("\n");
+  test("detects common patch shapes across line endings and terminal wrappers", () => {
+    const patchFixtures = [
+      [
+        "diff --git a/src/example.ts b/src/example.ts",
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1 +1 @@",
+        "-export const value = 1;",
+        "+export const value = 2;",
+      ],
+      [
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1 +1,2 @@",
+        "-export const value = 1;",
+        "+export const value = 2;",
+        "+export const extra = true;",
+      ],
+      [
+        "header",
+        "@@ -10,0 +11,2 @@",
+        "+export const inserted = true;",
+        "+export const added = true;",
+      ],
+    ];
 
-    expect(looksLikePatchInput(branchOutput)).toBe(false);
+    for (const lines of patchFixtures) {
+      for (const newline of ["\n", "\r\n"]) {
+        const patch = lines.join(newline);
+        expect(looksLikePatchInput(patch)).toBe(true);
+        expect(looksLikePatchInput(`\u001b]0;title\u0007${patch}\u001bPignored\u001b\\`)).toBe(true);
+      }
+    }
+  });
+
+  test("does not misclassify partial diff markers or plain git pager text as a patch", () => {
+    const fixtures = [
+      ["* main", "  feat/persist-view-config", "  release/0.1.0"].join("\n"),
+      ["--- separator only", "still prose"].join("\n"),
+      ["+++ banner only", "still prose"].join("\n"),
+      ["@@section heading", "still prose"].join("\n"),
+      ["\u001b]0;title\u0007--- looks patchy", "+++but is just text"].join("\n"),
+    ];
+
+    for (const fixture of fixtures) {
+      expect(looksLikePatchInput(fixture)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- add malformed-input coverage for patch detection, inline patch bootstrap, invalid agent note ranges, and daemon reconnect races
- make patch bootstrap degrade to an empty review instead of throwing on malformed patch-like input
- tighten agent sidecar range validation to reject negative or reversed line spans

## Testing
- bun run typecheck
- bun test
- bun run check:pack