### PR TITLE
Add a dedicated README screenshot demo

### DIFF
--- a/examples/6-readme-screenshot/README.md
+++ b/examples/6-readme-screenshot/README.md
@@ -1,0 +1,26 @@
+# 6-readme-screenshot
+
+A screenshot-optimized demo for the main README: a multi-file UI refactor with inline agent rationale.
+
+## Run
+
+```bash
+hunk patch examples/6-readme-screenshot/change.patch \
+  --agent-context examples/6-readme-screenshot/agent-context.json \
+  --mode split \
+  --theme midnight
+```
+
+## Screenshot setup
+
+- use a wide terminal so the sidebar and split diff are both visible
+- keep the first file selected: `src/components/ReviewSummaryCard.tsx`
+- make sure agent notes are visible
+- capture the first annotated hunk with the note popover open
+
+## What it shows well
+
+- inline agent rationale beside the changed code
+- a clear mix of removed and added lines in one hunk
+- a visible multi-file sidebar
+- TSX prop renames, copy edits, and helper extraction with strong syntax color

--- a/examples/6-readme-screenshot/after/src/components/ReviewSummaryCard.tsx
+++ b/examples/6-readme-screenshot/after/src/components/ReviewSummaryCard.tsx
@@ -1,0 +1,42 @@
+import { reviewButtonLabel, reviewTimestampLabel } from "../lib/reviewCopy";
+
+type ReviewSummaryCardProps = {
+  heading: string;
+  supportingText: string;
+  fileCount: number;
+  lastUpdated: string;
+  onReview: () => void;
+};
+
+export function ReviewSummaryCard({
+  heading,
+  supportingText,
+  fileCount,
+  lastUpdated,
+  onReview,
+}: ReviewSummaryCardProps) {
+  return (
+    <box
+      style={{
+        padding: 2,
+        border: true,
+        borderColor: "#334155",
+        backgroundColor: "#0f172a",
+        flexDirection: "column",
+        gap: 1,
+      }}
+    >
+      <box style={{ flexDirection: "column", gap: 1 }}>
+        <text fg="#f8fafc">{heading}</text>
+        <text fg="#94a3b8">{supportingText}</text>
+      </box>
+
+      <box style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+        <text fg="#38bdf8">{fileCount} files ready for review</text>
+        <text fg="#64748b">{reviewTimestampLabel(lastUpdated)}</text>
+      </box>
+
+      <button label={reviewButtonLabel(fileCount)} onPress={onReview} />
+    </box>
+  );
+}

--- a/examples/6-readme-screenshot/after/src/lib/reviewCopy.ts
+++ b/examples/6-readme-screenshot/after/src/lib/reviewCopy.ts
@@ -1,0 +1,7 @@
+export function reviewButtonLabel(fileCount: number) {
+  return fileCount === 1 ? "Review 1 file" : `Review ${fileCount} files`;
+}
+
+export function reviewTimestampLabel(lastUpdated: string) {
+  return `Updated ${lastUpdated}`;
+}

--- a/examples/6-readme-screenshot/after/test/reviewSummaryCard.demo.ts
+++ b/examples/6-readme-screenshot/after/test/reviewSummaryCard.demo.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { ReviewSummaryCard } from "../src/components/ReviewSummaryCard";
+import { reviewButtonLabel, reviewTimestampLabel } from "../src/lib/reviewCopy";
+
+test("switches the card copy to review-oriented labels", () => {
+  expect(ReviewSummaryCard).toBeDefined();
+  expect(reviewButtonLabel(3)).toBe("Review 3 files");
+  expect(reviewTimestampLabel("2m ago")).toBe("Updated 2m ago");
+});

