### PR TITLE
feat: add session reload command

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,17 @@ Use explicit session targeting with either a live `<session-id>` or `--repo <pat
 hunk session list
 hunk session context --repo .
 hunk session navigate --repo . --file README.md --hunk 2
+hunk session reload --repo . -- diff
+hunk session reload --repo . -- show HEAD~1 -- README.md
 hunk session comment add --repo . --file README.md --new-line 103 --summary "Frame this as MCP-first"
 hunk session comment list --repo .
 hunk session comment rm --repo . mcp:1234
 hunk session comment clear --repo . --file README.md --yes
 ```
 
-The session CLI works against live session comments only. It does not edit `.hunk/latest.json`.
+`hunk session reload ... -- <hunk command>` swaps the live session to a new `diff`, `show`, or other reviewable Hunk input without opening a new TUI window.
+
+The session CLI can inspect, navigate, annotate, and reload a live session, but it does not edit `.hunk/latest.json`.
 
 ## Performance notes
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { Command } from "commander";
 import type {
+  CliInput,
   CommonOptions,
   HelpCommandInput,
   LayoutMode,
@@ -398,6 +399,24 @@ async function parseDifftoolCommand(tokens: string[], argv: string[]): Promise<P
   };
 }
 
+function requireReloadableCliInput(input: ParsedCliInput): CliInput {
+  if (input.kind === "help" || input.kind === "pager" || input.kind === "mcp-serve") {
+    throw new Error(
+      "Session reload requires a Hunk review command after --, such as `diff` or `show`.",
+    );
+  }
+
+  if (input.kind === "session") {
+    throw new Error("Session reload cannot invoke another session command.");
+  }
+
+  if (input.kind === "patch" && (!input.file || input.file === "-")) {
+    throw new Error("Session reload does not support `patch -` or stdin-backed patch input.");
+  }
+
+  return input;
+}
+
 /** Parse `hunk session ...` as live-session daemon-backed commands. */
 async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
   const [subcommand, ...rest] = tokens;
@@ -417,6 +436,8 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
           "  hunk session context <session-id>",
           "  hunk session context --repo <path>",
           "  hunk session navigate <session-id> --file <path> (--hunk <n> | --old-line <n> | --new-line <n>)",
+          "  hunk session reload <session-id> -- diff [ref] [-- <pathspec...>]",
+          "  hunk session reload <session-id> -- show [ref] [-- <pathspec...>]",
           "  hunk session comment add <session-id> --file <path> (--old-line <n> | --new-line <n>) --summary <text>",
           "  hunk session comment list <session-id>",
           "  hunk session comment rm <session-id> <comment-id>",
@@ -548,6 +569,64 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
             ? "new"
             : undefined,
       line: parsedOptions.oldLine ?? parsedOptions.newLine,
