### PR TITLE
chore(release): prepare 0.11.0 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
-## [0.11.0] - 2026-05-09
+## [0.11.0-beta.0] - 2026-05-09
 
 ### Added
 
@@ -269,8 +269,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Stabilized diff repainting, active-hunk scrolling, syntax highlighting, pager stdin patch handling, and terminal cleanup on exit.
 
-[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.11.0...HEAD
-[0.11.0]: https://github.com/modem-dev/hunk/compare/v0.10.0...v0.11.0
+[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.11.0-beta.0...HEAD
+[0.11.0-beta.0]: https://github.com/modem-dev/hunk/compare/v0.10.0...v0.11.0-beta.0
 [0.10.0]: https://github.com/modem-dev/hunk/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/modem-dev/hunk/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/modem-dev/hunk/compare/v0.9.3...v0.9.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.11.0] - 2026-05-09
+
+### Added
+
 - Added `vcs = "jj"` support, enabling `hunk diff [revset]` and `hunk show [revset]`.
 - Added a pager-mode sidebar file tree that can be revealed with the existing `s` shortcut while keeping pager chrome hidden by default.
 
@@ -13,7 +21,9 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed `git log -p` and multi-commit `git show -p` inputs so patch parsing ignores commit metadata instead of emitting Pierre parser warnings.
 - Fixed cross-file hunk navigation so near-boundary jumps keep the selected file pinned and backward jumps reveal the target hunk instead of the file top.
+- Fixed the View menu sidebar checkmark so it follows whether the responsive layout is actually rendering the sidebar.
 
 ## [0.10.0] - 2026-04-21
 
@@ -259,7 +269,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Stabilized diff repainting, active-hunk scrolling, syntax highlighting, pager stdin patch handling, and terminal cleanup on exit.
 
-[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/modem-dev/hunk/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/modem-dev/hunk/compare/v0.9.5...v0.10.0
 [0.9.5]: https://github.com/modem-dev/hunk/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/modem-dev/hunk/compare/v0.9.3...v0.9.4

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Load the Hunk skill and use it for this review.
 ```
 
 > [!NOTE]
-> `hunk skill path` lands in Hunk 0.10.0. Until that release is out, load the skill from the repo path above.
+> `hunk skill path` is available in Hunk 0.10.0 and newer. On older installs, load the skill from the repo path above.
 
 For the full live-session and `--agent-context` workflow guide, see [docs/agent-workflows.md](docs/agent-workflows.md).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.11.0",
+  "version": "0.11.0-beta.0",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Bump `hunkdiff` to `0.11.0-beta.0`.
- Move current Unreleased changelog entries into the `0.11.0-beta.0` release section and add missing user-visible fixes.
- Refresh the README note for `hunk skill path` now that 0.10.0 is already released.

## Validation

- `bun run ./scripts/check-release-version.ts v0.11.0-beta.0`
- `bun run format:check`
- `bun run typecheck`
- `bun test src/core/cli.test.ts src/core/loaders.gitLog.test.ts src/ui/AppHost.responsive.test.tsx src/ui/AppHost.interactions.test.tsx src/ui/lib/ui-lib.test.ts`

*This PR description was generated by Pi using OpenAI GPT-5.1 Codex*
