### PR TITLE
fix(ui): stabilize agent note navigation

### DIFF
--- a/src/core/liveComments.test.ts
+++ b/src/core/liveComments.test.ts
@@ -38,7 +38,9 @@ describe("live comment helpers", () => {
     const file = createExampleDiffFile();
 
     expect(findHunkIndexForLine(file, "old", 1)).toBe(0);
+    expect(findHunkIndexForLine(file, "old", 3)).toBe(0);
     expect(findHunkIndexForLine(file, "new", 2)).toBe(0);
+    expect(findHunkIndexForLine(file, "new", 4)).toBe(0);
     expect(findHunkIndexForLine(file, "new", 40)).toBe(-1);
   });
 
@@ -111,8 +113,8 @@ describe("live comment helpers", () => {
     const range = hunkLineRange(file.metadata.hunks[0]!);
 
     expect(range.oldRange[0]).toBeLessThanOrEqual(1);
-    expect(range.oldRange[1]).toBeGreaterThanOrEqual(2);
+    expect(range.oldRange[1]).toBeGreaterThanOrEqual(3);
     expect(range.newRange[0]).toBeLessThanOrEqual(1);
-    expect(range.newRange[1]).toBeGreaterThanOrEqual(2);
+    expect(range.newRange[1]).toBeGreaterThanOrEqual(4);
   });
 });

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -8,12 +8,16 @@ export interface ResolvedCommentTarget {
   line: number;
 }
 
