### PR TITLE
fix: normalize git patch prefixes for parser compatibility

### DIFF
--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -19,6 +19,24 @@ export function appendGitPathspecs(args: string[], pathspecs?: string[]) {
   args.push("--", ...pathspecs);
 }
 
+// @pierre/diffs currently assumes git-style a/ and b/ prefixes when parsing patch headers.
+// Force canonical prefixes for git-backed review commands so user/repo git diff config
+// (noprefix, mnemonicPrefix, custom src/dst prefixes) cannot break parsing.
+const DIFF_PREFIX_NORMALIZATION_ARGS = [
+  "-c",
+  "diff.noprefix=false",
+  "-c",
+  "diff.mnemonicPrefix=false",
+  "-c",
+  "diff.srcPrefix=a/",
+  "-c",
+  "diff.dstPrefix=b/",
+];
+
+function withNormalizedDiffPrefixes(args: string[]) {
+  return [...DIFF_PREFIX_NORMALIZATION_ARGS, ...args];
+}
+
 /** Build the exact `git diff` arguments used for the shared working-tree and range review path. */
 export function buildGitDiffArgs(input: GitCommandInput) {
   const args = ["diff", "--no-ext-diff", "--find-renames", "--no-color"];
@@ -32,7 +50,7 @@ export function buildGitDiffArgs(input: GitCommandInput) {
   }
 
   appendGitPathspecs(args, input.pathspecs);
-  return args;
+  return withNormalizedDiffPrefixes(args);
 }
 
 /** Build the exact `git show` arguments used for commit review. */
@@ -44,7 +62,7 @@ export function buildGitShowArgs(input: ShowCommandInput) {
   }
 
   appendGitPathspecs(args, input.pathspecs);
-  return args;
+  return withNormalizedDiffPrefixes(args);
 }
 
 /** Build the exact `git stash show -p` arguments used for stash review. */
@@ -55,7 +73,7 @@ export function buildGitStashShowArgs(input: StashShowCommandInput) {
     args.push(input.ref);
   }
 
-  return args;
+  return withNormalizedDiffPrefixes(args);
 }
 
 export function formatGitCommandLabel(input: GitBackedInput) {

--- a/test/loaders.test.ts
+++ b/test/loaders.test.ts
@@ -119,6 +119,46 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.changeset.files[0]?.stats.additions).toBeGreaterThan(0);
   });
 
+  test("loads git working tree changes when diff.noprefix is enabled", async () => {
+    const dir = createTempRepo("hunk-git-noprefix-");
+
+    writeFileSync(join(dir, "example.ts"), "export const value = 1;\n");
+    git(dir, "add", "example.ts");
+    git(dir, "commit", "-m", "initial");
+
+    git(dir, "config", "--local", "diff.noprefix", "true");
+    writeFileSync(join(dir, "example.ts"), "export const value = 2;\nexport const extra = true;\n");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "git",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]?.path).toBe("example.ts");
+  });
+
+  test("loads git working tree changes when diff.mnemonicPrefix is enabled", async () => {
+    const dir = createTempRepo("hunk-git-mnemonic-");
+
+    writeFileSync(join(dir, "example.ts"), "export const value = 1;\n");
+    git(dir, "add", "example.ts");
+    git(dir, "commit", "-m", "initial");
+
+    git(dir, "config", "--local", "diff.mnemonicPrefix", "true");
+    writeFileSync(join(dir, "example.ts"), "export const value = 2;\nexport const extra = true;\n");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "git",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]?.path).toBe("example.ts");
+  });
+
   test("reports a friendly error when git review runs outside a repository", async () => {
     const dir = mkdtempSync(join(tmpdir(), "hunk-nonrepo-"));
     tempDirs.push(dir);
@@ -201,6 +241,28 @@ describe("loadAppBootstrap", () => {
     git(dir, "add", "alpha.ts", "beta.ts");
     git(dir, "commit", "-m", "initial");
 
+    writeFileSync(join(dir, "alpha.ts"), "export const alpha = 2;\n");
+    git(dir, "add", "alpha.ts");
+    writeFileSync(join(dir, "beta.ts"), "export const beta = 2;\n");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "git",
+      staged: true,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["alpha.ts"]);
+  });
+
+  test("loads staged-only git diffs when diff.noprefix is enabled", async () => {
+    const dir = createTempRepo("hunk-git-staged-noprefix-");
+
+    writeFileSync(join(dir, "alpha.ts"), "export const alpha = 1;\n");
+    writeFileSync(join(dir, "beta.ts"), "export const beta = 1;\n");
+    git(dir, "add", "alpha.ts", "beta.ts");
+    git(dir, "commit", "-m", "initial");
+
+    git(dir, "config", "--local", "diff.noprefix", "true");
     writeFileSync(join(dir, "alpha.ts"), "export const alpha = 2;\n");
     git(dir, "add", "alpha.ts");
     writeFileSync(join(dir, "beta.ts"), "export const beta = 2;\n");
@@ -321,6 +383,25 @@ describe("loadAppBootstrap", () => {
 
     expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["alpha.ts"]);
     expect(bootstrap.changeset.title).toContain("stash");
+  });
+
+  test("loads stash show output when diff.noprefix is enabled", async () => {
+    const dir = createTempRepo("hunk-stash-noprefix-");
+
+    writeFileSync(join(dir, "alpha.ts"), "export const alpha = 1;\n");
+    git(dir, "add", "alpha.ts");
+    git(dir, "commit", "-m", "initial");
+
+    git(dir, "config", "--local", "diff.noprefix", "true");
+    writeFileSync(join(dir, "alpha.ts"), "export const alpha = 2;\n");
+    git(dir, "stash", "push", "-m", "update alpha");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "stash-show",
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["alpha.ts"]);
   });
 
   test("reports a friendly error when no stash entries exist", async () => {


### PR DESCRIPTION
## Summary
- force canonical git diff prefixes (`a/` and `b/`) for git-backed inputs by passing command-scoped git config in:
  - `hunk diff`
  - `hunk show`
  - `hunk stash show`
- keep behavior local to each git invocation (no persistent config changes)
- add parser-compatibility regression tests for config-sensitive cases

## Why
`@pierre/diffs` currently expects `a/`/`b/`-style headers. Repos/environments with settings like `diff.noprefix=true` or `diff.mnemonicPrefix=true` can emit non-canonical prefixes and lead to empty changesets in the UI.

## Tests
- `bun run typecheck`
- `bun test test/loaders.test.ts -t "loads git working tree changes when diff.noprefix is enabled|loads git working tree changes when diff.mnemonicPrefix is enabled|loads staged-only git diffs when diff.noprefix is enabled|loads stash show output when diff.noprefix is enabled"`

## Notes
- intentionally overrides user/repo diff prefix formatting for these commands to preserve parser compatibility
- does not include investigation doc in commit
