### PR TITLE
docs: update agent-workflows.md according to latest version

### DIFF
--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -9,13 +9,12 @@ Use Hunk with agents in two ways:
 
 1. Open Hunk in one terminal with a normal review command such as `hunk diff` or `hunk show`.
 2. Load the Hunk review skill: [`skills/hunk-review/SKILL.md`](../skills/hunk-review/SKILL.md).
-   The local path for the skill is provided when running `hunk skill path`.
-4. Ask the agent to use the skill and review the current session.
+3. Ask the agent to use the skill and review the current session.
 
 A good generic prompt is:
 
 ```text
-Load the Hunk skill and use it for this review. Get the path of the skill by running the cmd `hunk skill path`.
+Load the Hunk skill and use it for this review. Run `hunk skill path` to get the skill path.
 ```
 
 That skill teaches the agent how to inspect a live Hunk session, navigate it, reload it, and leave inline comments.

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -9,15 +9,13 @@ Use Hunk with agents in two ways:
 
 1. Open Hunk in one terminal with a normal review command such as `hunk diff` or `hunk show`.
 2. Load the Hunk review skill: [`skills/hunk-review/SKILL.md`](../skills/hunk-review/SKILL.md).
-3. Ask the agent to use the skill and review the current session.
-
-> [!NOTE]
-> `hunk skill path` lands in Hunk 0.10.0. Until that release is out, load the skill from the repo path above.
+   The local path for the skill is provided when running `hunk skill path`.
+4. Ask the agent to use the skill and review the current session.
 
 A good generic prompt is:
 
 ```text
-Load the Hunk skill and use it for this review.
+Load the Hunk skill and use it for this review. Get the path of the skill by running the cmd `hunk skill path`.
 ```
 
 That skill teaches the agent how to inspect a live Hunk session, navigate it, reload it, and leave inline comments.


### PR DESCRIPTION
Since `0.10.0` is out, `hunk skill path` cmd is available. This PR updates the docs to encourage the user to use it.