### PR TITLE
Refactor split diff rendering around an explicit review row plan

### DIFF
--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,136 +1,15 @@
-import { Fragment, useMemo } from "react";
-import type { AgentAnnotation, DiffFile, LayoutMode } from "../../core/types";
+import { useMemo } from "react";
+import type { DiffFile, LayoutMode } from "../../core/types";
 import { AgentInlineNote, AgentInlineNoteGuideCap } from "../components/panes/AgentInlineNote";
-import { annotationAnchor, type VisibleAgentNote } from "../lib/agentAnnotations";
-import { diffHunkId } from "../lib/ids";
+import { type VisibleAgentNote } from "../lib/agentAnnotations";
 import type { AppTheme } from "../themes";
-import { buildSplitRows, type DiffRow, buildStackRows } from "./pierre";
+import { buildSplitRows, buildStackRows } from "./pierre";
+import { buildReviewRenderPlan } from "./reviewRenderPlan";
 import { diffMessage, DiffRowView, findMaxLineNumber, fitText } from "./renderRows";
 import { useHighlightedDiff } from "./useHighlightedDiff";
 
 const EMPTY_ANNOTATED_HUNK_INDICES = new Set<number>();
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
-
-interface SelectedInlineNote {
-  anchorKey: string;
-  anchorSide?: "old" | "new";
-  coveredRowKeys: Set<string>;
-  endGuideAfterKey: string;
-  note: VisibleAgentNote;
-  noteCount: number;
-  noteIndex: number;
-}
-
-/** Check whether a rendered diff row visually covers the note anchor line. */
-function rowMatchesNote(
-  row: Extract<DiffRow, { type: "split-line" | "stack-line" }>,
-  annotation: AgentAnnotation,
-) {
-  const anchor = annotationAnchor(annotation);
-  if (!anchor) {
-    return false;
-  }
-
-  if (row.type === "split-line") {
-    return anchor.side === "new"
-      ? row.right.lineNumber === anchor.lineNumber
-      : row.left.lineNumber === anchor.lineNumber;
-  }
-
-  return anchor.side === "new"
-    ? row.cell.newLineNumber === anchor.lineNumber
-    : row.cell.oldLineNumber === anchor.lineNumber;
-}
-
-/** Check whether one rendered diff row falls inside the annotation range on either side. */
-function rowOverlapsAnnotation(
-  row: Extract<DiffRow, { type: "split-line" | "stack-line" }>,
-  annotation: AgentAnnotation,
-) {
-  const matchesOld =
-    annotation.oldRange &&
-    (row.type === "split-line"
-      ? row.left.lineNumber !== undefined &&
-        row.left.lineNumber >= annotation.oldRange[0] &&
-        row.left.lineNumber <= annotation.oldRange[1]
-      : row.cell.oldLineNumber !== undefined &&
-        row.cell.oldLineNumber >= annotation.oldRange[0] &&
-        row.cell.oldLineNumber <= annotation.oldRange[1]);
-
-  if (matchesOld) {
-    return true;
-  }
-
-  return Boolean(
-    annotation.newRange &&
-    (row.type === "split-line"
-      ? row.right.lineNumber !== undefined &&
-        row.right.lineNumber >= annotation.newRange[0] &&
-        row.right.lineNumber <= annotation.newRange[1]
-      : row.cell.newLineNumber !== undefined &&
-        row.cell.newLineNumber >= annotation.newRange[0] &&
-        row.cell.newLineNumber <= annotation.newRange[1]),
-  );
-}
-
-/** Resolve the rendered diff row before which the visible inline note should appear. */
-function findInlineNoteAnchorRow(
-  rows: DiffRow[],
-  annotation: AgentAnnotation,
-  selectedHunkIndex: number,
-) {
-  const selectedHunkRows = rows.filter((row) => row.hunkIndex === selectedHunkIndex);
-  const lineRows = selectedHunkRows.filter(
-    (row): row is Extract<DiffRow, { type: "split-line" | "stack-line" }> =>
-      row.type === "split-line" || row.type === "stack-line",
-  );
-  const headerRow = selectedHunkRows.find((row) => row.type === "hunk-header");
-
-  return lineRows.find((row) => rowMatchesNote(row, annotation)) ?? lineRows[0] ?? headerRow;
-}
-
-/** Return the one visible note, plus the diff rows that should show its guide rail. */
-function buildSelectedInlineNote(
-  rows: DiffRow[],
-  visibleAgentNotes: VisibleAgentNote[],
-  selectedHunkIndex: number,
-) {
-  if (visibleAgentNotes.length === 0 || selectedHunkIndex < 0) {
-    return null;
-  }
-
-  const note = visibleAgentNotes[0]!;
-  const anchorRow = findInlineNoteAnchorRow(rows, note.annotation, selectedHunkIndex);
-  if (!anchorRow) {
-    return null;
-  }
-
-  const selectedHunkLineRows = rows.filter(
-    (row): row is Extract<DiffRow, { type: "split-line" | "stack-line" }> =>
-      row.hunkIndex === selectedHunkIndex &&
-      (row.type === "split-line" || row.type === "stack-line"),
-  );
-  const coveredRows = selectedHunkLineRows.filter((row) =>
-    rowOverlapsAnnotation(row, note.annotation),
-  );
-  const fallbackGuideRow =
-    anchorRow.type === "split-line" || anchorRow.type === "stack-line"
-      ? anchorRow
-      : selectedHunkLineRows[0];
-  const guideRows =
-    coveredRows.length > 0 ? coveredRows : fallbackGuideRow ? [fallbackGuideRow] : [];
-  const endGuideAfterKey = guideRows.at(-1)?.key ?? anchorRow.key;
-
-  return {
-    anchorKey: anchorRow.key,
-    anchorSide: annotationAnchor(note.annotation)?.side,
-    coveredRowKeys: new Set(guideRows.map((row) => row.key)),
-    endGuideAfterKey,
-    note,
-    noteIndex: 0,
-    noteCount: visibleAgentNotes.length,
-  } satisfies SelectedInlineNote;
-}
 
 /** Render a file diff in split or stack mode, with inline agent notes inserted between diff rows. */
 export function PierreDiffView({
@@ -182,34 +61,20 @@ export function PierreDiffView({
         : [],
     [file, layout, resolvedHighlighted, theme],
   );
-  const hunkAnchorIds = useMemo(() => {
-    const anchors = new Map<string, string>();
-    const seenHunks = new Set<number>();
-
-    for (const row of rows) {
-      if (seenHunks.has(row.hunkIndex)) {
-        continue;
-      }
-
-      if (showHunkHeaders) {
-        if (row.type !== "hunk-header") {
-          continue;
-        }
-      } else if (row.type === "collapsed" || row.type === "hunk-header") {
-        continue;
-      }
-
-      anchors.set(row.key, diffHunkId(row.fileId, row.hunkIndex));
-      seenHunks.add(row.hunkIndex);
-    }
-
-    return anchors;
-  }, [rows, showHunkHeaders]);
-  const lineNumberDigits = useMemo(() => String(file ? findMaxLineNumber(file) : 1).length, [file]);
-  const selectedInlineNote = useMemo(
-    () => buildSelectedInlineNote(rows, visibleAgentNotes, selectedHunkIndex),
-    [rows, selectedHunkIndex, visibleAgentNotes],
+  const plannedRows = useMemo(
+    () =>
+      file
+        ? buildReviewRenderPlan({
+            fileId: file.id,
+            rows,
+            selectedHunkIndex,
+            showHunkHeaders,
+            visibleAgentNotes,
+          })
+        : [],
+    [file, rows, selectedHunkIndex, showHunkHeaders, visibleAgentNotes],
   );
+  const lineNumberDigits = useMemo(() => String(file ? findMaxLineNumber(file) : 1).length, [file]);
 
   if (!file) {
     return (
@@ -229,51 +94,55 @@ export function PierreDiffView({
 
   const content = (
     <box style={{ width: "100%", flexDirection: "column" }}>
-      {rows.map((row) => {
-        const showInlineNote = selectedInlineNote?.anchorKey === row.key;
-        const rowShowsGuide = Boolean(selectedInlineNote?.coveredRowKeys.has(row.key));
-        const showGuideCap = selectedInlineNote?.endGuideAfterKey === row.key;
+      {plannedRows.map((plannedRow) => {
+        if (plannedRow.kind === "inline-note") {
+          return (
+            <AgentInlineNote
+              key={plannedRow.key}
+              annotation={plannedRow.annotation}
+              anchorSide={plannedRow.anchorSide}
+              layout={layout}
+              noteCount={plannedRow.noteCount}
+              noteIndex={plannedRow.noteIndex}
+              theme={theme}
+              width={width}
+              onClose={
+                onDismissAgentNote ? () => onDismissAgentNote(plannedRow.annotationId) : undefined
+              }
+            />
+          );
+        }
+
+        if (plannedRow.kind === "note-guide-cap") {
+          return (
+            <AgentInlineNoteGuideCap
+              key={plannedRow.key}
+              side={plannedRow.side}
+              theme={theme}
+              width={width}
+            />
+          );
+        }
 
         return (
-          <Fragment key={row.key}>
-            {showInlineNote ? (
-              <AgentInlineNote
-                annotation={selectedInlineNote.note.annotation}
-                anchorSide={selectedInlineNote.anchorSide}
-                layout={layout}
-                noteCount={selectedInlineNote.noteCount}
-                noteIndex={selectedInlineNote.noteIndex}
-                theme={theme}
-                width={width}
-                onClose={
-                  onDismissAgentNote
-                    ? () => onDismissAgentNote(selectedInlineNote.note.id)
-                    : undefined
-                }
-              />
-            ) : null}
-            <DiffRowView
-              row={row}
-              width={width}
-              lineNumberDigits={lineNumberDigits}
-              showLineNumbers={showLineNumbers}
-              showHunkHeaders={showHunkHeaders}
-              wrapLines={wrapLines}
-              theme={theme}
-              selected={row.hunkIndex === selectedHunkIndex}
-              annotated={row.type === "hunk-header" && annotatedHunkIndices.has(row.hunkIndex)}
-              anchorId={hunkAnchorIds.get(row.key)}
-              noteGuideSide={rowShowsGuide ? selectedInlineNote?.anchorSide : undefined}
-              onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
-            />
-            {showGuideCap && selectedInlineNote?.anchorSide ? (
-              <AgentInlineNoteGuideCap
-                side={selectedInlineNote.anchorSide}
-                theme={theme}
-                width={width}
-              />
-            ) : null}
-          </Fragment>
+          <DiffRowView
+            key={plannedRow.key}
+            row={plannedRow.row}
+            width={width}
+            lineNumberDigits={lineNumberDigits}
+            showLineNumbers={showLineNumbers}
+            showHunkHeaders={showHunkHeaders}
+            wrapLines={wrapLines}
+            theme={theme}
+            selected={plannedRow.row.hunkIndex === selectedHunkIndex}
+            annotated={
+              plannedRow.row.type === "hunk-header" &&
+              annotatedHunkIndices.has(plannedRow.row.hunkIndex)
+            }
+            anchorId={plannedRow.anchorId}
+            noteGuideSide={plannedRow.noteGuideSide}
+            onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+          />
         );
       })}
     </box>

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -1,0 +1,226 @@
+import type { AgentAnnotation } from "../../core/types";
+import { annotationAnchor, type VisibleAgentNote } from "../lib/agentAnnotations";
+import { diffHunkId } from "../lib/ids";
+import type { DiffRow } from "./pierre";
+
+const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
+
+interface SelectedInlineNote {
+  anchorKey: string;
+  anchorSide?: "old" | "new";
+  coveredRowKeys: Set<string>;
+  endGuideAfterKey: string;
+  note: VisibleAgentNote;
+  noteCount: number;
+  noteIndex: number;
+}
+
+type DiffLineRow = Extract<DiffRow, { type: "split-line" | "stack-line" }>;
+
+export type PlannedReviewRow =
+  | {
+      kind: "diff-row";
+      key: string;
+      fileId: string;
+      hunkIndex: number;
+      row: DiffRow;
+      anchorId?: string;
+      noteGuideSide?: "old" | "new";
+    }
+  | {
+      kind: "inline-note";
+      key: string;
+      fileId: string;
+      hunkIndex: number;
+      annotationId: string;
+      annotation: AgentAnnotation;
+      anchorSide?: "old" | "new";
+      noteCount: number;
+      noteIndex: number;
+    }
+  | {
+      kind: "note-guide-cap";
+      key: string;
+      fileId: string;
+      hunkIndex: number;
+      side: "old" | "new";
+    };
+
+/** Check whether a rendered diff row visually covers the note anchor line. */
+function rowMatchesNote(row: DiffLineRow, annotation: AgentAnnotation) {
+  const anchor = annotationAnchor(annotation);
+  if (!anchor) {
+    return false;
+  }
+
+  if (row.type === "split-line") {
+    return anchor.side === "new"
+      ? row.right.lineNumber === anchor.lineNumber
+      : row.left.lineNumber === anchor.lineNumber;
+  }
+
+  return anchor.side === "new"
+    ? row.cell.newLineNumber === anchor.lineNumber
+    : row.cell.oldLineNumber === anchor.lineNumber;
+}
+
+/** Check whether one rendered diff row falls inside the annotation range on either side. */
+function rowOverlapsAnnotation(row: DiffLineRow, annotation: AgentAnnotation) {
+  const matchesOld =
+    annotation.oldRange &&
+    (row.type === "split-line"
+      ? row.left.lineNumber !== undefined &&
+        row.left.lineNumber >= annotation.oldRange[0] &&
+        row.left.lineNumber <= annotation.oldRange[1]
+      : row.cell.oldLineNumber !== undefined &&
+        row.cell.oldLineNumber >= annotation.oldRange[0] &&
+        row.cell.oldLineNumber <= annotation.oldRange[1]);
+
+  if (matchesOld) {
+    return true;
+  }
+
+  return Boolean(
+    annotation.newRange &&
+    (row.type === "split-line"
+      ? row.right.lineNumber !== undefined &&
+        row.right.lineNumber >= annotation.newRange[0] &&
+        row.right.lineNumber <= annotation.newRange[1]
+      : row.cell.newLineNumber !== undefined &&
+        row.cell.newLineNumber >= annotation.newRange[0] &&
+        row.cell.newLineNumber <= annotation.newRange[1]),
+  );
+}
+
+/** Resolve the rendered diff row before which the visible inline note should appear. */
+function findInlineNoteAnchorRow(
+  rows: DiffRow[],
+  annotation: AgentAnnotation,
+  selectedHunkIndex: number,
+) {
+  const selectedHunkRows = rows.filter((row) => row.hunkIndex === selectedHunkIndex);
+  const lineRows = selectedHunkRows.filter(
+    (row): row is DiffLineRow => row.type === "split-line" || row.type === "stack-line",
+  );
+  const headerRow = selectedHunkRows.find((row) => row.type === "hunk-header");
+
+  return lineRows.find((row) => rowMatchesNote(row, annotation)) ?? lineRows[0] ?? headerRow;
+}
+
+/** Return the one visible note, plus the diff rows that should show its guide rail. */
+function buildSelectedInlineNote(
+  rows: DiffRow[],
+  visibleAgentNotes: VisibleAgentNote[],
+  selectedHunkIndex: number,
+) {
+  if (visibleAgentNotes.length === 0 || selectedHunkIndex < 0) {
+    return null;
+  }
+
+  const note = visibleAgentNotes[0]!;
+  const anchorRow = findInlineNoteAnchorRow(rows, note.annotation, selectedHunkIndex);
+  if (!anchorRow) {
+    return null;
+  }
+
+  const selectedHunkLineRows = rows.filter(
+    (row): row is DiffLineRow =>
+      row.hunkIndex === selectedHunkIndex &&
+      (row.type === "split-line" || row.type === "stack-line"),
+  );
+  const coveredRows = selectedHunkLineRows.filter((row) =>
+    rowOverlapsAnnotation(row, note.annotation),
+  );
+  const fallbackGuideRow =
+    anchorRow.type === "split-line" || anchorRow.type === "stack-line"
+      ? anchorRow
+      : selectedHunkLineRows[0];
+  const guideRows =
+    coveredRows.length > 0 ? coveredRows : fallbackGuideRow ? [fallbackGuideRow] : [];
+  const endGuideAfterKey = guideRows.at(-1)?.key ?? anchorRow.key;
+
+  return {
+    anchorKey: anchorRow.key,
+    anchorSide: annotationAnchor(note.annotation)?.side,
+    coveredRowKeys: new Set(guideRows.map((row) => row.key)),
+    endGuideAfterKey,
+    note,
+    noteIndex: 0,
+    noteCount: visibleAgentNotes.length,
+  } satisfies SelectedInlineNote;
+}
+
+function rowCanAnchorHunk(row: DiffRow, showHunkHeaders: boolean) {
+  if (showHunkHeaders) {
+    return row.type === "hunk-header";
+  }
+
+  return row.type !== "collapsed" && row.type !== "hunk-header";
+}
+
+/** Build the explicit presentational row plan for one file diff body. */
+export function buildReviewRenderPlan({
+  fileId,
+  rows,
+  selectedHunkIndex,
+  showHunkHeaders,
+  visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
+}: {
+  fileId: string;
+  rows: DiffRow[];
+  selectedHunkIndex: number;
+  showHunkHeaders: boolean;
+  visibleAgentNotes?: VisibleAgentNote[];
+}) {
+  const selectedInlineNote = buildSelectedInlineNote(rows, visibleAgentNotes, selectedHunkIndex);
+  const plannedRows: PlannedReviewRow[] = [];
+  const anchoredHunks = new Set<number>();
+
+  for (const row of rows) {
+    const shouldAnchorHunk =
+      rowCanAnchorHunk(row, showHunkHeaders) && !anchoredHunks.has(row.hunkIndex);
+    const anchorId = shouldAnchorHunk ? diffHunkId(fileId, row.hunkIndex) : undefined;
+
+    if (shouldAnchorHunk) {
+      anchoredHunks.add(row.hunkIndex);
+    }
+
+    if (selectedInlineNote?.anchorKey === row.key) {
+      plannedRows.push({
+        kind: "inline-note",
+        key: `inline-note:${selectedInlineNote.note.id}:${row.key}`,
+        fileId,
+        hunkIndex: row.hunkIndex,
+        annotationId: selectedInlineNote.note.id,
+        annotation: selectedInlineNote.note.annotation,
+        anchorSide: selectedInlineNote.anchorSide,
+        noteCount: selectedInlineNote.noteCount,
+        noteIndex: selectedInlineNote.noteIndex,
+      });
+    }
+
+    plannedRows.push({
+      kind: "diff-row",
+      key: `diff-row:${row.key}`,
+      fileId: row.fileId,
+      hunkIndex: row.hunkIndex,
+      row,
+      anchorId,
+      noteGuideSide: selectedInlineNote?.coveredRowKeys.has(row.key)
+        ? selectedInlineNote.anchorSide
+        : undefined,
+    });
+
+    if (selectedInlineNote?.endGuideAfterKey === row.key && selectedInlineNote.anchorSide) {
+      plannedRows.push({
+        kind: "note-guide-cap",
+        key: `note-guide-cap:${selectedInlineNote.note.id}:${row.key}`,
+        fileId,
+        hunkIndex: row.hunkIndex,
+        side: selectedInlineNote.anchorSide,
+      });
+    }
+  }
+
+  return plannedRows;
+}

--- a/test/review-render-plan.test.ts
+++ b/test/review-render-plan.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { parseDiffFromFile } from "@pierre/diffs";
+import type { DiffFile } from "../src/core/types";
+import { resolveTheme } from "../src/ui/themes";
+
+const { buildSplitRows, buildStackRows } = await import("../src/ui/diff/pierre");
+const { buildReviewRenderPlan } = await import("../src/ui/diff/reviewRenderPlan");
+
+function createDiffFile(id: string, path: string, before: string, after: string): DiffFile {
+  const metadata = parseDiffFromFile(
+    {
+      name: path,
+      contents: before,
+      cacheKey: `${id}:before`,
+    },
+    {
+      name: path,
+      contents: after,
+      cacheKey: `${id}:after`,
+    },
+    { context: 3 },
+    true,
+  );
+
+  let additions = 0;
+  let deletions = 0;
+  for (const hunk of metadata.hunks) {
+    for (const content of hunk.hunkContent) {
+      if (content.type === "change") {
+        additions += content.additions;
+        deletions += content.deletions;
+      }
+    }
+  }
+
+  return {
+    id,
+    path,
+    patch: "",
+    language: "typescript",
+    stats: { additions, deletions },
+    metadata,
+    agent: null,
+  };
+}
+
+describe("review render plan", () => {
+  test("inserts an inline note before the anchor row and continues the guide through the covered range", () => {
+    const theme = resolveTheme("midnight", null);
+    const file = createDiffFile(
+      "alpha",
+      "alpha.ts",
+      "export const alpha = 1;\n",
+      "export const alpha = 2;\nexport const beta = 3;\nexport const gamma = 4;\n",
+    );
+    const rows = buildSplitRows(file, null, theme);
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      selectedHunkIndex: 0,
+      showHunkHeaders: true,
+      visibleAgentNotes: [
+        {
+          id: "annotation:alpha:0:0",
+          annotation: {
+            newRange: [2, 3],
+            summary: "Explain the expanded new-side range",
+            rationale: "The annotation should anchor to the first matching new-side row.",
+          },
+        },
+      ],
+    });
+
+    const noteIndex = plannedRows.findIndex((row) => row.kind === "inline-note");
+    expect(noteIndex).toBeGreaterThan(0);
+
+    const anchoredRow = plannedRows[noteIndex + 1];
+    expect(anchoredRow?.kind).toBe("diff-row");
+    if (anchoredRow?.kind === "diff-row") {
+      expect(anchoredRow.row.type).toBe("split-line");
+      if (anchoredRow.row.type === "split-line") {
+        expect(anchoredRow.row.right.lineNumber).toBe(2);
+      }
+    }
+
+    const guidedRows = plannedRows.filter(
+      (row) => row.kind === "diff-row" && row.noteGuideSide === "new",
+    );
+    expect(guidedRows).toHaveLength(2);
+    expect(
+      guidedRows.map((row) =>
+        row.kind === "diff-row" && row.row.type === "split-line" ? row.row.right.lineNumber : null,
+      ),
+    ).toEqual([2, 3]);
+
+    const capIndex = plannedRows.findIndex((row) => row.kind === "note-guide-cap");
+    expect(capIndex).toBeGreaterThan(noteIndex);
+    expect(plannedRows[capIndex - 1]?.kind).toBe("diff-row");
+  });
+
+  test("assigns hunk anchor ids from the first visible row when hunk headers are hidden", () => {
+    const theme = resolveTheme("midnight", null);
+    const file = createDiffFile(
+      "beta",
+      "beta.ts",
+      "export const beta = 1;\n",
+      "export const beta = 2;\nexport const gamma = true;\n",
+    );
+    const rows = buildSplitRows(file, null, theme);
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      selectedHunkIndex: 0,
+      showHunkHeaders: false,
+      visibleAgentNotes: [],
+    });
+
+    const anchorRow = plannedRows.find((row) => row.kind === "diff-row" && row.anchorId);
+    expect(anchorRow?.kind).toBe("diff-row");
+    if (anchorRow?.kind === "diff-row") {
+      expect(anchorRow.row.type).toBe("split-line");
+      expect(anchorRow.anchorId).toBe(`diff-hunk:${file.id}:0`);
+    }
+  });
+
+  test("anchors range-less notes to the first visible line row without guide rows", () => {
+    const theme = resolveTheme("midnight", null);
+    const file = createDiffFile(
+      "stack",
+      "stack.ts",
+      "export const value = 1;\n",
+      "export const value = 2;\nexport const added = true;\n",
+    );
+    const rows = buildStackRows(file, null, theme);
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      selectedHunkIndex: 0,
+      showHunkHeaders: true,
+      visibleAgentNotes: [
+        {
+          id: "annotation:stack:0:0",
+          annotation: {
+            summary: "General hunk note",
+            rationale: "No explicit line range is attached yet.",
+          },
+        },
+      ],
+    });
+
+    const noteIndex = plannedRows.findIndex((row) => row.kind === "inline-note");
+    expect(noteIndex).toBe(1);
+    expect(plannedRows.some((row) => row.kind === "note-guide-cap")).toBe(false);
+    expect(
+      plannedRows.some((row) => row.kind === "diff-row" && row.noteGuideSide !== undefined),
+    ).toBe(false);
+
+    const anchoredRow = plannedRows[noteIndex + 1];
+    expect(anchoredRow?.kind).toBe("diff-row");
+    if (anchoredRow?.kind === "diff-row") {
+      expect(anchoredRow.row.type).toBe("stack-line");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `buildReviewRenderPlan(...)` as an explicit presentational planning layer on top of semantic Pierre diff rows
- move inline-note anchoring, guide-range membership, guide-cap placement, and hunk anchor assignment out of `PierreDiffView`'s ad hoc render loop
- add planner-focused coverage for split note ranges, hidden hunk headers, and range-less note fallback behavior

## Testing
- bun test
- bun run typecheck
- bunx oxlint . --deny-warnings
- bunx oxfmt --check .
- bun run test:tty-smoke
