### PR TITLE
mcp: shut down idle session daemons

### DIFF
--- a/src/mcp/daemonState.ts
+++ b/src/mcp/daemonState.ts
@@ -163,6 +163,10 @@ export class HunkDaemonState {
     return comments.filter((comment) => comment.filePath === filter.filePath);
   }
 
+  getSessionCount() {
+    return this.sessions.size;
+  }
+
   getPendingCommandCount() {
     return this.pendingCommands.size;
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,8 +11,9 @@ import {
   type SessionDaemonResponse,
 } from "../session/protocol";
 
-const STALE_SESSION_TTL_MS = 45_000;
-const STALE_SESSION_SWEEP_INTERVAL_MS = 15_000;
+const DEFAULT_STALE_SESSION_TTL_MS = 45_000;
+const DEFAULT_STALE_SESSION_SWEEP_INTERVAL_MS = 15_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
 
 const SUPPORTED_SESSION_ACTIONS: SessionDaemonAction[] = [
   "list",
@@ -25,6 +26,12 @@ const SUPPORTED_SESSION_ACTIONS: SessionDaemonAction[] = [
   "comment-rm",
   "comment-clear",
 ];
+
+export interface ServeHunkMcpServerOptions {
+  idleTimeoutMs?: number;
+  staleSessionTtlMs?: number;
+  staleSessionSweepIntervalMs?: number;
+}
 
 function formatDaemonServeError(error: unknown, host: string, port: number) {
   const message = error instanceof Error ? error.message : String(error);
@@ -154,18 +161,90 @@ async function handleSessionApiRequest(state: HunkDaemonState, request: Request)
 }
 
 /** Serve the local Hunk session daemon and websocket session broker. */
-export function serveHunkMcpServer() {
+export function serveHunkMcpServer(options: ServeHunkMcpServerOptions = {}) {
   const config = resolveHunkMcpConfig();
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const staleSessionTtlMs = options.staleSessionTtlMs ?? DEFAULT_STALE_SESSION_TTL_MS;
+  const staleSessionSweepIntervalMs =
+    options.staleSessionSweepIntervalMs ?? DEFAULT_STALE_SESSION_SWEEP_INTERVAL_MS;
   const state = new HunkDaemonState();
   const startedAt = Date.now();
+  let lastActivityAt = startedAt;
   let shuttingDown = false;
+  let sweepTimer: Timer | null = null;
+  let idleTimer: Timer | null = null;
+  let server: ReturnType<typeof Bun.serve<{}>> | null = null;
 
-  const sweepTimer = setInterval(() => {
-    state.pruneStaleSessions({ ttlMs: STALE_SESSION_TTL_MS });
-  }, STALE_SESSION_SWEEP_INTERVAL_MS);
+  const hasActiveWork = () => state.getSessionCount() > 0 || state.getPendingCommandCount() > 0;
+
+  const clearIdleShutdownTimer = () => {
+    if (!idleTimer) {
+      return;
+    }
+
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  };
+
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    if (sweepTimer) {
+      clearInterval(sweepTimer);
+      sweepTimer = null;
+    }
+
+    clearIdleShutdownTimer();
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+
+    state.shutdown();
+    server?.stop(true);
+  };
+
+  const refreshIdleShutdownTimer = () => {
+    clearIdleShutdownTimer();
+
+    if (shuttingDown || idleTimeoutMs <= 0 || hasActiveWork()) {
+      return;
+    }
+
+    const idleForMs = Date.now() - lastActivityAt;
+    const remainingMs = Math.max(0, idleTimeoutMs - idleForMs);
+
+    idleTimer = setTimeout(() => {
+      idleTimer = null;
+
+      if (shuttingDown || hasActiveWork()) {
+        return;
+      }
+
+      if (Date.now() - lastActivityAt < idleTimeoutMs) {
+        refreshIdleShutdownTimer();
+        return;
+      }
+
+      shutdown();
+    }, remainingMs);
+    idleTimer.unref?.();
+  };
+
+  const noteActivity = () => {
+    lastActivityAt = Date.now();
+    refreshIdleShutdownTimer();
+  };
+
+  sweepTimer = setInterval(() => {
+    const removed = state.pruneStaleSessions({ ttlMs: staleSessionTtlMs });
+    if (removed > 0) {
+      noteActivity();
+    }
+  }, staleSessionSweepIntervalMs);
   sweepTimer.unref?.();
 
-  let server: ReturnType<typeof Bun.serve<{}>>;
   try {
     server = Bun.serve<{}>({
       hostname: config.host,
@@ -174,7 +253,11 @@ export function serveHunkMcpServer() {
         const url = new URL(request.url);
 
         if (url.pathname === "/health") {
-          state.pruneStaleSessions({ ttlMs: STALE_SESSION_TTL_MS });
+          const removed = state.pruneStaleSessions({ ttlMs: staleSessionTtlMs });
+          if (removed > 0) {
+            noteActivity();
+          }
+
           return Response.json({
             ok: true,
             pid: process.pid,
@@ -183,17 +266,19 @@ export function serveHunkMcpServer() {
             sessionApi: `${config.httpOrigin}${HUNK_SESSION_API_PATH}`,
             sessionCapabilities: `${config.httpOrigin}${HUNK_SESSION_CAPABILITIES_PATH}`,
             sessionSocket: `${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`,
-            sessions: state.listSessions().length,
+            sessions: state.getSessionCount(),
             pendingCommands: state.getPendingCommandCount(),
-            staleSessionTtlMs: STALE_SESSION_TTL_MS,
+            staleSessionTtlMs,
           });
         }
 
         if (url.pathname === HUNK_SESSION_CAPABILITIES_PATH) {
+          noteActivity();
           return Response.json(sessionCapabilities());
         }
 
         if (url.pathname === HUNK_SESSION_API_PATH) {
+          noteActivity();
           return handleSessionApiRequest(state, request);
         }
 
@@ -230,44 +315,41 @@ export function serveHunkMcpServer() {
           switch (parsed.type) {
             case "register":
               state.registerSession(socket, parsed.registration, parsed.snapshot);
+              noteActivity();
               break;
             case "snapshot":
               state.updateSnapshot(parsed.sessionId, parsed.snapshot);
+              noteActivity();
               break;
             case "heartbeat":
               state.markSessionSeen(parsed.sessionId);
+              noteActivity();
               break;
             case "command-result":
               state.handleCommandResult(parsed);
+              noteActivity();
               break;
           }
         },
         close: (socket) => {
           state.unregisterSocket(socket);
+          noteActivity();
         },
       },
     });
   } catch (error) {
-    clearInterval(sweepTimer);
+    if (sweepTimer) {
+      clearInterval(sweepTimer);
+      sweepTimer = null;
+    }
+
+    clearIdleShutdownTimer();
     throw formatDaemonServeError(error, config.host, config.port);
   }
 
-  const shutdown = () => {
-    if (shuttingDown) {
-      return;
-    }
-
-    shuttingDown = true;
-    clearInterval(sweepTimer);
-    process.off("SIGINT", shutdown);
-    process.off("SIGTERM", shutdown);
-
-    state.shutdown();
-    server.stop(true);
-  };
-
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
+  refreshIdleShutdownTimer();
 
   console.log(`Hunk session daemon listening on ${config.httpOrigin}${HUNK_SESSION_API_PATH}`);
   console.log(`Hunk session websocket listening on ${config.wsOrigin}${HUNK_SESSION_SOCKET_PATH}`);

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -6,6 +6,13 @@ const originalHost = process.env.HUNK_MCP_HOST;
 const originalPort = process.env.HUNK_MCP_PORT;
 const originalUnsafeRemote = process.env.HUNK_MCP_UNSAFE_ALLOW_REMOTE;
 
+interface HealthResponse {
+  ok: boolean;
+  pid: number;
+  sessions: number;
+  pendingCommands: number;
+}
+
 async function reserveLoopbackPort() {
   const listener = createServer(() => undefined);
   await new Promise<void>((resolve, reject) => {
@@ -17,6 +24,126 @@ async function reserveLoopbackPort() {
   const port = typeof address === "object" && address ? address.port : 0;
   await new Promise<void>((resolve) => listener.close(() => resolve()));
   return port;
+}
+
+async function waitUntil<T>(
+  label: string,
+  fn: () => Promise<T | null> | T | null,
+  timeoutMs = 1_500,
+  intervalMs = 20,
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const value = await fn();
+    if (value !== null) {
+      return value;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${label}.`);
+    }
+
+    await Bun.sleep(intervalMs);
+  }
+}
+
+async function readHealth(port: number) {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as HealthResponse;
+  } catch {
+    return null;
+  }
+}
+
+async function waitForHealth(port: number) {
+  return waitUntil("daemon health", () => readHealth(port));
+}
+
+async function waitForShutdown(port: number, timeoutMs = 1_500) {
+  await waitUntil(
+    "daemon shutdown",
+    async () => ((await readHealth(port)) === null ? true : null),
+    timeoutMs,
+  );
+}
+
+async function waitForSessionCount(port: number, count: number) {
+  await waitUntil("session registration", async () => {
+    const health = await readHealth(port);
+    return health?.sessions === count ? health : null;
+  });
+}
+
+async function openRegisteredSession(port: number, sessionId = "session-1") {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}/session`);
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Timed out waiting for websocket open.")),
+      500,
+    );
+    timeout.unref?.();
+
+    socket.addEventListener(
+      "open",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true },
+    );
+    socket.addEventListener(
+      "error",
+      () => {
+        clearTimeout(timeout);
+        reject(new Error("Websocket failed to open."));
+      },
+      { once: true },
+    );
+  });
+
+  socket.send(
+    JSON.stringify({
+      type: "register",
+      registration: {
+        sessionId,
+        pid: process.pid,
+        cwd: "/repo",
+        repoRoot: "/repo",
+        inputKind: "git",
+        title: "repo working tree",
+        sourceLabel: "/repo",
+        launchedAt: "2026-03-24T00:00:00.000Z",
+        files: [
+          {
+            id: "file-1",
+            path: "src/example.ts",
+            additions: 1,
+            deletions: 1,
+            hunkCount: 1,
+          },
+        ],
+      },
+      snapshot: {
+        selectedFileId: "file-1",
+        selectedFilePath: "src/example.ts",
+        selectedHunkIndex: 0,
+        showAgentNotes: false,
+        liveCommentCount: 0,
+        liveComments: [],
+        updatedAt: "2026-03-24T00:00:00.000Z",
+      },
+    }),
+  );
+
+  await waitForSessionCount(port, 1);
+  return socket;
 }
 
 afterEach(() => {
@@ -104,6 +231,72 @@ describe("Hunk session daemon server", () => {
         error: expect.stringContaining("Use `hunk session ...` instead"),
       });
     } finally {
+      server.stop(true);
+    }
+  });
+
+  test("stays alive while at least one live session remains registered", async () => {
+    const port = await reserveLoopbackPort();
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    const server = serveHunkMcpServer({
+      idleTimeoutMs: 60,
+      staleSessionTtlMs: 500,
+      staleSessionSweepIntervalMs: 25,
+    });
+    const socket = await openRegisteredSession(port);
+
+    try {
+      await Bun.sleep(150);
+      await expect(waitForHealth(port)).resolves.toMatchObject({
+        ok: true,
+        sessions: 1,
+      });
+    } finally {
+      socket.close();
+      server.stop(true);
+    }
+  });
+
+  test("shuts down after the last live session disconnects", async () => {
+    const port = await reserveLoopbackPort();
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    const server = serveHunkMcpServer({
+      idleTimeoutMs: 75,
+      staleSessionTtlMs: 500,
+      staleSessionSweepIntervalMs: 25,
+    });
+    const socket = await openRegisteredSession(port);
+
+    try {
+      socket.close();
+      await waitForSessionCount(port, 0);
+      await waitForShutdown(port, 800);
+    } finally {
+      socket.close();
+      server.stop(true);
+    }
+  });
+
+  test("shuts down after stale-session pruning leaves zero live sessions", async () => {
+    const port = await reserveLoopbackPort();
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    const server = serveHunkMcpServer({
+      idleTimeoutMs: 75,
+      staleSessionTtlMs: 80,
+      staleSessionSweepIntervalMs: 20,
+    });
+    const socket = await openRegisteredSession(port);
+
+    try {
+      await waitForShutdown(port, 1_000);
+    } finally {
+      socket.close();
       server.stop(true);
     }
   });


### PR DESCRIPTION
## Summary
- add daemon-side idle shutdown for the local session broker
- keep the daemon alive while sessions or pending commands still exist
- add server tests that cover live-session retention, disconnect shutdown, and stale-session shutdown

## Testing
- bun run typecheck
- bun test
