### PR TITLE
fix(git): pass --no-ext-diff when diffing untracked files

### DIFF
--- a/src/core/git.test.ts
+++ b/src/core/git.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import { runGitText } from "./git";
+import { buildGitStashShowArgs, runGitText } from "./git";
 
 describe("git command helpers", () => {
+  test("disables external diff tools for stash patches", () => {
+    const args = buildGitStashShowArgs({
+      kind: "stash-show",
+      options: { mode: "auto" },
+    });
+
+    expect(args).toContain("--no-ext-diff");
+  });
+
   test("reports a friendly error when git is not installed or not on PATH", () => {
     expect(() =>
       runGitText({

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -126,7 +126,7 @@ export function buildGitShowArgs(input: ShowCommandInput) {
 
 /** Build the exact `git stash show -p` arguments used for stash review. */
 export function buildGitStashShowArgs(input: StashShowCommandInput) {
-  const args = ["stash", "show", "-p", "--find-renames", "--no-color"];
+  const args = ["stash", "show", "-p", "--no-ext-diff", "--find-renames", "--no-color"];
 
   if (input.ref) {
     args.push(input.ref);

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -99,8 +99,11 @@ function buildGitStatusArgs(input: VcsCommandInput) {
 
 /** Build the synthetic patch used to render one untracked file as a new-file diff. */
 function buildGitNewFileDiffArgs(filePath: string) {
+  // `--no-ext-diff` keeps user-configured `diff.external` tools (difftastic, delta, etc.)
+  // from replacing the unified-diff output Pierre needs to parse this synthetic patch.
   return withNormalizedDiffPrefixes([
     "diff",
+    "--no-ext-diff",
     "--no-index",
     "--no-color",
     "--",

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -518,6 +518,29 @@ describe("loadAppBootstrap", () => {
     expect(paths).toHaveLength(fixtureFiles.length);
   });
 
+  test("loads untracked files even when diff.external is configured in the repo", async () => {
+    // Regression: a user-configured `diff.external` (e.g. difftastic) silently replaces
+    // git's unified-diff output, which left the untracked-file synthesizer with patch
+    // text Pierre couldn't parse and threw "Expected one parsed file ..., got 0".
+    const dir = createTempRepo("hunk-git-untracked-ext-diff-");
+
+    writeFileSync(join(dir, "tracked.ts"), "export const tracked = 1;\n");
+    git(dir, "add", "tracked.ts");
+    git(dir, "commit", "-m", "initial");
+
+    git(dir, "config", "diff.external", "/usr/bin/true");
+    writeFileSync(join(dir, "untracked.ts"), "export const added = true;\n");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["untracked.ts"]);
+    expect(bootstrap.changeset.files[0]?.patch).toContain("new file mode");
+  });
+
   test("still shows an untracked agent sidecar when it lives inside the repo", async () => {
     const dir = createTempRepo("hunk-git-agent-sidecar-");
 

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -528,7 +528,7 @@ describe("loadAppBootstrap", () => {
     git(dir, "add", "tracked.ts");
     git(dir, "commit", "-m", "initial");
 
-    git(dir, "config", "diff.external", "/usr/bin/true");
+    git(dir, "config", "diff.external", "git --version");
     writeFileSync(join(dir, "untracked.ts"), "export const added = true;\n");
 
     const bootstrap = await loadFromRepo(dir, {

--- a/test/cli/entrypoint.test.ts
+++ b/test/cli/entrypoint.test.ts
@@ -197,20 +197,13 @@ describe("CLI entrypoint contracts", () => {
   });
 
   test("general pager mode falls back to plain text for non-diff stdin", () => {
-    const proc = Bun.spawnSync(
-      [
-        "bash",
-        "-lc",
-        "printf '* main\\n  feature/demo\\n' | HUNK_TEXT_PAGER=cat bun run src/main.tsx pager",
-      ],
-      {
-        cwd: process.cwd(),
-        stdin: "ignore",
-        stdout: "pipe",
-        stderr: "pipe",
-        env: process.env,
-      },
-    );
+    const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "pager"], {
+      cwd: process.cwd(),
+      stdin: Buffer.from("* main\n  feature/demo\n"),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: process.env,
+    });
 
     const stdout = Buffer.from(proc.stdout).toString("utf8");
     const stderr = Buffer.from(proc.stderr).toString("utf8");


### PR DESCRIPTION
## Summary

If you have `diff.external` set in git config (difftastic, delta, etc.), `hunk diff` crashes on any untracked file:

```bash
$ hunk diff
hunk: Expected one parsed file for untracked patch "foo.txt", got 0.
```

hunk forms untracked patches via `git diff --no-index`, which honors `diff.external` and outputs whatever that tool prints instead of unified diff. The regular diff/show paths already use `--no-ext-diff`, the untracked path was missing it.

## Test

- Added a regression that sets `diff.external` on a temp repo and loads an untracked file.
- Repro'd locally with `diff.external = difft`; works after the fix.