### PR TITLE
docs: tighten README and simplify session docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ git diff --no-color | hunk patch -  # review a patch from stdin
 | Structural diffing                 | ❌   | ✅         | ❌    | ❌            | ❌   |
 | Pager-compatible mode              | ✅   | ✅         | ✅    | ✅            | ✅   |
 
-Hunk is optimized for reviewing a full changeset interactively. If you primarily want syntax-aware diffing, `difftastic` is still the stronger fit.
+Hunk is optimized for reviewing a full changeset interactively.
 
 ## Git integration
 


### PR DESCRIPTION
## Summary
- tighten the README intro and quick-start flow
- merge agent skill + advanced workflows into a clearer live sessions and agent workflows section
- clarify that normal sessions auto-register and `hunk mcp serve` is mainly for manual startup/debugging

## Testing
- not run (README-only change)