-/** Compute the inclusive old/new line spans covered by one hunk. */
+/** Compute the inclusive old/new line spans covered by one hunk, including context rows. */
 export function hunkLineRange(hunk: Hunk) {
-  const additionSpan = hunk.additionCount ?? hunk.additionLines;
-  const deletionSpan = hunk.deletionCount ?? hunk.deletionLines;
-  const newEnd = Math.max(hunk.additionStart, hunk.additionStart + Math.max(additionSpan, 1) - 1);
-  const oldEnd = Math.max(hunk.deletionStart, hunk.deletionStart + Math.max(deletionSpan, 1) - 1);
+  const newEnd = Math.max(
+    hunk.additionStart,
+    hunk.additionStart + Math.max(hunk.additionCount, 1) - 1,
+  );
+  const oldEnd = Math.max(
+    hunk.deletionStart,
+    hunk.deletionStart + Math.max(hunk.deletionCount, 1) - 1,
+  );
 
   return {
     oldRange: [hunk.deletionStart, oldEnd] as [number, number],

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -8,16 +8,12 @@ export interface ResolvedCommentTarget {
   line: number;
 }
 
-/** Compute the inclusive old/new line spans touched by one hunk. */
+/** Compute the inclusive old/new line spans covered by one hunk. */
 export function hunkLineRange(hunk: Hunk) {
-  const newEnd = Math.max(
-    hunk.additionStart,
-    hunk.additionStart + Math.max(hunk.additionLines, 1) - 1,
-  );
-  const oldEnd = Math.max(
-    hunk.deletionStart,
-    hunk.deletionStart + Math.max(hunk.deletionLines, 1) - 1,
-  );
+  const additionSpan = hunk.additionCount ?? hunk.additionLines;
+  const deletionSpan = hunk.deletionCount ?? hunk.deletionLines;
+  const newEnd = Math.max(hunk.additionStart, hunk.additionStart + Math.max(additionSpan, 1) - 1);
+  const oldEnd = Math.max(hunk.deletionStart, hunk.deletionStart + Math.max(deletionSpan, 1) - 1);
 
   return {
     oldRange: [hunk.deletionStart, oldEnd] as [number, number],

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -40,7 +40,6 @@ import { VerticalScrollbar, type VerticalScrollbarHandle } from "../scrollbar/Ve
 import { prefetchHighlightedDiff } from "../../diff/useHighlightedDiff";
 
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
-const EMPTY_VISIBLE_AGENT_NOTES_BY_FILE = new Map<string, VisibleAgentNote[]>();
 
 /**
  * Clamp one vertical scroll target into the currently reachable review-stream extent.
@@ -270,8 +269,9 @@ export function DiffPane({
     return next;
   }, [files, showAgentNotes]);
 
-  // Keep exact row rendering for wrapped lines and the selected file's visible notes;
-  // other files can still use placeholders and viewport windowing.
+  // Keep exact row rendering for wrapped lines; other files can still use placeholders and viewport
+  // windowing. Rendered sections always include their note rows so their concrete height matches the
+  // geometry used for scroll planning.
   const windowingEnabled = !wrapLines;
   const [scrollViewport, setScrollViewport] = useState({ top: 0, height: 0 });
   const scrollbarRef = useRef<VerticalScrollbarHandle>(null);
@@ -391,35 +391,11 @@ export function DiffPane({
     return collectIntersectingFileSectionIds(baseFileSectionLayouts, minVisibleY, maxVisibleY);
   }, [baseFileSectionLayouts, scrollViewport.height, scrollViewport.top]);
 
-  const visibleAgentNotesByFile = useMemo(() => {
-    const next = new Map<string, VisibleAgentNote[]>();
-
-    if (!showAgentNotes) {
-      return EMPTY_VISIBLE_AGENT_NOTES_BY_FILE;
-    }
-
-    const fileIdsToMeasure = new Set(visibleViewportFileIds);
-    // Always measure the selected file with its real note rows so hunk navigation can compute
-    // accurate bounds even before the file scrolls into the visible viewport.
-    if (selectedFileId) {
-      fileIdsToMeasure.add(selectedFileId);
-    }
-
-    for (const fileId of fileIdsToMeasure) {
-      const visibleNotes = allAgentNotesByFile.get(fileId);
-      if (visibleNotes && visibleNotes.length > 0) {
-        next.set(fileId, visibleNotes);
-      }
-    }
-
-    return next;
-  }, [allAgentNotesByFile, selectedFileId, showAgentNotes, visibleViewportFileIds]);
-
   const sectionGeometry = useMemo(
     () =>
       files.map((file, index) => {
-        const visibleNotes = visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES;
-        if (visibleNotes.length === 0) {
+        const agentNotes = allAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES;
+        if (agentNotes.length === 0) {
           return baseSectionGeometry[index]!;
         }
 
@@ -428,7 +404,7 @@ export function DiffPane({
           layout,
           showHunkHeaders,
           theme,
-          visibleNotes,
+          agentNotes,
           diffContentWidth,
           showLineNumbers,
           wrapLines,
@@ -436,13 +412,13 @@ export function DiffPane({
       }),
     [
       baseSectionGeometry,
+      allAgentNotesByFile,
       diffContentWidth,
       files,
       layout,
       showHunkHeaders,
       showLineNumbers,
       theme,
-      visibleAgentNotesByFile,
       wrapLines,
     ],
   );
@@ -1094,7 +1070,7 @@ export function DiffPane({
                       theme={theme}
                       viewWidth={diffContentWidth}
                       visibleAgentNotes={
-                        visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
+                        allAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
                       }
                       onOpenAgentNotesAtHunk={(hunkIndex) =>
                         onOpenAgentNotesAtHunk(file.id, hunkIndex)

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -858,8 +858,20 @@ describe("UI components", () => {
 
   test("DiffPane lets manual scrolling move away from a bottom-clamped file-top alignment", async () => {
     const theme = resolveTheme("midnight", null);
+    const firstFile = createTallDiffFile("first", "first.ts", 30);
+    firstFile.agent = {
+      path: firstFile.path,
+      summary: "first file note",
+      annotations: [
+        {
+          newRange: [12, 12],
+          summary: "Offscreen note rows must stay in geometry.",
+          rationale: "This note is on the file above the bottom-clamped selected file.",
+        },
+      ],
+    };
     const files = [
-      createTallDiffFile("first", "first.ts", 30),
+      firstFile,
       createTestDiffFile(
         "second",
         "second.ts",
@@ -895,6 +907,7 @@ describe("UI components", () => {
             selectedHunkIndex: 0,
             selectedFileTopAlignRequestId,
             separatorWidth: 84,
+            showAgentNotes: true,
             width: 92,
           })}
         />

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -81,16 +81,11 @@ export function useAppKeyboardShortcuts({
 }: UseAppKeyboardShortcutsOptions) {
   const activeMenuIdRef = useRef(activeMenuId);
   const focusAreaRef = useRef(focusArea);
-  // Keep navigation shortcuts resilient if the keyboard hook changes how it stores callbacks.
-  const moveToAnnotatedHunkRef = useRef(moveToAnnotatedHunk);
-  const moveToHunkRef = useRef(moveToHunk);
   const pagerModeRef = useRef(pagerMode);
   const showHelpRef = useRef(showHelp);
 
   activeMenuIdRef.current = activeMenuId;
   focusAreaRef.current = focusArea;
-  moveToAnnotatedHunkRef.current = moveToAnnotatedHunk;
-  moveToHunkRef.current = moveToHunk;
   pagerModeRef.current = pagerMode;
   showHelpRef.current = showHelp;
 
@@ -367,22 +362,22 @@ export function useAppKeyboardShortcuts({
     }
 
     if (key.name === "[") {
-      runAndCloseMenu(() => moveToHunkRef.current(-1));
+      runAndCloseMenu(() => moveToHunk(-1));
       return;
     }
 
     if (key.name === "]") {
-      runAndCloseMenu(() => moveToHunkRef.current(1));
+      runAndCloseMenu(() => moveToHunk(1));
       return;
     }
 
     if (key.sequence === "{") {
-      runAndCloseMenu(() => moveToAnnotatedHunkRef.current(-1));
+      runAndCloseMenu(() => moveToAnnotatedHunk(-1));
       return;
     }
 
     if (key.sequence === "}") {
-      runAndCloseMenu(() => moveToAnnotatedHunkRef.current(1));
+      runAndCloseMenu(() => moveToAnnotatedHunk(1));
     }
   };
 

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -81,11 +81,16 @@ export function useAppKeyboardShortcuts({
 }: UseAppKeyboardShortcutsOptions) {
   const activeMenuIdRef = useRef(activeMenuId);
   const focusAreaRef = useRef(focusArea);
+  // Keep navigation shortcuts resilient if the keyboard hook changes how it stores callbacks.
+  const moveToAnnotatedHunkRef = useRef(moveToAnnotatedHunk);
+  const moveToHunkRef = useRef(moveToHunk);
   const pagerModeRef = useRef(pagerMode);
   const showHelpRef = useRef(showHelp);
 
   activeMenuIdRef.current = activeMenuId;
   focusAreaRef.current = focusArea;
+  moveToAnnotatedHunkRef.current = moveToAnnotatedHunk;
+  moveToHunkRef.current = moveToHunk;
   pagerModeRef.current = pagerMode;
   showHelpRef.current = showHelp;
 
@@ -362,22 +367,22 @@ export function useAppKeyboardShortcuts({
     }
 
     if (key.name === "[") {
-      runAndCloseMenu(() => moveToHunk(-1));
+      runAndCloseMenu(() => moveToHunkRef.current(-1));
       return;
     }
 
     if (key.name === "]") {
-      runAndCloseMenu(() => moveToHunk(1));
+      runAndCloseMenu(() => moveToHunkRef.current(1));
       return;
     }
 
     if (key.sequence === "{") {
-      runAndCloseMenu(() => moveToAnnotatedHunk(-1));
+      runAndCloseMenu(() => moveToAnnotatedHunkRef.current(-1));
       return;
     }
 
     if (key.sequence === "}") {
-      runAndCloseMenu(() => moveToAnnotatedHunk(1));
+      runAndCloseMenu(() => moveToAnnotatedHunkRef.current(1));
     }
   };
 

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -199,6 +199,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         selectedFile?.id,
         selectedHunkIndex,
         delta,
+        hunkCursors,
       );
       if (!nextCursor) {
         return;
@@ -224,6 +225,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         selectedFile?.id,
         selectedHunkIndex,
         delta,
+        hunkCursors,
       );
       if (!nextCursor) {
         return;
@@ -231,7 +233,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
 
       selectHunk(nextCursor.fileId, nextCursor.hunkIndex, { scrollToNote: true });
     },
-    [annotatedHunkCursors, selectHunk, selectedFile?.id, selectedHunkIndex],
+    [annotatedHunkCursors, hunkCursors, selectHunk, selectedFile?.id, selectedHunkIndex],
   );
 
   /** Cycle through only the currently visible files that carry annotations. */

--- a/src/ui/lib/agentAnnotations.ts
+++ b/src/ui/lib/agentAnnotations.ts
@@ -1,4 +1,5 @@
 import type { Hunk } from "@pierre/diffs";
+import { hunkLineRange } from "../../core/liveComments";
 import type { AgentAnnotation, DiffFile } from "../../core/types";
 import { fileLabel } from "./files";
 
@@ -15,23 +16,6 @@ export interface AnnotationAnchor {
 /** Check whether two inclusive line ranges overlap. */
 function overlap(rangeA: [number, number], rangeB: [number, number]) {
   return rangeA[0] <= rangeB[1] && rangeB[0] <= rangeA[1];
-}
-
-/** Compute the old/new line ranges covered by a hunk, including single-line edge cases. */
-function hunkLineRange(hunk: Hunk) {
-  const newEnd = Math.max(
-    hunk.additionStart,
-    hunk.additionStart + Math.max(hunk.additionLines, 1) - 1,
-  );
-  const oldEnd = Math.max(
-    hunk.deletionStart,
-    hunk.deletionStart + Math.max(hunk.deletionLines, 1) - 1,
-  );
-
-  return {
-    oldRange: [hunk.deletionStart, oldEnd] as [number, number],
-    newRange: [hunk.additionStart, newEnd] as [number, number],
-  };
 }
 
 /** Check whether an annotation belongs to the visible span of a hunk. */

--- a/src/ui/lib/hunks.test.ts
+++ b/src/ui/lib/hunks.test.ts
@@ -176,6 +176,7 @@ describe("annotated hunk navigation", () => {
       { fileId: "beta", hunkIndex: 0 },
       { fileId: "gamma", hunkIndex: 0 },
       { fileId: "gamma", hunkIndex: 1 },
+      { fileId: "omega", hunkIndex: 0 },
     ];
     const annotatedCursors: HunkCursor[] = [
       { fileId: "alpha", hunkIndex: 1 },
@@ -196,6 +197,10 @@ describe("annotated hunk navigation", () => {
       hunkIndex: 1,
     });
     expect(findNextHunkCursor(annotatedCursors, "gamma", 1, 1, streamCursors)).toEqual({
+      fileId: "gamma",
+      hunkIndex: 1,
+    });
+    expect(findNextHunkCursor(annotatedCursors, "omega", 0, 1, streamCursors)).toEqual({
       fileId: "gamma",
       hunkIndex: 1,
     });

--- a/src/ui/lib/hunks.test.ts
+++ b/src/ui/lib/hunks.test.ts
@@ -73,11 +73,10 @@ describe("annotated hunk navigation", () => {
   const afterB = "new\n";
 
   test("only includes hunks that have overlapping annotations", () => {
-    // Hunk 0 new range is [1,1], hunk 1 new range is [17,17].
-    // Annotate only hunk 1 in file alpha, and hunk 0 in file beta.
+    // Annotate the changed line in alpha hunk 1 and the only hunk in beta.
     const fileA = createTestFile("alpha", "alpha.ts", beforeA, afterA, {
       path: "alpha.ts",
-      annotations: [{ newRange: [17, 17], summary: "Note on hunk 1" }],
+      annotations: [{ newRange: [20, 20], summary: "Note on hunk 1" }],
     });
     const fileB = createTestFile("beta", "beta.ts", beforeB, afterB, {
       path: "beta.ts",
@@ -166,6 +165,38 @@ describe("annotated hunk navigation", () => {
     // Backward from an unknown position should land on the last annotated cursor.
     expect(findNextHunkCursor(annotatedCursors, "alpha", 0, -1)).toEqual({
       fileId: "alpha",
+      hunkIndex: 1,
+    });
+  });
+
+  test("uses full stream position when annotated navigation starts on an unannotated hunk", () => {
+    const streamCursors: HunkCursor[] = [
+      { fileId: "alpha", hunkIndex: 0 },
+      { fileId: "alpha", hunkIndex: 1 },
+      { fileId: "beta", hunkIndex: 0 },
+      { fileId: "gamma", hunkIndex: 0 },
+      { fileId: "gamma", hunkIndex: 1 },
+    ];
+    const annotatedCursors: HunkCursor[] = [
+      { fileId: "alpha", hunkIndex: 1 },
+      { fileId: "gamma", hunkIndex: 0 },
+      { fileId: "gamma", hunkIndex: 1 },
+    ];
+
+    expect(findNextHunkCursor(annotatedCursors, "beta", 0, 1, streamCursors)).toEqual({
+      fileId: "gamma",
+      hunkIndex: 0,
+    });
+    expect(findNextHunkCursor(annotatedCursors, "beta", 0, -1, streamCursors)).toEqual({
+      fileId: "alpha",
+      hunkIndex: 1,
+    });
+    expect(findNextHunkCursor(annotatedCursors, "alpha", 0, 1, streamCursors)).toEqual({
+      fileId: "alpha",
+      hunkIndex: 1,
+    });
+    expect(findNextHunkCursor(annotatedCursors, "gamma", 1, 1, streamCursors)).toEqual({
+      fileId: "gamma",
       hunkIndex: 1,
     });
   });

--- a/src/ui/lib/hunks.ts
+++ b/src/ui/lib/hunks.ts
@@ -29,6 +29,7 @@ export function findNextHunkCursor(
   currentFileId: string | undefined,
   currentHunkIndex: number,
   delta: number,
+  streamCursors: HunkCursor[] = cursors,
 ): HunkCursor | null {
   if (cursors.length === 0) {
     return null;
@@ -40,9 +41,54 @@ export function findNextHunkCursor(
   const nextIndex =
     currentIndex >= 0
       ? Math.min(Math.max(currentIndex + delta, 0), cursors.length - 1)
-      : delta >= 0
-        ? 0
-        : cursors.length - 1;
+      : findNearestCursorIndex(cursors, streamCursors, currentFileId, currentHunkIndex, delta);
 
   return cursors[nextIndex] ?? null;
+}
+
+/** Resolve relative movement when the current hunk is not in the target cursor subset. */
+function findNearestCursorIndex(
+  cursors: HunkCursor[],
+  streamCursors: HunkCursor[],
+  currentFileId: string | undefined,
+  currentHunkIndex: number,
+  delta: number,
+) {
+  if (!currentFileId) {
+    return delta >= 0 ? 0 : cursors.length - 1;
+  }
+
+  const currentStreamIndex = streamCursors.findIndex(
+    (cursor) => cursor.fileId === currentFileId && cursor.hunkIndex === currentHunkIndex,
+  );
+  if (currentStreamIndex < 0) {
+    return delta >= 0 ? 0 : cursors.length - 1;
+  }
+
+  const streamIndexByCursor = new Map(
+    streamCursors.map((cursor, index) => [`${cursor.fileId}\0${cursor.hunkIndex}`, index] as const),
+  );
+  const cursorStreamIndex = (cursor: HunkCursor) =>
+    streamIndexByCursor.get(`${cursor.fileId}\0${cursor.hunkIndex}`) ?? -1;
+  const indexedCursors = cursors
+    .map((cursor, index) => ({ index, streamIndex: cursorStreamIndex(cursor) }))
+    .filter(({ streamIndex }) => streamIndex >= 0);
+
+  if (indexedCursors.length === 0) {
+    return delta >= 0 ? 0 : cursors.length - 1;
+  }
+
+  if (delta >= 0) {
+    const nextCursor = indexedCursors.find(({ streamIndex }) => streamIndex > currentStreamIndex);
+    return nextCursor?.index ?? indexedCursors[indexedCursors.length - 1]!.index;
+  }
+
+  for (let index = indexedCursors.length - 1; index >= 0; index -= 1) {
+    const indexedCursor = indexedCursors[index]!;
+    if (indexedCursor.streamIndex < currentStreamIndex) {
+      return indexedCursor.index;
+    }
+  }
+
+  return indexedCursors[0]!.index;
 }

--- a/src/ui/lib/hunks.ts
+++ b/src/ui/lib/hunks.ts
@@ -78,6 +78,8 @@ function findNearestCursorIndex(
     return delta >= 0 ? 0 : cursors.length - 1;
   }
 
+  // Comment navigation is non-cyclic like normal hunk navigation, so positions outside
+  // the annotated span clamp to the nearest annotated edge instead of wrapping.
   if (delta >= 0) {
     const nextCursor = indexedCursors.find(({ streamIndex }) => streamIndex > currentStreamIndex);
     return nextCursor?.index ?? indexedCursors[indexedCursors.length - 1]!.index;

--- a/src/ui/lib/reviewState.ts
+++ b/src/ui/lib/reviewState.ts
@@ -132,8 +132,15 @@ export function resolveReviewNavigationTarget({
 }): ReviewNavigationTarget {
   if (input.commentDirection) {
     const delta = input.commentDirection === "next" ? 1 : -1;
+    const hunkCursors = buildHunkCursors(visibleFiles);
     const annotatedCursors = buildAnnotatedHunkCursors(visibleFiles);
-    const nextCursor = findNextHunkCursor(annotatedCursors, currentFileId, currentHunkIndex, delta);
+    const nextCursor = findNextHunkCursor(
+      annotatedCursors,
+      currentFileId,
+      currentHunkIndex,
+      delta,
+      hunkCursors,
+    );
 
     if (!nextCursor) {
       throw new Error("No annotated hunks found in the current review.");

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -155,6 +155,73 @@ export function createPtyHarness() {
     return { dir, before, after, agentContext };
   }
 
+  function createAgentNavigationRepoFixture() {
+    const alphaBeforeLines = createNumberedExportLines(1, 80).split("\n");
+    const alphaAfterLines = [...alphaBeforeLines];
+    alphaAfterLines[0] = "export const line01 = 1001;";
+    alphaAfterLines[59] = "export const line60 = 6000;";
+
+    const betaBeforeLines = createNumberedExportLines(81, 20).split("\n");
+    const betaAfterLines = [...betaBeforeLines];
+    betaAfterLines[0] = "export const line81 = 8100;";
+
+    const gammaBeforeLines = createNumberedExportLines(101, 80).split("\n");
+    const gammaAfterLines = [...gammaBeforeLines];
+    gammaAfterLines[0] = "export const line101 = 10100;";
+    gammaAfterLines[59] = "export const line160 = 16000;";
+
+    const fixture = createGitRepoFixture([
+      {
+        path: "alpha.ts",
+        before: `${alphaBeforeLines.join("\n")}\n`,
+        after: `${alphaAfterLines.join("\n")}\n`,
+      },
+      {
+        path: "beta.ts",
+        before: `${betaBeforeLines.join("\n")}\n`,
+        after: `${betaAfterLines.join("\n")}\n`,
+      },
+      {
+        path: "gamma.ts",
+        before: `${gammaBeforeLines.join("\n")}\n`,
+        after: `${gammaAfterLines.join("\n")}\n`,
+      },
+    ]);
+    const agentContext = join(fixture.dir, "agent-context.json");
+
+    writeText(
+      agentContext,
+      JSON.stringify({
+        version: 1,
+        summary: "Agent navigation notes",
+        files: [
+          {
+            path: "alpha.ts",
+            annotations: [
+              {
+                newRange: [60, 60],
+                summary: "Alpha note for navigation.",
+                rationale: "A taller note keeps note rows in the scroll geometry.",
+              },
+            ],
+          },
+          {
+            path: "gamma.ts",
+            annotations: [
+              {
+                newRange: [60, 60],
+                summary: "Gamma note for navigation.",
+                rationale: "Navigation should reach this note without crashing.",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    return { ...fixture, agentContext };
+  }
+
   function createMultiHunkFilePair() {
     const dir = makeTempDir("hunk-tuistory-hunks-");
     const before = join(dir, "before.ts");
@@ -515,6 +582,7 @@ export function createPtyHarness() {
     cleanup,
     countMatches,
     createAgentFilePair,
+    createAgentNavigationRepoFixture,
     createBottomClampedRepoFixture,
     createCollapsedTopRepoFixture,
     createCrossFileHunkNavigationRepoFixture,

--- a/test/pty/ui-integration.test.ts
+++ b/test/pty/ui-integration.test.ts
@@ -92,6 +92,43 @@ describe("live UI integration", () => {
     }
   });
 
+  test("comment navigation between agent-context notes does not crash the live UI", async () => {
+    const fixture = harness.createAgentNavigationRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split", "--agent-context", fixture.agentContext, "--agent-notes"],
+      cwd: fixture.dir,
+      cols: 160,
+      rows: 14,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      expect(initial).not.toContain("Maximum update depth exceeded");
+
+      await session.press("}");
+      const alphaNote = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("Alpha note for navigation."),
+        5_000,
+      );
+      expect(alphaNote).not.toContain("Maximum update depth exceeded");
+
+      await session.press("}");
+      const gammaNote = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("Gamma note for navigation."),
+        5_000,
+      );
+
+      expect(gammaNote).toContain("Gamma note for navigation.");
+      expect(gammaNote).not.toContain("Maximum update depth exceeded");
+    } finally {
+      session.close();
+    }
+  });
+
   test("real hunk navigation jumps to later hunks in the review stream", async () => {
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Summary

This is a combined fix for the agent-note navigation failures I hit while reviewing a live `--agent-context` session:

- keep agent-note geometry stable so total review height no longer changes as note-bearing files enter/leave the viewport
- resolve `{` / `}` and `hunk session navigate --next-comment` / `--prev-comment` relative to the full review stream when the current hunk is not itself annotated
- match annotation ranges against the full visible hunk span, including context rows, so saved `agent-context` anchors inside a hunk remain navigable
- keep comment navigation non-cyclic at annotated-stream edges, matching normal hunk-navigation clamp behavior

Fixes #234.
Fixes #235.
Refs #233.

## Relationship to the other open PRs

There are three related open PRs. This PR overlaps with them, but it is not identical.

- #242 is the direct fix for #233. It coalesces viewport listener updates with `queueMicrotask` to avoid setState during OpenTUI scrollbar/layout event emission. This PR does **not** include that direct viewport-loop guard, so it should not close #233. What this PR does for #233 is indirect: it removes the agent-note height oscillation that can feed the same update loop.
- #243 fixes #234 with a narrower `DiffPane` change: measure geometry with all notes, but keep rendering on the viewport-restricted note set. This PR fixes the same root cause by removing the split source entirely: geometry and rendered sections both receive `allAgentNotesByFile`. That is simpler and matches the one-source-of-truth direction, but it has a possible rendering-work tradeoff for visible/prefetched sections with many notes.
- #244 fixes one comment-navigation failure by widening `hunkLineRange` to use the full hunk header span. This PR includes that same category of fix, but also fixes a separate #235 path: when the current selected hunk is not annotated, `{` / `}` used to fall back to the first/last annotated hunk instead of resolving the next annotated hunk relative to the current full-stream position.

## What is worth keeping if the other PRs land first

If #242, #243, and #244 land before this PR, I can rebase and narrow this branch. The part that still appears worth merging from this PR is:

- stream-relative annotated navigation in `src/ui/lib/hunks.ts`
- the React/session callsites that pass the full hunk stream into that helper (`useReviewController.ts`, `reviewState.ts`)
- the unit regression in `src/ui/lib/hunks.test.ts`
- the live PTY regression for repeated `}` navigation through an `agent-context` sidecar

Those pieces are not reflected in #242, #243, or #244 as currently written.

Optional pieces after a rebase:

- The `DiffPane` geometry work should be dropped if maintainers prefer #243's narrower measurement-only approach.
- The `hunkLineRange` consolidation should be dropped if #244 lands first, unless maintainers prefer this branch's shared-helper shape.

## Repro Steps

### Bottom-edge snap-back with notes (#234)

1. Open a multi-file review: `hunk diff <range>`.
2. Attach agent notes to a file that can scroll off the top, for example:
   ```sh
   printf '%s\n' '{"comments":[{"filePath":"<early-file>","hunkNumber":1,"summary":"note"}]}' \
     | hunk session comment apply --repo <repo> --stdin
   ```
3. Scroll to the last line of the last file.
4. Try to scroll one line farther.

Before this change, the viewport can snap upward by roughly the height of off-top note rows because total content height changes with the viewport.

### Next/previous comment from a non-annotated hunk (#235)

1. Open a multi-file review and attach notes to several hunks.
2. Press `}` a couple of times to move through notes.
3. Scroll or press `]` so the selected/centered hunk is not one of the annotated hunks.
4. Press `}` again.

Before this change, the fallback path in `findNextHunkCursor` treats the current hunk as absent from the filtered annotated cursor list and jumps to the first annotated hunk instead of the next annotated hunk after the current stream position.

### Context-row anchors skipped by comment navigation

1. Use a hunk with leading context before the changed line.
2. Add a hunk-level comment so Hunk resolves the note anchor to the first changed row inside the visible hunk span.
3. Navigate with `}` or `hunk session navigate --next-comment`.

Before this change, `hunkLineRange` used `additionLines` / `deletionLines`, which count changed lines only, not the full hunk header extent. Anchors on context-adjacent rows could then fall outside the hunk range and never enter the annotated cursor list.

## Fix

### Stable agent-note geometry

`DiffPane` now derives `sectionGeometry` from the full per-file note map rather than a viewport-restricted note map. That keeps `totalContentHeight` independent of `scrollViewport.top`, so bottom-edge clamping has a stable ceiling while scrolling.

### Stream-relative annotated navigation

`findNextHunkCursor` now accepts the full stream cursor list. If the current hunk is absent from the target subset, annotated navigation finds the nearest target cursor before/after the current stream position instead of falling back to the first/last annotated cursor.

When the current stream position is outside the annotated span, comment navigation clamps to the nearest annotated edge instead of wrapping. That matches normal hunk navigation and is now documented/tested explicitly.

Both the React review controller and session command path pass the full stream into that helper.

### Full hunk-span range matching

`hunkLineRange` now uses Pierre's required header span counts (`additionCount` / `deletionCount`). `agentAnnotations` uses that shared helper, so live comments, sidecar notes, and annotated-hunk discovery all agree on hunk extent.

### Review follow-up

After Greptile review, this branch drops the defensive keyboard callback refs rather than expanding that pattern. OpenTUI's current `useKeyboard` already keeps the latest handler via `useEffectEvent`, and the refs were not part of the root fix.

## Tradeoffs

- This intentionally removes the separate viewport-restricted note-measurement path. Rendered sections now receive the same full note set used for geometry. File-level windowing still limits which sections render, but a visible/prefetched section with many notes may do more per-render note placement work than #243's narrower measurement-only approach.
- This is a combined fix across related failure modes. If maintainers prefer the split upstream PRs, I can rebase this branch after they land and keep only the stream-relative annotated-navigation pieces listed above.
- This does not include the microtask coalescing approach from #242, so #233 should stay assigned to #242 or a similar direct viewport-loop fix.

## Testing

Passed on current branch head:

```sh
bun test src/core/liveComments.test.ts src/ui/lib/hunks.test.ts src/ui/components/ui-components.test.tsx src/ui/AppHost.interactions.test.tsx -t "line numbers|hunk ranges|overlapping annotations|uses full stream position|manual scrolling move away|comment"
tmp=$(mktemp -d); XDG_CONFIG_HOME="$tmp" bun test test/pty/ui-integration.test.ts -t "comment navigation between agent-context notes"; rc=$?; rm -rf "$tmp"; exit $rc
bun run lint
bun run format:check
```

`bun run typecheck` currently fails on `main` itself, independent of this branch:

```text
src/ui/AppHost.interactions.test.tsx(267,10): error TS2552: Cannot find name 'createTestGitAppBootstrap'. Did you mean 'createTestVcsAppBootstrap'?
```

I left that unrelated base issue out of this PR. I can rebase once `main` is fixed.
