### PR TITLE
chore(pierre): upgrade @pierre/diffs to 1.1.19

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hunk",
       "dependencies": {
-        "@pierre/diffs": "^1.1.0",
+        "@pierre/diffs": "^1.1.19",
         "bun": "^1.3.10",
         "commander": "^14.0.3",
         "diff": "^8.0.3",
@@ -247,9 +247,9 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.0", "", { "dependencies": { "@pierre/theme": "0.0.22", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-wbxrzcmanJuHZb81iir09j42uU9AnKxXDtAuEQJbAnti5f2UfYdCQYejawuHZStFrlsMacCZLh/dDHmqvAaQCw=="],
+    "@pierre/diffs": ["@pierre/diffs@1.1.19", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-eYyDW69heXd7i9zdkWogGYosHzoYF2dstV6uDcmnQAf72uRChs3hrpf/7ym/ayTiwD8a+TQ7oZ5vNNb0tstJvA=="],
 
-    "@pierre/theme": ["@pierre/theme@0.0.22", "", {}, "sha512-ePUIdQRNGjrveELTU7fY89Xa7YGHHEy5Po5jQy/18lm32eRn96+tnYJEtFooGdffrx55KBUtOXfvVy/7LDFFhA=="],
+    "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
 
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "bench:large-stream-profile": "bun run benchmarks/large-stream-profile.ts"
   },
   "dependencies": {
-    "@pierre/diffs": "^1.1.0",
+    "@pierre/diffs": "^1.1.19",
     "bun": "^1.3.10",
     "commander": "^14.0.3",
     "diff": "^8.0.3",

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -24,13 +24,17 @@ function pierreThemeName(appearance: AppTheme["appearance"]) {
 const PIERRE_RENDER_OPTIONS_BY_APPEARANCE = {
   light: {
     theme: pierreThemeName("light"),
+    useTokenTransformer: false,
     tokenizeMaxLineLength: 1_000,
     lineDiffType: "word-alt" as const,
+    maxLineDiffLength: 10_000,
   },
   dark: {
     theme: pierreThemeName("dark"),
+    useTokenTransformer: false,
     tokenizeMaxLineLength: 1_000,
     lineDiffType: "word-alt" as const,
+    maxLineDiffLength: 10_000,
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- upgrade `@pierre/diffs` from `^1.1.0` to `^1.1.19`
- update Hunk's Pierre render options to satisfy the newer `RenderDiffOptions` contract
- verify the current low-level Pierre integration still typechecks and passes targeted diff tests

## What changed

- bumped `@pierre/diffs` in `package.json`
- refreshed `bun.lock`
- added `useTokenTransformer: false` and `maxLineDiffLength: 10_000` in `src/ui/diff/pierre.ts`

## Notes

- existing imports in `src/ui/diff/pierre.ts`, `src/core/loaders.ts`, `src/opentui/index.ts`, and test helpers remained valid
- Hunk's flattening pipeline already matches the newer Pierre output assumptions we care about here, including direct `color:` styles and `data-diff-span` emphasis markers

## Verification

- `bun run typecheck`
- `bun test src/ui/diff/pierre.test.ts src/ui/diff/reviewRenderPlan.test.ts src/ui/lib/hunks.test.ts src/ui/lib/ui-lib.test.ts`

*This PR description was generated by Pi using GPT-5 Codex*
