### PR TITLE
Support hunk-targeted live comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Use it to:
 - inspect the current review context
 - jump to a file, hunk, or line
 - reload the current window with a different `diff` or `show` command
-- add, list, and remove inline comments
+- add, list, and remove inline comments (by hunk or by line)
 
 Most users only need `hunk session ...`. Use `hunk mcp serve` only for manual startup or debugging of the local daemon.
 
@@ -175,6 +175,7 @@ hunk session reload --repo . -- diff
 hunk session reload --repo /path/to/worktree -- diff
 hunk session reload --session-path /path/to/live-window --source /path/to/other-checkout -- diff
 hunk session reload --repo . -- show HEAD~1 -- README.md
+hunk session comment add --repo . --file README.md --hunk 2 --summary "Explain this hunk"
 hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording"
 hunk session comment list --repo .
 hunk session comment rm --repo . <comment-id>

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Use it to:
 - inspect the current review context
 - jump to a file, hunk, or line
 - reload the current window with a different `diff` or `show` command
-- add, list, and remove inline comments (by hunk or by line)
+- add, batch-apply, list, and remove inline comments (by hunk or by line)
 
 Most users only need `hunk session ...`. Use `hunk mcp serve` only for manual startup or debugging of the local daemon.
 
@@ -177,12 +177,16 @@ hunk session reload --session-path /path/to/live-window --source /path/to/other-
 hunk session reload --repo . -- show HEAD~1 -- README.md
 hunk session comment add --repo . --file README.md --hunk 2 --summary "Explain this hunk"
 hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording"
+hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording" --focus
+printf '%s\n' '{"comments":[{"filePath":"README.md","hunk":2,"summary":"Explain this hunk"}]}' | hunk session comment apply --repo . --stdin
+printf '%s\n' '{"comments":[{"filePath":"README.md","hunk":2,"summary":"Explain this hunk"}]}' | hunk session comment apply --repo . --stdin --focus
 hunk session comment list --repo .
 hunk session comment rm --repo . <comment-id>
 hunk session comment clear --repo . --file README.md --yes
 ```
 
 `hunk session reload ... -- <hunk command>` swaps what a live session is showing without opening a new TUI window.
+Pass `--focus` to jump the live session to a new note or the first note in a batch apply.
 
 - `--repo <path>` selects the live session by its current loaded repo root.
 - `--source <path>` is reload-only: it changes where the nested `diff` / `show` command runs, but does not select the session.

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -17,7 +17,8 @@ If no session exists, ask the user to launch Hunk in their terminal first.
 3. hunk session context --repo .        # check current focus
 4. hunk session navigate ...            # move to the right place
 5. hunk session reload -- <command>     # swap contents if needed
-6. hunk session comment add ...         # leave review notes
+6. hunk session comment add ...         # leave one review note
+7. hunk session comment apply ...       # apply many agent notes in one stdin batch
 ```
 
 ## Session selection
@@ -91,16 +92,20 @@ hunk session reload --session-path /path/to/live-window --source /path/to/other-
 ### Comments
 
 ```bash
-hunk session comment add --repo . --file README.md --hunk 2 --summary "Explain the hunk" [--rationale "..."] [--author "agent"] [--no-reveal]
-hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording" [--rationale "..."] [--author "agent"] [--no-reveal]
+hunk session comment add --repo . --file README.md --hunk 2 --summary "Explain the hunk" [--rationale "..."] [--author "agent"] [--focus]
+hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording" [--rationale "..."] [--author "agent"] [--focus]
+printf '%s\n' '{"comments":[{"filePath":"README.md","hunk":2,"summary":"Explain the hunk"}]}' | hunk session comment apply --repo . --stdin [--focus]
 hunk session comment list --repo . [--file README.md]
 hunk session comment rm --repo . <comment-id>
 hunk session comment clear --repo . --yes [--file README.md]
 ```
 
+- `comment add` is best for one note; `comment apply` is best when an agent already has several notes ready
 - `comment add` requires `--file`, `--summary`, and exactly one of `--hunk`, `--old-line`, or `--new-line`
+- `comment apply` payload items require `filePath`, `summary`, and one target such as `hunk`, `oldLine`, or `newLine`
 - Prefer `--hunk <n>` when you want to annotate the whole diff hunk instead of picking a single line manually
-- `comment add` reveals the note by default; pass `--no-reveal` to keep the current focus
+- `comment add` and `comment apply` both keep the current focus by default; pass `--focus` when you want to jump to the new note or the first note in a batch
+- `comment apply` reads a JSON batch from stdin and validates the full batch before mutating the live session
 - `comment list` and `comment clear` accept optional `--file`
 - Quote `--summary` and `--rationale` defensively in the shell
 
@@ -121,13 +126,14 @@ Typical flow:
 1. Load the right content (`reload` if needed)
 2. Navigate to the first interesting file / hunk
 3. Add a comment explaining what's happening and why
-4. Move to the next point of interest -- repeat
+4. If you already have several notes ready, prefer one `comment apply` batch over many separate shell invocations
 5. Summarize when done
 
 Guidelines:
 
 - Work in the order that tells the clearest story, not necessarily file order
 - Navigate before commenting so the user sees the code you're discussing
+- Use `comment apply` for agent-generated batches and `comment add` for one-off notes
 - Keep comments focused: intent, structure, risks, or follow-ups
 - Don't comment on every hunk -- highlight what the user wouldn't spot themselves
 
@@ -140,3 +146,4 @@ Guidelines:
 - **"Pass the replacement Hunk command after `--`"** -- include `--` before the nested `diff` / `show` command.
 - **"Specify exactly one navigation target"** -- pick one of `--hunk`, `--old-line`, or `--new-line`.
 - **"Specify either --next-comment or --prev-comment, not both."** -- choose one comment-navigation direction.
+- **"Pass --stdin to read batch comments from stdin JSON."** -- `comment apply` only reads its batch payload from stdin.

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -91,13 +91,15 @@ hunk session reload --session-path /path/to/live-window --source /path/to/other-
 ### Comments
 
 ```bash
+hunk session comment add --repo . --file README.md --hunk 2 --summary "Explain the hunk" [--rationale "..."] [--author "agent"] [--no-reveal]
 hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording" [--rationale "..."] [--author "agent"] [--no-reveal]
 hunk session comment list --repo . [--file README.md]
 hunk session comment rm --repo . <comment-id>
 hunk session comment clear --repo . --yes [--file README.md]
 ```
 
-- `comment add` requires `--file`, `--summary`, and exactly one of `--old-line` or `--new-line`
+- `comment add` requires `--file`, `--summary`, and exactly one of `--hunk`, `--old-line`, or `--new-line`
+- Prefer `--hunk <n>` when you want to annotate the whole diff hunk instead of picking a single line manually
 - `comment add` reveals the note by default; pass `--no-reveal` to keep the current focus
 - `comment list` and `comment clear` accept optional `--file`
 - Quote `--summary` and `--rationale` defensively in the shell

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -484,7 +484,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
           "  hunk session navigate (<session-id> | --repo <path>) (--next-comment | --prev-comment)",
           "  hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] -- diff [ref] [-- <pathspec...>]",
           "  hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] -- show [ref] [-- <pathspec...>]",
-          "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --summary <text>",
+          "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) --summary <text>",
           "  hunk session comment list (<session-id> | --repo <path>)",
           "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
           "  hunk session comment clear (<session-id> | --repo <path>) --yes",
