### PR TITLE
fix: refresh stale MCP daemon for session CLI

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -23,7 +23,7 @@ import type {
   SessionLiveCommentSummary,
 } from "../mcp/types";
 
-interface HunkDaemonCliClient {
+export interface HunkDaemonCliClient {
   connect(): Promise<void>;
   close(): Promise<void>;
   listToolNames(): Promise<Set<string>>;
@@ -44,6 +44,22 @@ const REQUIRED_TOOLS_BY_ACTION: Partial<Record<SessionCommandInput["action"], st
   "comment-rm": ["remove_comment"],
   "comment-clear": ["clear_comments"],
 };
+
+interface SessionCommandTestHooks {
+  createClient?: () => HunkDaemonCliClient;
+  resolveDaemonAvailability?: (action: SessionCommandInput["action"]) => Promise<boolean>;
+  restartDaemonForMissingTools?: (missingTools: string[], selector?: SessionSelectorInput) => Promise<void>;
+}
+
+let sessionCommandTestHooks: SessionCommandTestHooks | null = null;
+
+export function setSessionCommandTestHooks(hooks: SessionCommandTestHooks | null) {
+  sessionCommandTestHooks = hooks;
+}
+
+function createDaemonCliClient() {
+  return sessionCommandTestHooks?.createClient?.() ?? new McpHunkDaemonCliClient();
+}
 
 function extractToolValue<ResultType>(
   result: Awaited<ReturnType<Client["callTool"]>>,
@@ -271,7 +287,7 @@ async function waitForSessionRegistration(selector: SessionSelectorInput, timeou
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const client = new McpHunkDaemonCliClient();
+    const client = createDaemonCliClient();
     await client.connect();
 
     try {
@@ -332,7 +348,7 @@ async function ensureRequiredTools(action: SessionCommandInput["action"], select
     return;
   }
 
-  const client = new McpHunkDaemonCliClient();
+  const client = createDaemonCliClient();
   await client.connect();
 
   try {
@@ -352,7 +368,8 @@ async function ensureRequiredTools(action: SessionCommandInput["action"], select
     await client.close();
   }
 
-  await restartDaemonForMissingTools(requiredTools, selector);
+  await (sessionCommandTestHooks?.restartDaemonForMissingTools?.(requiredTools, selector)
+    ?? restartDaemonForMissingTools(requiredTools, selector));
 }
 
 function stringifyJson(value: unknown) {
@@ -500,7 +517,7 @@ function renderOutput(output: SessionCommandOutput, value: unknown, formatText: 
 }
 
 export async function runSessionCommand(input: SessionCommandInput) {
-  const daemonAvailable = await resolveDaemonAvailability(input.action);
+  const daemonAvailable = await (sessionCommandTestHooks?.resolveDaemonAvailability?.(input.action) ?? resolveDaemonAvailability(input.action));
   if (!daemonAvailable && input.action === "list") {
     return renderOutput(input.output, { sessions: [] }, () => formatListOutput([]));
   }
@@ -508,7 +525,7 @@ export async function runSessionCommand(input: SessionCommandInput) {
   const normalizedSelector = "selector" in input ? normalizeRepoRoot(input.selector) : null;
   await ensureRequiredTools(input.action, normalizedSelector ?? undefined);
 
-  const client = new McpHunkDaemonCliClient();
+  const client = createDaemonCliClient();
   await client.connect();
 
   try {

--- a/test/session-commands.test.ts
+++ b/test/session-commands.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { SessionCommandInput, SessionSelectorInput } from "../src/core/types";
+import { runSessionCommand, setSessionCommandTestHooks, type HunkDaemonCliClient } from "../src/session/commands";
+
+function createListedSession(sessionId: string) {
+  return {
+    sessionId,
+    pid: 123,
+    cwd: "/repo",
+    repoRoot: "/repo",
+    inputKind: "diff" as const,
+    title: "repo diff",
+    sourceLabel: "/repo",
+    launchedAt: "2026-03-22T00:00:00.000Z",
+    fileCount: 1,
+    files: [
+      {
+        id: "file-1",
+        path: "README.md",
+        additions: 1,
+        deletions: 0,
+        hunkCount: 1,
+      },
+    ],
+    snapshot: {
+      selectedFileId: "file-1",
+      selectedFilePath: "README.md",
+      selectedHunkIndex: 0,
+      selectedHunkOldRange: [1, 1] as [number, number],
+      selectedHunkNewRange: [1, 2] as [number, number],
+      showAgentNotes: false,
+      liveCommentCount: 0,
+      liveComments: [],
+      updatedAt: "2026-03-22T00:00:00.000Z",
+    },
+  };
+}
+
+function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliClient {
+  return {
+    connect: async () => undefined,
+    close: async () => undefined,
+    listToolNames: async () => new Set<string>(),
+    listSessions: async () => [],
+    getSession: async () => createListedSession("session-1"),
+    getSelectedContext: async () => ({
+      sessionId: "session-1",
+      title: "repo diff",
+      sourceLabel: "/repo",
+      repoRoot: "/repo",
+      inputKind: "diff",
+      selectedFile: {
+        id: "file-1",
+        path: "README.md",
+        additions: 1,
+        deletions: 0,
+        hunkCount: 1,
+      },
+      selectedHunk: {
+        index: 0,
+        oldRange: [1, 1],
+        newRange: [1, 2],
+      },
+      showAgentNotes: false,
+      liveCommentCount: 0,
+    }),
+    navigateToHunk: async () => ({
+      fileId: "file-1",
+      filePath: "README.md",
+      hunkIndex: 0,
+    }),
+    addComment: async () => ({
+      commentId: "comment-1",
+      fileId: "file-1",
+      filePath: "README.md",
+      hunkIndex: 0,
+      side: "new",
+      line: 1,
+    }),
+    listComments: async () => [],
+    removeComment: async () => ({
+      commentId: "comment-1",
+      removed: true,
+      remainingCommentCount: 0,
+    }),
+    clearComments: async () => ({
+      removedCount: 0,
+      remainingCommentCount: 0,
+    }),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  setSessionCommandTestHooks(null);
+});
+
+describe("session command compatibility checks", () => {
+  test("refreshes an older Hunk daemon before running a newer context command", async () => {
+    const selector: SessionSelectorInput = { sessionId: "session-1" };
+    const restartCalls: Array<{ missingTools: string[]; selector?: SessionSelectorInput }> = [];
+    const createdClients: string[] = [];
+
+    const clients = [
+      createClient({
+        listToolNames: async () => {
+          createdClients.push("stale-tools");
+          return new Set(["list_sessions", "get_session", "comment"]);
+        },
+      }),
+      createClient({
+        getSelectedContext: async (receivedSelector) => {
+          createdClients.push("fresh-context");
+          expect(receivedSelector).toEqual(selector);
+          return {
+            sessionId: "session-1",
+            title: "repo diff",
+            sourceLabel: "/repo",
+            repoRoot: "/repo",
+            inputKind: "diff",
+            selectedFile: {
+              id: "file-1",
+              path: "README.md",
+              additions: 1,
+              deletions: 0,
+              hunkCount: 1,
+            },
+            selectedHunk: {
+              index: 0,
+              oldRange: [1, 1],
+              newRange: [1, 2],
+            },
+            showAgentNotes: false,
+            liveCommentCount: 0,
+          };
+        },
+      }),
+    ];
+
+    setSessionCommandTestHooks({
+      createClient: () => {
+        const client = clients.shift();
+        if (!client) {
+          throw new Error("No fake session client remaining.");
+        }
+
+        return client;
+      },
+      resolveDaemonAvailability: async () => true,
+      restartDaemonForMissingTools: async (missingTools, receivedSelector) => {
+        restartCalls.push({ missingTools, selector: receivedSelector });
+      },
+    });
+
+    const output = await runSessionCommand({
+      kind: "session",
+      action: "context",
+      selector,
+      output: "json",
+    } satisfies SessionCommandInput);
+
+    expect(JSON.parse(output)).toMatchObject({
+      context: {
+        sessionId: "session-1",
+        selectedFile: {
+          path: "README.md",
+        },
+        selectedHunk: {
+          index: 0,
+        },
+      },
+    });
+    expect(restartCalls).toEqual([
+      {
+        missingTools: ["get_selected_context"],
+        selector,
+      },
+    ]);
+    expect(createdClients).toEqual(["stale-tools", "fresh-context"]);
+  });
+
+  test("throws a clear error when the daemon is missing tools but does not look like Hunk", async () => {
+    setSessionCommandTestHooks({
+      createClient: () =>
+        createClient({
+          listToolNames: async () => new Set(["list_sessions", "strange_tool"]),
+        }),
+      resolveDaemonAvailability: async () => true,
+      restartDaemonForMissingTools: async () => {
+        throw new Error("should not restart");
+      },
+    });
+
+    await expect(
+      runSessionCommand({
+        kind: "session",
+        action: "comment-list",
+        selector: { sessionId: "session-1" },
+        output: "json",
+      } satisfies SessionCommandInput),
+    ).rejects.toThrow("missing required tools (list_comments)");
+  });
+});


### PR DESCRIPTION
## Summary
- detect when `hunk session` is talking to an older live Hunk MCP daemon missing newer tools
- refresh that stale daemon from the current source tree before running newer session commands
- surface real MCP tool errors instead of vague empty-payload failures

## Problem
A real live Hunk session could stay connected to an older daemon that only exposed `list_sessions`, `get_session`, and `comment`. In that state:
- `hunk session list` worked
- `hunk session get` worked
- `hunk session comment add` worked
- but `hunk session context`, `comment list`, and `comment rm` failed

This happened because the CLI was talking to a stale daemon rather than the current checkout's newer MCP tool surface.

## Fix
- probe available MCP tools before running session commands
- if a command requires newer tools and the daemon looks like an older Hunk daemon, stop it and start a fresh daemon from the current source tree
- wait for the target live Hunk session to reconnect before proceeding
- throw actual MCP tool errors instead of silently treating them as missing payloads

## Validation
- `bun run typecheck`
- `bun test test/session-cli.test.ts test/cli.test.ts test/mcp-client.test.ts test/mcp-daemon.test.ts`
- manual verification against a real live Hunk session:
  - `session context` works
  - `session comment list` works
  - `session comment rm` works