--- a/examples/6-readme-screenshot/agent-context.json
+++ b/examples/6-readme-screenshot/agent-context.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "summary": "Reframes a small dashboard card around review language instead of sync language, while extracting the button and timestamp copy into a helper so the main component reads more like layout than string assembly.",
+  "files": [
+    {
+      "path": "src/components/ReviewSummaryCard.tsx",
+      "summary": "Renames the card props around review terminology and keeps the CTA and timestamp copy derived from helpers.",
+      "annotations": [
+        {
+          "newRange": [1, 37],
+          "summary": "Shift the component language from sync status to review intent.",
+          "rationale": "The old names and labels sounded like a background sync card. Renaming the props and CTA makes the purpose feel like a review entrypoint, which reads better in the product and in the screenshot."
+        }
+      ]
+    },
+    {
+      "path": "src/lib/reviewCopy.ts",
+      "summary": "Extracts the button and timestamp strings into a tiny helper module.",
+      "annotations": [
+        {
+          "newRange": [1, 7],
+          "summary": "Keep pluralization and timestamp phrasing out of the component body.",
+          "rationale": "The main diff already has enough visual motion from the prop renames. Pulling the small copy helpers out keeps the UI file easier to scan while still leaving a second file in the review stream."
+        }
+      ]
+    },
+    {
+      "path": "test/reviewSummaryCard.demo.ts",
+      "summary": "Updates the demo test to lock in the new review-oriented copy.",
+      "annotations": [
+        {
+          "newRange": [1, 9],
+          "summary": "The test now checks the new CTA and timestamp helpers directly.",
+          "rationale": "That makes the behavioral intent explicit and gives the sidebar a small third file so the screenshot reads as a real multi-file review rather than a one-file toy edit."
+        }
+      ]
+    }
+  ]
+}

--- a/examples/6-readme-screenshot/before/src/components/ReviewSummaryCard.tsx
+++ b/examples/6-readme-screenshot/before/src/components/ReviewSummaryCard.tsx
@@ -1,0 +1,39 @@
+type ChangeSummaryCardProps = {
+  title: string;
+  note: string;
+  changes: number;
+  lastSynced: string;
+  onOpen: () => void;
+};
+
+export function ChangeSummaryCard({
+  title,
+  note,
+  changes,
+  lastSynced,
+  onOpen,
+}: ChangeSummaryCardProps) {
+  return (
+    <box
+      style={{
+        padding: 2,
+        border: true,
+        borderColor: "#334155",
+        backgroundColor: "#0f172a",
+        flexDirection: "column",
+      }}
+    >
+      <box style={{ flexDirection: "column", gap: 0 }}>
+        <text fg="#f8fafc">{title}</text>
+        <text fg="#94a3b8">{note}</text>
+      </box>
+
+      <box style={{ flexDirection: "row", justifyContent: "space-between", marginTop: 1 }}>
+        <text fg="#38bdf8">{changes} files changed</text>
+        <text fg="#64748b">Synced {lastSynced}</text>
+      </box>
+
+      <button label="Open diff" onPress={onOpen} />
+    </box>
+  );
+}

--- a/examples/6-readme-screenshot/before/test/reviewSummaryCard.demo.ts
+++ b/examples/6-readme-screenshot/before/test/reviewSummaryCard.demo.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { ChangeSummaryCard } from "../src/components/ReviewSummaryCard";
+
+test("keeps the old sync-oriented labels", () => {
+  expect(ChangeSummaryCard).toBeDefined();
+  expect("Open diff").toContain("diff");
+  expect("Synced 2m ago").toContain("Synced");
+});

