### PR TITLE
fix(ui): smooth mouse-wheel review scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Smoothed mouse-wheel review scrolling so small diffs stay precise while sustained wheel gestures still speed up.
+
 ## [0.9.4] - 2026-04-14
 
 ### Added

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -16,6 +16,7 @@ import {
   measureDiffSectionGeometry,
   type DiffSectionGeometry,
 } from "../../lib/diffSectionGeometry";
+import { createReviewMouseWheelScrollAcceleration } from "../../lib/scrollAcceleration";
 import {
   buildFileSectionLayouts,
   buildInStreamFileHeaderHeights,
@@ -182,6 +183,10 @@ export function DiffPane({
   onViewportCenteredHunkChange?: (fileId: string, hunkIndex: number) => void;
 }) {
   const renderer = useRenderer();
+  const mouseWheelScrollAcceleration = useMemo(
+    () => createReviewMouseWheelScrollAcceleration(),
+    [],
+  );
 
   const adjacentPrefetchFileIds = useMemo(
     () => buildAdjacentPrefetchFileIds(files, selectedFileId),
@@ -977,7 +982,7 @@ export function DiffPane({
     suppressViewportSelectionSync,
   ]);
 
-  // Configure scroll step size to scroll exactly 1 line per step
+  // Keep keyboard step scrolling at exactly one row while wheel scrolling uses its own multiplier.
   useEffect(() => {
     const scrollBox = scrollRef.current;
     if (scrollBox) {
@@ -1020,6 +1025,7 @@ export function DiffPane({
               viewportCulling={true}
               focused={pagerMode}
               onMouseScroll={handleMouseScroll}
+              scrollAcceleration={mouseWheelScrollAcceleration}
               rootOptions={{ backgroundColor: theme.panel }}
               wrapperOptions={{ backgroundColor: theme.panel }}
               viewportOptions={{ backgroundColor: theme.panel }}

--- a/src/ui/lib/scrollAcceleration.ts
+++ b/src/ui/lib/scrollAcceleration.ts
@@ -1,0 +1,15 @@
+import { MacOSScrollAccel, type ScrollAcceleration } from "@opentui/core";
+
+/**
+ * Keep the first wheel tick precise, then ramp up during sustained bursts.
+ *
+ * This matches the general pattern used by terminal UIs better than scaling by total diff size:
+ * short diffs stay controllable, while long repeated wheel gestures still speed up.
+ */
+export function createReviewMouseWheelScrollAcceleration(): ScrollAcceleration {
+  return new MacOSScrollAccel({
+    A: 0.4,
+    tau: 4,
+    maxMultiplier: 3,
+  });
+}


### PR DESCRIPTION
## Summary

- replace the fixed multi-row mouse wheel jump with cadence-based OpenTUI acceleration
- keep single wheel ticks precise on small diffs while allowing sustained wheel gestures to speed up
- document the scrolling improvement in `CHANGELOG.md`

## Testing

- `bun run typecheck`
- `bun test src/ui/AppHost.interactions.test.tsx -t "mouse wheel scrolling updates the active file and hunk to the viewport center|shift plus mouse wheel scrolls code horizontally|shift plus mouse wheel does not move the vertical review position"`
- `bun test test/pty/ui-integration.test.ts -t "mouse wheel scrolling moves the review pane|the first mouse-wheel step still advances content under the always-pinned file header above a collapsed gap|one mouse-wheel step down then up restores the collapsed-gap view beneath the pinned file header"`

*This PR description was generated by Pi using OpenAI o3*
