### PR TITLE
fix(renderer): strip newline from Pierre empty-line placeholder spans

### DIFF
--- a/src/ui/diff/pierre.test.ts
+++ b/src/ui/diff/pierre.test.ts
@@ -35,6 +35,36 @@ function createDiffFile(): DiffFile {
   };
 }
 
+function createEmptyLineDiffFile(): DiffFile {
+  const metadata = parseDiffFromFile(
+    {
+      name: "empty.ts",
+      contents: "function foo() {\n  return 1;\n}\n",
+      cacheKey: "before-empty",
+    },
+    {
+      name: "empty.ts",
+      contents: "function foo() {\n\n  return 2;\n}\n",
+      cacheKey: "after-empty",
+    },
+    { context: 3 },
+    true,
+  );
+
+  return {
+    id: "empty",
+    path: "empty.ts",
+    patch: "",
+    language: "typescript",
+    stats: {
+      additions: 2,
+      deletions: 1,
+    },
+    metadata,
+    agent: null,
+  };
+}
+
 function createMarkdownDiffFile(): DiffFile {
   const metadata = parseDiffFromFile(
     {
@@ -123,6 +153,23 @@ describe("Pierre diff rows", () => {
     expect(deletionRow.cell.newLineNumber).toBeUndefined();
     expect(additionRow.cell.oldLineNumber).toBeUndefined();
     expect(additionRow.cell.newLineNumber).toBe(1);
+  });
+
+  test("does not produce newline characters in spans for highlighted empty lines", async () => {
+    const file = createEmptyLineDiffFile();
+    const theme = resolveTheme("midnight", null);
+    const highlighted = await loadHighlightedDiff(file);
+
+    for (const buildRows of [buildSplitRows, buildStackRows]) {
+      const rows = buildRows(file, highlighted, theme);
+      const allSpans = rows.flatMap((row) => {
+        if (row.type === "split-line") return [...row.left.spans, ...row.right.spans];
+        if (row.type === "stack-line") return row.cell.spans;
+        return [];
+      });
+
+      expect(allSpans.every((span) => !span.text.includes("\n"))).toBe(true);
+    }
   });
 
   test("remaps Pierre markdown reds and greens away from diff-semantic hues", async () => {

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -233,8 +233,11 @@ function flattenHighlightedLine(node: HastNode | undefined, theme: AppTheme, emp
     }
 
     if (current.type === "text") {
+      // Pierre injects a "\n" placeholder into empty line nodes so they aren't childless.
+      // Strip it the same way cleanDiffLine does for the unhighlighted path, or the literal
+      // newline ends up in the span text and breaks terminal row rendering.
       mergeSpan(spans, {
-        text: tabify(current.value),
+        text: tabify(cleanLastNewline(current.value)),
         fg: inherited.fg,
         bg: inherited.bg,
       });


### PR DESCRIPTION
## Summary

- Pierre's `processLine` injects a `{ type: "text", value: "\n" }` placeholder into empty line nodes so they aren't childless HAST elements
- `flattenHighlightedLine` was passing that value straight through `tabify`, leaving a literal `\n` in the rendered span text
- That newline broke terminal row rendering for lines containing only `\n`: line numbers disappeared and row backgrounds (e.g. green for additions) weren't painted
- Fix: wrap `current.value` with `cleanLastNewline` before `tabify`, matching what the unhighlighted fallback path already does in `cleanDiffLine`

## Test plan

- [ ] New unit test in `pierre.test.ts`: asserts no span in highlighted split or stack rows contains `\n`, using a diff that adds an empty line
- [ ] `bun test src/ui/diff/pierre.test.ts` passes (5/5)
- [ ] Smoke: open a diff with empty addition/deletion lines and scroll — line numbers and green/red backgrounds remain stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)