### PR TITLE
docs: improve hunk-review skill guidance

### DIFF
--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -6,11 +6,11 @@ compatibility: Requires Hunk from this repo or the published hunkdiff package. W
 
 # Hunk Review
 
-Use this skill when working with Hunk itself or when the user wants an interactive review workflow centered on Hunk.
+Use this skill when the task involves Hunk itself or when the user wants an interactive review workflow centered on a live Hunk session.
 
-Start by briefly explaining Hunk in plain language: it is a review-first terminal diff viewer for agent-authored changesets.
+Start by explaining Hunk plainly: **Hunk is a review-first terminal diff viewer for agent-authored changesets.**
 
-## Core model
+## Mental model
 
 Keep these product rules in mind:
 
@@ -20,24 +20,17 @@ Keep these product rules in mind:
 - `[` and `]` navigate hunks across the full review stream
 - agent notes belong beside the code they explain
 
-## Default rule
+Your job is not just to inspect the diff privately. Use Hunk as a shared explanation surface for the code author.
+
+## Default operating rule
 
 If a live Hunk session already exists, prefer `hunk session ...` over scraping terminal output or opening another review window.
 
-Hunk uses one local-only loopback session daemon to broker commands to live sessions. Normal Hunk sessions register automatically. `hunk mcp serve` is for manual startup or debugging only. `HUNK_MCP_DISABLE=1` disables registration for one session.
+Hunk uses one local-only loopback daemon to broker commands to live sessions. Normal Hunk sessions register automatically. `hunk mcp serve` is for manual startup or debugging only. `HUNK_MCP_DISABLE=1` disables registration for one session.
 
-## Primary goal
+## Default review workflow
 
-Use Hunk as a shared explanation surface for the code author, not just as a private inspection tool for the agent.
-
-- change what is visible with `hunk session reload -- <hunk command>` when a different diff, commit, or path-limited view would better explain the code
-- move to the relevant location with `hunk session navigate`
-- add concise inline annotations with `hunk session comment add`
-- prefer comments that help the author understand intent, structure, and why a hunk matters
-
-## Review loop
-
-Use this flow by default:
+Use this loop unless there is a strong reason not to:
 
 1. `hunk session list`
 2. `hunk session context`
@@ -48,11 +41,42 @@ Use this flow by default:
 Guidelines:
 
 - if multiple sessions are live, pass `sessionId` explicitly
+- use `--repo <path>` when you want the session whose repo root matches one checkout
 - use `hunk session get` only when you need broad session metadata
-- use `navigate` to move within the current changeset
-- use `reload` to swap the loaded changeset in place
-- use concise inline comments tied to real diff lines
 - keep the visible review state aligned with the explanation you are giving
+- prefer concise inline comments tied to real diff lines or hunks
+
+## Precise command patterns
+
+### Navigate precisely
+
+Use exact `navigate` targets instead of guessing flags:
+
+```bash
+hunk session navigate --repo . --file README.md --hunk 2
+hunk session navigate --repo . --file src/ui/App.tsx --new-line 372
+hunk session navigate --repo . --file src/ui/App.tsx --old-line 355
+```
+
+Targeting rules:
+
+- use `--hunk <n>` for a 1-based hunk number within the file
+- use `--new-line <n>` for a line on the new side
+- use `--old-line <n>` for a line on the old side
+- do not invent extra flags; stick to the supported selectors above
+
+### Add and manage comments
+
+Use exact comment-management syntax:
+
+```bash
+hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording"
+hunk session comment list --repo . --file README.md
+hunk session comment rm --repo . <comment-id>
+hunk session comment rm <session-id> <comment-id>
+```
+
+When passing comment text through a shell, quote `--summary` and `--rationale` defensively. Avoid raw backticks unless you are sure the shell will not interpret them.
 
 ## Common commands
 
@@ -82,6 +106,53 @@ hunk session comment add --repo . --file README.md --new-line 103 --summary "Tig
 
 Use `hunk diff --agent-context path/to/context.json` when a local rationale sidecar already exists.
 
+## Working-tree review playbook
+
+For the common case of steering one live `hunk diff` session while local files are changing:
+
+```bash
+hunk session list
+hunk session context --repo .
+git add -N src/new-file.ts                 # if a new file is missing from the review
+hunk session reload --repo . -- diff       # refresh the live working-tree review
+hunk session navigate --repo . --file src/new-file.ts --hunk 1
+hunk session comment add --repo . --file src/new-file.ts --new-line 10 --summary "Explain why this matters"
+```
+
+Important mental model:
+
+- live session commands only operate on files visible in the currently loaded review
+- for working-tree reviews, that means the file must appear in Git's diff
+- newly created files often need `git add -N <path>` before Hunk can navigate to them or attach comments there
+
+## Comment style
+
+Prefer comments that help the author understand the change, not comments that just restate the diff.
+
+Good comments usually do one of these:
+
+- explain intent
+- explain structure
+- point out why one hunk matters to the rest of the change
+- suggest a specific follow-up or risk to inspect
+
+Keep comments concise and spatially tied to the code they describe.
+
+## Common failure modes
+
+- `No visible diff file matches ...`
+  - the file is not part of the currently loaded review
+  - check `hunk session context --repo .`
+  - for a new file in a working-tree review, run `git add -N <path>` and then `hunk session reload --repo . -- diff`
+- the session is showing the wrong changeset
+  - use `hunk session reload --repo . -- diff`, `-- show ...`, or another nested Hunk review command
+- navigation target is ambiguous
+  - use one of `--hunk`, `--old-line`, or `--new-line`
+- multiple live sessions exist and commands hit the wrong one
+  - pass `sessionId` explicitly
+- no live session exists yet
+  - launch Hunk in a real terminal, then return to `hunk session list`
+
 ## When no live session exists
 
 If the user wants interactive review and no live session exists, launch Hunk with a minimal review command, then go back to `hunk session list`.
@@ -100,7 +171,7 @@ When using Hunk for agent changes in this repo:
 ## What this skill should steer toward
 
 - prefer visible, review-oriented actions over shell parsing of rendered terminal output
-- use Hunk to help the code author understand the code, not just to help yourself inspect it
 - inspect the current live diff session before navigating blindly
 - reload the current live session instead of opening a second review window when the user wants to swap contents
-- keep comments concise and spatially tied to the code they describe
+- use Hunk to help the code author understand the code, not just to help yourself inspect it
+- keep comments concise, concrete, and attached to the right place in the diff


### PR DESCRIPTION
## Summary
- rewrite the `skills/hunk-review/SKILL.md` guidance as a more complete operator playbook
- add precise examples for session navigation and comment management
- document working-tree review gotchas like new files needing `git add -N` before they appear in a live review

## Details
- clarify the Hunk mental model and default review workflow
- add a practical working-tree steering sequence for live sessions
- add troubleshooting for common failures such as `No visible diff file matches ...`
- add guidance on concise, review-oriented inline comments and defensive shell quoting
