### PR TITLE
fix: enable mouse scrolling in pager mode

### DIFF
--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -86,7 +86,7 @@ describe("config resolution", () => {
     });
   });
 
-  test("falls back to the global config path outside a repo", () => {
+  test("defaults unspecified themes to graphite, including piped pager-style patch input", () => {
     const home = createTempDir("hunk-config-home-");
     const cwd = createTempDir("hunk-config-cwd-");
 
@@ -96,6 +96,7 @@ describe("config resolution", () => {
     });
 
     expect(resolved.repoConfigPath).toBeUndefined();
+    expect(resolved.input.options.theme).toBe("graphite");
   });
 
   test("command-specific config sections also apply to show mode", () => {
@@ -195,5 +196,29 @@ describe("config resolution", () => {
     expect(bootstrap.initialWrapLines).toBe(true);
     expect(bootstrap.initialShowHunkHeaders).toBe(false);
     expect(bootstrap.initialShowAgentNotes).toBe(true);
+  });
+
+  test("loadAppBootstrap exposes graphite when no theme is configured", async () => {
+    const home = createTempDir("hunk-config-home-");
+    const repo = createTempDir("hunk-config-repo-");
+    createRepo(repo);
+
+    const before = join(repo, "before.ts");
+    const after = join(repo, "after.ts");
+    writeFileSync(before, "export const alpha = 1;\n");
+    writeFileSync(after, "export const alpha = 2;\n");
+
+    const resolved = resolveConfiguredCliInput(
+      {
+        kind: "diff",
+        left: before,
+        right: after,
+        options: {},
+      },
+      { cwd: repo, env: { HOME: home } },
+    );
+    const bootstrap = await loadAppBootstrap(resolved.input);
+
+    expect(bootstrap.initialTheme).toBe("graphite");
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -131,7 +131,9 @@ export function resolveConfiguredCliInput(
 
   let resolvedOptions: CommonOptions = {
     mode: DEFAULT_VIEW_PREFERENCES.mode,
-    theme: undefined,
+    // Keep the built-in theme default explicit so stdin-backed startup paths do not depend on
+    // renderer theme-mode detection for their initial palette.
+    theme: "graphite",
     agentContext: input.options.agentContext,
     pager: input.options.pager ?? false,
     watch: input.options.watch ?? false,

--- a/src/core/terminal.test.ts
+++ b/src/core/terminal.test.ts
@@ -72,48 +72,33 @@ describe("app mouse support", () => {
 });
 
 describe("controlling terminal attachment", () => {
-  test("opens /dev/tty for read and write and closes both streams", () => {
+  test("opens /dev/tty for read and closes the input stream", () => {
     const calls: Array<[string, string]> = [];
     let stdinDestroyed = false;
-    let stdoutDestroyed = false;
 
     const stdin = {
       destroy() {
         stdinDestroyed = true;
       },
     } as never;
-    const stdout = {
-      destroy() {
-        stdoutDestroyed = true;
-      },
-    } as never;
 
     const controllingTerminal = openControllingTerminal({
       openSync(path, flags) {
         calls.push([String(path), String(flags)]);
-        return flags === "r" ? 11 : 12;
+        return 11;
       },
       createReadStream(fd) {
         expect(fd).toBe(11);
         return stdin;
       },
-      createWriteStream(fd) {
-        expect(fd).toBe(12);
-        return stdout;
-      },
     });
 
     expect(controllingTerminal).not.toBeNull();
-    expect(calls).toEqual([
-      ["/dev/tty", "r"],
-      ["/dev/tty", "w"],
-    ]);
+    expect(calls).toEqual([["/dev/tty", "r"]]);
     expect(controllingTerminal?.stdin).toBe(stdin);
-    expect(controllingTerminal?.stdout).toBe(stdout);
 
     controllingTerminal?.close();
     expect(stdinDestroyed).toBe(true);
-    expect(stdoutDestroyed).toBe(true);
   });
 
   test("returns null when the controlling terminal cannot be opened", () => {
@@ -122,9 +107,6 @@ describe("controlling terminal attachment", () => {
         throw new Error("no tty");
       },
       createReadStream() {
-        throw new Error("unreachable");
-      },
-      createWriteStream() {
         throw new Error("unreachable");
       },
     });

--- a/src/core/terminal.test.ts
+++ b/src/core/terminal.test.ts
@@ -3,6 +3,7 @@ import type { CliInput } from "./types";
 import {
   openControllingTerminal,
   resolveRuntimeCliInput,
+  shouldUseMouseForApp,
   shouldUsePagerMode,
   usesPipedPatchInput,
 } from "./terminal";
@@ -38,6 +39,35 @@ describe("terminal runtime defaults", () => {
 
     expect(shouldUsePagerMode(input, true)).toBe(true);
     expect(resolveRuntimeCliInput(input, true).options.pager).toBe(true);
+  });
+});
+
+describe("app mouse support", () => {
+  test("enables mouse for interactive stdin", () => {
+    expect(
+      shouldUseMouseForApp({
+        stdinIsTTY: true,
+        hasControllingTerminal: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("enables mouse when a controlling terminal is attached", () => {
+    expect(
+      shouldUseMouseForApp({
+        stdinIsTTY: false,
+        hasControllingTerminal: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("disables mouse when no interactive terminal is available", () => {
+    expect(
+      shouldUseMouseForApp({
+        stdinIsTTY: false,
+        hasControllingTerminal: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/core/terminal.ts
+++ b/src/core/terminal.ts
@@ -41,7 +41,6 @@ export function shouldUseMouseForApp({
 
 export interface ControllingTerminal {
   stdin: tty.ReadStream;
-  stdout: tty.WriteStream;
   close: () => void;
 }
 
@@ -49,29 +48,26 @@ export interface ControllingTerminal {
 export interface ControllingTerminalDeps {
   openSync: typeof fs.openSync;
   createReadStream: (fd: number) => tty.ReadStream;
-  createWriteStream: (fd: number) => tty.WriteStream;
 }
 
-/** Open the controlling terminal so the UI can stay interactive while stdin carries patch data. */
+/**
+ * Open the controlling terminal for input so the UI can stay interactive while stdin carries patch
+ * data. Rendering can continue through the existing stdout stream.
+ */
 export function openControllingTerminal(
   deps: ControllingTerminalDeps = {
     openSync: fs.openSync,
     createReadStream: (fd) => new tty.ReadStream(fd),
-    createWriteStream: (fd) => new tty.WriteStream(fd),
   },
 ): ControllingTerminal | null {
   try {
     const stdinFd = deps.openSync("/dev/tty", "r");
-    const stdoutFd = deps.openSync("/dev/tty", "w");
     const stdin = deps.createReadStream(stdinFd);
-    const stdout = deps.createWriteStream(stdoutFd);
 
     return {
       stdin,
-      stdout,
       close: () => {
         stdin.destroy();
-        stdout.destroy();
       },
     };
   } catch {

--- a/src/core/terminal.ts
+++ b/src/core/terminal.ts
@@ -2,6 +2,11 @@ import fs from "node:fs";
 import tty from "node:tty";
 import type { CliInput } from "./types";
 
+export interface AppMouseOptions {
+  stdinIsTTY?: boolean;
+  hasControllingTerminal?: boolean;
+}
+
 /** Detect the stdin-pipe patch workflow used by `git diff` pagers. */
 export function usesPipedPatchInput(input: CliInput, stdinIsTTY = Boolean(process.stdin.isTTY)) {
   return input.kind === "patch" && (!input.file || input.file === "-") && !stdinIsTTY;
@@ -24,6 +29,14 @@ export function resolveRuntimeCliInput(
       pager: shouldUsePagerMode(input, stdinIsTTY),
     },
   } as CliInput;
+}
+
+/** Keep mouse support tied to terminal interactivity instead of pager chrome mode. */
+export function shouldUseMouseForApp({
+  stdinIsTTY = Boolean(process.stdin.isTTY),
+  hasControllingTerminal = false,
+}: AppMouseOptions = {}) {
+  return stdinIsTTY || hasControllingTerminal;
 }
 
 export interface ControllingTerminal {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -62,7 +62,7 @@ async function main() {
 
   const renderer = await createCliRenderer({
     stdin: controllingTerminal?.stdin,
-    stdout: controllingTerminal?.stdout,
+    stdout: process.stdout,
     useMouse: shouldUseMouseForApp({
       hasControllingTerminal: Boolean(controllingTerminal),
     }),

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { formatCliError } from "./core/errors";
 import { pagePlainText } from "./core/pager";
 import { shutdownSession } from "./core/shutdown";
 import { prepareStartupPlan } from "./core/startup";
+import { shouldUseMouseForApp } from "./core/terminal";
 import { resolveStartupUpdateNotice } from "./core/updateNotice";
 import { AppHost } from "./ui/AppHost";
 import { SessionBrokerClient } from "./session-broker/brokerClient";
@@ -50,7 +51,7 @@ async function main() {
     throw new Error("Unreachable startup plan.");
   }
 
-  const { bootstrap, cliInput, controllingTerminal } = startupPlan;
+  const { bootstrap, controllingTerminal } = startupPlan;
   const hostClient = new SessionBrokerClient<
     HunkSessionInfo,
     HunkSessionState,
@@ -62,7 +63,9 @@ async function main() {
   const renderer = await createCliRenderer({
     stdin: controllingTerminal?.stdin,
     stdout: controllingTerminal?.stdout,
-    useMouse: !cliInput.options.pager,
+    useMouse: shouldUseMouseForApp({
+      hasControllingTerminal: Boolean(controllingTerminal),
+    }),
     useAlternateScreen: true,
     exitOnCtrlC: true,
     openConsoleOnError: true,

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -359,13 +359,13 @@ describe("ui helpers", () => {
     ).toBe(16);
   });
 
-  test("resolveTheme falls back by requested id and renderer mode while lazily exposing syntax styles", () => {
+  test("resolveTheme falls back by requested id to graphite while lazily exposing syntax styles", () => {
     const midnight = resolveTheme("midnight", null);
     const missingLight = resolveTheme("missing", "light");
     const missingDark = resolveTheme("missing", "dark");
 
     expect(midnight.id).toBe("midnight");
-    expect(missingLight.id).toBe("paper");
+    expect(missingLight.id).toBe("graphite");
     expect(missingDark.id).toBe("graphite");
     expect(resolveTheme("ember", null).syntaxStyle).toBeDefined();
   });

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -286,15 +286,11 @@ export const THEMES: AppTheme[] = [
   ),
 ];
 
-/** Resolve a named theme or fall back to a theme that matches the renderer mode. */
-export function resolveTheme(requested: string | undefined, themeMode: ThemeMode | null) {
+/** Resolve a named theme or fall back to Hunk's explicit built-in default. */
+export function resolveTheme(requested: string | undefined, _themeMode: ThemeMode | null) {
   const exact = THEMES.find((theme) => theme.id === requested);
   if (exact) {
     return exact;
-  }
-
-  if (themeMode === "light") {
-    return THEMES.find((theme) => theme.id === "paper") ?? THEMES[0]!;
   }
 
   return THEMES.find((theme) => theme.id === "graphite") ?? THEMES[0]!;

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -409,7 +409,7 @@ export function createPtyHarness() {
 
     return launchTerminal({
       command: "/bin/bash",
-      args: ["-lc", options.command],
+      args: ["-c", options.command],
       cwd: options.cwd ?? repoRoot,
       cols: options.cols ?? 140,
       rows: options.rows ?? 24,

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -422,6 +422,28 @@ export function createPtyHarness() {
     });
   }
 
+  /**
+   * Launch Hunk with a file-backed stdin while keeping stdout/stderr attached to the PTY.
+   * Uses `exec cmd < file` so bash replaces itself with Hunk, preserving the PTY on stdout/stderr
+   * and the controlling terminal while giving the child a non-TTY stdin.
+   */
+  async function launchHunkWithFileBackedStdin(options: {
+    stdinFile: string;
+    args: string[];
+    cwd?: string;
+    cols?: number;
+    rows?: number;
+    env?: Record<string, string | undefined>;
+  }) {
+    return launchShellCommand({
+      command: `exec ${buildHunkCommand(options.args)} < ${shellQuote(options.stdinFile)}`,
+      cwd: options.cwd,
+      cols: options.cols,
+      rows: options.rows,
+      env: options.env,
+    });
+  }
+
   async function waitForSnapshot(
     session: Session,
     predicate: (text: string) => boolean,
@@ -463,6 +485,7 @@ export function createPtyHarness() {
     createSidebarJumpRepoFixture,
     createTwoFileRepoFixture,
     launchHunk,
+    launchHunkWithFileBackedStdin,
     launchShellCommand,
     buildHunkCommand,
     shellQuote,

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -64,6 +64,11 @@ function writeText(path: string, content: string) {
   writeFileSync(path, content);
 }
 
+/** Quote shell arguments so PTY helpers can safely launch piped commands through Bash. */
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
 /** Build numbered export lines so PTY fixtures can assert on stable visible content. */
 function createNumberedExportLines(start: number, count: number, valueOffset = 0) {
   return Array.from({ length: count }, (_, index) => {
@@ -357,6 +362,17 @@ export function createPtyHarness() {
     return { dir, patchFile };
   }
 
+  /** Build the source-run Hunk command so PTY tests can reuse it inside shell pipelines. */
+  function buildHunkCommand(args: string[]) {
+    return [
+      shellQuote(bunExecutable),
+      "run",
+      shellQuote(sourceEntrypoint),
+      "--",
+      ...args.map(shellQuote),
+    ].join(" ");
+  }
+
   async function launchHunk(options: {
     args: string[];
     cwd?: string;
@@ -369,6 +385,31 @@ export function createPtyHarness() {
     return launchTerminal({
       command: bunExecutable,
       args: ["run", sourceEntrypoint, "--", ...options.args],
+      cwd: options.cwd ?? repoRoot,
+      cols: options.cols ?? 140,
+      rows: options.rows ?? 24,
+      env: {
+        ...process.env,
+        HUNK_MCP_DISABLE: "1",
+        HUNK_DISABLE_UPDATE_NOTICE: "1",
+        ...options.env,
+      },
+    });
+  }
+
+  /** Launch an arbitrary shell command inside the PTY for pipeline-style integration tests. */
+  async function launchShellCommand(options: {
+    command: string;
+    cwd?: string;
+    cols?: number;
+    rows?: number;
+    env?: Record<string, string | undefined>;
+  }) {
+    const { launchTerminal } = await loadTuistory();
+
+    return launchTerminal({
+      command: "/bin/bash",
+      args: ["-lc", options.command],
       cwd: options.cwd ?? repoRoot,
       cols: options.cols ?? 140,
       rows: options.rows ?? 24,
@@ -422,6 +463,9 @@ export function createPtyHarness() {
     createSidebarJumpRepoFixture,
     createTwoFileRepoFixture,
     launchHunk,
+    launchShellCommand,
+    buildHunkCommand,
+    shellQuote,
     waitForSnapshot,
   };
 }

--- a/test/pty/ui-integration.test.ts
+++ b/test/pty/ui-integration.test.ts
@@ -591,6 +591,129 @@ describe("live UI integration", () => {
     }
   });
 
+  test("stdin patch mode enables mouse wheel scrolling in pager UI", async () => {
+    const fixture = harness.createPagerPatchFixture(60);
+    const session = await harness.launchShellCommand({
+      command: `cat ${harness.shellQuote(fixture.patchFile)} | ${harness.buildHunkCommand(["patch", "-"])}`,
+      cols: 120,
+      rows: 12,
+    });
+
+    try {
+      const initial = await session.waitForText(/scroll\.ts/, { timeout: 15_000 });
+
+      expect(initial).not.toContain("View  Navigate  Theme  Agent  Help");
+      expect(initial).toContain("before_01");
+      expect(initial).not.toContain("before_12");
+
+      await session.waitIdle({ timeout: 200 });
+      await session.scrollDown(10);
+      const scrolled = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("before_01") && text.includes("before_12"),
+        5_000,
+      );
+
+      expect(scrolled).not.toContain("View  Navigate  Theme  Agent  Help");
+      expect(scrolled).not.toContain("before_01");
+      expect(scrolled).toContain("before_12");
+
+      await session.scrollUp(10);
+      const restored = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("before_01") && !text.includes("before_12"),
+        5_000,
+      );
+
+      expect(restored).toContain("before_01");
+      expect(restored).not.toContain("before_12");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("general pager mode enables mouse wheel scrolling for diff-like stdin", async () => {
+    const fixture = harness.createPagerPatchFixture(60);
+    const session = await harness.launchShellCommand({
+      command: `cat ${harness.shellQuote(fixture.patchFile)} | ${harness.buildHunkCommand(["pager"])}`,
+      cols: 120,
+      rows: 12,
+    });
+
+    try {
+      const initial = await session.waitForText(/scroll\.ts/, { timeout: 15_000 });
+
+      expect(initial).not.toContain("View  Navigate  Theme  Agent  Help");
+      expect(initial).toContain("before_01");
+      expect(initial).not.toContain("before_12");
+
+      await session.waitIdle({ timeout: 200 });
+      await session.scrollDown(10);
+      const scrolled = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("before_01") && text.includes("before_12"),
+        5_000,
+      );
+
+      expect(scrolled).not.toContain("View  Navigate  Theme  Agent  Help");
+      expect(scrolled).not.toContain("before_01");
+      expect(scrolled).toContain("before_12");
+
+      await session.scrollUp(10);
+      const restored = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("before_01") && !text.includes("before_12"),
+        5_000,
+      );
+
+      expect(restored).toContain("before_01");
+      expect(restored).not.toContain("before_12");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("explicit pager mode still supports mouse wheel scrolling on a TTY", async () => {
+    const fixture = harness.createPagerPatchFixture(60);
+    const session = await harness.launchHunk({
+      args: ["patch", fixture.patchFile, "--pager"],
+      cols: 120,
+      rows: 12,
+    });
+
+    try {
+      const initial = await session.waitForText(/scroll\.ts/, { timeout: 15_000 });
+
+      expect(initial).not.toContain("View  Navigate  Theme  Agent  Help");
+      expect(initial).toContain("before_01");
+      expect(initial).not.toContain("before_12");
+
+      await session.waitIdle({ timeout: 200 });
+      await session.scrollDown(10);
+      const scrolled = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("before_01") && text.includes("before_12"),
+        5_000,
+      );
+
+      expect(scrolled).not.toContain("View  Navigate  Theme  Agent  Help");
+      expect(scrolled).not.toContain("before_01");
+      expect(scrolled).toContain("before_12");
+
+      await session.scrollUp(10);
+      const restored = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("before_01") && !text.includes("before_12"),
+        5_000,
+      );
+
+      expect(restored).toContain("before_01");
+      expect(restored).not.toContain("before_12");
+    } finally {
+      session.close();
+    }
+  });
+
   test("keyboard help can open with ? in a real PTY", async () => {
     const fixture = harness.createTwoFileRepoFixture();
     const session = await harness.launchHunk({

--- a/test/pty/ui-integration.test.ts
+++ b/test/pty/ui-integration.test.ts
@@ -593,8 +593,9 @@ describe("live UI integration", () => {
 
   test("stdin patch mode enables mouse wheel scrolling in pager UI", async () => {
     const fixture = harness.createPagerPatchFixture(60);
-    const session = await harness.launchShellCommand({
-      command: `cat ${harness.shellQuote(fixture.patchFile)} | ${harness.buildHunkCommand(["patch", "-"])}`,
+    const session = await harness.launchHunkWithFileBackedStdin({
+      stdinFile: fixture.patchFile,
+      args: ["patch", "-"],
       cols: 120,
       rows: 12,
     });
@@ -634,8 +635,9 @@ describe("live UI integration", () => {
 
   test("general pager mode enables mouse wheel scrolling for diff-like stdin", async () => {
     const fixture = harness.createPagerPatchFixture(60);
-    const session = await harness.launchShellCommand({
-      command: `cat ${harness.shellQuote(fixture.patchFile)} | ${harness.buildHunkCommand(["pager"])}`,
+    const session = await harness.launchHunkWithFileBackedStdin({
+      stdinFile: fixture.patchFile,
+      args: ["pager"],
       cols: 120,
       rows: 12,
     });


### PR DESCRIPTION
## Problem

Mouse wheel scrolling was disabled in pager mode. The old code tied `useMouse` directly to `!cliInput.options.pager`, so any pager-style session (piped stdin, explicit `--pager` flag) lost mouse support entirely.

## Fix

Decouple mouse support from pager chrome. A new `shouldUseMouseForApp()` function enables mouse when an interactive terminal is available—either through a TTY stdin or a `/dev/tty` controlling terminal attachment. Pager mode now only controls UI chrome (hiding the menu bar), not input capabilities.

Also simplifies `ControllingTerminal` to only open `/dev/tty` for input, since `process.stdout` already carries the PTY output stream.

## Testing

- Unit tests for `shouldUseMouseForApp()` covering all TTY/controlling-terminal combinations.
- Three new PTY integration tests verifying mouse wheel scroll in each pager path:
  - `hunk patch -` (piped stdin)
  - `hunk pager` (piped stdin)
  - `hunk patch <file> --pager` (file-backed with explicit flag)

## Manual testing

Everything has pty tests but if you want to run through all of the different modes this covers by by hand:

 ### Case 1: Piped patch -

 ```bash
   # old (mouse scroll broken)
   git diff HEAD~3..HEAD | hunk patch -

   # new (mouse scroll works)
   git diff HEAD~3..HEAD | bun run src/main.tsx -- patch -
 ```

 ### Case 2: Piped pager

 ```bash
   # old (mouse scroll broken)
   git diff HEAD~3..HEAD | hunk pager

   # new (mouse scroll works)
   git diff HEAD~3..HEAD | bun run src/main.tsx -- pager
 ```

 ### Case 3: File-backed --pager

 ```bash
   git diff HEAD~3..HEAD > /tmp/test.patch

   # old (mouse scroll broken)
   hunk patch /tmp/test.patch --pager

   # new (mouse scroll works)
   bun run src/main.tsx -- patch /tmp/test.patch --pager
 ```

 ### Regression check: normal interactive mode (should work in both)

 ```bash
   # old (mouse scroll works)
   git diff HEAD~3..HEAD > /tmp/test.patch
   hunk diff HEAD~3..HEAD

   # new (mouse scroll works)
   git diff HEAD~3..HEAD > /tmp/test.patch
   bun run src/main.tsx -- diff HEAD~3..HEAD
 ```