### PR TITLE
docs: add lumen to README comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,17 @@ Open Hunk in another window, then ask your agent to leave comments.
 
 ## Feature comparison
 
-| Capability                         | hunk | lumen | difftastic | delta | diff-so-fancy | diff |
-| ---------------------------------- | ---- | ----- | ---------- | ----- | ------------- | ---- |
-| Review-first interactive UI        | ✅   | ✅    | ❌         | ❌    | ❌            | ❌   |
-| Multi-file review stream + sidebar | ✅   | ✅    | ❌         | ❌    | ❌            | ❌   |
-| Inline agent / AI annotations      | ✅   | ❌    | ❌         | ❌    | ❌            | ❌   |
-| Responsive auto split/stack layout | ✅   | ❌    | ❌         | ❌    | ❌            | ❌   |
-| Mouse support inside the viewer    | ✅   | ✅    | ❌         | ❌    | ❌            | ❌   |
-| Runtime view toggles               | ✅   | ✅    | ❌         | ❌    | ❌            | ❌   |
-| Syntax highlighting                | ✅   | ✅    | ✅         | ✅    | ❌            | ❌   |
-| Structural diffing                 | ❌   | ❌    | ✅         | ❌    | ❌            | ❌   |
-| Pager-compatible mode              | ✅   | ❌    | ✅         | ✅    | ✅            | ✅   |
+| Capability                         | [hunk](https://github.com/modem-dev/hunk) | [lumen](https://github.com/jnsahaj/lumen) | [difftastic](https://github.com/Wilfred/difftastic) | [delta](https://github.com/dandavison/delta) | [diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) | [diff](https://www.gnu.org/software/diffutils/) |
+| ---------------------------------- | ----------------------------------------- | ----------------------------------------- | --------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------- | ----------------------------------------------- |
+| Review-first interactive UI        | ✅                                        | ✅                                        | ❌                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Multi-file review stream + sidebar | ✅                                        | ✅                                        | ❌                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Inline agent / AI annotations      | ✅                                        | ❌                                        | ❌                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Responsive auto split/stack layout | ✅                                        | ❌                                        | ❌                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Mouse support inside the viewer    | ✅                                        | ✅                                        | ❌                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Runtime view toggles               | ✅                                        | ✅                                        | ❌                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Syntax highlighting                | ✅                                        | ✅                                        | ✅                                                  | ✅                                           | ❌                                                         | ❌                                              |
+| Structural diffing                 | ❌                                        | ❌                                        | ✅                                                  | ❌                                           | ❌                                                         | ❌                                              |
+| Pager-compatible mode              | ✅                                        | ❌                                        | ✅                                                  | ✅                                           | ✅                                                         | ✅                                              |
 
 Hunk is optimized for reviewing a full changeset interactively.
 


### PR DESCRIPTION
## Summary
- add Lumen to the README comparison table
- mark it as a review-first interactive diff tool
- keep the existing AI-annotation distinction for Hunk

## Testing
- not run (README-only change)