### PR TITLE
docs(readme): tighten the agent quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Load the Hunk skill and use it for this review.
 ```
 
 > [!NOTE]
-> `hunk skill path` is coming in Hunk 0.10.0. That release is not out yet. Once it ships, it will print the absolute path to the installed skill file so you can load or symlink it from your agent setup.
+> `hunk skill path` lands in Hunk 0.10.0. Until that release is out, load the skill from the repo path above.
 
 For the full live-session and `--agent-context` workflow guide, see [docs/agent-workflows.md](docs/agent-workflows.md).
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,20 @@ git diff --no-color | hunk patch -          # review a patch from stdin
 
 ### Working with agents
 
-Load the [`skills/hunk-review/SKILL.md`](skills/hunk-review/SKILL.md) skill in your coding agent (e.g. Claude, Codex, Opencode, Pi).
+1. Load the Hunk review skill: [`skills/hunk-review/SKILL.md`](skills/hunk-review/SKILL.md).
+2. Open Hunk in another terminal with `hunk diff` or `hunk show`.
+3. Ask your agent to use the skill against the live Hunk session.
 
-You can get the absolute path to the skill file from your local install by running `hunk skill path`. Prefer loading or symlinking that file in your agent instead of copying it so Hunk upgrades stay in sync automatically.
+A good generic prompt is:
 
-Open Hunk in another window, then ask your agent to leave comments. For the full live-session and `--agent-context` workflow guide, see [docs/agent-workflows.md](docs/agent-workflows.md).
+```text
+Load the Hunk skill and use it for this review.
+```
+
+> [!NOTE]
+> `hunk skill path` is coming in Hunk 0.10.0. That release is not out yet. Once it ships, it will print the absolute path to the installed skill file so you can load or symlink it from your agent setup.
+
+For the full live-session and `--agent-context` workflow guide, see [docs/agent-workflows.md](docs/agent-workflows.md).
 
 ## Feature comparison
 
@@ -135,27 +144,6 @@ If you want to keep Git's default pager and add opt-in aliases instead:
 git config --global alias.hdiff "-c core.pager=\"hunk pager\" diff"
 git config --global alias.hshow "-c core.pager=\"hunk pager\" show"
 ```
-
-### Agent workflows
-
-Hunk supports two agent workflows:
-
-- steer a live Hunk window from another terminal with `hunk session ...` (recommended)
-- load agent comments from a file with `--agent-context`
-
-Start by loading the Hunk review skill: [`skills/hunk-review/SKILL.md`](skills/hunk-review/SKILL.md).
-
-You can get the absolute path to the skill file from your local install by running `hunk skill path`.
-
-A good generic prompt is:
-
-```text
-Load the Hunk skill and use it for this review.
-```
-
-That skill teaches the agent how to inspect a live Hunk session, navigate it, reload it, and leave inline comments.
-
-For more, see [docs/agent-workflows.md](docs/agent-workflows.md).
 
 ### OpenTUI component
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ git diff --no-color | hunk patch -          # review a patch from stdin
 
 ### Working with agents
 
-1. Load the Hunk review skill: [`skills/hunk-review/SKILL.md`](skills/hunk-review/SKILL.md).
-2. Open Hunk in another terminal with `hunk diff` or `hunk show`.
+1. Open Hunk in another terminal with `hunk diff` or `hunk show`.
+2. Load the Hunk review skill: [`skills/hunk-review/SKILL.md`](skills/hunk-review/SKILL.md).
 3. Ask your agent to use the skill against the live Hunk session.
 
 A good generic prompt is:

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -12,7 +12,7 @@ Use Hunk with agents in two ways:
 3. Ask the agent to use the skill and review the current session.
 
 > [!NOTE]
-> `hunk skill path` is coming in Hunk 0.10.0. That release is not out yet. Once it ships, it will print the absolute path to the installed skill file so you can load or symlink it from your agent setup.
+> `hunk skill path` lands in Hunk 0.10.0. Until that release is out, load the skill from the repo path above.
 
 A good generic prompt is:
 

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -9,8 +9,10 @@ Use Hunk with agents in two ways:
 
 1. Open Hunk in one terminal with a normal review command such as `hunk diff` or `hunk show`.
 2. Load the Hunk review skill: [`skills/hunk-review/SKILL.md`](../skills/hunk-review/SKILL.md).
-3. If your agent needs an absolute path to the skill file, run `hunk skill path` from your local install.
-4. Ask the agent to use the skill and review the current session.
+3. Ask the agent to use the skill and review the current session.
+
+> [!NOTE]
+> `hunk skill path` is coming in Hunk 0.10.0. That release is not out yet. Once it ships, it will print the absolute path to the installed skill file so you can load or symlink it from your agent setup.
 
 A good generic prompt is:
 


### PR DESCRIPTION
## Summary
- tighten the README agent quickstart into a short 3-step flow with a sample prompt
- remove the duplicated advanced agent section from the README and keep the detailed guide in `docs/agent-workflows.md`
- add a short note that `hunk skill path` lands in Hunk 0.10.0 and is not available yet

## Testing
- docs-only change
- formatting already applied via `oxfmt`

*This PR description was generated by Pi using OpenAI o3*
