### PR TITLE
fix(review): keep cross-file hunk navigation anchored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed cross-file hunk navigation so near-boundary jumps keep the selected file pinned and backward jumps reveal the target hunk instead of the file top.
+
 ## [0.10.0] - 2026-04-21
 
 ### Added

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -238,6 +238,51 @@ function createTwoFileHunkBootstrap(): AppBootstrap {
   });
 }
 
+/** Build the cross-file hunk-navigation shape that used to flash the previous pinned header. */
+function createCrossFileHunkNavigationBootstrap(): AppBootstrap {
+  const longBeforeLines = Array.from(
+    { length: 342 },
+    (_, index) => `line ${String(index + 1).padStart(3, "0")}`,
+  );
+  const longAfterLines = [...longBeforeLines];
+  for (const lineNumber of [
+    2, 21, 41, 61, 81, 101, 121, 141, 161, 181, 201, 221, 241, 261, 281, 301, 321, 341,
+  ]) {
+    longAfterLines[lineNumber - 1] = `line ${String(lineNumber).padStart(3, "0")} changed`;
+  }
+
+  const shortBeforeLines = [
+    "// hunk 0 - at the very top of the file",
+    "export const top = 1;",
+    "",
+    "",
+    ...Array.from({ length: 25 }, (_, index) => `// filler ${index + 1}`),
+    "// hunk 1 - mid-file",
+    "export const mid = 3;",
+  ];
+  const shortAfterLines = [...shortBeforeLines];
+  shortAfterLines[1] = "export const top = 2;";
+  shortAfterLines[30] = "export const mid = 4;";
+
+  return createTestGitAppBootstrap({
+    changesetId: "changeset:cross-file-hunk-navigation",
+    files: [
+      createTestDiffFile(
+        "long-file",
+        "long-file.txt",
+        lines(...longBeforeLines),
+        lines(...longAfterLines),
+      ),
+      createTestDiffFile(
+        "short-file",
+        "short-file.ts",
+        lines(...shortBeforeLines),
+        lines(...shortAfterLines),
+      ),
+    ],
+  });
+}
+
 function createMouseScrollSelectionBootstrap(): AppBootstrap {
   const firstBeforeLines = createNumberedAssignmentLines(1, 12);
   const secondBeforeLines = Array.from(
@@ -337,6 +382,28 @@ async function waitForFrame(
   }
 
   return frame;
+}
+
+async function pressHunkNavigationKey(
+  setup: Awaited<ReturnType<typeof testRender>>,
+  key: "]" | "[",
+  count: number,
+) {
+  for (let index = 0; index < count; index += 1) {
+    await act(async () => {
+      await setup.mockInput.typeText(key);
+    });
+    await flush(setup);
+  }
+}
+
+function firstCrossFileHunkNavigationHeader(frame: string) {
+  return (
+    frame
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.startsWith("long-file.txt") || line.startsWith("short-file.ts")) ?? ""
+  );
 }
 
 async function waitForSnapshot(
@@ -1830,6 +1897,74 @@ describe("App interactions", () => {
       );
       expect(frame).toContain("second.ts");
       expect((frame.match(/first\.ts/g) ?? []).length).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("forward cross-file hunk navigation keeps the destination file owning the review pane", async () => {
+    const setup = await testRender(
+      <AppHost bootstrap={createCrossFileHunkNavigationBootstrap()} />,
+      {
+        width: 120,
+        height: 16,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await pressHunkNavigationKey(setup, "]", 18);
+
+      let frame = await waitForFrame(
+        setup,
+        (nextFrame) =>
+          nextFrame.includes("short-file.ts") && nextFrame.includes("export const top = 2;"),
+        24,
+      );
+      expect(firstCrossFileHunkNavigationHeader(frame)).toContain("short-file.ts");
+
+      await pressHunkNavigationKey(setup, "]", 1);
+      frame = await waitForFrame(
+        setup,
+        (nextFrame) => nextFrame.includes("export const mid = 4;"),
+        24,
+      );
+
+      expect(firstCrossFileHunkNavigationHeader(frame)).toContain("short-file.ts");
+      expect(frame).not.toContain("line 341 changed");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("backward cross-file hunk navigation reveals the target hunk instead of the file top", async () => {
+    const setup = await testRender(
+      <AppHost bootstrap={createCrossFileHunkNavigationBootstrap()} />,
+      {
+        width: 120,
+        height: 16,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await pressHunkNavigationKey(setup, "]", 19);
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("export const mid = 4;"), 24);
+
+      await pressHunkNavigationKey(setup, "[", 2);
+      const frame = await waitForFrame(
+        setup,
+        (nextFrame) =>
+          nextFrame.includes("line 341 changed") || nextFrame.includes("line 002 changed"),
+        24,
+      );
+
+      expect(frame).toContain("line 341 changed");
+      expect(frame).not.toContain("line 002 changed");
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -664,6 +664,10 @@ export function DiffPane({
   const selectedNoteTop = selectedNoteBounds?.top ?? null;
   const selectedNoteHeight = selectedNoteBounds?.height ?? null;
 
+  /** The bodyTop of the currently selected file's section layout, used to floor hunk reveal scroll targets so they never cross above the owning file boundary. */
+  const selectedFileBodyTop =
+    selectedFileIndex >= 0 ? (fileSectionLayouts[selectedFileIndex]?.bodyTop ?? 0) : 0;
+
   // Track the previous selected anchor to detect actual selection changes.
   const prevSelectedAnchorIdRef = useRef<string | null>(null);
   const prevPinnedHeaderFileIdRef = useRef<string | null>(null);
@@ -902,17 +906,16 @@ export function DiffPane({
       // hunk can request a top offset that is no longer reachable once the viewport hits EOF.
       // Using the reachable value keeps the reveal logic from fighting later manual scrolling.
       if (selectedNoteBounds) {
-        scrollBox.scrollTo(
-          clampReviewScrollTop(
-            computeHunkRevealScrollTop({
-              hunkTop: selectedNoteBounds.top,
-              hunkHeight: selectedNoteBounds.height,
-              preferredTopPadding,
-              viewportHeight,
-            }),
-            viewportHeight,
-          ),
-        );
+        const revealScrollTop = computeHunkRevealScrollTop({
+          hunkTop: selectedNoteBounds.top,
+          hunkHeight: selectedNoteBounds.height,
+          preferredTopPadding,
+          viewportHeight,
+        });
+        // Floor against the owning file's body boundary so the viewport never crosses above it
+        // and triggers a pinned-header flash.
+        const flooredScrollTop = Math.max(revealScrollTop, selectedFileBodyTop);
+        scrollBox.scrollTo(clampReviewScrollTop(flooredScrollTop, viewportHeight));
         return;
       }
 
@@ -938,17 +941,16 @@ export function DiffPane({
           ? Math.max(0, renderedBottom - renderedTop)
           : selectedEstimatedHunkBounds.height;
 
-        scrollBox.scrollTo(
-          clampReviewScrollTop(
-            computeHunkRevealScrollTop({
-              hunkTop,
-              hunkHeight,
-              preferredTopPadding,
-              viewportHeight,
-            }),
-            viewportHeight,
-          ),
-        );
+        const revealScrollTop = computeHunkRevealScrollTop({
+          hunkTop,
+          hunkHeight,
+          preferredTopPadding,
+          viewportHeight,
+        });
+        // Floor against the owning file's body boundary so the viewport never crosses above it
+        // and triggers a pinned-header flash.
+        const flooredScrollTop = Math.max(revealScrollTop, selectedFileBodyTop);
+        scrollBox.scrollTo(clampReviewScrollTop(flooredScrollTop, viewportHeight));
         return;
       }
 
@@ -988,6 +990,7 @@ export function DiffPane({
     selectedFileIndex,
     selectedHunkIndex,
     selectedHunkRevealRequestId,
+    selectedFileBodyTop,
     selectedNoteHeight,
     selectedNoteTop,
     suppressViewportSelectionSync,

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -204,8 +204,13 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         return;
       }
 
+      const crossingFileBoundary = nextCursor.fileId !== selectedFile?.id;
       selectHunk(nextCursor.fileId, nextCursor.hunkIndex, {
-        alignFileHeaderTop: nextCursor.fileId !== selectedFile?.id,
+        // Align the file header to top only for forward cross-file jumps so the new file
+        // starts at its header. Backward jumps should reveal the target hunk directly,
+        // since the target is often near the bottom of the previous file and the file-top
+        // align would require an extra navigation press to reach it.
+        alignFileHeaderTop: crossingFileBoundary && delta > 0,
       });
     },
     [hunkCursors, selectHunk, selectedFile?.id, selectedHunkIndex],

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -332,6 +332,46 @@ export function createPtyHarness() {
     ]);
   }
 
+  /** Build the cross-file hunk-navigation shape that used to jump backward to the file top. */
+  function createCrossFileHunkNavigationRepoFixture() {
+    const longBeforeLines = Array.from(
+      { length: 342 },
+      (_, index) => `line ${String(index + 1).padStart(3, "0")}`,
+    );
+    const longAfterLines = [...longBeforeLines];
+    for (const lineNumber of [
+      2, 21, 41, 61, 81, 101, 121, 141, 161, 181, 201, 221, 241, 261, 281, 301, 321, 341,
+    ]) {
+      longAfterLines[lineNumber - 1] = `line ${String(lineNumber).padStart(3, "0")} changed`;
+    }
+
+    const shortBeforeLines = [
+      "// hunk 0 - at the very top of the file",
+      "export const top = 1;",
+      "",
+      "",
+      ...Array.from({ length: 25 }, (_, index) => `// filler ${index + 1}`),
+      "// hunk 1 - mid-file",
+      "export const mid = 3;",
+    ];
+    const shortAfterLines = [...shortBeforeLines];
+    shortAfterLines[1] = "export const top = 2;";
+    shortAfterLines[30] = "export const mid = 4;";
+
+    return createGitRepoFixture([
+      {
+        path: "long-file.txt",
+        before: `${longBeforeLines.join("\n")}\n`,
+        after: `${longAfterLines.join("\n")}\n`,
+      },
+      {
+        path: "short-file.ts",
+        before: `${shortBeforeLines.join("\n")}\n`,
+        after: `${shortAfterLines.join("\n")}\n`,
+      },
+    ]);
+  }
+
   function createPagerPatchFixture(lines = 40) {
     const dir = makeTempDir("hunk-tuistory-pager-");
     const beforeDir = join(dir, "before");
@@ -477,6 +517,7 @@ export function createPtyHarness() {
     createAgentFilePair,
     createBottomClampedRepoFixture,
     createCollapsedTopRepoFixture,
+    createCrossFileHunkNavigationRepoFixture,
     createLongWrapFilePair,
     createMultiHunkFilePair,
     createPagerPatchFixture,

--- a/test/pty/ui-integration.test.ts
+++ b/test/pty/ui-integration.test.ts
@@ -122,6 +122,47 @@ describe("live UI integration", () => {
     }
   });
 
+  test("backward cross-file hunk navigation reveals the target hunk in a real PTY", async () => {
+    const fixture = harness.createCrossFileHunkNavigationRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 16,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      for (let index = 0; index < 19; index += 1) {
+        await session.press("]");
+        await session.waitIdle({ timeout: 40 });
+      }
+
+      await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("export const mid = 4;"),
+        5_000,
+      );
+
+      await session.press("[");
+      await session.waitIdle({ timeout: 80 });
+      await session.press("[");
+      const backward = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("line 341 changed") || text.includes("line 002 changed"),
+        5_000,
+      );
+
+      expect(backward).toContain("line 341 changed");
+      expect(backward).not.toContain("line 002 changed");
+    } finally {
+      session.close();
+    }
+  });
+
   test("a short last file does not trap upward scrolling at the bottom edge", async () => {
     const fixture = harness.createBottomClampedRepoFixture();
     const session = await harness.launchHunk({


### PR DESCRIPTION
Hello!

Noticed this bug a couple of days ago: when navigating between hunks with `[` or `]`, the pinned header could sometime revert to the previous/next file when close to the newly entered file.

- When going to the next hunk with `]`, and going to the next file, doing `]` again shows the previous file again
- When navigating back with `[`, it could jump prematurely to the previous file.

It's a bit hard to explain so I had gpt-5.5 make narrated repro videos:



<details><summary>Before</summary>
<p>


https://github.com/user-attachments/assets/d0879a3d-c4c5-4537-b0df-72fac7574579



</p>
</details> 

<details><summary>After</summary>
<p>


https://github.com/user-attachments/assets/07cf3924-e2d4-4423-aeee-f10c83f49451



</p>
</details> 

Let me know if you want / need other changes!

------

<details><summary>Summary by GPT-5.5:</summary>
<p>

## Summary

- Fix cross-file `]` hunk navigation so near-top hunks in the destination file cannot scroll above that file's body and briefly hand the pinned header back to the previous file.
- Fix cross-file `[` hunk navigation so backward jumps reveal the target hunk in the previous file instead of aligning that file's header to the top.
- Add regression coverage for the long-file/short-file navigation shape that reproduced the pinned-header flash and backward file-top jump.
- Document the user-visible fix in `CHANGELOG.md`.

## Files changed

- `src/ui/components/panes/DiffPane.tsx`: floors hunk and note reveal scroll targets to the selected file `bodyTop` before final viewport clamping.
- `src/ui/hooks/useReviewController.ts`: makes cross-file header alignment direction-aware, using file-top alignment only for forward jumps.
- `src/ui/AppHost.interactions.test.tsx`: adds forward and backward cross-file hunk navigation regression tests.
- `test/pty/harness.ts`: adds a PTY fixture with a long first file and short second file.
- `test/pty/ui-integration.test.ts`: adds live PTY regression coverage for backward cross-file hunk navigation.

## Verification

- `bun test src/ui/AppHost.interactions.test.tsx -t "cross-file hunk navigation"`
- `bun test test/pty/ui-integration.test.ts -t "backward cross-file hunk navigation reveals the target hunk in a real PTY"`
- `bun run typecheck`
- `bun run format:check`

Also verified the new tests fail when the fix files are stashed and pass after restoring the fix.

</p>
</details>