### PR TITLE
Make local sidecar guidance optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,8 @@ CLI input
 - `[` and `]` navigate hunks across the full review stream. Do not reintroduce `j`/`k` hunk navigation unless the user asks.
 - Agent context belongs beside the code, not hidden in a separate mode or workflow.
 - Agent notes are hunk-specific: show notes for the selected hunk, render them in the diff flow near the annotated row, and keep a clear spatial relationship to the code they explain.
-- When making code changes in this repo, also refresh `.hunk/latest.json` so the next review can load agent rationale with `hunk diff --agent-context .hunk/latest.json`.
-- Keep `.hunk/latest.json` concise and review-oriented: one changeset summary, file summaries in narrative order, and a few hunk-level annotations with real rationale.
-- File order in `.hunk/latest.json` is intentional, but the visible note UI should stay hunk-note driven rather than showing generic file or changeset explainer cards.
+- If you choose to use a local sidecar such as `.hunk/latest.json`, keep it concise and review-oriented: one changeset summary, file summaries in narrative order, and a few hunk-level annotations with real rationale.
+- If a local sidecar is present, its file order is intentional, but the visible note UI should stay hunk-note driven rather than showing generic file or changeset explainer cards.
 - If newly created files should appear in `hunk diff` before commit, use `git add -N <paths>` so they show up in the review stream without staging content.
 
 ## commands
@@ -81,6 +80,6 @@ CLI input
 
 ## repo notes
 
-- `.hunk/latest.json` is ignored on purpose. Update it when you change code, but do not commit it.
+- `.hunk/latest.json` is ignored on purpose. Use it only if you want temporary local review context, and do not commit it.
 - Do not auto-commit after making changes. Leave edits uncommitted so the user can review them in `hunk`, and only commit when the user explicitly asks.
 - Keep this doc short and architectural. Fresh-context agents can discover file paths themselves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Key rules:
 
 - Keep scope tight and explain user-visible behavior changes clearly.
 - Update docs and examples when behavior or workflows change.
-- If you change this repo locally, refresh `.hunk/latest.json` for review, but do not commit it.
+- If you want temporary local review notes, you can use `.hunk/latest.json`, but do not commit it.
 - If newly created files should appear in `hunk diff` before commit, use `git add -N <paths>`.
 
 ## Release notes

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -78,9 +78,8 @@ For more CLI entrypoints, read [references/commands.md](references/commands.md).
 
 When using Hunk for agent changes:
 - prefer a real TTY or tmux session over redirected stdout captures
-- use `hunk diff --agent-context .hunk/latest.json` when the repo has fresh review notes
-- refresh `.hunk/latest.json` after code changes if the repo expects it
-- keep `.hunk/latest.json` concise and review-oriented
+- if a repo already has a fresh local sidecar, you can load it with `hunk diff --agent-context <file>`
+- treat `.hunk/latest.json` as an optional local convention, not required repo hygiene
 - if new files should show up before commit, use `git add -N <path>`
 
 ## What this skill should steer Pi toward

--- a/skills/hunk-review/references/commands.md
+++ b/skills/hunk-review/references/commands.md
@@ -55,10 +55,10 @@ git diff --no-color | hunk patch -
 ### Review with agent rationale sidecar
 
 ```bash
-hunk diff --agent-context .hunk/latest.json
+hunk diff --agent-context path/to/context.json
 ```
 
-Use this when the repo keeps `.hunk/latest.json` fresh for review. Keep that file concise, narrative, and hunk-oriented.
+Use this when you already have a sidecar file for local review context. `.hunk/latest.json` is one optional convention, not a required repo workflow.
 
 ## TTY guidance
 


### PR DESCRIPTION
## Summary
- remove repo guidance that implied `.hunk/latest.json` should always be refreshed
- treat local sidecar files as optional review context instead of required repo hygiene
- update the bundled `hunk-review` skill to match that guidance

## Testing
- not run (docs/skill guidance only)