### PR TITLE
feat(ui): add Catppuccin themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+- Added Catppuccin Latte and Mocha as built-in themes.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can persist preferences to a config file:
 Example:
 
 ```toml
-theme = "graphite"   # graphite, midnight, paper, ember
+theme = "graphite"   # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha
 mode = "auto"        # auto, split, stack
 vcs = "git"          # git, jj
 exclude_untracked = false

--- a/docs/opentui-component.md
+++ b/docs/opentui-component.md
@@ -99,19 +99,19 @@ if (!metadata) {
 
 ## Props
 
-| Prop                | Type                                             | Default      | Notes                                                                     |
-| ------------------- | ------------------------------------------------ | ------------ | ------------------------------------------------------------------------- |
-| `diff`              | `HunkDiffFile`                                   | `undefined`  | File to render. When omitted, the component shows an empty-state message. |
-| `layout`            | `"split" \| "stack"`                             | `"split"`    | Chooses side-by-side or stacked rendering.                                |
-| `width`             | `number`                                         | —            | Required content width in terminal columns.                               |
-| `theme`             | `"graphite" \| "midnight" \| "paper" \| "ember"` | `"graphite"` | Matches Hunk's built-in themes.                                           |
-| `showLineNumbers`   | `boolean`                                        | `true`       | Toggles line-number columns.                                              |
-| `showHunkHeaders`   | `boolean`                                        | `true`       | Toggles `@@ ... @@` hunk header rows.                                     |
-| `wrapLines`         | `boolean`                                        | `false`      | Wraps long lines instead of clipping horizontally.                        |
-| `horizontalOffset`  | `number`                                         | `0`          | Scroll offset for non-wrapped code rows.                                  |
-| `highlight`         | `boolean`                                        | `true`       | Enables syntax highlighting.                                              |
-| `scrollable`        | `boolean`                                        | `true`       | Set to `false` if your parent view owns scrolling.                        |
-| `selectedHunkIndex` | `number`                                         | `0`          | Highlights one hunk as the active target.                                 |
+| Prop                | Type                                                                                         | Default      | Notes                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------- |
+| `diff`              | `HunkDiffFile`                                                                               | `undefined`  | File to render. When omitted, the component shows an empty-state message. |
+| `layout`            | `"split" \| "stack"`                                                                         | `"split"`    | Chooses side-by-side or stacked rendering.                                |
+| `width`             | `number`                                                                                     | —            | Required content width in terminal columns.                               |
+| `theme`             | `"graphite" \| "midnight" \| "paper" \| "ember" \| "catppuccin-latte" \| "catppuccin-mocha"` | `"graphite"` | Matches Hunk's built-in themes.                                           |
+| `showLineNumbers`   | `boolean`                                                                                    | `true`       | Toggles line-number columns.                                              |
+| `showHunkHeaders`   | `boolean`                                                                                    | `true`       | Toggles `@@ ... @@` hunk header rows.                                     |
+| `wrapLines`         | `boolean`                                                                                    | `false`      | Wraps long lines instead of clipping horizontally.                        |
+| `horizontalOffset`  | `number`                                                                                     | `0`          | Scroll offset for non-wrapped code rows.                                  |
+| `highlight`         | `boolean`                                                                                    | `true`       | Enables syntax highlighting.                                              |
+| `scrollable`        | `boolean`                                                                                    | `true`       | Set to `false` if your parent view owns scrolling.                        |
+| `selectedHunkIndex` | `number`                                                                                     | `0`          | Highlights one hunk as the active target.                                 |
 
 ## Other exports
 

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -61,6 +61,13 @@ describe("HunkDiffView", () => {
   });
 
   test("exports the documented built-in theme names", () => {
-    expect(HUNK_DIFF_THEME_NAMES).toEqual(["graphite", "midnight", "paper", "ember"]);
+    expect(HUNK_DIFF_THEME_NAMES).toEqual([
+      "graphite",
+      "midnight",
+      "paper",
+      "ember",
+      "catppuccin-latte",
+      "catppuccin-mocha",
+    ]);
   });
 });

--- a/src/opentui/themes.ts
+++ b/src/opentui/themes.ts
@@ -1,3 +1,10 @@
-export const HUNK_DIFF_THEME_NAMES = ["graphite", "midnight", "paper", "ember"] as const;
+export const HUNK_DIFF_THEME_NAMES = [
+  "graphite",
+  "midnight",
+  "paper",
+  "ember",
+  "catppuccin-latte",
+  "catppuccin-mocha",
+] as const;
 
 export type HunkDiffThemeName = (typeof HUNK_DIFF_THEME_NAMES)[number];

--- a/src/ui/diff/pierre.test.ts
+++ b/src/ui/diff/pierre.test.ts
@@ -184,7 +184,7 @@ describe("Pierre diff rows", () => {
   test("remaps Pierre markdown reds and greens away from diff-semantic hues", async () => {
     const file = createMarkdownDiffFile();
 
-    for (const themeId of ["midnight", "paper"] as const) {
+    for (const themeId of ["midnight", "paper", "catppuccin-latte", "catppuccin-mocha"] as const) {
       const theme = resolveTheme(themeId, null);
       const highlighted = await loadHighlightedDiff(file, theme.appearance);
       const rows = buildStackRows(file, highlighted, theme).filter(
@@ -229,7 +229,7 @@ describe("Pierre diff rows", () => {
     const file = createMarkdownDiffFile();
     const highlighted = await loadHighlightedDiff(file, "dark");
 
-    for (const themeId of ["graphite", "midnight", "ember"] as const) {
+    for (const themeId of ["graphite", "midnight", "ember", "catppuccin-mocha"] as const) {
       const theme = resolveTheme(themeId, null);
       const rows = buildStackRows(file, highlighted, theme).filter(
         (row): row is Extract<DiffRow, { type: "stack-line" }> =>

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -169,7 +169,7 @@ describe("ui helpers", () => {
       menus.theme
         .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
         .map((entry) => entry.label),
-    ).toEqual(["Graphite", "Midnight", "Paper", "Ember"]);
+    ).toEqual(["Graphite", "Midnight", "Paper", "Ember", "Catppuccin Latte", "Catppuccin Mocha"]);
     expect(
       menus.theme.some(
         (entry) => entry.kind === "item" && entry.label === "Graphite" && entry.checked,
@@ -368,5 +368,7 @@ describe("ui helpers", () => {
     expect(missingLight.id).toBe("graphite");
     expect(missingDark.id).toBe("graphite");
     expect(resolveTheme("ember", null).syntaxStyle).toBeDefined();
+    expect(resolveTheme("catppuccin-latte", null).syntaxStyle).toBeDefined();
+    expect(resolveTheme("catppuccin-mocha", null).syntaxStyle).toBeDefined();
   });
 });

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { blendHex, hexColorDistance } from "./lib/color";
+import { CATPPUCCIN_PALETTES, resolveTheme } from "./themes";
+
+describe("themes", () => {
+  test("resolves Catppuccin Latte and Mocha by theme id", () => {
+    const latte = resolveTheme("catppuccin-latte", null);
+    const mocha = resolveTheme("catppuccin-mocha", null);
+
+    expect(latte.id).toBe("catppuccin-latte");
+    expect(latte.label).toBe("Catppuccin Latte");
+    expect(latte.appearance).toBe("light");
+    expect(mocha.id).toBe("catppuccin-mocha");
+    expect(mocha.label).toBe("Catppuccin Mocha");
+    expect(mocha.appearance).toBe("dark");
+  });
+
+  test("keeps official Catppuccin sentinel colors in source", () => {
+    expect(CATPPUCCIN_PALETTES.latte.base).toBe("#eff1f5");
+    expect(CATPPUCCIN_PALETTES.latte.mauve).toBe("#8839ef");
+    expect(CATPPUCCIN_PALETTES.latte.green).toBe("#40a02b");
+    expect(CATPPUCCIN_PALETTES.latte.red).toBe("#d20f39");
+    expect(CATPPUCCIN_PALETTES.mocha.base).toBe("#1e1e2e");
+    expect(CATPPUCCIN_PALETTES.mocha.mauve).toBe("#cba6f7");
+    expect(CATPPUCCIN_PALETTES.mocha.green).toBe("#a6e3a1");
+    expect(CATPPUCCIN_PALETTES.mocha.red).toBe("#f38ba8");
+  });
+
+  test("derives Catppuccin diff backgrounds from official semantic tokens", () => {
+    const latte = resolveTheme("catppuccin-latte", null);
+    const mocha = resolveTheme("catppuccin-mocha", null);
+
+    expect(latte.addedBg).toBe(blendHex(CATPPUCCIN_PALETTES.latte.green, latte.contextBg, 0.15));
+    expect(latte.removedBg).toBe(blendHex(CATPPUCCIN_PALETTES.latte.red, latte.contextBg, 0.15));
+    expect(latte.addedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.latte.green, latte.contextBg, 0.25),
+    );
+    expect(latte.removedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.latte.red, latte.contextBg, 0.25),
+    );
+    expect(mocha.addedBg).toBe(blendHex(CATPPUCCIN_PALETTES.mocha.green, mocha.contextBg, 0.15));
+    expect(mocha.removedBg).toBe(blendHex(CATPPUCCIN_PALETTES.mocha.red, mocha.contextBg, 0.15));
+    expect(mocha.addedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.mocha.green, mocha.contextBg, 0.25),
+    );
+    expect(mocha.removedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.mocha.red, mocha.contextBg, 0.25),
+    );
+  });
+
+  test("keeps Catppuccin add and remove rows semantically distinct", () => {
+    for (const theme of [
+      resolveTheme("catppuccin-latte", null),
+      resolveTheme("catppuccin-mocha", null),
+    ]) {
+      expect(theme.addedBg).not.toBe(theme.removedBg);
+      expect(hexColorDistance(theme.addedBg, theme.contextBg)).toBeGreaterThan(0);
+      expect(hexColorDistance(theme.removedBg, theme.contextBg)).toBeGreaterThan(0);
+      expect(hexColorDistance(theme.addedContentBg, theme.contextBg)).toBeGreaterThan(
+        hexColorDistance(theme.addedBg, theme.contextBg),
+      );
+      expect(hexColorDistance(theme.removedContentBg, theme.contextBg)).toBeGreaterThan(
+        hexColorDistance(theme.removedBg, theme.contextBg),
+      );
+    }
+  });
+
+  test("maps Catppuccin syntax roles to documented editor tokens", () => {
+    const latte = resolveTheme("catppuccin-latte", null);
+    const mocha = resolveTheme("catppuccin-mocha", null);
+
+    expect(latte.syntaxColors).toMatchObject({
+      keyword: CATPPUCCIN_PALETTES.latte.mauve,
+      string: CATPPUCCIN_PALETTES.latte.green,
+      comment: CATPPUCCIN_PALETTES.latte.overlay2,
+      number: CATPPUCCIN_PALETTES.latte.peach,
+      function: CATPPUCCIN_PALETTES.latte.blue,
+      property: CATPPUCCIN_PALETTES.latte.blue,
+      type: CATPPUCCIN_PALETTES.latte.yellow,
+      punctuation: CATPPUCCIN_PALETTES.latte.overlay2,
+    });
+    expect(mocha.syntaxColors).toMatchObject({
+      keyword: CATPPUCCIN_PALETTES.mocha.mauve,
+      string: CATPPUCCIN_PALETTES.mocha.green,
+      comment: CATPPUCCIN_PALETTES.mocha.overlay2,
+      number: CATPPUCCIN_PALETTES.mocha.peach,
+      function: CATPPUCCIN_PALETTES.mocha.blue,
+      property: CATPPUCCIN_PALETTES.mocha.blue,
+      type: CATPPUCCIN_PALETTES.mocha.yellow,
+      punctuation: CATPPUCCIN_PALETTES.mocha.overlay2,
+    });
+  });
+});

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -1,4 +1,5 @@
 import { RGBA, SyntaxStyle, type ThemeMode } from "@opentui/core";
+import { blendHex } from "./lib/color";
 
 export interface AppTheme {
   id: string;
@@ -51,6 +52,99 @@ type SyntaxColors = {
   punctuation: string;
 };
 
+type CatppuccinPalette = {
+  rosewater: string;
+  flamingo: string;
+  pink: string;
+  mauve: string;
+  red: string;
+  maroon: string;
+  peach: string;
+  yellow: string;
+  green: string;
+  teal: string;
+  sky: string;
+  sapphire: string;
+  blue: string;
+  lavender: string;
+  text: string;
+  subtext1: string;
+  subtext0: string;
+  overlay2: string;
+  overlay1: string;
+  overlay0: string;
+  surface2: string;
+  surface1: string;
+  surface0: string;
+  base: string;
+  mantle: string;
+  crust: string;
+};
+
+// Source: https://github.com/catppuccin/palette/blob/main/palette.json
+// Cross-check reference: https://catppuccin.com/palette/
+// Semantic guidance: https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md
+export const CATPPUCCIN_PALETTES = {
+  latte: {
+    rosewater: "#dc8a78",
+    flamingo: "#dd7878",
+    pink: "#ea76cb",
+    mauve: "#8839ef",
+    red: "#d20f39",
+    maroon: "#e64553",
+    peach: "#fe640b",
+    yellow: "#df8e1d",
+    green: "#40a02b",
+    teal: "#179299",
+    sky: "#04a5e5",
+    sapphire: "#209fb5",
+    blue: "#1e66f5",
+    lavender: "#7287fd",
+    text: "#4c4f69",
+    subtext1: "#5c5f77",
+    subtext0: "#6c6f85",
+    overlay2: "#7c7f93",
+    overlay1: "#8c8fa1",
+    overlay0: "#9ca0b0",
+    surface2: "#acb0be",
+    surface1: "#bcc0cc",
+    surface0: "#ccd0da",
+    base: "#eff1f5",
+    mantle: "#e6e9ef",
+    crust: "#dce0e8",
+  },
+  mocha: {
+    rosewater: "#f5e0dc",
+    flamingo: "#f2cdcd",
+    pink: "#f5c2e7",
+    mauve: "#cba6f7",
+    red: "#f38ba8",
+    maroon: "#eba0ac",
+    peach: "#fab387",
+    yellow: "#f9e2af",
+    green: "#a6e3a1",
+    teal: "#94e2d5",
+    sky: "#89dceb",
+    sapphire: "#74c7ec",
+    blue: "#89b4fa",
+    lavender: "#b4befe",
+    text: "#cdd6f4",
+    subtext1: "#bac2de",
+    subtext0: "#a6adc8",
+    overlay2: "#9399b2",
+    overlay1: "#7f849c",
+    overlay0: "#6c7086",
+    surface2: "#585b70",
+    surface1: "#45475a",
+    surface0: "#313244",
+    base: "#1e1e2e",
+    mantle: "#181825",
+    crust: "#11111b",
+  },
+} as const satisfies Record<"latte" | "mocha", CatppuccinPalette>;
+
+type CatppuccinFlavor = keyof typeof CATPPUCCIN_PALETTES;
+
 /** Build the syntax palette OpenTUI should use for in-terminal code rendering. */
 function createSyntaxStyle(colors: SyntaxColors) {
   return SyntaxStyle.fromStyles({
@@ -85,6 +179,70 @@ function withLazySyntaxStyle(
       return syntaxStyle;
     },
   };
+}
+
+/** Blend one official Catppuccin token into another for terminal-safe opacity guidance. */
+function catppuccinBlend(fg: string, bg: string, opacity: number) {
+  return blendHex(fg, bg, opacity);
+}
+
+/** Map official Catppuccin palette tokens into Hunk's semantic theme slots. */
+function createCatppuccinTheme(flavor: CatppuccinFlavor, appearance: AppTheme["appearance"]) {
+  const palette = CATPPUCCIN_PALETTES[flavor];
+  const label = flavor === "latte" ? "Catppuccin Latte" : "Catppuccin Mocha";
+  const panel = flavor === "latte" ? palette.base : palette.mantle;
+  const panelAlt = flavor === "latte" ? palette.mantle : palette.base;
+  const contextBg = palette.base;
+
+  return withLazySyntaxStyle(
+    {
+      id: `catppuccin-${flavor}`,
+      label,
+      appearance,
+      background: palette.crust,
+      panel,
+      panelAlt,
+      border: palette.surface1,
+      accent: palette.mauve,
+      accentMuted: catppuccinBlend(palette.mauve, panel, 0.2),
+      text: palette.text,
+      muted: palette.subtext0,
+      addedBg: catppuccinBlend(palette.green, contextBg, 0.15),
+      removedBg: catppuccinBlend(palette.red, contextBg, 0.15),
+      contextBg,
+      addedContentBg: catppuccinBlend(palette.green, contextBg, 0.25),
+      removedContentBg: catppuccinBlend(palette.red, contextBg, 0.25),
+      contextContentBg: contextBg,
+      addedSignColor: palette.green,
+      removedSignColor: palette.red,
+      lineNumberBg: palette.mantle,
+      lineNumberFg: palette.overlay1,
+      selectedHunk: catppuccinBlend(palette.overlay2, contextBg, 0.25),
+      badgeAdded: palette.green,
+      badgeRemoved: palette.red,
+      badgeNeutral: palette.overlay2,
+      fileNew: palette.green,
+      fileDeleted: palette.red,
+      fileRenamed: palette.yellow,
+      fileModified: palette.mauve,
+      fileUntracked: palette.sky,
+      noteBorder: palette.mauve,
+      noteBackground: catppuccinBlend(palette.mauve, panel, 0.12),
+      noteTitleBackground: catppuccinBlend(palette.mauve, panel, 0.22),
+      noteTitleText: palette.text,
+    },
+    {
+      default: palette.text,
+      keyword: palette.mauve,
+      string: palette.green,
+      comment: palette.overlay2,
+      number: palette.peach,
+      function: palette.blue,
+      property: palette.blue,
+      type: palette.yellow,
+      punctuation: palette.overlay2,
+    },
+  );
 }
 
 export const THEMES: AppTheme[] = [
@@ -284,6 +442,8 @@ export const THEMES: AppTheme[] = [
       punctuation: "#a17d69",
     },
   ),
+  createCatppuccinTheme("latte", "light"),
+  createCatppuccinTheme("mocha", "dark"),
 ];
 
 /** Resolve a named theme or fall back to Hunk's explicit built-in default. */


### PR DESCRIPTION
## Summary

- add Catppuccin Latte and Mocha as built-in themes
- derive Catppuccin diff, selection, and note colors from official palette tokens
- expose the themes through CLI config and the OpenTUI component API

## Verification

- bun run typecheck
- bun run format:check
- bun run lint
- bun test src/ui/themes.test.ts src/opentui/HunkDiffView.test.tsx src/ui/lib/ui-lib.test.ts src/ui/diff/pierre.test.ts