### PR TITLE
fix(theme): make graphite the explicit default across startup modes

### DIFF
--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -86,7 +86,7 @@ describe("config resolution", () => {
     });
   });
 
-  test("falls back to the global config path outside a repo", () => {
+  test("defaults unspecified themes to graphite, including piped pager-style patch input", () => {
     const home = createTempDir("hunk-config-home-");
     const cwd = createTempDir("hunk-config-cwd-");
 
@@ -96,6 +96,7 @@ describe("config resolution", () => {
     });
 
     expect(resolved.repoConfigPath).toBeUndefined();
+    expect(resolved.input.options.theme).toBe("graphite");
   });
 
   test("command-specific config sections also apply to show mode", () => {
@@ -195,5 +196,29 @@ describe("config resolution", () => {
     expect(bootstrap.initialWrapLines).toBe(true);
     expect(bootstrap.initialShowHunkHeaders).toBe(false);
     expect(bootstrap.initialShowAgentNotes).toBe(true);
+  });
+
+  test("loadAppBootstrap exposes graphite when no theme is configured", async () => {
+    const home = createTempDir("hunk-config-home-");
+    const repo = createTempDir("hunk-config-repo-");
+    createRepo(repo);
+
+    const before = join(repo, "before.ts");
+    const after = join(repo, "after.ts");
+    writeFileSync(before, "export const alpha = 1;\n");
+    writeFileSync(after, "export const alpha = 2;\n");
+
+    const resolved = resolveConfiguredCliInput(
+      {
+        kind: "diff",
+        left: before,
+        right: after,
+        options: {},
+      },
+      { cwd: repo, env: { HOME: home } },
+    );
+    const bootstrap = await loadAppBootstrap(resolved.input);
+
+    expect(bootstrap.initialTheme).toBe("graphite");
   });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -131,7 +131,9 @@ export function resolveConfiguredCliInput(
 
   let resolvedOptions: CommonOptions = {
     mode: DEFAULT_VIEW_PREFERENCES.mode,
-    theme: undefined,
+    // Keep the built-in theme default explicit so stdin-backed startup paths do not depend on
+    // renderer theme-mode detection for their initial palette.
+    theme: "graphite",
     agentContext: input.options.agentContext,
     pager: input.options.pager ?? false,
     watch: input.options.watch ?? false,

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -359,13 +359,13 @@ describe("ui helpers", () => {
     ).toBe(16);
   });
 
-  test("resolveTheme falls back by requested id and renderer mode while lazily exposing syntax styles", () => {
+  test("resolveTheme falls back by requested id to graphite while lazily exposing syntax styles", () => {
     const midnight = resolveTheme("midnight", null);
     const missingLight = resolveTheme("missing", "light");
     const missingDark = resolveTheme("missing", "dark");
 
     expect(midnight.id).toBe("midnight");
-    expect(missingLight.id).toBe("paper");
+    expect(missingLight.id).toBe("graphite");
     expect(missingDark.id).toBe("graphite");
     expect(resolveTheme("ember", null).syntaxStyle).toBeDefined();
   });

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -286,15 +286,11 @@ export const THEMES: AppTheme[] = [
   ),
 ];
 
-/** Resolve a named theme or fall back to a theme that matches the renderer mode. */
-export function resolveTheme(requested: string | undefined, themeMode: ThemeMode | null) {
+/** Resolve a named theme or fall back to Hunk's explicit built-in default. */
+export function resolveTheme(requested: string | undefined, _themeMode: ThemeMode | null) {
   const exact = THEMES.find((theme) => theme.id === requested);
   if (exact) {
     return exact;
-  }
-
-  if (themeMode === "light") {
-    return THEMES.find((theme) => theme.id === "paper") ?? THEMES[0]!;
   }
 
   return THEMES.find((theme) => theme.id === "graphite") ?? THEMES[0]!;


### PR DESCRIPTION
## Summary

Make `graphite` the single built-in fallback theme across startup modes, removing implicit renderer-mode-based fallback selection for unspecified themes.

This is intentionally scoped on top of `elucid/tty-mouse-pager-fixes`, where stdin-backed `patch -` / `pager` sessions need split terminal plumbing to preserve mouse scrolling.

## Why this change

On `main`, piped patch/pager sessions happened to come up dark under the old all-`/dev/tty` renderer wiring.

On `elucid/tty-mouse-pager-fixes`, fixing mouse scrolling required keeping interactive input on `/dev/tty` while rendering through `process.stdout`. That change is necessary for the branch goal, but it also changes the effective renderer theme-mode signal in stdin-backed startup paths. As a result, an unspecified theme can resolve to light there even though other startup modes still resolve to graphite.

We tested the obvious alternative: reverting the stdout-side plumbing change. That does make the piped patch/pager theme dark again, but it also regresses the mouse-scroll fix that motivated the branch. So reverting the transport change is not a viable fix.

Given that constraint, the pragmatic choice is to stop treating an unspecified theme as an implicit auto-detect mode and instead make the built-in fallback explicit: `graphite`.

## What this changes

- Config/bootstrap resolution now defaults unspecified themes to `graphite`.
- Theme fallback resolution now also defaults to `graphite` regardless of renderer-reported light/dark mode.
- Explicit user and config overrides still work (`--theme`, `theme = "paper"`, etc.).

In other words, Hunk no longer treats an omitted theme as an implicit terminal-following mode.

## Why this is pragmatic

- Preserves the branch's mouse-scroll behavior.
- Removes startup-path-dependent theme drift.
- Keeps behavior deterministic across `diff`, file-backed `patch`, stdin-backed `patch -`, and `pager`.
- Avoids depending on a renderer-mode signal that changes under the tty plumbing required for stdin-backed interactivity.
- Still allows explicit overrides via CLI or config.

This chooses a stable product fallback over transport-sensitive autodetect behavior.

## Tradeoff

This intentionally changes the old behavior where an unspecified or unrecognized theme could fall back through renderer light/dark detection (`paper` on light terminals, `graphite` on dark terminals). After this change, Hunk always falls back to `graphite` unless a specific theme is requested via config or CLI.

That tradeoff is intentional. If terminal-following theme selection is something we want to preserve as a product feature, the cleaner long-term design is to make that explicit (for example with a future `theme = auto` / `--theme auto`) rather than relying on renderer startup details.

## Tests

- `bun test src/core/config.test.ts src/ui/lib/ui-lib.test.ts`
- `bun test test/pty/ui-integration.test.ts -t "(stdin patch mode enables mouse wheel scrolling in pager UI|general pager mode enables mouse wheel scrolling for diff-like stdin)"`
- `bun run typecheck`
