### PR TITLE
feat(ui): add F9 shortcut to toggle the menu bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+- Menu bar can now be hidden via `F9` or View → Menu bar, giving the diff full vertical space.
+
 ### Changed
 
 ### Fixed

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -109,6 +109,7 @@ export function App({
   const [wrapLines, setWrapLines] = useState(bootstrap.initialWrapLines ?? false);
   const [codeHorizontalOffset, setCodeHorizontalOffset] = useState(0);
   const [showHunkHeaders, setShowHunkHeaders] = useState(bootstrap.initialShowHunkHeaders ?? true);
+  const [showMenuBar, setShowMenuBar] = useState(true);
   const [sidebarVisible, setSidebarVisible] = useState(true);
   const [forceSidebarOpen, setForceSidebarOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -326,6 +327,11 @@ export function App({
     setShowHunkHeaders((current) => !current);
   };
 
+  /** Toggle the top menu bar on or off. */
+  const toggleMenuBar = () => {
+    setShowMenuBar((current) => !current);
+  };
+
   /** Jump to an annotated hunk without changing the global note visibility toggle. */
   const openAgentNotesAtHunk = useCallback(
     (fileId: string, hunkIndex: number) => {
@@ -486,6 +492,7 @@ export function App({
         showHelp,
         showHunkHeaders,
         showLineNumbers,
+        showMenuBar,
         sidebarVisible,
         toggleAgentNotes,
         toggleFocusArea,
@@ -493,6 +500,7 @@ export function App({
         toggleHunkHeaders,
         toggleLineNumbers,
         toggleLineWrap,
+        toggleMenuBar,
         toggleSidebar,
         wrapLines,
       }),
@@ -511,6 +519,7 @@ export function App({
       showHelp,
       showHunkHeaders,
       showLineNumbers,
+      showMenuBar,
       sidebarVisible,
       toggleAgentNotes,
       toggleFocusArea,
@@ -518,6 +527,7 @@ export function App({
       toggleHunkHeaders,
       toggleLineNumbers,
       toggleLineWrap,
+      toggleMenuBar,
       toggleSidebar,
       wrapLines,
     ],
@@ -565,6 +575,7 @@ export function App({
     toggleHunkHeaders,
     toggleLineNumbers,
     toggleLineWrap,
+    toggleMenuBar,
     toggleSidebar,
     triggerRefreshCurrentInput,
   });
@@ -636,7 +647,7 @@ export function App({
         backgroundColor: activeTheme.background,
       }}
     >
-      {!pagerMode ? (
+      {!pagerMode && showMenuBar ? (
         <MenuBar
           activeMenuId={activeMenuId}
           menuSpecs={menuSpecs}

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1730,6 +1730,41 @@ describe("App interactions", () => {
     }
   });
 
+  test("F9 toggles the top menu bar off and back on", async () => {
+    const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
+      width: 220,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+
+      let frame = setup.captureCharFrame();
+      expect(frame).toMatch(/File\s+View\s+Navigate\s+Theme\s+Agent\s+Help/);
+
+      await act(async () => {
+        await setup.mockInput.pressKey("F9");
+      });
+      frame = await waitForFrame(
+        setup,
+        (nextFrame) => !/File\s+View\s+Navigate\s+Theme\s+Agent\s+Help/.test(nextFrame),
+      );
+      expect(frame).not.toMatch(/File\s+View\s+Navigate\s+Theme\s+Agent\s+Help/);
+
+      await act(async () => {
+        await setup.mockInput.pressKey("F9");
+      });
+      frame = await waitForFrame(setup, (nextFrame) =>
+        /File\s+View\s+Navigate\s+Theme\s+Agent\s+Help/.test(nextFrame),
+      );
+      expect(frame).toMatch(/File\s+View\s+Navigate\s+Theme\s+Agent\s+Help/);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("sidebar visibility can toggle off and back on", async () => {
     const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
       width: 240,

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -42,6 +42,7 @@ export function HelpDialog({
       title: "View",
       items: [
         ["1 / 2 / 0", "split / stack / auto"],
+        ["F9", "toggle menu bar"],
         ["s / t", "sidebar / theme"],
         ["a", "toggle AI notes"],
         ["l / w / m", "lines / wrap / metadata"],

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1527,6 +1527,7 @@ describe("UI components", () => {
       "Shift+Wheel     scroll code horizontally",
       "View",
       "1 / 2 / 0       split / stack / auto",
+      "F9              toggle menu bar",
       "s / t           sidebar / theme",
       "a               toggle AI notes",
       "l / w / m       lines / wrap / metadata",

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -45,6 +45,7 @@ export interface UseAppKeyboardShortcutsOptions {
   toggleHunkHeaders: () => void;
   toggleLineNumbers: () => void;
   toggleLineWrap: () => void;
+  toggleMenuBar: () => void;
   toggleSidebar: () => void;
   triggerRefreshCurrentInput: () => void;
 }
@@ -76,6 +77,7 @@ export function useAppKeyboardShortcuts({
   toggleHunkHeaders,
   toggleLineNumbers,
   toggleLineWrap,
+  toggleMenuBar,
   toggleSidebar,
   triggerRefreshCurrentInput,
 }: UseAppKeyboardShortcutsOptions) {
@@ -358,6 +360,11 @@ export function useAppKeyboardShortcuts({
 
     if (key.name === "m" || key.sequence === "m") {
       runAndCloseMenu(toggleHunkHeaders);
+      return;
+    }
+
+    if (key.name === "f9") {
+      runAndCloseMenu(toggleMenuBar);
       return;
     }
 

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -18,6 +18,7 @@ export interface BuildAppMenusOptions {
   showHelp: boolean;
   showHunkHeaders: boolean;
   showLineNumbers: boolean;
+  showMenuBar: boolean;
   sidebarVisible: boolean;
   toggleAgentNotes: () => void;
   toggleFocusArea: () => void;
@@ -25,6 +26,7 @@ export interface BuildAppMenusOptions {
   toggleHunkHeaders: () => void;
   toggleLineNumbers: () => void;
   toggleLineWrap: () => void;
+  toggleMenuBar: () => void;
   toggleSidebar: () => void;
   wrapLines: boolean;
 }
@@ -46,6 +48,7 @@ export function buildAppMenus({
   showHelp,
   showHunkHeaders,
   showLineNumbers,
+  showMenuBar,
   sidebarVisible,
   toggleAgentNotes,
   toggleFocusArea,
@@ -53,6 +56,7 @@ export function buildAppMenus({
   toggleHunkHeaders,
   toggleLineNumbers,
   toggleLineWrap,
+  toggleMenuBar,
   toggleSidebar,
   wrapLines,
 }: BuildAppMenusOptions): Record<MenuId, MenuEntry[]> {
@@ -122,6 +126,13 @@ export function buildAppMenus({
         action: () => selectLayoutMode("auto"),
       },
       { kind: "separator" },
+      {
+        kind: "item",
+        label: "Menu bar",
+        hint: "F9",
+        checked: showMenuBar,
+        action: toggleMenuBar,
+      },
       {
         kind: "item",
         label: "Sidebar",

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -136,6 +136,7 @@ describe("ui helpers", () => {
       showHelp: false,
       showHunkHeaders: false,
       showLineNumbers: true,
+      showMenuBar: true,
       sidebarVisible: false,
       toggleAgentNotes: () => {},
       toggleFocusArea: () => {},
@@ -143,6 +144,7 @@ describe("ui helpers", () => {
       toggleHunkHeaders: () => {},
       toggleLineNumbers: () => {},
       toggleLineWrap: () => {},
+      toggleMenuBar: () => {},
       toggleSidebar: () => {},
       wrapLines: true,
     });
@@ -164,7 +166,13 @@ describe("ui helpers", () => {
             entry.kind === "item" && Boolean(entry.checked),
         )
         .map((entry) => entry.label),
-    ).toEqual(["Stacked view", "Agent notes", "Line numbers", "Line wrapping"]);
+    ).toEqual(["Stacked view", "Menu bar", "Agent notes", "Line numbers", "Line wrapping"]);
+    expect(
+      menus.view.find(
+        (entry): entry is Extract<MenuEntry, { kind: "item" }> =>
+          entry.kind === "item" && entry.label === "Menu bar",
+      ),
+    ).toMatchObject({ hint: "F9" });
     expect(
       menus.theme
         .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")


### PR DESCRIPTION
## Summary

- Adds `showMenuBar` state to `App` with a `toggleMenuBar` handler
- Wires `F9` keyboard shortcut via `useAppKeyboardShortcuts`
- Exposes "Menu bar" entry (with `F9` hint) in the View menu
- Updates `HelpDialog` to show the shortcut
- Adds interaction test and unit test coverage

## Test plan

- [ ] Press `F9` — menu bar disappears, giving the diff full vertical space
- [ ] Press `F9` again — menu bar reappears
- [ ] Open View menu → "Menu bar" — same toggle behavior
- [ ] Help dialog shows `F9  toggle menu bar` under the View section
- [ ] `bun test` passes (interaction + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)