### PR TITLE
docs(agent): note sandboxed session access

### DIFF
--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -25,6 +25,18 @@ When a Hunk TUI starts, it registers with a local loopback daemon. `hunk session
 
 Most users only need `hunk session ...`. Use `hunk mcp serve` only for manual startup or debugging of the local daemon.
 
+Some agent sandboxes restrict localhost access. If an agent reports no active sessions while a
+Hunk TUI is visibly running, first check whether the agent can reach the loopback daemon:
+
+```bash
+curl -s -X POST http://127.0.0.1:47657/session-api \
+  -H 'content-type: application/json' \
+  --data '{"action":"list"}'
+```
+
+If that direct API call shows sessions, rerun the same `hunk session ...` command with the
+agent's local-network or sandbox-escalation mechanism instead of restarting Hunk.
+
 ## The commands you will use most
 
 ### Inspect the current review

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -25,8 +25,7 @@ When a Hunk TUI starts, it registers with a local loopback daemon. `hunk session
 
 Most users only need `hunk session ...`. Use `hunk mcp serve` only for manual startup or debugging of the local daemon.
 
-Some agent sandboxes restrict localhost access. If an agent reports no active sessions while a
-Hunk TUI is visibly running, first check whether the agent can reach the loopback daemon:
+If `hunk session list` reports no sessions while Hunk is visibly running, the agent sandbox may be blocking loopback access. Probe the daemon directly:
 
 ```bash
 curl -s -X POST http://127.0.0.1:47657/session-api \
@@ -34,10 +33,7 @@ curl -s -X POST http://127.0.0.1:47657/session-api \
   --data '{"action":"list"}'
 ```
 
-> **Note:** the default port is `47657`. If you have set `HUNK_MCP_PORT`, substitute that value in the URL above.
-
-If that direct API call shows sessions, rerun the same `hunk session ...` command with the
-agent's local-network or sandbox-escalation mechanism instead of restarting Hunk.
+If this shows sessions, rerun the command with the agent's network/sandbox escalation. If you run the daemon with a custom `HUNK_MCP_PORT`, use that port instead.
 
 ## The commands you will use most
 

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -34,6 +34,8 @@ curl -s -X POST http://127.0.0.1:47657/session-api \
   --data '{"action":"list"}'
 ```
 
+> **Note:** the default port is `47657`. If you have set `HUNK_MCP_PORT`, substitute that value in the URL above.
+
 If that direct API call shows sessions, rerun the same `hunk session ...` command with the
 agent's local-network or sandbox-escalation mechanism instead of restarting Hunk.
 

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -40,24 +40,6 @@ Use `--source` only for advanced reloads where the live session you want to cont
 
 ## Commands
 
-### Sandboxed agents
-
-`hunk session *` talks to the local Hunk daemon over loopback. Some agent sandboxes may block
-those localhost requests, which can make `hunk session list` report no sessions even while a Hunk
-TUI is open. If the user can see Hunk running, check whether the sandbox can reach the daemon
-before assuming the session failed to register.
-
-A useful probe is (port defaults to `47657`; use `$HUNK_MCP_PORT` if you have overridden it):
-
-```bash
-curl -s -X POST http://127.0.0.1:47657/session-api \
-  -H 'content-type: application/json' \
-  --data '{"action":"list"}'
-```
-
-If the direct API shows sessions, rerun the same `hunk session ...` command with the agent's
-local-network or sandbox-escalation mechanism.
-
 ### Inspect
 
 ```bash
@@ -163,7 +145,7 @@ Guidelines:
 ## Common errors
 
 - **"No visible diff file matches ..."** -- the file is not in the loaded review. Check `context`, then `reload` if needed.
-- **"No active Hunk sessions"** -- if the user can see Hunk running, first check sandbox loopback access (see [Sandboxed agents](#sandboxed-agents) above); otherwise ask the user to open Hunk in their terminal.
+- **"No active Hunk sessions"** -- if Hunk is visibly running, localhost may be blocked by the agent sandbox; retry with network/sandbox escalation. Otherwise ask the user to open Hunk.
 - **"Multiple active sessions match"** -- pass `<session-id>` explicitly.
 - **"No active Hunk session matches session path ..."** -- for advanced split-path reloads, verify the live window `Path` via `hunk session get` or `list`, then use `--session-path`.
 - **"Pass the replacement Hunk command after `--`"** -- include `--` before the nested `diff` / `show` command.

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -40,6 +40,24 @@ Use `--source` only for advanced reloads where the live session you want to cont
 
 ## Commands
 
+### Sandboxed agents
+
+`hunk session *` talks to the local Hunk daemon over loopback. Some agent sandboxes may block
+those localhost requests, which can make `hunk session list` report no sessions even while a Hunk
+TUI is open. If the user can see Hunk running, check whether the sandbox can reach the daemon
+before assuming the session failed to register.
+
+A useful probe is:
+
+```bash
+curl -s -X POST http://127.0.0.1:47657/session-api \
+  -H 'content-type: application/json' \
+  --data '{"action":"list"}'
+```
+
+If the direct API shows sessions, rerun the same `hunk session ...` command with the agent's
+local-network or sandbox-escalation mechanism.
+
 ### Inspect
 
 ```bash

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -47,7 +47,7 @@ those localhost requests, which can make `hunk session list` report no sessions 
 TUI is open. If the user can see Hunk running, check whether the sandbox can reach the daemon
 before assuming the session failed to register.
 
-A useful probe is:
+A useful probe is (port defaults to `47657`; use `$HUNK_MCP_PORT` if you have overridden it):
 
 ```bash
 curl -s -X POST http://127.0.0.1:47657/session-api \
@@ -163,7 +163,7 @@ Guidelines:
 ## Common errors
 
 - **"No visible diff file matches ..."** -- the file is not in the loaded review. Check `context`, then `reload` if needed.
-- **"No active Hunk sessions"** -- ask the user to open Hunk in their terminal.
+- **"No active Hunk sessions"** -- if the user can see Hunk running, first check sandbox loopback access (see [Sandboxed agents](#sandboxed-agents) above); otherwise ask the user to open Hunk in their terminal.
 - **"Multiple active sessions match"** -- pass `<session-id>` explicitly.
 - **"No active Hunk session matches session path ..."** -- for advanced split-path reloads, verify the live window `Path` via `hunk session get` or `list`, then use `--session-path`.
 - **"Pass the replacement Hunk command after `--`"** -- include `--` before the nested `diff` / `show` command.


### PR DESCRIPTION
Adds a short troubleshooting note for agent workflows where `hunk session *` cannot reach the local loopback daemon from inside a sandbox.

  I hit this specifically with Codex sandbox mode: `hunk session list` reported no active sessions even though a Hunk TUI was running and the daemon's `/session-api` endpoint showed a
  registered session. This can make the normal "No active Hunk sessions" guidance misleading.

  The docs now suggest probing `/session-api` directly and rerunning session commands with the agent's local-network or sandbox-escalation mechanism when the daemon does have registered
  sessions.

  I’d avoid mentioning Claude unless someone confirms it has the same behavior.