@@ -728,7 +728,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         text:
           [
             "Usage:",
-            "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --summary <text>",
+            "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) --summary <text>",
             "  hunk session comment list (<session-id> | --repo <path>) [--file <path>]",
             "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
             "  hunk session comment clear (<session-id> | --repo <path>) [--file <path>] --yes",
@@ -743,6 +743,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         .requiredOption("--file <path>", "diff file path as shown by Hunk")
         .requiredOption("--summary <text>", "short review note")
         .option("--repo <path>", "target the live session whose repo root matches this path")
+        .option("--hunk <n>", "1-based hunk number within the file", parsePositiveInt)
         .option("--old-line <n>", "1-based line number on the old side", parsePositiveInt)
         .option("--new-line <n>", "1-based line number on the new side", parsePositiveInt)
         .option("--rationale <text>", "optional longer explanation")
@@ -756,6 +757,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         repo?: string;
         file: string;
         summary: string;
+        hunk?: number;
         oldLine?: number;
         newLine?: number;
         rationale?: string;
@@ -774,6 +776,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
             repo?: string;
             file: string;
             summary: string;
+            hunk?: number;
             oldLine?: number;
             newLine?: number;
             rationale?: string;
@@ -794,11 +797,14 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       await parseStandaloneCommand(command, commentRest);
 
       const selectors = [
+        parsedOptions.hunk !== undefined,
         parsedOptions.oldLine !== undefined,
         parsedOptions.newLine !== undefined,
       ].filter(Boolean);
       if (selectors.length !== 1) {
-        throw new Error("Specify exactly one comment target: --old-line <n> or --new-line <n>.");
+        throw new Error(
+          "Specify exactly one comment target: --hunk <n>, --old-line <n>, or --new-line <n>.",
+        );
       }
 
       return {
@@ -807,8 +813,14 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         output: resolveJsonOutput(parsedOptions),
         selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
         filePath: parsedOptions.file,
-        side: parsedOptions.oldLine !== undefined ? "old" : "new",
-        line: parsedOptions.oldLine ?? parsedOptions.newLine ?? 0,
+        hunkNumber: parsedOptions.hunk,
+        side:
+          parsedOptions.oldLine !== undefined
+            ? "old"
+            : parsedOptions.newLine !== undefined
+              ? "new"
+              : undefined,
+        line: parsedOptions.oldLine ?? parsedOptions.newLine,
         summary: parsedOptions.summary,
         rationale: parsedOptions.rationale,
         author: parsedOptions.author,

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -8,6 +8,7 @@ import type {
   LayoutMode,
   PagerCommandInput,
   ParsedCliInput,
+  SessionCommentApplyItemInput,
 } from "./types";
 import { resolveCliVersion } from "./version";
 
@@ -190,6 +191,94 @@ function createCommand(name: string, description: string) {
 /** Resolve whether one nested CLI command requested JSON output. */
 function resolveJsonOutput(options: { json?: boolean }) {
   return options.json ? "json" : "text";
+}
+
+function parsePositiveJsonInt(
+  value: unknown,
+  { field, itemNumber }: { field: string; itemNumber: number },
+) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`Comment ${itemNumber} field \`${field}\` must be a positive integer.`);
+  }
+
+  return value;
+}
+
+function parseSessionCommentApplyPayload(raw: string): SessionCommentApplyItemInput[] {
+  if (raw.trim().length === 0) {
+    throw new Error("Session comment apply expected one JSON object on stdin.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Session comment apply expected valid JSON on stdin.");
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Session comment apply expected one JSON object with a comments array.");
+  }
+
+  const value = parsed as Record<string, unknown>;
+  if (!Array.isArray(value.comments)) {
+    throw new Error("Session comment apply expected a top-level `comments` array.");
+  }
+
+  return value.comments.map((comment, index) => {
+    const itemNumber = index + 1;
+    if (!comment || typeof comment !== "object") {
+      throw new Error(`Comment ${itemNumber} must be a JSON object.`);
+    }
+
+    const item = comment as Record<string, unknown>;
+    const filePath = item.filePath;
+    if (typeof filePath !== "string" || filePath.length === 0) {
+      throw new Error(`Comment ${itemNumber} requires a non-empty \`filePath\`.`);
+    }
+
+    const summary = item.summary;
+    if (typeof summary !== "string" || summary.length === 0) {
+      throw new Error(`Comment ${itemNumber} requires a non-empty \`summary\`.`);
+    }
+
+    const hunk = parsePositiveJsonInt(item.hunk, { field: "hunk", itemNumber });
+    const hunkNumber = parsePositiveJsonInt(item.hunkNumber, { field: "hunkNumber", itemNumber });
+    if (hunk !== undefined && hunkNumber !== undefined && hunk !== hunkNumber) {
+      throw new Error(
+        `Comment ${itemNumber} must not disagree between \`hunk\` and \`hunkNumber\`.`,
+      );
+    }
+
+    const oldLine = parsePositiveJsonInt(item.oldLine, { field: "oldLine", itemNumber });
+    const newLine = parsePositiveJsonInt(item.newLine, { field: "newLine", itemNumber });
+    const resolvedHunkNumber = hunk ?? hunkNumber;
+
+    const selectors = [
+      resolvedHunkNumber !== undefined,
+      oldLine !== undefined,
+      newLine !== undefined,
+    ].filter(Boolean);
+    if (selectors.length !== 1) {
+      throw new Error(
+        `Comment ${itemNumber} must specify exactly one of \`hunk\`, \`hunkNumber\`, \`oldLine\`, or \`newLine\`.`,
+      );
+    }
+
+    return {
+      filePath,
+      hunkNumber: resolvedHunkNumber,
+      side: oldLine !== undefined ? "old" : newLine !== undefined ? "new" : undefined,
+      line: oldLine ?? newLine,
+      summary,
+      rationale: typeof item.rationale === "string" ? item.rationale : undefined,
+      author: typeof item.author === "string" ? item.author : undefined,
+    };
+  });
 }
 
 /** Normalize one explicit session selector from either session id or repo root. */
@@ -484,7 +573,8 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
           "  hunk session navigate (<session-id> | --repo <path>) (--next-comment | --prev-comment)",
           "  hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] -- diff [ref] [-- <pathspec...>]",
           "  hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] -- show [ref] [-- <pathspec...>]",
-          "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) --summary <text>",
+          "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) --summary <text> [--focus]",
+          "  hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
           "  hunk session comment list (<session-id> | --repo <path>)",
           "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
           "  hunk session comment clear (<session-id> | --repo <path>) --yes",
@@ -728,7 +818,8 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         text:
           [
             "Usage:",
-            "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) --summary <text>",
+            "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) --summary <text> [--focus]",
+            "  hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
             "  hunk session comment list (<session-id> | --repo <path>) [--file <path>]",
             "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
             "  hunk session comment clear (<session-id> | --repo <path>) [--file <path>] --yes",
@@ -748,8 +839,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         .option("--new-line <n>", "1-based line number on the new side", parsePositiveInt)
         .option("--rationale <text>", "optional longer explanation")
         .option("--author <name>", "optional author label")
-        .option("--reveal", "jump to and reveal the note")
-        .option("--no-reveal", "add the note without moving focus")
+        .option("--focus", "add the note and focus the viewport on it")
         .option("--json", "emit structured JSON");
 
       let parsedSessionId: string | undefined;
@@ -762,7 +852,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         newLine?: number;
         rationale?: string;
         author?: string;
-        reveal?: boolean;
+        focus?: boolean;
         json?: boolean;
       } = {
         file: "",
@@ -781,7 +871,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
             newLine?: number;
             rationale?: string;
             author?: string;
-            reveal?: boolean;
+            focus?: boolean;
             json?: boolean;
           },
         ) => {
@@ -824,7 +914,81 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         summary: parsedOptions.summary,
         rationale: parsedOptions.rationale,
         author: parsedOptions.author,
-        reveal: parsedOptions.reveal ?? true,
+        reveal: parsedOptions.focus ?? false,
+      };
+    }
+
+    if (commentSubcommand === "apply") {
+      const command = new Command("session comment apply")
+        .description("apply many live inline review notes from stdin JSON")
+        .argument("[sessionId]")
+        .option("--repo <path>", "target the live session whose repo root matches this path")
+        .option("--stdin", "read the comment batch from stdin as JSON")
+        .option("--focus", "apply the batch and focus the first note")
+        .option("--json", "emit structured JSON");
+
+      let parsedSessionId: string | undefined;
+      let parsedOptions: {
+        repo?: string;
+        stdin?: boolean;
+        focus?: boolean;
+        json?: boolean;
+      } = {};
+
+      command.action(
+        (
+          sessionId: string | undefined,
+          options: {
+            repo?: string;
+            stdin?: boolean;
+            focus?: boolean;
+            json?: boolean;
+          },
+        ) => {
+          parsedSessionId = sessionId;
+          parsedOptions = options;
+        },
+      );
+
+      if (commentRest.includes("--help") || commentRest.includes("-h")) {
+        return {
+          kind: "help",
+          text:
+            `${command.helpInformation().trimEnd()}\n\n` +
+            [
+              "Stdin JSON shape:",
+              "  {",
+              '    "comments": [',
+              "      {",
+              '        "filePath": "README.md",',
+              '        "hunk": 2,',
+              '        "summary": "Explain this hunk",',
+              '        "rationale": "Optional detail",',
+              '        "author": "Pi"',
+              "      }",
+              "    ]",
+              "  }",
+            ].join("\n") +
+            "\n",
+        };
+      }
+
+      await parseStandaloneCommand(command, commentRest);
+      if (!parsedOptions.stdin) {
+        throw new Error("Pass --stdin to read batch comments from stdin JSON.");
+      }
+
+      const comments = parseSessionCommentApplyPayload(
+        await new Response(Bun.stdin.stream()).text(),
+      );
+
+      return {
+        kind: "session",
+        action: "comment-apply",
+        output: resolveJsonOutput(parsedOptions),
+        selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
+        comments,
+        revealMode: parsedOptions.focus ? "first" : "none",
       };
     }
 
@@ -954,7 +1118,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       };
     }
 
