### PR TITLE
fix(core): use header counts for hunkLineRange so context lines are in range

### DIFF
--- a/src/core/liveComments.test.ts
+++ b/src/core/liveComments.test.ts
@@ -115,4 +115,41 @@ describe("live comment helpers", () => {
     expect(range.newRange[0]).toBeLessThanOrEqual(1);
     expect(range.newRange[1]).toBeGreaterThanOrEqual(2);
   });
+
+  // Regression: a hunk with one addition surrounded by lots of context used to report
+  // newRange = [start, start] (additions-only), so a comment anchored past the leading
+  // context fell outside the hunk's range, annotationOverlapsHunk returned false, and
+  // the hunk silently disappeared from getAnnotatedHunkIndices / annotated-cursor lists.
+  // Fix: hunkLineRange uses additionCount/deletionCount (header total, includes context)
+  // instead of additionLines/deletionLines (just '+' / '-' counts).
+  test("includes context lines when one hunk has many context rows around few changes", () => {
+    // 12 leading + 1 added + many trailing context lines on the new side.
+    const beforeLines = Array.from({ length: 25 }, (_, i) => `line${i + 1}`);
+    const afterLines = [
+      ...beforeLines.slice(0, 12),
+      "INSERTED",
+      ...beforeLines.slice(12),
+    ];
+
+    const file = createTestDiffFile({
+      before: lines(...beforeLines),
+      after: lines(...afterLines),
+      context: 100,
+      id: "file:context-heavy",
+      path: "src/sparse.ts",
+      previousPath: "src/sparse.ts",
+    });
+
+    expect(file.metadata.hunks.length).toBe(1);
+    const hunk = file.metadata.hunks[0]!;
+    expect(hunk.additionLines).toBe(1);
+
+    const range = hunkLineRange(hunk);
+
+    // The range must cover the inserted line at position 13 — additions-only bounds
+    // would put newEnd at additionStart and miss it.
+    expect(range.newRange[1]).toBeGreaterThanOrEqual(13);
+    expect(findHunkIndexForLine(file, "new", 13)).toBe(0);
+    expect(findHunkIndexForLine(file, "new", 20)).toBe(0);
+  });
 });