--- a/examples/6-readme-screenshot/change.patch
+++ b/examples/6-readme-screenshot/change.patch
@@ -1,0 +1,98 @@
+diff --git a/src/components/ReviewSummaryCard.tsx b/src/components/ReviewSummaryCard.tsx
+index 73a5e7f..9136307 100644
+--- a/src/components/ReviewSummaryCard.tsx
++++ b/src/components/ReviewSummaryCard.tsx
+@@ -1,18 +1,20 @@
+-type ChangeSummaryCardProps = {
+-  title: string;
+-  note: string;
+-  changes: number;
+-  lastSynced: string;
+-  onOpen: () => void;
++import { reviewButtonLabel, reviewTimestampLabel } from "../lib/reviewCopy";
++
++type ReviewSummaryCardProps = {
++  heading: string;
++  supportingText: string;
++  fileCount: number;
++  lastUpdated: string;
++  onReview: () => void;
+ };
+ 
+-export function ChangeSummaryCard({
+-  title,
+-  note,
+-  changes,
+-  lastSynced,
+-  onOpen,
+-}: ChangeSummaryCardProps) {
++export function ReviewSummaryCard({
++  heading,
++  supportingText,
++  fileCount,
++  lastUpdated,
++  onReview,
++}: ReviewSummaryCardProps) {
+   return (
+     <box
+       style={{
+@@ -21,19 +23,20 @@ export function ChangeSummaryCard({
+         borderColor: "#334155",
+         backgroundColor: "#0f172a",
+         flexDirection: "column",
++        gap: 1,
+       }}
+     >
+-      <box style={{ flexDirection: "column", gap: 0 }}>
+-        <text fg="#f8fafc">{title}</text>
+-        <text fg="#94a3b8">{note}</text>
++      <box style={{ flexDirection: "column", gap: 1 }}>
++        <text fg="#f8fafc">{heading}</text>
++        <text fg="#94a3b8">{supportingText}</text>
+       </box>
+ 
+-      <box style={{ flexDirection: "row", justifyContent: "space-between", marginTop: 1 }}>
+-        <text fg="#38bdf8">{changes} files changed</text>
+-        <text fg="#64748b">Synced {lastSynced}</text>
++      <box style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
++        <text fg="#38bdf8">{fileCount} files ready for review</text>
++        <text fg="#64748b">{reviewTimestampLabel(lastUpdated)}</text>
+       </box>
+ 
+-      <button label="Open diff" onPress={onOpen} />
++      <button label={reviewButtonLabel(fileCount)} onPress={onReview} />
+     </box>
+   );
+ }
+diff --git a/src/lib/reviewCopy.ts b/src/lib/reviewCopy.ts
+new file mode 100644
+index 0000000..d211039
+--- /dev/null
++++ b/src/lib/reviewCopy.ts
+@@ -0,0 +1,7 @@
++export function reviewButtonLabel(fileCount: number) {
++  return fileCount === 1 ? "Review 1 file" : `Review ${fileCount} files`;
++}
++
++export function reviewTimestampLabel(lastUpdated: string) {
++  return `Updated ${lastUpdated}`;
++}
+diff --git a/test/reviewSummaryCard.demo.ts b/test/reviewSummaryCard.demo.ts
+index 5acb770..03f9616 100644
+--- a/test/reviewSummaryCard.demo.ts
++++ b/test/reviewSummaryCard.demo.ts
+@@ -1,8 +1,9 @@
+ import { expect, test } from "bun:test";
+-import { ChangeSummaryCard } from "../src/components/ReviewSummaryCard";
++import { ReviewSummaryCard } from "../src/components/ReviewSummaryCard";
++import { reviewButtonLabel, reviewTimestampLabel } from "../src/lib/reviewCopy";
+ 
+-test("keeps the old sync-oriented labels", () => {
+-  expect(ChangeSummaryCard).toBeDefined();
+-  expect("Open diff").toContain("diff");
+-  expect("Synced 2m ago").toContain("Synced");
++test("switches the card copy to review-oriented labels", () => {
++  expect(ReviewSummaryCard).toBeDefined();
++  expect(reviewButtonLabel(3)).toBe("Review 3 files");
++  expect(reviewTimestampLabel("2m ago")).toBe("Updated 2m ago");
+ });

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ Each folder tells a small review story and includes the exact command to run fro
 | `3-agent-review-demo` | inline agent rationale | `hunk patch examples/3-agent-review-demo/change.patch --agent-context examples/3-agent-review-demo/agent-context.json` |
 | `4-ui-polish` | screenshot-friendly TSX diff | `hunk diff examples/4-ui-polish/before.tsx examples/4-ui-polish/after.tsx` |
 | `5-pager-tour` | line scrolling, paging, and hunk jumps | `hunk diff --pager examples/5-pager-tour/before.ts examples/5-pager-tour/after.ts` |
+| `6-readme-screenshot` | README screenshot with agent notes | `hunk patch examples/6-readme-screenshot/change.patch --agent-context examples/6-readme-screenshot/agent-context.json --mode split --theme midnight` |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add a new `examples/6-readme-screenshot` demo tuned for the README screenshot
- include a multi-file patch with inline agent rationale and a clear add/remove mix
- add the demo to `examples/README.md` with a copy-paste launch command

## Testing
- smoke-ran the demo command locally
- validated the agent-context JSON