### PR TITLE
Use the render plan for section heights and scroll math

### DIFF
--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -2,7 +2,7 @@ import type { ScrollBoxRenderable } from "@opentui/core";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState, type RefObject } from "react";
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types";
 import type { VisibleAgentNote } from "../../lib/agentAnnotations";
-import { estimateDiffBodyRows, estimateHunkAnchorRow } from "../../lib/sectionHeights";
+import { measureDiffSectionMetrics } from "../../lib/sectionHeights";
 import { diffHunkId, diffSectionId } from "../../lib/ids";
 import type { AppTheme } from "../../themes";
 import { DiffSection } from "./DiffSection";
@@ -142,9 +142,13 @@ export function DiffPane({
     return () => clearInterval(interval);
   }, [scrollRef]);
 
+  const sectionMetrics = useMemo(
+    () => files.map((file) => measureDiffSectionMetrics(file, layout, showHunkHeaders, theme)),
+    [files, layout, showHunkHeaders, theme],
+  );
   const estimatedBodyHeights = useMemo(
-    () => files.map((file) => estimateDiffBodyRows(file, layout, showHunkHeaders)),
-    [files, layout, showHunkHeaders],
+    () => sectionMetrics.map((metrics) => metrics.bodyHeight),
+    [sectionMetrics],
   );
 
   const visibleViewportFileIds = useMemo(() => {
@@ -211,17 +215,17 @@ export function DiffPane({
     }
 
     top += 1;
-    top += estimateHunkAnchorRow(selectedFile, layout, showHunkHeaders, selectedHunkIndex);
+
+    if (selectedFile.metadata.hunks.length > 0) {
+      const clampedHunkIndex = Math.max(
+        0,
+        Math.min(selectedHunkIndex, selectedFile.metadata.hunks.length - 1),
+      );
+      top += sectionMetrics[selectedFileIndex]?.hunkAnchorRows.get(clampedHunkIndex) ?? 0;
+    }
+
     return top;
-  }, [
-    estimatedBodyHeights,
-    files,
-    layout,
-    selectedFile,
-    selectedFileIndex,
-    selectedHunkIndex,
-    showHunkHeaders,
-  ]);
+  }, [estimatedBodyHeights, sectionMetrics, selectedFile, selectedFileIndex, selectedHunkIndex]);
 
   useLayoutEffect(() => {
     if (!selectedAnchorId) {

--- a/src/ui/lib/sectionHeights.ts
+++ b/src/ui/lib/sectionHeights.ts
@@ -1,83 +1,86 @@
-import type { FileDiffMetadata } from "@pierre/diffs";
 import type { DiffFile, LayoutMode } from "../../core/types";
+import { buildSplitRows, buildStackRows } from "../diff/pierre";
+import { buildReviewRenderPlan, type PlannedReviewRow } from "../diff/reviewRenderPlan";
+import type { AppTheme } from "../themes";
 
-/** Count hidden unchanged lines after the final visible hunk when Pierre omits them. */
-function trailingCollapsedLines(metadata: FileDiffMetadata) {
-  const lastHunk = metadata.hunks.at(-1);
-  if (!lastHunk || metadata.isPartial) {
-    return 0;
-  }
-
-  const additionRemaining =
-    metadata.additionLines.length - (lastHunk.additionLineIndex + lastHunk.additionCount);
-  const deletionRemaining =
-    metadata.deletionLines.length - (lastHunk.deletionLineIndex + lastHunk.deletionCount);
-
-  if (additionRemaining !== deletionRemaining) {
-    return 0;
-  }
-
-  return Math.max(additionRemaining, 0);
+export interface DiffSectionMetrics {
+  bodyHeight: number;
+  hunkAnchorRows: Map<number, number>;
 }
 
-/** Count render rows for one hunk when wrapping and note cards are off. */
-function estimateHunkRows(
+function buildBasePlannedRows(
   file: DiffFile,
   layout: Exclude<LayoutMode, "auto">,
   showHunkHeaders: boolean,
-  hunkIndex: number,
+  theme: AppTheme,
 ) {
-  const hunk = file.metadata.hunks[hunkIndex];
-  if (!hunk) {
+  const rows =
+    layout === "split" ? buildSplitRows(file, null, theme) : buildStackRows(file, null, theme);
+
+  return buildReviewRenderPlan({
+    fileId: file.id,
+    rows,
+    selectedHunkIndex: -1,
+    showHunkHeaders,
+    visibleAgentNotes: [],
+  });
+}
+
+function plannedRowHeight(row: PlannedReviewRow, showHunkHeaders: boolean) {
+  if (row.kind !== "diff-row") {
     return 0;
   }
 
-  let rows = 0;
-
-  if (hunk.collapsedBefore > 0) {
-    rows += 1;
+  if (row.row.type === "hunk-header") {
+    return showHunkHeaders ? 1 : 0;
   }
 
-  if (showHunkHeaders) {
-    rows += 1;
-  }
-
-  for (const content of hunk.hunkContent) {
-    if (content.type === "context") {
-      rows += content.lines;
-      continue;
-    }
-
-    rows +=
-      layout === "split"
-        ? Math.max(content.deletions, content.additions)
-        : content.deletions + content.additions;
-  }
-
-  return rows;
+  return 1;
 }
 
-/** Estimate the number of diff-body rows for one file when wrapping and note cards are off. */
+/**
+ * Measure one file section from the same render plan used by PierreDiffView.
+ * This drives the no-wrap/no-note windowing path, where every visible planned row is one terminal row.
+ */
+export function measureDiffSectionMetrics(
+  file: DiffFile,
+  layout: Exclude<LayoutMode, "auto">,
+  showHunkHeaders: boolean,
+  theme: AppTheme,
+): DiffSectionMetrics {
+  if (file.metadata.hunks.length === 0) {
+    return {
+      bodyHeight: 1,
+      hunkAnchorRows: new Map(),
+    };
+  }
+
+  const plannedRows = buildBasePlannedRows(file, layout, showHunkHeaders, theme);
+  const hunkAnchorRows = new Map<number, number>();
+  let bodyHeight = 0;
+
+  for (const row of plannedRows) {
+    if (row.kind === "diff-row" && row.anchorId && !hunkAnchorRows.has(row.hunkIndex)) {
+      hunkAnchorRows.set(row.hunkIndex, bodyHeight);
+    }
+
+    bodyHeight += plannedRowHeight(row, showHunkHeaders);
+  }
+
+  return {
+    bodyHeight,
+    hunkAnchorRows,
+  };
+}
+
+/** Estimate the number of diff-body rows for one file in the windowed path. */
 export function estimateDiffBodyRows(
   file: DiffFile,
   layout: Exclude<LayoutMode, "auto">,
   showHunkHeaders: boolean,
+  theme: AppTheme,
 ) {
-  if (file.metadata.hunks.length === 0) {
-    return 1;
-  }
-
-  let rows = 0;
-
-  for (const [hunkIndex] of file.metadata.hunks.entries()) {
-    rows += estimateHunkRows(file, layout, showHunkHeaders, hunkIndex);
-  }
-
-  if (trailingCollapsedLines(file.metadata) > 0) {
-    rows += 1;
-  }
-
-  return rows;
+  return measureDiffSectionMetrics(file, layout, showHunkHeaders, theme).bodyHeight;
 }
 
 /** Estimate the body-row offset for the anchor that should represent the selected hunk. */
@@ -86,22 +89,16 @@ export function estimateHunkAnchorRow(
   layout: Exclude<LayoutMode, "auto">,
   showHunkHeaders: boolean,
   hunkIndex: number,
+  theme: AppTheme,
 ) {
   if (file.metadata.hunks.length === 0) {
     return 0;
   }
 
   const clampedHunkIndex = Math.max(0, Math.min(hunkIndex, file.metadata.hunks.length - 1));
-  let rows = 0;
-
-  for (let index = 0; index < clampedHunkIndex; index += 1) {
-    rows += estimateHunkRows(file, layout, showHunkHeaders, index);
-  }
-
-  const selectedHunk = file.metadata.hunks[clampedHunkIndex]!;
-  if (selectedHunk.collapsedBefore > 0) {
-    rows += 1;
-  }
-
-  return rows;
+  return (
+    measureDiffSectionMetrics(file, layout, showHunkHeaders, theme).hunkAnchorRows.get(
+      clampedHunkIndex,
+    ) ?? 0
+  );
 }

--- a/test/ui-lib.test.ts
+++ b/test/ui-lib.test.ts
@@ -15,20 +15,27 @@ import {
 } from "../src/ui/lib/agentPopover";
 import { buildAppMenus } from "../src/ui/lib/appMenus";
 import { fitText, padText } from "../src/ui/lib/text";
-import { estimateDiffBodyRows } from "../src/ui/lib/sectionHeights";
+import { estimateDiffBodyRows, measureDiffSectionMetrics } from "../src/ui/lib/sectionHeights";
 import { resizeSidebarWidth } from "../src/ui/lib/sidebar";
 import { resolveTheme } from "../src/ui/themes";
 
-function createDiffFile(): DiffFile {
+function lines(...values: string[]) {
+  return `${values.join("\n")}\n`;
+}
+
+function createDiffFile(
+  before = "const alpha = 1;\nconst beta = 2;\nconst gamma = 3;\nconst stable = true;\n",
+  after = "const alpha = 10;\nconst beta = 2;\nconst gamma = 30;\nconst stable = true;\n",
+): DiffFile {
   const metadata = parseDiffFromFile(
     {
       name: "example.ts",
-      contents: "const alpha = 1;\nconst beta = 2;\nconst gamma = 3;\nconst stable = true;\n",
+      contents: before,
       cacheKey: "before",
     },
     {
       name: "example.ts",
-      contents: "const alpha = 10;\nconst beta = 2;\nconst gamma = 30;\nconst stable = true;\n",
+      contents: after,
       cacheKey: "after",
     },
     { context: 0 },
@@ -189,16 +196,57 @@ describe("ui helpers", () => {
     expect(resizeSidebarWidth(34, 33, 120, 22, 80)).toBe(80);
   });
 
-  test("estimateDiffBodyRows matches split and stack row counts for hidden-context diffs", async () => {
+  test("estimateDiffBodyRows matches split and stack row counts from the render plan", async () => {
     const file = createDiffFile();
+    const theme = resolveTheme("midnight", null);
 
-    expect(estimateDiffBodyRows(file, "split", true)).toBeGreaterThan(0);
-    expect(estimateDiffBodyRows(file, "stack", true)).toBeGreaterThan(
-      estimateDiffBodyRows(file, "split", true),
+    expect(estimateDiffBodyRows(file, "split", true, theme)).toBeGreaterThan(0);
+    expect(estimateDiffBodyRows(file, "stack", true, theme)).toBeGreaterThan(
+      estimateDiffBodyRows(file, "split", true, theme),
     );
-    expect(estimateDiffBodyRows(file, "split", false)).toBe(
-      estimateDiffBodyRows(file, "split", true) - file.metadata.hunks.length,
+    expect(estimateDiffBodyRows(file, "split", false, theme)).toBe(
+      estimateDiffBodyRows(file, "split", true, theme) - file.metadata.hunks.length,
     );
+  });
+
+  test("measureDiffSectionMetrics tracks hidden-header anchor rows across multiple hunks", () => {
+    const file = createDiffFile(
+      lines(
+        "const line1 = 1;",
+        "const line2 = 2;",
+        "const line3 = 3;",
+        "const line4 = 4;",
+        "const line5 = 5;",
+        "const line6 = 6;",
+        "const line7 = 7;",
+        "const line8 = 8;",
+        "const line9 = 9;",
+        "const line10 = 10;",
+        "const line11 = 11;",
+        "const line12 = 12;",
+      ),
+      lines(
+        "const line1 = 1;",
+        "const line2 = 200;",
+        "const line3 = 3;",
+        "const line4 = 4;",
+        "const line5 = 5;",
+        "const line6 = 6;",
+        "const line7 = 7;",
+        "const line8 = 8;",
+        "const line9 = 9;",
+        "const line10 = 10;",
+        "const line11 = 1100;",
+        "const line12 = 12;",
+      ),
+    );
+    const theme = resolveTheme("midnight", null);
+    const metrics = measureDiffSectionMetrics(file, "split", false, theme);
+
+    expect(metrics.bodyHeight).toBeGreaterThan(0);
+    expect(metrics.hunkAnchorRows.get(0)).toBe(1);
+    expect(metrics.hunkAnchorRows.get(1)).toBe(3);
+    expect(metrics.hunkAnchorRows.get(1)).toBeGreaterThan(metrics.hunkAnchorRows.get(0) ?? -1);
   });
 
   test("resolveTheme falls back by requested id and renderer mode while lazily exposing syntax styles", () => {


### PR DESCRIPTION
## Summary
- drive diff section metrics from the review render plan instead of separate metadata-only estimators
- use shared per-file metrics in `DiffPane` for placeholder body heights and selected-hunk scroll targeting
- add coverage for render-plan-backed body height estimation and hidden-header multi-hunk anchor offsets

## Why
The review render plan is now the source of truth for what the diff stream actually shows. This follow-up makes the windowing and scroll-positioning math follow that same row stream instead of maintaining a parallel counting model.

That reduces drift between:
- what `PierreDiffView` renders
- what offscreen placeholders reserve
- where `DiffPane` estimates the selected hunk should scroll

## Testing
- bun run typecheck
- bun test
- pseudo-TTY smoke run of `bun run src/main.tsx diff ...`
