### PR TITLE
build: add linux arm64 prebuilt package release support

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -29,6 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - package_name: hunkdiff-linux-arm64
+            runner: ubuntu-24.04-arm
           - package_name: hunkdiff-linux-x64
             runner: ubuntu-latest
           - package_name: hunkdiff-darwin-x64

--- a/scripts/prebuilt-package-helpers.ts
+++ b/scripts/prebuilt-package-helpers.ts
@@ -42,6 +42,13 @@ export const PLATFORM_PACKAGE_MATRIX: PlatformPackageSpec[] = [
     binaryRelativePath: "bin/hunk",
   },
   {
+    packageName: "hunkdiff-linux-arm64",
+    os: "linux",
+    cpu: "arm64",
+    binaryName: "hunk",
+    binaryRelativePath: "bin/hunk",
+  },
+  {
     packageName: "hunkdiff-linux-x64",
     os: "linux",
     cpu: "x64",

--- a/test/prebuilt-package-helpers.test.ts
+++ b/test/prebuilt-package-helpers.test.ts
@@ -68,8 +68,8 @@ describe("prebuilt package helpers", () => {
     expect(() => getPlatformPackageSpecForHost("linux", "ia32" as NodeJS.Architecture)).toThrow(
       "Unsupported host architecture for prebuilt packaging: ia32",
     );
-    expect(() => getPlatformPackageSpecForHost("linux", "arm64")).toThrow(
-      "No published prebuilt package spec matches linux/arm64",
+    expect(getPlatformPackageSpecForHost("linux", "arm64").packageName).toBe(
+      "hunkdiff-linux-arm64",
     );
   });
 
@@ -84,6 +84,7 @@ describe("prebuilt package helpers", () => {
     expect(sortPlatformPackageSpecs(reversed).map((spec) => spec.packageName)).toEqual([
       "hunkdiff-darwin-arm64",
       "hunkdiff-darwin-x64",
+      "hunkdiff-linux-arm64",
       "hunkdiff-linux-x64",
     ]);
   });


### PR DESCRIPTION
Hello again!

This adds linux arm64 to the built pipeline. I tried to figure out if there was a particular reason this wasn't already the case but couldn't find one, please lmk if there's something I missed!

For context, I work on some projects from inside a [Lima](https://lima-vm.io/) vm on my mac, which by defaults re-uses the same arch but on linux. 


<details><summary>summary by gpt 5.3</summary>
<p>

## Summary

Add Linux ARM64 (`aarch64`) to the prebuilt release pipeline so `hunkdiff` can publish a native `hunkdiff-linux-arm64` package.

## Changes

- Update prebuilt package matrix:
  - `scripts/prebuilt-package-helpers.ts`
  - add `hunkdiff-linux-arm64` spec
- Update release workflow:
  - `.github/workflows/release-prebuilt-npm.yml`
  - add `hunkdiff-linux-arm64` build job on `ubuntu-24.04-arm`
- Update tests:
  - `test/prebuilt-package-helpers.test.ts`
  - expect `linux/arm64` to resolve
  - include linux arm64 in stable sort expectation

## Why

Source build on Linux ARM64 already works (validated in `lima-default`), but prebuilt publishing did not include linux arm64. This aligns packaging with actual runtime support.

## Validation

- `bun run typecheck`
- `bun test test/prebuilt-package-helpers.test.ts`
- `bash ./scripts/build-bin.sh`
- `bun ./scripts/stage-prebuilt-npm.ts`
- `bun ./scripts/check-prebuilt-pack.ts`

## Notes

- No behavior changes for existing platforms.
- This only extends prebuilt package coverage.

</p>
</details> 