+    };
+  }
+
+  if (subcommand === "reload") {
+    const separatorIndex = rest.indexOf("--");
+    const outerTokens = separatorIndex === -1 ? rest : rest.slice(0, separatorIndex);
+
+    const command = new Command("session reload")
+      .description("replace the contents of one live Hunk session")
+      .argument("[sessionId]")
+      .option("--repo <path>", "target the live session whose repo root matches this path")
+      .option("--json", "emit structured JSON");
+
+    let parsedSessionId: string | undefined;
+    let parsedOptions: { repo?: string; json?: boolean } = {};
+
+    command.action((sessionId: string | undefined, options: { repo?: string; json?: boolean }) => {
+      parsedSessionId = sessionId;
+      parsedOptions = options;
+    });
+
+    if (outerTokens.includes("--help") || outerTokens.includes("-h")) {
+      return {
+        kind: "help",
+        text:
+          `${command.helpInformation().trimEnd()}\n\n` +
+          [
+            "Examples:",
+            "  hunk session reload --repo . -- diff",
+            "  hunk session reload --repo . -- diff main...feature -- src/ui",
+            "  hunk session reload --repo . -- show HEAD~1 -- README.md",
+          ].join("\n") +
+          "\n",
+      };
+    }
+
+    if (separatorIndex === -1) {
+      throw new Error(
+        "Pass the replacement Hunk command after `--`, for example `hunk session reload <session-id> -- diff`.",
+      );
+    }
+
+    const nestedTokens = rest.slice(separatorIndex + 1);
+    if (nestedTokens.length === 0) {
+      throw new Error(
+        "Pass the replacement Hunk command after `--`, for example `hunk session reload <session-id> -- diff`.",
+      );
+    }
+
+    await parseStandaloneCommand(command, outerTokens);
+    const nextInput = requireReloadableCliInput(await parseCli(["bun", "hunk", ...nestedTokens]));
+
+    return {
+      kind: "session",
+      action: "reload",
+      output: resolveJsonOutput(parsedOptions),
+      selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
+      nextInput,
     };
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -115,6 +115,14 @@ export interface SessionNavigateCommandInput {
   line?: number;
 }
 
+export interface SessionReloadCommandInput {
+  kind: "session";
+  action: "reload";
+  output: SessionCommandOutput;
+  selector: SessionSelectorInput;
+  nextInput: CliInput;
+}
+
 export interface SessionCommentAddCommandInput {
   kind: "session";
   action: "comment-add";
@@ -158,6 +166,7 @@ export type SessionCommandInput =
   | SessionListCommandInput
   | SessionGetCommandInput
   | SessionNavigateCommandInput
+  | SessionReloadCommandInput
   | SessionCommentAddCommandInput
   | SessionCommentListCommandInput
   | SessionCommentRemoveCommandInput

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -4,6 +4,7 @@ import type {
   HunkSessionRegistration,
   HunkSessionSnapshot,
   NavigatedSelectionResult,
+  ReloadedSessionResult,
   RemovedCommentResult,
   SessionClientMessage,
   SessionCommandResult,
@@ -33,6 +34,9 @@ interface HunkAppBridge {
   navigateToHunk: (
     message: Extract<SessionServerMessage, { command: "navigate_to_hunk" }>,
   ) => Promise<NavigatedSelectionResult>;
+  reloadSession: (
+    message: Extract<SessionServerMessage, { command: "reload_session" }>,
+  ) => Promise<ReloadedSessionResult>;
   removeComment: (
     message: Extract<SessionServerMessage, { command: "remove_comment" }>,
   ) => Promise<RemovedCommentResult>;
@@ -54,7 +58,7 @@ export class HunkHostClient {
   private lastConnectionWarning: string | null = null;
 
   constructor(
-    private readonly registration: HunkSessionRegistration,
+    private registration: HunkSessionRegistration,
     private snapshot: HunkSessionSnapshot,
   ) {}
 
@@ -91,6 +95,20 @@ export class HunkHostClient {
     this.stopHeartbeat();
     this.websocket?.close();
     this.websocket = null;
+  }
+
+  getRegistration() {
+    return this.registration;
+  }
+
+  replaceSession(registration: HunkSessionRegistration, snapshot: HunkSessionSnapshot) {
+    this.registration = registration;
+    this.snapshot = snapshot;
+    this.send({
+      type: "register",
+      registration,
+      snapshot,
+    });
   }
 
   private resolveConfig() {
@@ -281,6 +299,8 @@ export class HunkHostClient {
         return this.bridge.applyComment(message);
       case "navigate_to_hunk":
         return this.bridge.navigateToHunk(message);
+      case "reload_session":
+        return this.bridge.reloadSession(message);
       case "remove_comment":
         return this.bridge.removeComment(message);
       case "clear_comments":

--- a/src/mcp/daemonState.ts
+++ b/src/mcp/daemonState.ts
@@ -9,6 +9,8 @@ import type {
   ListedSession,
   NavigateToHunkToolInput,
   NavigatedSelectionResult,
+  ReloadSessionToolInput,
+  ReloadedSessionResult,
   RemoveCommentToolInput,
   RemovedCommentResult,
   SelectedSessionContext,
@@ -267,6 +269,16 @@ export class HunkDaemonState {
     );
   }
 
+  sendReloadSession(input: ReloadSessionToolInput) {
+    return this.sendCommand<ReloadedSessionResult, "reload_session">(
+      { sessionId: input.sessionId, repoRoot: input.repoRoot },
+      "reload_session",
+      input,
+      "Timed out waiting for the Hunk session to reload the requested contents.",
+      30_000,
+    );
+  }
+
   sendRemoveComment(input: RemoveCommentToolInput) {
     return this.sendCommand<RemovedCommentResult, "remove_comment">(
       { sessionId: input.sessionId, repoRoot: input.repoRoot },
@@ -326,6 +338,7 @@ export class HunkDaemonState {
     command: CommandName,
     input: Extract<SessionServerMessage, { command: CommandName }>["input"],
     timeoutMessage: string,
+    timeoutMs = 15_000,
   ) {
     const session = resolveSessionTarget(this.listSessions(), selector);
     const requestId = randomUUID();
@@ -334,7 +347,7 @@ export class HunkDaemonState {
       const timeout = setTimeout(() => {
         this.pendingCommands.delete(requestId);
         reject(new Error(timeoutMessage));
-      }, 15_000);
+      }, timeoutMs);
 
       this.pendingCommands.set(requestId, {
         sessionId: session.sessionId,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ const SUPPORTED_SESSION_ACTIONS: SessionDaemonAction[] = [
   "get",
   "context",
   "navigate",
+  "reload",
   "comment-add",
   "comment-list",
   "comment-rm",
@@ -99,6 +100,14 @@ async function handleSessionApiRequest(state: HunkDaemonState, request: Request)
         };
         break;
       }
+      case "reload":
+        response = {
+          result: await state.sendReloadSession({
+            ...input.selector,
+            nextInput: input.nextInput,
+          }),
+        };
+        break;
       case "comment-add":
         response = {
           result: await state.sendComment({

--- a/src/mcp/sessionRegistration.ts
+++ b/src/mcp/sessionRegistration.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { AppBootstrap } from "../core/types";
 import { hunkLineRange } from "../core/liveComments";
-import type { HunkSessionRegistration, HunkSessionSnapshot } from "./types";
+import type { HunkSessionRegistration, HunkSessionSnapshot, SessionFileSummary } from "./types";
 
 function inferRepoRoot(bootstrap: AppBootstrap) {
   return bootstrap.input.kind === "git" ||
@@ -9,6 +9,17 @@ function inferRepoRoot(bootstrap: AppBootstrap) {
     bootstrap.input.kind === "stash-show"
     ? bootstrap.changeset.sourceLabel
     : undefined;
+}
+
+function buildSessionFiles(bootstrap: AppBootstrap): SessionFileSummary[] {
+  return bootstrap.changeset.files.map((file) => ({
+    id: file.id,
+    path: file.path,
+    previousPath: file.previousPath,
+    additions: file.stats.additions,
+    deletions: file.stats.deletions,
+    hunkCount: file.metadata.hunks.length,
+  }));
 }
 
 /** Build the daemon-facing metadata for one live Hunk TUI session. */
@@ -22,14 +33,22 @@ export function createSessionRegistration(bootstrap: AppBootstrap): HunkSessionR
     title: bootstrap.changeset.title,
     sourceLabel: bootstrap.changeset.sourceLabel,
     launchedAt: new Date().toISOString(),
-    files: bootstrap.changeset.files.map((file) => ({
-      id: file.id,
-      path: file.path,
-      previousPath: file.previousPath,
-      additions: file.stats.additions,
-      deletions: file.stats.deletions,
-      hunkCount: file.metadata.hunks.length,
-    })),
+    files: buildSessionFiles(bootstrap),
+  };
+}
+
+/** Rebuild registration metadata after a live session reload while preserving session identity. */
+export function updateSessionRegistration(
+  current: HunkSessionRegistration,
+  bootstrap: AppBootstrap,
+): HunkSessionRegistration {
+  return {
+    ...current,
+    repoRoot: inferRepoRoot(bootstrap),
+    inputKind: bootstrap.input.kind,
+    title: bootstrap.changeset.title,
+    sourceLabel: bootstrap.changeset.sourceLabel,
+    files: buildSessionFiles(bootstrap),
   };
 }
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -68,6 +68,10 @@ export interface NavigateToHunkToolInput extends SessionTargetInput {
   line?: number;
 }
 
+export interface ReloadSessionToolInput extends SessionTargetInput {
+  nextInput: CliInput;
+}
+
 export interface LiveComment extends AgentAnnotation {
   id: string;
   source: "mcp";
@@ -119,6 +123,16 @@ export interface ClearedCommentsResult {
   filePath?: string;
 }
 
+export interface ReloadedSessionResult {
+  sessionId: string;
+  inputKind: CliInput["kind"];
+  title: string;
+  sourceLabel: string;
+  fileCount: number;
+  selectedFilePath?: string;
+  selectedHunkIndex: number;
+}
+
 export interface ListedSessionFile extends SessionFileSummary {
   selected: boolean;
 }
@@ -139,7 +153,8 @@ export type SessionCommandResult =
   | AppliedCommentResult
   | NavigatedSelectionResult
   | RemovedCommentResult
-  | ClearedCommentsResult;
+  | ClearedCommentsResult
+  | ReloadedSessionResult;
 
 export type SessionClientMessage =
   | {
@@ -193,6 +208,12 @@ export type SessionServerMessage =
       requestId: string;
       command: "navigate_to_hunk";
       input: NavigateToHunkToolInput;
+    }
+  | {
+      type: "command";
+      requestId: string;
+      command: "reload_session";
+      input: ReloadSessionToolInput;
     }
   | {
       type: "command";

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -7,6 +7,7 @@ import type {
   SessionCommentListCommandInput,
   SessionCommentRemoveCommandInput,
   SessionNavigateCommandInput,
+  SessionReloadCommandInput,
   SessionSelectorInput,
 } from "../core/types";
 import {
@@ -21,6 +22,7 @@ import type {
   ClearedCommentsResult,
   ListedSession,
   NavigatedSelectionResult,
+  ReloadedSessionResult,
   RemovedCommentResult,
   SelectedSessionContext,
   SessionLiveCommentSummary,
@@ -40,6 +42,7 @@ export interface HunkDaemonCliClient {
   getSession(selector: SessionSelectorInput): Promise<ListedSession>;
   getSelectedContext(selector: SessionSelectorInput): Promise<SelectedSessionContext>;
   navigateToHunk(input: SessionNavigateCommandInput): Promise<NavigatedSelectionResult>;
+  reloadSession(input: SessionReloadCommandInput): Promise<ReloadedSessionResult>;
   addComment(input: SessionCommentAddCommandInput): Promise<AppliedCommentResult>;
   listComments(input: SessionCommentListCommandInput): Promise<SessionLiveCommentSummary[]>;
   removeComment(input: SessionCommentRemoveCommandInput): Promise<RemovedCommentResult>;
@@ -51,6 +54,7 @@ const REQUIRED_ACTION_BY_COMMAND: Record<SessionCommandInput["action"], SessionD
   get: "get",
   context: "context",
   navigate: "navigate",
+  reload: "reload",
   "comment-add": "comment-add",
   "comment-list": "comment-list",
   "comment-rm": "comment-rm",
@@ -149,6 +153,16 @@ class HttpHunkDaemonCliClient implements HunkDaemonCliClient {
         hunkNumber: input.hunkNumber,
         side: input.side,
         line: input.line,
+      })
+    ).result;
+  }
+
+  async reloadSession(input: SessionReloadCommandInput) {
+    return (
+      await this.request<{ result: ReloadedSessionResult }>({
+        action: "reload",
+        selector: input.selector,
+        nextInput: input.nextInput,
       })
     ).result;
   }
@@ -411,6 +425,13 @@ function formatNavigationOutput(selector: SessionSelectorInput, result: Navigate
   return `Focused ${result.filePath} hunk ${result.hunkIndex + 1} in ${formatSelector(selector)}.\n`;
 }
 
+function formatReloadOutput(selector: SessionSelectorInput, result: ReloadedSessionResult) {
+  const selected = result.selectedFilePath
+    ? `${result.selectedFilePath} hunk ${result.selectedHunkIndex + 1}`
+    : "(no files)";
+  return `Reloaded ${formatSelector(selector)} with ${result.title} (${result.fileCount} files). Selected: ${selected}.\n`;
+}
+
 function formatCommentOutput(selector: SessionSelectorInput, result: AppliedCommentResult) {
   return `Added live comment ${result.commentId} on ${result.filePath}:${result.line} (${result.side}) in hunk ${result.hunkIndex + 1} for ${formatSelector(selector)}.\n`;
 }
@@ -521,6 +542,15 @@ export async function runSessionCommand(input: SessionCommandInput) {
       });
       return renderOutput(input.output, { result }, () =>
         formatNavigationOutput(input.selector, result),
+      );
+    }
+    case "reload": {
+      const result = await client.reloadSession({
+        ...input,
+        selector: normalizedSelector!,
+      });
+      return renderOutput(input.output, { result }, () =>
+        formatReloadOutput(input.selector, result),
       );
     }
     case "comment-add": {

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -4,6 +4,7 @@ import type {
   SessionCommentListCommandInput,
   SessionCommentRemoveCommandInput,
   SessionNavigateCommandInput,
+  SessionReloadCommandInput,
   SessionSelectorInput,
 } from "../core/types";
 import type {
@@ -11,6 +12,7 @@ import type {
   ClearedCommentsResult,
   ListedSession,
   NavigatedSelectionResult,
+  ReloadedSessionResult,
   RemovedCommentResult,
   SelectedSessionContext,
   SessionLiveCommentSummary,
@@ -25,6 +27,7 @@ export type SessionDaemonAction =
   | "get"
   | "context"
   | "navigate"
+  | "reload"
   | "comment-add"
   | "comment-list"
   | "comment-rm"
@@ -54,6 +57,11 @@ export type SessionDaemonRequest =
       hunkNumber?: number;
       side?: "old" | "new";
       line?: number;
+    }
+  | {
+      action: "reload";
+      selector: SessionReloadCommandInput["selector"];
+      nextInput: SessionReloadCommandInput["nextInput"];
     }
   | {
       action: "comment-add";
@@ -87,6 +95,7 @@ export type SessionDaemonResponse =
   | { session: ListedSession }
   | { context: SelectedSessionContext }
   | { result: NavigatedSelectionResult }
+  | { result: ReloadedSessionResult }
   | { result: AppliedCommentResult }
   | { comments: SessionLiveCommentSummary[] }
   | { result: RemovedCommentResult }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,11 +13,19 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState,
+  useRef,
 } from "react";
-import type { AppBootstrap, LayoutMode } from "../core/types";
+import { resolveConfiguredCliInput } from "../core/config";
+import { loadAppBootstrap } from "../core/loaders";
+import { resolveRuntimeCliInput } from "../core/terminal";
+import type { AppBootstrap, CliInput, LayoutMode } from "../core/types";
 import { HunkHostClient } from "../mcp/client";
+import {
+  createInitialSessionSnapshot,
+  updateSessionRegistration,
+} from "../mcp/sessionRegistration";
+import type { ReloadedSessionResult } from "../mcp/types";
 import { MenuBar } from "./components/chrome/MenuBar";
 import { StatusBar } from "./components/chrome/StatusBar";
 import { DiffPane } from "./components/panes/DiffPane";
@@ -49,14 +57,16 @@ function clamp(value: number, min: number, max: number) {
 }
 
 /** Orchestrate global app state, layout, navigation, and pane coordination. */
-export function App({
+function AppShell({
   bootstrap,
   hostClient,
   onQuit = () => process.exit(0),
+  onReloadSession,
 }: {
   bootstrap: AppBootstrap;
   hostClient?: HunkHostClient;
   onQuit?: () => void;
+  onReloadSession: (nextInput: CliInput) => Promise<ReloadedSessionResult>;
 }) {
   const FILES_MIN_WIDTH = 22;
   const DIFF_MIN_WIDTH = 48;
@@ -112,6 +122,7 @@ export function App({
     hostClient,
     jumpToFile,
     openAgentNotes,
+    reloadSession: onReloadSession,
     selectedFile: baseSelectedFile,
     selectedHunkIndex,
     showAgentNotes,
@@ -839,5 +850,62 @@ export function App({
         </Suspense>
       ) : null}
     </box>
+  );
+}
+
+/** Keep one live Hunk window mounted while allowing daemon-driven session reloads. */
+export function App({
+  bootstrap,
+  hostClient,
+  onQuit = () => process.exit(0),
+}: {
+  bootstrap: AppBootstrap;
+  hostClient?: HunkHostClient;
+  onQuit?: () => void;
+}) {
+  const [activeBootstrap, setActiveBootstrap] = useState(bootstrap);
+  const [shellVersion, setShellVersion] = useState(0);
+
+  const reloadSession = useCallback(
+    async (nextInput: CliInput) => {
+      const runtimeInput = resolveRuntimeCliInput(nextInput);
+      const configuredInput = resolveConfiguredCliInput(runtimeInput).input;
+      const nextBootstrap = await loadAppBootstrap(configuredInput);
+      const nextSnapshot = createInitialSessionSnapshot(nextBootstrap);
+
+      let sessionId = "local-session";
+      if (hostClient) {
+        const nextRegistration = updateSessionRegistration(
+          hostClient.getRegistration(),
+          nextBootstrap,
+        );
+        sessionId = nextRegistration.sessionId;
+        hostClient.replaceSession(nextRegistration, nextSnapshot);
+      }
+
+      setActiveBootstrap(nextBootstrap);
+      setShellVersion((current) => current + 1);
+
+      return {
+        sessionId,
+        inputKind: nextBootstrap.input.kind,
+        title: nextBootstrap.changeset.title,
+        sourceLabel: nextBootstrap.changeset.sourceLabel,
+        fileCount: nextBootstrap.changeset.files.length,
+        selectedFilePath: nextSnapshot.selectedFilePath,
+        selectedHunkIndex: nextSnapshot.selectedHunkIndex,
+      };
+    },
+    [hostClient],
+  );
+
+  return (
+    <AppShell
+      key={shellVersion}
+      bootstrap={activeBootstrap}
+      hostClient={hostClient}
+      onQuit={onQuit}
+      onReloadSession={reloadSession}
+    />
   );
 }

--- a/src/ui/hooks/useHunkSessionBridge.ts
+++ b/src/ui/hooks/useHunkSessionBridge.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { DiffFile } from "../../core/types";
+import type { CliInput, DiffFile } from "../../core/types";
 import {
   buildLiveComment,
   findDiffFileByPath,
@@ -7,7 +7,12 @@ import {
   hunkLineRange,
 } from "../../core/liveComments";
 import { HunkHostClient } from "../../mcp/client";
-import type { LiveComment, SessionLiveCommentSummary, SessionServerMessage } from "../../mcp/types";
+import type {
+  LiveComment,
+  ReloadedSessionResult,
+  SessionLiveCommentSummary,
+  SessionServerMessage,
+} from "../../mcp/types";
 
 /** Bridge one live Hunk review session to the local MCP daemon. */
 export function useHunkSessionBridge({
@@ -16,6 +21,7 @@ export function useHunkSessionBridge({
   hostClient,
   jumpToFile,
   openAgentNotes,
+  reloadSession,
   selectedFile,
   selectedHunkIndex,
   showAgentNotes,
@@ -25,6 +31,7 @@ export function useHunkSessionBridge({
   hostClient?: HunkHostClient;
   jumpToFile: (fileId: string, nextHunkIndex?: number) => void;
   openAgentNotes: () => void;
+  reloadSession: (nextInput: CliInput) => Promise<ReloadedSessionResult>;
   selectedFile: DiffFile | undefined;
   selectedHunkIndex: number;
   showAgentNotes: boolean;
@@ -125,6 +132,12 @@ export function useHunkSessionBridge({
     liveCommentsByFileIdRef.current = liveCommentsByFileId;
   }, [liveCommentsByFileId]);
 
+  const reloadIncomingSession = useCallback(
+    async (message: Extract<SessionServerMessage, { command: "reload_session" }>) =>
+      reloadSession(message.input.nextInput),
+    [reloadSession],
+  );
+
   const removeIncomingComment = useCallback(
     async (message: Extract<SessionServerMessage, { command: "remove_comment" }>) => {
       const current = liveCommentsByFileIdRef.current;
@@ -208,6 +221,7 @@ export function useHunkSessionBridge({
     hostClient.setBridge({
       applyComment: applyIncomingComment,
       navigateToHunk: navigateToHunkSelection,
+      reloadSession: reloadIncomingSession,
       removeComment: removeIncomingComment,
       clearComments: clearIncomingComments,
     });
@@ -220,6 +234,7 @@ export function useHunkSessionBridge({
     clearIncomingComments,
     hostClient,
     navigateToHunkSelection,
+    reloadIncomingSession,
     removeIncomingComment,
   ]);
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -207,6 +207,40 @@ describe("parseCli", () => {
     });
   });
 
+  test("parses session reload with nested show syntax", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "reload",
+      "session-1",
+      "--json",
+      "--",
+      "show",
+      "HEAD~1",
+      "--",
+      "README.md",
+    ]);
+
+    expect(parsed).toMatchObject({
+      kind: "session",
+      action: "reload",
+      selector: { sessionId: "session-1" },
+      nextInput: {
+        kind: "show",
+        ref: "HEAD~1",
+        pathspecs: ["README.md"],
+      },
+      output: "json",
+    });
+  });
+
+  test("rejects session reload without a nested command separator", async () => {
+    await expect(
+      parseCli(["bun", "hunk", "session", "reload", "session-1", "show", "HEAD~1"]),
+    ).rejects.toThrow("Pass the replacement Hunk command after `--`");
+  });
+
   test("parses session comment add", async () => {
     const parsed = await parseCli([
       "bun",

--- a/test/help-output.test.ts
+++ b/test/help-output.test.ts
@@ -24,6 +24,24 @@ describe("CLI help output", () => {
     expect(stdout).not.toContain("\u001b[?1049h");
   });
 
+  test("prints session reload help without terminal takeover sequences", () => {
+    const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "session", "reload", "--help"], {
+      cwd: process.cwd(),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout = Buffer.from(proc.stdout).toString("utf8");
+    const stderr = Buffer.from(proc.stderr).toString("utf8");
+
+    expect(proc.exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage: session reload");
+    expect(stdout).toContain("hunk session reload --repo . -- diff");
+    expect(stdout).not.toContain("\u001b[?1049h");
+  });
+
   test("prints the package version for --version without terminal takeover sequences", () => {
     const expectedVersion = require("../package.json").version;
     const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "--version"], {

--- a/test/mcp-daemon.test.ts
+++ b/test/mcp-daemon.test.ts
@@ -7,6 +7,7 @@ import type {
   HunkSessionSnapshot,
   ListedSession,
   NavigatedSelectionResult,
+  ReloadedSessionResult,
   RemovedCommentResult,
   SessionLiveCommentSummary,
 } from "../src/mcp/types";
@@ -251,6 +252,58 @@ describe("Hunk MCP daemon state", () => {
         oldRange: [1, 2],
         newRange: [1, 4],
       },
+    };
+
+    state.handleCommandResult({
+      requestId: outgoing.requestId,
+      ok: true,
+      result,
+    });
+
+    await expect(pending).resolves.toEqual(result);
+  });
+
+  test("routes reload commands to the live session and resolves the async result", async () => {
+    const state = new HunkDaemonState();
+    const sent: string[] = [];
+    const socket = {
+      send(data: string) {
+        sent.push(data);
+      },
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+
+    const pending = state.sendReloadSession({
+      sessionId: "session-1",
+      nextInput: {
+        kind: "show",
+        ref: "HEAD~1",
+        options: {},
+      },
+    });
+
+    expect(sent).toHaveLength(1);
+    const outgoing = JSON.parse(sent[0]!) as {
+      requestId: string;
+      command: string;
+      input: { nextInput: { kind: string; ref?: string; options?: Record<string, unknown> } };
+    };
+    expect(outgoing.command).toBe("reload_session");
+    expect(outgoing.input.nextInput).toEqual({
+      kind: "show",
+      ref: "HEAD~1",
+      options: {},
+    });
+
+    const result: ReloadedSessionResult = {
+      sessionId: "session-1",
+      inputKind: "show",
+      title: "repo show HEAD~1",
+      sourceLabel: "/repo",
+      fileCount: 1,
+      selectedFilePath: "src/example.ts",
+      selectedHunkIndex: 0,
     };
 
     state.handleCommandResult({

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -84,6 +84,7 @@ describe("Hunk session daemon server", () => {
           "get",
           "context",
           "navigate",
+          "reload",
           "comment-add",
           "comment-list",
           "comment-rm",

--- a/test/session-cli.test.ts
+++ b/test/session-cli.test.ts
@@ -188,6 +188,79 @@ describe("session CLI", () => {
     }
   });
 
+  test("reload replaces what a live session is showing", async () => {
+    if (!ttyToolsAvailable) {
+      return;
+    }
+
+    const port = 48963;
+    const fixtureA = createFixtureFiles(
+      "reload-alpha",
+      ["export const alpha = 1;"],
+      ["export const alpha = 2;", "export const beta = true;"],
+    );
+    const fixtureB = createFixtureFiles(
+      "reload-beta",
+      ["export const before = 10;"],
+      ["export const after = 20;", "export const extra = 'yes';"],
+    );
+    const session = spawnHunkSession(fixtureA, { port, quitAfterSeconds: 18, timeoutSeconds: 20 });
+
+    try {
+      const listed = await waitUntil("registered live session", () => {
+        const { proc, stdout } = runSessionCli(["list", "--json"], port);
+        if (proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(stdout) as SessionListJson;
+        return parsed.sessions.length > 0 ? parsed.sessions : null;
+      });
+
+      const sessionId = listed[0]!.sessionId;
+      const reload = runSessionCli(
+        ["reload", sessionId, "--json", "--", "diff", fixtureB.before, fixtureB.after],
+        port,
+      );
+      expect(reload.proc.exitCode).toBe(0);
+      expect(reload.stderr).toBe("");
+      expect(JSON.parse(reload.stdout)).toMatchObject({
+        result: {
+          sessionId,
+          inputKind: "diff",
+          fileCount: 1,
+          selectedFilePath: fixtureB.afterName,
+          selectedHunkIndex: 0,
+        },
+      });
+
+      const reloaded = await waitUntil("reloaded session metadata", () => {
+        const get = runSessionCli(["get", sessionId, "--json"], port);
+        if (get.proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(get.stdout) as {
+          session?: {
+            inputKind?: string;
+            files?: Array<{ path: string }>;
+          };
+        };
+        return parsed.session?.files?.[0]?.path === fixtureB.afterName ? parsed : null;
+      });
+
+      expect(reloaded).toMatchObject({
+        session: {
+          inputKind: "diff",
+          files: [{ path: fixtureB.afterName }],
+        },
+      });
+    } finally {
+      session.kill();
+      await session.exited;
+    }
+  }, 20_000);
+
   test("navigate and comment add control a live Hunk session", async () => {
     if (!ttyToolsAvailable) {
       return;

--- a/test/session-commands.test.ts
+++ b/test/session-commands.test.ts
@@ -49,6 +49,7 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
         "get",
         "context",
         "navigate",
+        "reload",
         "comment-add",
         "comment-list",
         "comment-rm",
@@ -82,6 +83,15 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
       fileId: "file-1",
       filePath: "README.md",
       hunkIndex: 0,
+    }),
+    reloadSession: async () => ({
+      sessionId: "session-1",
+      inputKind: "show",
+      title: "repo show HEAD~1",
+      sourceLabel: "/repo",
+      fileCount: 1,
+      selectedFilePath: "README.md",
+      selectedHunkIndex: 0,
     }),
     addComment: async () => ({
       commentId: "comment-1",
@@ -193,6 +203,57 @@ describe("session command compatibility checks", () => {
     expect(createdClients).toEqual(["stale-capabilities", "fresh-context"]);
   });
 
+  test("runs reload commands through the daemon and returns the replacement session summary", async () => {
+    setSessionCommandTestHooks({
+      createClient: () =>
+        createClient({
+          reloadSession: async (input) => {
+            expect(input.selector).toEqual({ sessionId: "session-1" });
+            expect(input.nextInput).toEqual({
+              kind: "show",
+              ref: "HEAD~1",
+              options: {},
+            });
+
+            return {
+              sessionId: "session-1",
+              inputKind: "show",
+              title: "repo show HEAD~1",
+              sourceLabel: "/repo",
+              fileCount: 1,
+              selectedFilePath: "README.md",
+              selectedHunkIndex: 0,
+            };
+          },
+        }),
+      resolveDaemonAvailability: async () => true,
+    });
+
+    const output = await runSessionCommand({
+      kind: "session",
+      action: "reload",
+      selector: { sessionId: "session-1" },
+      nextInput: {
+        kind: "show",
+        ref: "HEAD~1",
+        options: {},
+      },
+      output: "json",
+    } satisfies SessionCommandInput);
+
+    expect(JSON.parse(output)).toEqual({
+      result: {
+        sessionId: "session-1",
+        inputKind: "show",
+        title: "repo show HEAD~1",
+        sourceLabel: "/repo",
+        fileCount: 1,
+        selectedFilePath: "README.md",
+        selectedHunkIndex: 0,
+      },
+    });
+  });
+
   test("does not restart when the daemon already exposes the needed session action", async () => {
     const restartCalls: string[] = [];
 
@@ -206,6 +267,7 @@ describe("session command compatibility checks", () => {
               "get",
               "context",
               "navigate",
+              "reload",
               "comment-add",
               "comment-list",
               "comment-rm",


### PR DESCRIPTION
## Summary
- add `hunk session reload (<session-id> | --repo <path>) -- <hunk command>` so agents can swap the contents of a live Hunk TUI in place
- route a new `reload` action through the session daemon/websocket bridge and preserve the same session identity while refreshing registration metadata
- remount the app shell on reload so it behaves like restarting the session with new input, and cover the flow with CLI, daemon, help, and live session tests

## Examples
```bash
hunk session reload --repo . -- diff
hunk session reload --repo . -- diff main...feature -- src/ui
hunk session reload --repo . -- show HEAD~1 -- README.md
```

## Verification
- bun run format:check
- bun run lint
- bun run typecheck
- bun test
- bun run check:pack