### PR TITLE
feat(nix): add flake to support nix builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 out
 dist
 *.tgz
+result
 
 # code coverage
 coverage

--- a/.nix/nix-deps-hash.txt
+++ b/.nix/nix-deps-hash.txt
@@ -1,0 +1,1 @@
+sha256-Lr3M22JlMcX+HTZay2A1rN/zwGnznIjaib3E3y0Aob0=

--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -1,0 +1,65 @@
+{pkgs}: let
+  packageData = builtins.fromJSON (builtins.readFile ../package.json);
+
+  # Fetch dependencies (Network enabled, verified by hash)
+  bunDeps = pkgs.stdenv.mkDerivation {
+    pname = "hunk-deps";
+    inherit (packageData) version;
+    src = ../.;
+    dontCheckForBrokenSymlinks = true;
+    nativeBuildInputs = [pkgs.bun];
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+    outputHash = pkgs.lib.fileContents ./nix-deps-hash.txt;
+
+    buildPhase = ''
+      export HOME=$TMPDIR
+      bun install --frozen-lockfile --no-progress --ignore-scripts
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R node_modules $out/
+    '';
+  };
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "hunk";
+    inherit (packageData) version;
+    src = ../.;
+    dontStrip = true;
+
+    nativeBuildInputs = with pkgs; [
+      bun
+      bash
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      # Copy the pre-fetched dependencies
+      cp -R ${bunDeps}/node_modules ./node_modules
+      chmod -R +w ./node_modules
+
+      # Use project's custom build script
+      bun run build:bin
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin
+      cp ./dist/hunk $out/bin/hunk
+      chmod +x $out/bin/hunk
+      runHook postInstall
+    '';
+
+    meta = with pkgs.lib; {
+      description = "Terminal diff viewer for agentic changesets";
+      homepage = "https://github.com/modem-dev/hunk";
+      license = licenses.mit;
+      mainProgram = "hunk";
+      platforms = platforms.all;
+    };
+  }

--- a/.nix/package.nix
+++ b/.nix/package.nix
@@ -60,6 +60,6 @@ in
       homepage = "https://github.com/modem-dev/hunk";
       license = licenses.mit;
       mainProgram = "hunk";
-      platforms = platforms.all;
+      platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     };
   }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Hunk - Review-first terminal diff viewer for agentic coders";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = {
+    systems,
+    nixpkgs,
+    ...
+  }: let
+    eachSystem = nixpkgs.lib.genAttrs (import systems);
+  in {
+    packages = eachSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+      in {
+        default = import ./.nix/package.nix {inherit pkgs;};
+      }
+    );
+    devShells = eachSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+      in {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            bun
+            nodejs
+          ];
+        };
+      }
+    );
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           buildInputs = with pkgs; [
             bun
             nodejs
+            git
           ];
         };
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "bench:bootstrap-load": "bun run benchmarks/bootstrap-load.ts",
     "bench:highlight-prefetch": "bun run benchmarks/highlight-prefetch.ts",
     "bench:large-stream": "bun run benchmarks/large-stream.ts",
-    "bench:large-stream-profile": "bun run benchmarks/large-stream-profile.ts"
+    "bench:large-stream-profile": "bun run benchmarks/large-stream-profile.ts",
+    "nix:update-hash": "bash ./scripts/update-nix-hash.sh"
   },
   "dependencies": {
     "@pierre/diffs": "^1.1.19",

--- a/scripts/update-nix-hash.sh
+++ b/scripts/update-nix-hash.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Resetting Nix dependency hash..."
+echo "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" >.nix/nix-deps-hash.txt
+
+echo "Running Nix build to calculate new hash (this will intentionally fail)..."
+OUTPUT=$(nix build 2>&1 || true)
+NEW_HASH=$(echo "$OUTPUT" | grep -oP 'got:\s+\Ksha256-[a-zA-Z0-9+/=]+')
+
+if [ -n "$NEW_HASH" ]; then
+  echo "$NEW_HASH" >.nix/nix-deps-hash.txt
+  echo "✅ Successfully updated .nix/nix-deps-hash.txt to: $NEW_HASH"
+else
+  echo "❌ Failed to extract hash. Did the build succeed unexpectedly?"
+  echo "Nix output:"
+  echo "$OUTPUT"
+  exit 1
+fi

--- a/scripts/update-nix-hash.sh
+++ b/scripts/update-nix-hash.sh
@@ -6,7 +6,7 @@ echo "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" >.nix/nix-deps-hash.t
 
 echo "Running Nix build to calculate new hash (this will intentionally fail)..."
 OUTPUT=$(nix build 2>&1 || true)
-NEW_HASH=$(echo "$OUTPUT" | grep -oP 'got:\s+\Ksha256-[a-zA-Z0-9+/=]+')
+NEW_HASH=$(echo "$OUTPUT" | grep -oE 'got:[[:space:]]+sha256-[a-zA-Z0-9+/=]+' | sed 's/got:[[:space:]]*//')
 
 if [ -n "$NEW_HASH" ]; then
   echo "$NEW_HASH" >.nix/nix-deps-hash.txt


### PR DESCRIPTION
Closes #215 

As suggested in the issue, this PR adds a flake.nix file that Nix users can use to natively install and run the package.

The way I structured it is a top-level `flake.nix` that imports `.nix/package.nix`, the file containing the actual logic for building Hunk.

This is designed so no core maintainer needs any Nix knowledge:
Inside `.nix/`, there is a `nix-deps-hash.txt` file that's generated by the new `bun run nix:update-hash` script. Whenever the project's dependencies change, the Nix build will temporarily fall out of sync until someone runs this script to fetch the new hash. I suggest automating this via CI in the future so it's entirely hands-off for you, but I didn't want to make this initial PR too broad.

Since @MarkusZoppelt has already opened a PR (NixOS/nixpkgs#517626) to officially add Hunk to nixpkgs, this flake can be used by the community in the present while we wait for that to merge. Later, it will remain highly useful for local development (nix develop) and building purposes directly from source (the local building strategy is different from how nixpkgs will fetch the binary). I also used the exact same package name he chose, as discussed in his PR.