-    throw new Error("Supported comment subcommands are add, list, rm, and clear.");
+    throw new Error("Supported comment subcommands are add, apply, list, rm, and clear.");
   }
 
   throw new Error(`Unknown session command: ${subcommand}`);

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -1,6 +1,6 @@
 import type { Hunk } from "@pierre/diffs";
+import type { CommentTargetInput, DiffSide, LiveComment } from "../mcp/types";
 import type { DiffFile } from "./types";
-import type { CommentToolInput, DiffSide, LiveComment } from "../mcp/types";
 
 export interface ResolvedCommentTarget {
   hunkIndex: number;
@@ -83,7 +83,7 @@ export function firstCommentTargetForHunk(hunk: Hunk): Omit<ResolvedCommentTarge
 /** Resolve a line-based or hunk-based live-comment target against one visible diff file. */
 export function resolveCommentTarget(
   file: DiffFile,
-  input: CommentToolInput,
+  input: CommentTargetInput,
 ): ResolvedCommentTarget {
   if (input.hunkIndex !== undefined) {
     const hunk = file.metadata.hunks[input.hunkIndex];
@@ -115,7 +115,7 @@ export function resolveCommentTarget(
 
 /** Convert one incoming MCP comment command into a live annotation. */
 export function buildLiveComment(
-  input: CommentToolInput & { side: DiffSide; line: number },
+  input: CommentTargetInput & { side: DiffSide; line: number },
   commentId: string,
   createdAt: string,
   hunkIndex: number,

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -43,6 +43,7 @@ export function findHunkIndexForLine(file: DiffFile, side: DiffSide, line: numbe
 export function firstCommentTargetForHunk(hunk: Hunk): Omit<ResolvedCommentTarget, "hunkIndex"> {
   let deletionLineNumber = hunk.deletionStart;
   let additionLineNumber = hunk.additionStart;
+  let firstDeletionLine: number | undefined;
 
   for (const content of hunk.hunkContent) {
     if (content.type === "context") {
@@ -58,12 +59,19 @@ export function firstCommentTargetForHunk(hunk: Hunk): Omit<ResolvedCommentTarge
       };
     }
 
-    if (content.deletions > 0) {
-      return {
-        side: "old",
-        line: deletionLineNumber,
-      };
+    if (content.deletions > 0 && firstDeletionLine === undefined) {
+      firstDeletionLine = deletionLineNumber;
     }
+
+    deletionLineNumber += content.deletions;
+    additionLineNumber += content.additions;
+  }
+
+  if (firstDeletionLine !== undefined) {
+    return {
+      side: "old",
+      line: firstDeletionLine,
+    };
   }
 
   const fallbackRange = hunkLineRange(hunk);

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -2,6 +2,12 @@ import type { Hunk } from "@pierre/diffs";
 import type { DiffFile } from "./types";
 import type { CommentToolInput, DiffSide, LiveComment } from "../mcp/types";
 
+export interface ResolvedCommentTarget {
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+}
+
 /** Compute the inclusive old/new line spans touched by one hunk. */
 export function hunkLineRange(hunk: Hunk) {
   const newEnd = Math.max(
@@ -33,9 +39,75 @@ export function findHunkIndexForLine(file: DiffFile, side: DiffSide, line: numbe
   });
 }
 
+/** Pick one stable anchor line inside a hunk, preferring new-side changes when present. */
+export function firstCommentTargetForHunk(hunk: Hunk): Omit<ResolvedCommentTarget, "hunkIndex"> {
+  let deletionLineNumber = hunk.deletionStart;
+  let additionLineNumber = hunk.additionStart;
+
+  for (const content of hunk.hunkContent) {
+    if (content.type === "context") {
+      deletionLineNumber += content.lines;
+      additionLineNumber += content.lines;
+      continue;
+    }
+
+    if (content.additions > 0) {
+      return {
+        side: "new",
+        line: additionLineNumber,
+      };
+    }
+
+    if (content.deletions > 0) {
+      return {
+        side: "old",
+        line: deletionLineNumber,
+      };
+    }
+  }
+
+  const fallbackRange = hunkLineRange(hunk);
+  return hunk.additionLines > 0
+    ? { side: "new", line: fallbackRange.newRange[0] }
+    : { side: "old", line: fallbackRange.oldRange[0] };
+}
+
+/** Resolve a line-based or hunk-based live-comment target against one visible diff file. */
+export function resolveCommentTarget(
+  file: DiffFile,
+  input: CommentToolInput,
+): ResolvedCommentTarget {
+  if (input.hunkIndex !== undefined) {
+    const hunk = file.metadata.hunks[input.hunkIndex];
+    if (!hunk) {
+      throw new Error(`No diff hunk ${input.hunkIndex + 1} exists in ${input.filePath}.`);
+    }
+
+    return {
+      hunkIndex: input.hunkIndex,
+      ...firstCommentTargetForHunk(hunk),
+    };
+  }
+
+  if (!input.side || input.line === undefined) {
+    throw new Error("comment requires either hunkIndex or both side and line.");
+  }
+
+  const hunkIndex = findHunkIndexForLine(file, input.side, input.line);
+  if (hunkIndex < 0) {
+    throw new Error(`No ${input.side} diff hunk in ${input.filePath} covers line ${input.line}.`);
+  }
+
+  return {
+    hunkIndex,
+    side: input.side,
+    line: input.line,
+  };
+}
+
 /** Convert one incoming MCP comment command into a live annotation. */
 export function buildLiveComment(
-  input: CommentToolInput,
+  input: CommentToolInput & { side: DiffSide; line: number },
   commentId: string,
   createdAt: string,
   hunkIndex: number,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -144,6 +144,25 @@ export interface SessionCommentAddCommandInput {
   reveal: boolean;
 }
 
+export interface SessionCommentApplyItemInput {
+  filePath: string;
+  hunkNumber?: number;
+  side?: "old" | "new";
+  line?: number;
+  summary: string;
+  rationale?: string;
+  author?: string;
+}
+
+export interface SessionCommentApplyCommandInput {
+  kind: "session";
+  action: "comment-apply";
+  output: SessionCommandOutput;
+  selector: SessionSelectorInput;
+  comments: SessionCommentApplyItemInput[];
+  revealMode: "none" | "first";
+}
+
 export interface SessionCommentListCommandInput {
   kind: "session";
   action: "comment-list";
@@ -175,6 +194,7 @@ export type SessionCommandInput =
   | SessionNavigateCommandInput
   | SessionReloadCommandInput
   | SessionCommentAddCommandInput
+  | SessionCommentApplyCommandInput
   | SessionCommentListCommandInput
   | SessionCommentRemoveCommandInput
   | SessionCommentClearCommandInput;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -135,8 +135,9 @@ export interface SessionCommentAddCommandInput {
   output: SessionCommandOutput;
   selector: SessionSelectorInput;
   filePath: string;
-  side: "old" | "new";
-  line: number;
+  hunkNumber?: number;
+  side?: "old" | "new";
+  line?: number;
   summary: string;
   rationale?: string;
   author?: string;

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AppliedCommentBatchResult,
   AppliedCommentResult,
   ClearedCommentsResult,
   HunkSessionRegistration,
@@ -25,6 +26,9 @@ interface HunkAppBridge {
   applyComment: (
     message: Extract<SessionServerMessage, { command: "comment" }>,
   ) => Promise<AppliedCommentResult>;
+  applyCommentBatch: (
+    message: Extract<SessionServerMessage, { command: "comment_batch" }>,
+  ) => Promise<AppliedCommentBatchResult>;
   navigateToHunk: (
     message: Extract<SessionServerMessage, { command: "navigate_to_hunk" }>,
   ) => Promise<NavigatedSelectionResult>;
@@ -261,6 +265,8 @@ export class HunkHostClient {
     switch (message.command) {
       case "comment":
         return this.bridge.applyComment(message);
+      case "comment_batch":
+        return this.bridge.applyCommentBatch(message);
       case "navigate_to_hunk":
         return this.bridge.navigateToHunk(message);
       case "reload_session":

--- a/src/mcp/daemonState.ts
+++ b/src/mcp/daemonState.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type {
+  AppliedCommentBatchResult,
   AppliedCommentResult,
   ClearedCommentsResult,
   ClearCommentsToolInput,
+  CommentBatchToolInput,
   CommentToolInput,
   HunkSessionRegistration,
   HunkSessionSnapshot,
@@ -281,6 +283,16 @@ export class HunkDaemonState {
       "comment",
       input,
       "Timed out waiting for the Hunk session to apply the comment.",
+    );
+  }
+
+  sendCommentBatch(input: CommentBatchToolInput) {
+    return this.sendCommand<AppliedCommentBatchResult, "comment_batch">(
+      { sessionId: input.sessionId, sessionPath: input.sessionPath, repoRoot: input.repoRoot },
+      "comment_batch",
+      input,
+      "Timed out waiting for the Hunk session to apply the comment batch.",
+      30_000,
     );
   }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -122,11 +122,19 @@ async function handleSessionApiRequest(state: HunkDaemonState, request: Request)
           }),
         };
         break;
-      case "comment-add":
+      case "comment-add": {
+        if (
+          input.hunkNumber === undefined &&
+          (input.side === undefined || input.line === undefined)
+        ) {
+          throw new Error("comment-add requires either hunkNumber or both side and line.");
+        }
+
         response = {
           result: await state.sendComment({
             ...input.selector,
             filePath: input.filePath,
+            hunkIndex: input.hunkNumber !== undefined ? input.hunkNumber - 1 : undefined,
             side: input.side,
             line: input.line,
             summary: input.summary,
@@ -136,6 +144,7 @@ async function handleSessionApiRequest(state: HunkDaemonState, request: Request)
           }),
         };
         break;
+      }
       case "comment-list":
         response = {
           comments: state.listComments(input.selector, { filePath: input.filePath }),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -22,6 +22,7 @@ const SUPPORTED_SESSION_ACTIONS: SessionDaemonAction[] = [
   "navigate",
   "reload",
   "comment-add",
+  "comment-apply",
   "comment-list",
   "comment-rm",
   "comment-clear",
@@ -145,6 +146,23 @@ async function handleSessionApiRequest(state: HunkDaemonState, request: Request)
         };
         break;
       }
+      case "comment-apply":
+        response = {
+          result: await state.sendCommentBatch({
+            ...input.selector,
+            comments: input.comments.map((comment) => ({
+              filePath: comment.filePath,
+              hunkIndex: comment.hunkNumber !== undefined ? comment.hunkNumber - 1 : undefined,
+              side: comment.side,
+              line: comment.line,
+              summary: comment.summary,
+              rationale: comment.rationale,
+              author: comment.author,
+            })),
+            revealMode: input.revealMode,
+          }),
+        };
+        break;
       case "comment-list":
         response = {
           comments: state.listComments(input.selector, { filePath: input.filePath }),

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -63,15 +63,25 @@ export interface HunkSessionSnapshot {
   updatedAt: string;
 }
 
-export interface CommentToolInput extends SessionTargetInput {
+export interface CommentTargetInput {
   filePath: string;
   hunkIndex?: number;
   side?: DiffSide;
   line?: number;
   summary: string;
   rationale?: string;
-  reveal?: boolean;
   author?: string;
+}
+
+export interface CommentToolInput extends SessionTargetInput, CommentTargetInput {
+  reveal?: boolean;
+}
+
+export interface CommentBatchItemInput extends CommentTargetInput {}
+
+export interface CommentBatchToolInput extends SessionTargetInput {
+  comments: CommentBatchItemInput[];
+  revealMode?: "none" | "first";
 }
 
 export interface NavigateToFileToolInput extends SessionTargetInput {
@@ -124,6 +134,10 @@ export interface AppliedCommentResult {
   line: number;
 }
 
+export interface AppliedCommentBatchResult {
+  applied: AppliedCommentResult[];
+}
+
 export interface NavigatedSelectionResult {
   fileId: string;
   filePath: string;
@@ -172,6 +186,7 @@ export interface SelectedSessionContext {
 
 export type SessionCommandResult =
   | AppliedCommentResult
+  | AppliedCommentBatchResult
   | NavigatedSelectionResult
   | RemovedCommentResult
   | ClearedCommentsResult
@@ -223,6 +238,12 @@ export type SessionServerMessage =
       requestId: string;
       command: "comment";
       input: CommentToolInput;
+    }
+  | {
+      type: "command";
+      requestId: string;
+      command: "comment_batch";
+      input: CommentBatchToolInput;
     }
   | {
       type: "command";

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -65,8 +65,9 @@ export interface HunkSessionSnapshot {
 
 export interface CommentToolInput extends SessionTargetInput {
   filePath: string;
-  side: DiffSide;
-  line: number;
+  hunkIndex?: number;
+  side?: DiffSide;
+  line?: number;
   summary: string;
   rationale?: string;
   reveal?: boolean;

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -176,6 +176,7 @@ class HttpHunkDaemonCliClient implements HunkDaemonCliClient {
         action: "comment-add",
         selector: input.selector,
         filePath: input.filePath,
+        hunkNumber: input.hunkNumber,
         side: input.side,
         line: input.line,
         summary: input.summary,

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -3,6 +3,7 @@ import type {
   SessionCommandInput,
   SessionCommandOutput,
   SessionCommentAddCommandInput,
+  SessionCommentApplyCommandInput,
   SessionCommentClearCommandInput,
   SessionCommentListCommandInput,
   SessionCommentRemoveCommandInput,
@@ -17,6 +18,7 @@ import {
 } from "../mcp/daemonLauncher";
 import { resolveHunkMcpConfig } from "../mcp/config";
 import type {
+  AppliedCommentBatchResult,
   AppliedCommentResult,
   ClearedCommentsResult,
   ListedSession,
@@ -45,6 +47,7 @@ export interface HunkDaemonCliClient {
   navigateToHunk(input: SessionNavigateCommandInput): Promise<NavigatedSelectionResult>;
   reloadSession(input: SessionReloadCommandInput): Promise<ReloadedSessionResult>;
   addComment(input: SessionCommentAddCommandInput): Promise<AppliedCommentResult>;
+  applyComments(input: SessionCommentApplyCommandInput): Promise<AppliedCommentBatchResult>;
   listComments(input: SessionCommentListCommandInput): Promise<SessionLiveCommentSummary[]>;
   removeComment(input: SessionCommentRemoveCommandInput): Promise<RemovedCommentResult>;
   clearComments(input: SessionCommentClearCommandInput): Promise<ClearedCommentsResult>;
@@ -57,6 +60,7 @@ const REQUIRED_ACTION_BY_COMMAND: Record<SessionCommandInput["action"], SessionD
   navigate: "navigate",
   reload: "reload",
   "comment-add": "comment-add",
+  "comment-apply": "comment-apply",
   "comment-list": "comment-list",
   "comment-rm": "comment-rm",
   "comment-clear": "comment-clear",
@@ -183,6 +187,17 @@ class HttpHunkDaemonCliClient implements HunkDaemonCliClient {
         rationale: input.rationale,
         author: input.author,
         reveal: input.reveal,
+      })
+    ).result;
+  }
+
+  async applyComments(input: SessionCommentApplyCommandInput) {
+    return (
+      await this.request<{ result: AppliedCommentBatchResult }>({
+        action: "comment-apply",
+        selector: input.selector,
+        comments: input.comments,
+        revealMode: input.revealMode,
       })
     ).result;
   }
@@ -518,6 +533,24 @@ function formatCommentOutput(selector: SessionSelectorInput, result: AppliedComm
   return `Added live comment ${result.commentId} on ${result.filePath}:${result.line} (${result.side}) in hunk ${result.hunkIndex + 1} for ${formatSelector(selector)}.\n`;
 }
 
+function formatCommentApplyOutput(
+  selector: SessionSelectorInput,
+  result: AppliedCommentBatchResult,
+) {
+  if (result.applied.length === 0) {
+    return `Applied 0 live comments to ${formatSelector(selector)}.\n`;
+  }
+
+  return `${[
+    `Applied ${result.applied.length} live comments to ${formatSelector(selector)}:`,
+    ...result.applied.map(
+      (comment) =>
+        `  - ${comment.commentId} on ${comment.filePath}:${comment.line} (${comment.side}) hunk ${comment.hunkIndex + 1}`,
+    ),
+    "",
+  ].join("\n")}`;
+}
+
 function formatCommentListOutput(
   selector: SessionSelectorInput,
   comments: SessionLiveCommentSummary[],
@@ -639,6 +672,15 @@ export async function runSessionCommand(input: SessionCommandInput) {
       });
       return renderOutput(input.output, { result }, () =>
         formatCommentOutput(input.selector, result),
+      );
+    }
+    case "comment-apply": {
+      const result = await client.applyComments({
+        ...input,
+        selector: normalizedSelector!,
+      });
+      return renderOutput(input.output, { result }, () =>
+        formatCommentApplyOutput(input.selector, result),
       );
     }
     case "comment-list": {

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -69,8 +69,9 @@ export type SessionDaemonRequest =
       action: "comment-add";
       selector: SessionCommentAddCommandInput["selector"];
       filePath: string;
-      side: "old" | "new";
-      line: number;
+      hunkNumber?: number;
+      side?: "old" | "new";
+      line?: number;
       summary: string;
       rationale?: string;
       author?: string;

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -1,5 +1,6 @@
 import type {
   SessionCommentAddCommandInput,
+  SessionCommentApplyCommandInput,
   SessionCommentClearCommandInput,
   SessionCommentListCommandInput,
   SessionCommentRemoveCommandInput,
@@ -8,6 +9,7 @@ import type {
   SessionSelectorInput,
 } from "../core/types";
 import type {
+  AppliedCommentBatchResult,
   AppliedCommentResult,
   ClearedCommentsResult,
   ListedSession,
@@ -29,6 +31,7 @@ export type SessionDaemonAction =
   | "navigate"
   | "reload"
   | "comment-add"
+  | "comment-apply"
   | "comment-list"
   | "comment-rm"
   | "comment-clear";
@@ -78,6 +81,12 @@ export type SessionDaemonRequest =
       reveal: boolean;
     }
   | {
+      action: "comment-apply";
+      selector: SessionCommentApplyCommandInput["selector"];
+      comments: SessionCommentApplyCommandInput["comments"];
+      revealMode: SessionCommentApplyCommandInput["revealMode"];
+    }
+  | {
       action: "comment-list";
       selector: SessionCommentListCommandInput["selector"];
       filePath?: string;
@@ -100,6 +109,7 @@ export type SessionDaemonResponse =
   | { result: NavigatedSelectionResult }
   | { result: ReloadedSessionResult }
   | { result: AppliedCommentResult }
+  | { result: AppliedCommentBatchResult }
   | { comments: SessionLiveCommentSummary[] }
   | { result: RemovedCommentResult }
   | { result: ClearedCommentsResult };

--- a/src/ui/hooks/useHunkSessionBridge.ts
+++ b/src/ui/hooks/useHunkSessionBridge.ts
@@ -5,6 +5,7 @@ import {
   findDiffFileByPath,
   findHunkIndexForLine,
   hunkLineRange,
+  resolveCommentTarget,
 } from "../../core/liveComments";
 import { HunkHostClient } from "../../mcp/client";
 import { filterReviewFiles, mergeFileAnnotationsByFileId } from "../lib/files";
@@ -157,19 +158,18 @@ export function useHunkSessionBridge({
         throw new Error(`No visible diff file matches ${message.input.filePath}.`);
       }
 
-      const hunkIndex = findHunkIndexForLine(file, message.input.side, message.input.line);
-      if (hunkIndex < 0) {
-        throw new Error(
-          `No ${message.input.side} diff hunk in ${message.input.filePath} covers line ${message.input.line}.`,
-        );
-      }
+      const target = resolveCommentTarget(file, message.input);
 
       const commentId = `mcp:${message.requestId}`;
       const liveComment = buildLiveComment(
-        message.input,
+        {
+          ...message.input,
+          side: target.side,
+          line: target.line,
+        },
         commentId,
         new Date().toISOString(),
-        hunkIndex,
+        target.hunkIndex,
       );
 
       setLiveCommentsByFileId((current) => ({
@@ -178,7 +178,7 @@ export function useHunkSessionBridge({
       }));
 
       if (message.input.reveal ?? true) {
-        jumpToFile(file.id, hunkIndex);
+        jumpToFile(file.id, target.hunkIndex);
         openAgentNotes();
       }
 
@@ -186,9 +186,9 @@ export function useHunkSessionBridge({
         commentId,
         fileId: file.id,
         filePath: file.path,
-        hunkIndex,
-        side: message.input.side,
-        line: message.input.line,
+        hunkIndex: target.hunkIndex,
+        side: target.side,
+        line: target.line,
       };
     },
     [files, jumpToFile, openAgentNotes],

--- a/src/ui/hooks/useHunkSessionBridge.ts
+++ b/src/ui/hooks/useHunkSessionBridge.ts
@@ -11,6 +11,7 @@ import { HunkHostClient } from "../../mcp/client";
 import { filterReviewFiles, mergeFileAnnotationsByFileId } from "../lib/files";
 import { buildAnnotatedHunkCursors, findNextHunkCursor } from "../lib/hunks";
 import type {
+  AppliedCommentBatchResult,
   LiveComment,
   ReloadedSessionResult,
   SessionLiveCommentSummary,
@@ -194,6 +195,62 @@ export function useHunkSessionBridge({
     [files, jumpToFile, openAgentNotes],
   );
 
+  const applyIncomingCommentBatch = useCallback(
+    async (
+      message: Extract<SessionServerMessage, { command: "comment_batch" }>,
+    ): Promise<AppliedCommentBatchResult> => {
+      const createdAt = new Date().toISOString();
+      const prepared = message.input.comments.map((input, index) => {
+        const file = findDiffFileByPath(files, input.filePath);
+        if (!file) {
+          throw new Error(`No visible diff file matches ${input.filePath}.`);
+        }
+
+        const target = resolveCommentTarget(file, input);
+        return {
+          file,
+          target,
+          liveComment: buildLiveComment(
+            {
+              ...input,
+              side: target.side,
+              line: target.line,
+            },
+            `mcp:${message.requestId}:${index}`,
+            createdAt,
+            target.hunkIndex,
+          ),
+        };
+      });
+
+      setLiveCommentsByFileId((current) => {
+        const next = { ...current };
+        for (const entry of prepared) {
+          next[entry.file.id] = [...(next[entry.file.id] ?? []), entry.liveComment];
+        }
+        return next;
+      });
+
+      if (message.input.revealMode === "first" && prepared.length > 0) {
+        const first = prepared[0]!;
+        jumpToFile(first.file.id, first.target.hunkIndex);
+        openAgentNotes();
+      }
+
+      return {
+        applied: prepared.map(({ file, target, liveComment }) => ({
+          commentId: liveComment.id,
+          fileId: file.id,
+          filePath: file.path,
+          hunkIndex: target.hunkIndex,
+          side: target.side,
+          line: target.line,
+        })),
+      };
+    },
+    [files, jumpToFile, openAgentNotes],
+  );
+
   useEffect(() => {
     liveCommentsByFileIdRef.current = liveCommentsByFileId;
   }, [liveCommentsByFileId]);
@@ -286,6 +343,7 @@ export function useHunkSessionBridge({
 
     hostClient.setBridge({
       applyComment: applyIncomingComment,
+      applyCommentBatch: applyIncomingCommentBatch,
       navigateToHunk: navigateToHunkSelection,
       reloadSession: reloadIncomingSession,
       removeComment: removeIncomingComment,
@@ -297,6 +355,7 @@ export function useHunkSessionBridge({
     };
   }, [
     applyIncomingComment,
+    applyIncomingCommentBatch,
     clearIncomingComments,
     hostClient,
     navigateToHunkSelection,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -342,6 +342,39 @@ describe("parseCli", () => {
     });
   });
 
+  test("parses session comment add by hunk number", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "comment",
+      "add",
+      "session-1",
+      "--file",
+      "README.md",
+      "--hunk",
+      "2",
+      "--summary",
+      "Anchor this note to the whole hunk",
+      "--json",
+    ]);
+
+    expect(parsed).toEqual({
+      kind: "session",
+      action: "comment-add",
+      selector: { sessionId: "session-1" },
+      filePath: "README.md",
+      hunkNumber: 2,
+      side: undefined,
+      line: undefined,
+      summary: "Anchor this note to the whole hunk",
+      rationale: undefined,
+      author: undefined,
+      reveal: true,
+      output: "json",
+    });
+  });
+
   test("parses session comment list with file filter", async () => {
     const parsed = await parseCli([
       "bun",
@@ -489,6 +522,27 @@ describe("parseCli", () => {
         "103",
       ]),
     ).rejects.toThrow("Specify exactly one navigation target");
+  });
+
+  test("rejects session comment add with multiple target selectors", async () => {
+    await expect(
+      parseCli([
+        "bun",
+        "hunk",
+        "session",
+        "comment",
+        "add",
+        "session-1",
+        "--file",
+        "README.md",
+        "--hunk",
+        "2",
+        "--new-line",
+        "103",
+        "--summary",
+        "Too many targets",
+      ]),
+    ).rejects.toThrow("Specify exactly one comment target");
   });
 
   test("rejects session comment clear without confirmation", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -306,7 +306,7 @@ describe("parseCli", () => {
     ).rejects.toThrow("Pass the replacement Hunk command after `--`");
   });
 
-  test("parses session comment add", async () => {
+  test("parses session comment add without focusing by default", async () => {
     const parsed = await parseCli([
       "bun",
       "hunk",
@@ -324,7 +324,6 @@ describe("parseCli", () => {
       "Live review is the main value.",
       "--author",
       "Pi",
-      "--no-reveal",
     ]);
 
     expect(parsed).toEqual({
@@ -370,9 +369,85 @@ describe("parseCli", () => {
       summary: "Anchor this note to the whole hunk",
       rationale: undefined,
       author: undefined,
-      reveal: true,
+      reveal: false,
       output: "json",
     });
+  });
+
+  test("parses session comment add with --focus", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "comment",
+      "add",
+      "session-1",
+      "--file",
+      "README.md",
+      "--new-line",
+      "103",
+      "--summary",
+      "Frame this as MCP-first",
+      "--focus",
+    ]);
+
+    expect(parsed).toEqual({
+      kind: "session",
+      action: "comment-add",
+      selector: { sessionId: "session-1" },
+      filePath: "README.md",
+      side: "new",
+      line: 103,
+      summary: "Frame this as MCP-first",
+      reveal: true,
+      output: "text",
+    });
+  });
+
+  test("parses session comment apply with --focus", async () => {
+    const originalStdin = Bun.stdin.stream;
+    Bun.stdin.stream = () =>
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              '{"comments":[{"filePath":"README.md","hunk":2,"summary":"Explain this hunk"}]}',
+            ),
+          );
+          controller.close();
+        },
+      });
+
+    try {
+      const parsed = await parseCli([
+        "bun",
+        "hunk",
+        "session",
+        "comment",
+        "apply",
+        "session-1",
+        "--stdin",
+        "--focus",
+        "--json",
+      ]);
+
+      expect(parsed).toEqual({
+        kind: "session",
+        action: "comment-apply",
+        selector: { sessionId: "session-1" },
+        comments: [
+          {
+            filePath: "README.md",
+            hunkNumber: 2,
+            summary: "Explain this hunk",
+          },
+        ],
+        revealMode: "first",
+        output: "json",
+      });
+    } finally {
+      Bun.stdin.stream = originalStdin;
+    }
   });
 
   test("parses session comment list with file filter", async () => {

--- a/test/help-output.test.ts
+++ b/test/help-output.test.ts
@@ -70,6 +70,28 @@ describe("CLI help output", () => {
     expect(stdout).not.toContain("\u001b[?1049h");
   });
 
+  test("prints session comment apply help with --focus wording", () => {
+    const proc = Bun.spawnSync(
+      ["bun", "run", "src/main.tsx", "session", "comment", "apply", "--help"],
+      {
+        cwd: process.cwd(),
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const stdout = Buffer.from(proc.stdout).toString("utf8");
+    const stderr = Buffer.from(proc.stderr).toString("utf8");
+
+    expect(proc.exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Usage: session comment apply");
+    expect(stdout).toContain("--focus");
+    expect(stdout).not.toContain("--reveal-last");
+    expect(stdout).not.toContain("\u001b[?1049h");
+  });
+
   test("prints the package version for --version without terminal takeover sequences", () => {
     const expectedVersion = require("../package.json").version;
     const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "--version"], {

--- a/test/live-comments.test.ts
+++ b/test/live-comments.test.ts
@@ -4,6 +4,7 @@ import {
   buildLiveComment,
   findDiffFileByPath,
   findHunkIndexForLine,
+  firstCommentTargetForHunk,
   hunkLineRange,
   resolveCommentTarget,
 } from "../src/core/liveComments";
@@ -122,6 +123,25 @@ describe("live comment helpers", () => {
       hunkIndex: 0,
       side: "new",
       line: 10,
+    });
+  });
+
+  test("prefers a later addition over an earlier deletion-only chunk", () => {
+    const target = firstCommentTargetForHunk({
+      additionStart: 20,
+      additionLines: 1,
+      deletionStart: 20,
+      deletionLines: 1,
+      hunkContent: [
+        { type: "change", deletions: 1, additions: 0 },
+        { type: "context", lines: 2 },
+        { type: "change", deletions: 0, additions: 1 },
+      ],
+    } as Parameters<typeof firstCommentTargetForHunk>[0]);
+
+    expect(target).toEqual({
+      side: "new",
+      line: 22,
     });
   });
 

--- a/test/live-comments.test.ts
+++ b/test/live-comments.test.ts
@@ -5,6 +5,7 @@ import {
   findDiffFileByPath,
   findHunkIndexForLine,
   hunkLineRange,
+  resolveCommentTarget,
 } from "../src/core/liveComments";
 import type { DiffFile } from "../src/core/types";
 
@@ -58,6 +59,40 @@ function createDiffFile(): DiffFile {
   };
 }
 
+function createLateChangeDiffFile(): DiffFile {
+  const beforeLines = Array.from(
+    { length: 10 },
+    (_, index) => `export const line${index + 1} = ${index + 1};`,
+  );
+  const afterLines = [...beforeLines];
+  afterLines[9] = "export const line10 = 100;";
+
+  const metadata = parseDiffFromFile(
+    {
+      name: "src/late.ts",
+      contents: `${beforeLines.join("\n")}\n`,
+      cacheKey: "late-before",
+    },
+    {
+      name: "src/late.ts",
+      contents: `${afterLines.join("\n")}\n`,
+      cacheKey: "late-after",
+    },
+    { context: 3 },
+    true,
+  );
+
+  return {
+    id: "file:late",
+    path: "src/late.ts",
+    patch: "",
+    language: "typescript",
+    stats: { additions: 1, deletions: 1 },
+    metadata,
+    agent: null,
+  };
+}
+
 describe("live comment helpers", () => {
   test("finds a diff file by current or previous path", () => {
     const file = createDiffFile();
@@ -73,6 +108,21 @@ describe("live comment helpers", () => {
     expect(findHunkIndexForLine(file, "old", 1)).toBe(0);
     expect(findHunkIndexForLine(file, "new", 2)).toBe(0);
     expect(findHunkIndexForLine(file, "new", 40)).toBe(-1);
+  });
+
+  test("resolves hunk-targeted comments to the first changed line on the preferred side", () => {
+    const file = createLateChangeDiffFile();
+    const target = resolveCommentTarget(file, {
+      filePath: "src/late.ts",
+      hunkIndex: 0,
+      summary: "Late change",
+    });
+
+    expect(target).toEqual({
+      hunkIndex: 0,
+      side: "new",
+      line: 10,
+    });
   });
 
   test("builds a live MCP comment annotation", () => {

--- a/test/mcp-daemon.test.ts
+++ b/test/mcp-daemon.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { HunkDaemonState, resolveSessionTarget } from "../src/mcp/daemonState";
 import type {
+  AppliedCommentBatchResult,
   AppliedCommentResult,
   ClearedCommentsResult,
   HunkSessionRegistration,
@@ -233,6 +234,71 @@ describe("Hunk MCP daemon state", () => {
       hunkIndex: 0,
       side: "new",
       line: 4,
+    };
+
+    state.handleCommandResult({
+      requestId: outgoing.requestId,
+      ok: true,
+      result,
+    });
+
+    await expect(pending).resolves.toEqual(result);
+  });
+
+  test("routes comment-batch commands to the live session and resolves the async result", async () => {
+    const state = new HunkDaemonState();
+    const sent: string[] = [];
+    const socket = {
+      send(data: string) {
+        sent.push(data);
+      },
+    };
+
+    state.registerSession(socket, createRegistration(), createSnapshot());
+
+    const pending = state.sendCommentBatch({
+      sessionId: "session-1",
+      comments: [
+        {
+          filePath: "src/example.ts",
+          hunkIndex: 0,
+          summary: "Review note 1",
+        },
+        {
+          filePath: "src/example.ts",
+          hunkIndex: 0,
+          summary: "Review note 2",
+        },
+      ],
+      revealMode: "none",
+    });
+
+    expect(sent).toHaveLength(1);
+    const outgoing = JSON.parse(sent[0]!) as {
+      requestId: string;
+      command: string;
+    };
+    expect(outgoing.command).toBe("comment_batch");
+
+    const result: AppliedCommentBatchResult = {
+      applied: [
+        {
+          commentId: "comment-1",
+          fileId: "file-1",
+          filePath: "src/example.ts",
+          hunkIndex: 0,
+          side: "new",
+          line: 4,
+        },
+        {
+          commentId: "comment-2",
+          fileId: "file-1",
+          filePath: "src/example.ts",
+          hunkIndex: 0,
+          side: "new",
+          line: 9,
+        },
+      ],
     };
 
     state.handleCommandResult({

--- a/test/mcp-e2e.test.ts
+++ b/test/mcp-e2e.test.ts
@@ -131,6 +131,19 @@ function runSessionCli(args: string[], port: number) {
   return { proc, stdout, stderr };
 }
 
+async function reserveLoopbackPort() {
+  const listener = createServer(() => undefined);
+  await new Promise<void>((resolve, reject) => {
+    listener.once("error", reject);
+    listener.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = listener.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve) => listener.close(() => resolve()));
+  return port;
+}
+
 async function waitUntil<T>(
   label: string,
   fn: () => Promise<T | null> | T | null,
@@ -183,7 +196,7 @@ describe("live session end-to-end", () => {
       ["export const alpha = 1;", "export const keep = true;"],
       ["export const alpha = 2;", "export const keep = true;", "export const gamma = true;"],
     );
-    const port = 48000 + Math.floor(Math.random() * 1000);
+    const port = await reserveLoopbackPort();
     const hunkProc = spawnHunkSession(fixture, { port });
 
     let daemonPid: number | null = null;
@@ -221,6 +234,7 @@ describe("live session end-to-end", () => {
           "Injected after the Hunk session auto-started the local daemon.",
           "--author",
           "Pi",
+          "--focus",
           "--json",
         ],
         port,
@@ -286,7 +300,7 @@ describe("live session end-to-end", () => {
         "export const line10 = 110;",
       ],
     );
-    const port = 48500 + Math.floor(Math.random() * 1000);
+    const port = await reserveLoopbackPort();
     const hunkProc = spawnHunkSession(fixture, { port, quitAfterSeconds: 14, timeoutSeconds: 16 });
 
     let daemonPid: number | null = null;
@@ -377,7 +391,7 @@ describe("live session end-to-end", () => {
       ["export const beta = 1;", "export const shared = true;"],
       ["export const beta = 2;", "export const shared = true;", "export const onlyBeta = true;"],
     );
-    const port = 49000 + Math.floor(Math.random() * 1000);
+    const port = await reserveLoopbackPort();
     const hunkProcA = spawnHunkSession(fixtureA, {
       port,
       quitAfterSeconds: 10,
@@ -428,6 +442,7 @@ describe("live session end-to-end", () => {
           "Alpha note",
           "--rationale",
           "Delivered only to the alpha Hunk session.",
+          "--focus",
         ],
         port,
       );
@@ -446,6 +461,7 @@ describe("live session end-to-end", () => {
           "Beta note",
           "--rationale",
           "Delivered only to the beta Hunk session.",
+          "--focus",
         ],
         port,
       );

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -214,6 +214,7 @@ describe("Hunk session daemon server", () => {
           "navigate",
           "reload",
           "comment-add",
+          "comment-apply",
           "comment-list",
           "comment-rm",
           "comment-clear",
@@ -421,6 +422,100 @@ describe("Hunk session daemon server", () => {
       });
     } finally {
       HunkDaemonState.prototype.sendComment = original;
+      server.stop(true);
+    }
+  });
+
+  test("forwards comment batches through the session API", async () => {
+    const port = await reserveLoopbackPort();
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    const original = HunkDaemonState.prototype.sendCommentBatch;
+    HunkDaemonState.prototype.sendCommentBatch = function (input) {
+      expect(input).toMatchObject({
+        sessionId: "session-1",
+        revealMode: "none",
+        comments: [
+          {
+            filePath: "src/example.ts",
+            hunkIndex: 0,
+            summary: "First",
+            author: "Pi",
+          },
+          {
+            filePath: "src/example.ts",
+            hunkIndex: 1,
+            summary: "Second",
+            rationale: "Applied together.",
+            author: "Pi",
+          },
+        ],
+      });
+
+      return Promise.resolve({
+        applied: [
+          {
+            commentId: "comment-1",
+            fileId: "file-1",
+            filePath: "src/example.ts",
+            hunkIndex: 0,
+            side: "new",
+            line: 2,
+          },
+          {
+            commentId: "comment-2",
+            fileId: "file-1",
+            filePath: "src/example.ts",
+            hunkIndex: 1,
+            side: "new",
+            line: 13,
+          },
+        ],
+      });
+    };
+
+    const server = serveHunkMcpServer();
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/session-api`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "comment-apply",
+          selector: { sessionId: "session-1" },
+          revealMode: "none",
+          comments: [
+            {
+              filePath: "src/example.ts",
+              hunkNumber: 1,
+              summary: "First",
+              author: "Pi",
+            },
+            {
+              filePath: "src/example.ts",
+              hunkNumber: 2,
+              summary: "Second",
+              rationale: "Applied together.",
+              author: "Pi",
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        result: {
+          applied: [
+            { commentId: "comment-1", hunkIndex: 0, side: "new", line: 2 },
+            { commentId: "comment-2", hunkIndex: 1, side: "new", line: 13 },
+          ],
+        },
+      });
+    } finally {
+      HunkDaemonState.prototype.sendCommentBatch = original;
       server.stop(true);
     }
   });

--- a/test/mcp-server.test.ts
+++ b/test/mcp-server.test.ts
@@ -362,4 +362,66 @@ describe("Hunk session daemon server", () => {
       server.stop(true);
     }
   });
+
+  test("forwards hunk-targeted comment requests through the session API", async () => {
+    const port = await reserveLoopbackPort();
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    const original = HunkDaemonState.prototype.sendComment;
+    HunkDaemonState.prototype.sendComment = function (input) {
+      expect(input).toMatchObject({
+        sessionId: "session-1",
+        filePath: "src/example.ts",
+        hunkIndex: 1,
+        summary: "Whole-hunk note",
+        author: "Pi",
+        reveal: false,
+      });
+      expect(input.side).toBeUndefined();
+      expect(input.line).toBeUndefined();
+
+      return Promise.resolve({
+        commentId: "comment-1",
+        fileId: "file-1",
+        filePath: "src/example.ts",
+        hunkIndex: 1,
+        side: "new",
+        line: 13,
+      });
+    };
+
+    const server = serveHunkMcpServer();
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/session-api`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "comment-add",
+          selector: { sessionId: "session-1" },
+          filePath: "src/example.ts",
+          hunkNumber: 2,
+          summary: "Whole-hunk note",
+          author: "Pi",
+          reveal: false,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        result: {
+          commentId: "comment-1",
+          hunkIndex: 1,
+          side: "new",
+          line: 13,
+        },
+      });
+    } finally {
+      HunkDaemonState.prototype.sendComment = original;
+      server.stop(true);
+    }
+  });
 });

--- a/test/session-cli.test.ts
+++ b/test/session-cli.test.ts
@@ -80,8 +80,8 @@ function spawnHunkSession(
   fixture: ReturnType<typeof createFixtureFiles>,
   {
     port,
-    quitAfterSeconds = 8,
-    timeoutSeconds = 10,
+    quitAfterSeconds = 12,
+    timeoutSeconds = 15,
   }: {
     port: number;
     quitAfterSeconds?: number;
@@ -347,8 +347,8 @@ describe("session CLI", () => {
           sessionId,
           "--file",
           fixture.afterName,
-          "--new-line",
-          "10",
+          "--hunk",
+          "2",
           "--summary",
           "Second hunk note",
           "--rationale",
@@ -375,7 +375,7 @@ describe("session CLI", () => {
           filePath: fixture.afterName,
           hunkIndex: 1,
           side: "new",
-          line: 10,
+          line: 13,
         },
       });
 

--- a/test/session-cli.test.ts
+++ b/test/session-cli.test.ts
@@ -107,10 +107,10 @@ function spawnHunkSession(
   });
 }
 
-function runSessionCli(args: string[], port: number) {
+function runSessionCli(args: string[], port: number, stdinText?: string) {
   const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "session", ...args], {
     cwd: repoRoot,
-    stdin: "ignore",
+    stdin: stdinText === undefined ? "ignore" : Buffer.from(stdinText),
     stdout: "pipe",
     stderr: "pipe",
     env: {
@@ -380,6 +380,252 @@ describe("session CLI", () => {
       });
 
       expect(typeof addedComment.result?.commentId).toBe("string");
+    } finally {
+      session.kill();
+      await session.exited;
+    }
+  }, 20_000);
+
+  test("comment apply adds a batch from stdin without moving focus by default", async () => {
+    if (!ttyToolsAvailable) {
+      return;
+    }
+
+    const port = 48964;
+    const fixture = createFixtureFiles(
+      "apply-batch",
+      [
+        "export const one = 1;",
+        "export const two = 2;",
+        "export const three = 3;",
+        "export const four = 4;",
+        "export const five = 5;",
+        "export const six = 6;",
+        "export const seven = 7;",
+        "export const eight = 8;",
+        "export const nine = 9;",
+        "export const ten = 10;",
+        "export const eleven = 11;",
+        "export const twelve = 12;",
+        "export const thirteen = 13;",
+      ],
+      [
+        "export const one = 1;",
+        "export const two = 20;",
+        "export const three = 3;",
+        "export const four = 4;",
+        "export const five = 5;",
+        "export const six = 6;",
+        "export const seven = 7;",
+        "export const eight = 8;",
+        "export const nine = 9;",
+        "export const ten = 10;",
+        "export const eleven = 11;",
+        "export const twelve = 12;",
+        "export const thirteen = 130;",
+      ],
+    );
+    const session = spawnHunkSession(fixture, { port, quitAfterSeconds: 18, timeoutSeconds: 20 });
+
+    try {
+      const listed = await waitUntil("registered live session", () => {
+        const { proc, stdout } = runSessionCli(["list", "--json"], port);
+        if (proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(stdout) as SessionListJson;
+        return parsed.sessions.length > 0 ? parsed.sessions : null;
+      });
+
+      const sessionId = listed[0]!.sessionId;
+      const apply = runSessionCli(
+        ["comment", "apply", sessionId, "--stdin", "--json"],
+        port,
+        JSON.stringify({
+          comments: [
+            {
+              filePath: fixture.afterName,
+              hunk: 1,
+              summary: "First hunk note",
+              author: "Pi",
+            },
+            {
+              filePath: fixture.afterName,
+              hunk: 2,
+              summary: "Second hunk note",
+              rationale: "Applied in one batch.",
+              author: "Pi",
+            },
+          ],
+        }),
+      );
+
+      expect(apply.proc.exitCode).toBe(0);
+      expect(apply.stderr).toBe("");
+      const applied = JSON.parse(apply.stdout) as {
+        result?: {
+          applied?: Array<{
+            filePath?: string;
+            hunkIndex?: number;
+            side?: string;
+            line?: number;
+          }>;
+        };
+      };
+      expect(applied).toMatchObject({
+        result: {
+          applied: [
+            {
+              filePath: fixture.afterName,
+              hunkIndex: 0,
+              side: "new",
+              line: 2,
+            },
+            {
+              filePath: fixture.afterName,
+              hunkIndex: 1,
+              side: "new",
+              line: 13,
+            },
+          ],
+        },
+      });
+
+      const context = runSessionCli(["context", sessionId, "--json"], port);
+      expect(context.proc.exitCode).toBe(0);
+      expect(JSON.parse(context.stdout)).toMatchObject({
+        context: {
+          selectedHunk: {
+            index: 0,
+          },
+        },
+      });
+
+      const comments = runSessionCli(["comment", "list", sessionId, "--json"], port);
+      expect(comments.proc.exitCode).toBe(0);
+      expect(JSON.parse(comments.stdout)).toMatchObject({
+        comments: [{ summary: "First hunk note" }, { summary: "Second hunk note" }],
+      });
+    } finally {
+      session.kill();
+      await session.exited;
+    }
+  }, 20_000);
+
+  test("comment apply with --focus jumps to the first applied comment", async () => {
+    if (!ttyToolsAvailable) {
+      return;
+    }
+
+    const port = 48965;
+    const fixture = createFixtureFiles(
+      "apply-batch-focus",
+      [
+        "export const one = 1;",
+        "export const two = 2;",
+        "export const three = 3;",
+        "export const four = 4;",
+        "export const five = 5;",
+        "export const six = 6;",
+        "export const seven = 7;",
+        "export const eight = 8;",
+        "export const nine = 9;",
+        "export const ten = 10;",
+        "export const eleven = 11;",
+        "export const twelve = 12;",
+        "export const thirteen = 13;",
+      ],
+      [
+        "export const one = 1;",
+        "export const two = 20;",
+        "export const three = 3;",
+        "export const four = 4;",
+        "export const five = 5;",
+        "export const six = 6;",
+        "export const seven = 7;",
+        "export const eight = 8;",
+        "export const nine = 9;",
+        "export const ten = 10;",
+        "export const eleven = 11;",
+        "export const twelve = 12;",
+        "export const thirteen = 130;",
+      ],
+    );
+    const session = spawnHunkSession(fixture, { port, quitAfterSeconds: 18, timeoutSeconds: 20 });
+
+    try {
+      const listed = await waitUntil("registered live session", () => {
+        const { proc, stdout } = runSessionCli(["list", "--json"], port);
+        if (proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(stdout) as SessionListJson;
+        return parsed.sessions.length > 0 ? parsed.sessions : null;
+      });
+
+      const sessionId = listed[0]!.sessionId;
+      const navigate = runSessionCli(
+        ["navigate", sessionId, "--file", fixture.afterName, "--hunk", "2", "--json"],
+        port,
+      );
+      expect(navigate.proc.exitCode).toBe(0);
+
+      await waitUntil("second hunk selection", () => {
+        const context = runSessionCli(["context", sessionId, "--json"], port);
+        if (context.proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(context.stdout) as {
+          context?: { selectedHunk?: { index: number } };
+        };
+        return parsed.context?.selectedHunk?.index === 1 ? parsed : null;
+      });
+
+      const apply = runSessionCli(
+        ["comment", "apply", sessionId, "--stdin", "--focus", "--json"],
+        port,
+        JSON.stringify({
+          comments: [
+            {
+              filePath: fixture.afterName,
+              hunk: 1,
+              summary: "First hunk note",
+              author: "Pi",
+            },
+            {
+              filePath: fixture.afterName,
+              hunk: 2,
+              summary: "Second hunk note",
+              author: "Pi",
+            },
+          ],
+        }),
+      );
+      expect(apply.proc.exitCode).toBe(0);
+      expect(apply.stderr).toBe("");
+
+      const focused = await waitUntil("first hunk selection after focused batch apply", () => {
+        const context = runSessionCli(["context", sessionId, "--json"], port);
+        if (context.proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(context.stdout) as {
+          context?: { selectedHunk?: { index: number } };
+        };
+        return parsed.context?.selectedHunk?.index === 0 ? parsed : null;
+      });
+
+      expect(focused).toMatchObject({
+        context: {
+          selectedHunk: {
+            index: 0,
+          },
+        },
+      });
     } finally {
       session.kill();
       await session.exited;

--- a/test/session-commands.test.ts
+++ b/test/session-commands.test.ts
@@ -52,6 +52,7 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
         "navigate",
         "reload",
         "comment-add",
+        "comment-apply",
         "comment-list",
         "comment-rm",
         "comment-clear",
@@ -101,6 +102,18 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
       hunkIndex: 0,
       side: "new",
       line: 1,
+    }),
+    applyComments: async () => ({
+      applied: [
+        {
+          commentId: "comment-1",
+          fileId: "file-1",
+          filePath: "README.md",
+          hunkIndex: 0,
+          side: "new",
+          line: 1,
+        },
+      ],
     }),
     listComments: async () => [],
     removeComment: async () => ({
@@ -255,6 +268,99 @@ describe("session command compatibility checks", () => {
     });
   });
 
+  test("runs comment-apply through the daemon and returns the applied batch", async () => {
+    setSessionCommandTestHooks({
+      createClient: () =>
+        createClient({
+          applyComments: async (input) => {
+            expect(input.selector).toEqual({ sessionId: "session-1" });
+            expect(input.revealMode).toBe("none");
+            expect(input.comments).toEqual([
+              {
+                filePath: "README.md",
+                hunkNumber: 2,
+                summary: "Explain this hunk",
+                author: "Pi",
+              },
+              {
+                filePath: "README.md",
+                side: "new",
+                line: 103,
+                summary: "Tighten this wording",
+              },
+            ]);
+
+            return {
+              applied: [
+                {
+                  commentId: "comment-1",
+                  fileId: "file-1",
+                  filePath: "README.md",
+                  hunkIndex: 1,
+                  side: "new",
+                  line: 12,
+                },
+                {
+                  commentId: "comment-2",
+                  fileId: "file-1",
+                  filePath: "README.md",
+                  hunkIndex: 1,
+                  side: "new",
+                  line: 103,
+                },
+              ],
+            };
+          },
+        }),
+      resolveDaemonAvailability: async () => true,
+    });
+
+    const output = await runSessionCommand({
+      kind: "session",
+      action: "comment-apply",
+      selector: { sessionId: "session-1" },
+      comments: [
+        {
+          filePath: "README.md",
+          hunkNumber: 2,
+          summary: "Explain this hunk",
+          author: "Pi",
+        },
+        {
+          filePath: "README.md",
+          side: "new",
+          line: 103,
+          summary: "Tighten this wording",
+        },
+      ],
+      revealMode: "none",
+      output: "json",
+    } satisfies SessionCommandInput);
+
+    expect(JSON.parse(output)).toEqual({
+      result: {
+        applied: [
+          {
+            commentId: "comment-1",
+            fileId: "file-1",
+            filePath: "README.md",
+            hunkIndex: 1,
+            side: "new",
+            line: 12,
+          },
+          {
+            commentId: "comment-2",
+            fileId: "file-1",
+            filePath: "README.md",
+            hunkIndex: 1,
+            side: "new",
+            line: 103,
+          },
+        ],
+      },
+    });
+  });
+
   test("passes a separate source path through reload commands", async () => {
     setSessionCommandTestHooks({
       createClient: () =>
@@ -323,6 +429,7 @@ describe("session command compatibility checks", () => {
               "navigate",
               "reload",
               "comment-add",
+              "comment-apply",
               "comment-list",
               "comment-rm",
               "comment-clear",


### PR DESCRIPTION
## Summary
- allow `hunk session comment add` to target a hunk directly with `--hunk <n>`
- resolve hunk-targeted comments to the first changed line on a stable side inside the live session
- update the repo skill and docs so agents know they can annotate whole hunks without hand-picking a line number

## Testing
- `bun run typecheck`
- `bun test`

Part of #158.

*This PR description was generated by Pi using OpenAI o3*
