### PR TITLE
style: use AI note colors for AI badges

### DIFF
--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -627,7 +627,7 @@ function renderHeaderRow(
         style={{ width: badgeWidth, height: 1 }}
         onMouseUp={() => onOpenAgentNotesAtHunk?.(row.hunkIndex)}
       >
-        <text fg={theme.accent}>{badgeText}</text>
+        <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>{` ${badgeText}`}</text>
       </box>
     </box>
   );


### PR DESCRIPTION
## Summary
- use the AI note title text/background colors for the `[AI]` hunk badge
- align the badge styling with the existing purple AI comment theme

## Testing
- bun run typecheck
- bun test test/ui-components.test.tsx test/tty-render-smoke.test.ts