--- a/src/core/liveComments.test.ts
+++ b/src/core/liveComments.test.ts
@@ -125,11 +125,7 @@ describe("live comment helpers", () => {
   test("includes context lines when one hunk has many context rows around few changes", () => {
     // 12 leading + 1 added + many trailing context lines on the new side.
     const beforeLines = Array.from({ length: 25 }, (_, i) => `line${i + 1}`);
-    const afterLines = [
-      ...beforeLines.slice(0, 12),
-      "INSERTED",
-      ...beforeLines.slice(12),
-    ];
+    const afterLines = [...beforeLines.slice(0, 12), "INSERTED", ...beforeLines.slice(12)];
 
     const file = createTestDiffFile({
       before: lines(...beforeLines),

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -8,15 +8,25 @@ export interface ResolvedCommentTarget {
   line: number;
 }
 
-/** Compute the inclusive old/new line spans touched by one hunk. */
+/**
+ * Compute the inclusive old/new line spans for the visible extent of a hunk.
+ *
+ * Use the per-side `*Count` from the hunk header (`-X,count` / `+X,count`),
+ * which includes both context and changed lines, not the `*Lines` count which
+ * is only the `+` / `-` lines. Comments anchored at a context-region line
+ * (e.g. resolved by `firstCommentTargetForHunk` walking past leading context)
+ * fall outside the additions-only range and silently disappear from
+ * `getAnnotatedHunkIndices` / `findHunkIndexForLine` if those use the wrong
+ * extent.
+ */
 export function hunkLineRange(hunk: Hunk) {
   const newEnd = Math.max(
     hunk.additionStart,
-    hunk.additionStart + Math.max(hunk.additionLines, 1) - 1,
+    hunk.additionStart + Math.max(hunk.additionCount, 1) - 1,
   );
   const oldEnd = Math.max(
     hunk.deletionStart,
-    hunk.deletionStart + Math.max(hunk.deletionLines, 1) - 1,
+    hunk.deletionStart + Math.max(hunk.deletionCount, 1) - 1,
   );
 
   return {

--- a/src/ui/lib/agentAnnotations.test.ts
+++ b/src/ui/lib/agentAnnotations.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import { buildLiveComment, resolveCommentTarget } from "../../core/liveComments";
+import { getAnnotatedHunkIndices, getSelectedAnnotations } from "./agentAnnotations";
+
+function createContextHeavyHunkFile() {
+  const beforeLines = Array.from({ length: 25 }, (_, i) => `line${i + 1}`);
+  const afterLines = [...beforeLines.slice(0, 12), "INSERTED", ...beforeLines.slice(12)];
+
+  return createTestDiffFile({
+    before: lines(...beforeLines),
+    after: lines(...afterLines),
+    context: 100,
+    id: "file:context-heavy-annotation",
+    path: "src/sparse.ts",
+    previousPath: "src/sparse.ts",
+  });
+}
+
+describe("agent annotations", () => {
+  test("keeps hunk-number comments visible when anchored after leading context", () => {
+    const file = createContextHeavyHunkFile();
+    const hunk = file.metadata.hunks[0]!;
+
+    const target = resolveCommentTarget(file, {
+      filePath: file.path,
+      hunkIndex: 0,
+      summary: "Explain inserted line",
+      rationale: "The daemon resolves hunk-number comments to the first change row.",
+    });
+
+    expect(target).toMatchObject({ hunkIndex: 0, side: "new", line: 13 });
+    expect(hunk.additionLines).toBe(1);
+    expect(hunk.additionCount).toBeGreaterThan(target.line - hunk.additionStart + 1);
+
+    const comment = buildLiveComment(
+      {
+        filePath: file.path,
+        side: target.side,
+        line: target.line,
+        summary: "Explain inserted line",
+        rationale: "The daemon resolves hunk-number comments to the first change row.",
+      },
+      "comment-1",
+      "2026-03-22T00:00:00.000Z",
+      target.hunkIndex,
+    );
+    const annotatedFile = {
+      ...file,
+      agent: {
+        path: file.path,
+        annotations: [comment],
+      },
+    };
+
+    expect([...getAnnotatedHunkIndices(annotatedFile)]).toEqual([0]);
+    expect(getSelectedAnnotations(annotatedFile, hunk)).toEqual([comment]);
+  });
+});

--- a/src/ui/lib/agentAnnotations.ts
+++ b/src/ui/lib/agentAnnotations.ts
@@ -1,5 +1,6 @@
 import type { Hunk } from "@pierre/diffs";
 import type { AgentAnnotation, DiffFile } from "../../core/types";
+import { hunkLineRange } from "../../core/liveComments";
 import { fileLabel } from "./files";
 
 export interface VisibleAgentNote {
@@ -15,23 +16,6 @@ export interface AnnotationAnchor {
 /** Check whether two inclusive line ranges overlap. */
 function overlap(rangeA: [number, number], rangeB: [number, number]) {
   return rangeA[0] <= rangeB[1] && rangeB[0] <= rangeA[1];
-}
-
-/** Compute the old/new line ranges covered by a hunk, including single-line edge cases. */
-function hunkLineRange(hunk: Hunk) {
-  const newEnd = Math.max(
-    hunk.additionStart,
-    hunk.additionStart + Math.max(hunk.additionLines, 1) - 1,
-  );
-  const oldEnd = Math.max(
-    hunk.deletionStart,
-    hunk.deletionStart + Math.max(hunk.deletionLines, 1) - 1,
-  );
-
-  return {
-    oldRange: [hunk.deletionStart, oldEnd] as [number, number],
-    newRange: [hunk.additionStart, newEnd] as [number, number],
-  };
 }
 
 /** Check whether an annotation belongs to the visible span of a hunk. */


### PR DESCRIPTION
**User-visible:** `}` / `{` and `--next-comment` silently skip comments — visiting some, missing others. Repros whenever a comment is anchored on a line past the leading context of its hunk.

**Steps to reproduce (on `main`)**
1. `hunk diff <range>` on a diff that contains a hunk where the actual `+` / `-` line sits past leading context — e.g. a header like `@@ -28,20 +28,17 @@` whose first added line is around line 40.
2. Attach a comment to that hunk by hunk number (so the daemon resolves the anchor via `firstCommentTargetForHunk`):
   ```sh
   echo '{"comments":[{"filePath":"<file-with-context-heavy-hunk>","hunkNumber":1,"summary":"x","rationale":"y"}]}' \
     | hunk session comment apply --repo <repo> --stdin
   ```
3. Press `}` (or run `hunk session navigate --repo <repo> --next-comment`) repeatedly.
4. The hunk that the comment was applied to is silently skipped — the cursor list never includes it.

**Fix:** `hunkLineRange` now uses the per-side header total (`additionCount` / `deletionCount`, includes context), not the addition/deletion-only count, so comment-anchor lines fall inside the hunk's range and the hunks make it into the navigation cursor list. Also consolidates the duplicated copy in `agentAnnotations.ts` into a single import, and adds a regression test.

No user-facing docs or workflows change.

Fixes #235.