### PR TITLE
feat(config): auto-detect jj checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Changed
 
+- Auto-detect Jujutsu checkouts for `hunk diff` and `hunk show`, while keeping explicit `vcs` config overrides.
+
 ### Fixed
 
 ## [0.11.0] - 2026-05-09

--- a/README.md
+++ b/README.md
@@ -59,15 +59,7 @@ hunk show HEAD~1               # review an earlier commit
 
 ### Working with Jujutsu
 
-Set `vcs = "jj"` in config to use the same `hunk diff [revset]` and `hunk show [revset]` commands with Jujutsu revsets instead. When `vcs` is unset, Hunk uses Git.
-
-To use hunk as jj's pager, run `jj config edit --user` and update:
-
-```toml
-[ui]
-pager = ["hunk", "pager"]
-diff-formatter = ":git"
-```
+Hunk auto-detects Jujutsu checkouts, so `hunk diff [revset]` and `hunk show [revset]` use jj revsets inside a jj workspace. To override VCS detection, set `vcs = "git"` or `vcs = "jj"` in [config](#config).
 
 ### Working with raw files and patches
 
@@ -156,6 +148,16 @@ If you want to keep Git's default pager and add opt-in aliases instead:
 ```bash
 git config --global alias.hdiff "-c core.pager=\"hunk pager\" diff"
 git config --global alias.hshow "-c core.pager=\"hunk pager\" show"
+```
+
+### Jujutsu pager integration
+
+To use Hunk as jj's pager, run `jj config edit --user` and update:
+
+```toml
+[ui]
+pager = ["hunk", "pager"]
+diff-formatter = ":git"
 ```
 
 ### OpenTUI component

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -27,6 +27,10 @@ function createRepo(dir: string) {
   mkdirSync(join(dir, ".git"), { recursive: true });
 }
 
+function createJjRepo(dir: string) {
+  mkdirSync(join(dir, ".jj"), { recursive: true });
+}
+
 function createPatchPagerInput(overrides: Partial<CliInput["options"]> = {}): CliInput {
   return {
     kind: "patch",
@@ -182,6 +186,55 @@ describe("config resolution", () => {
 
     expect(defaultResolved.input.options.vcs).toBe("git");
     expect(configuredResolved.input.options.vcs).toBe("jj");
+  });
+
+  test("auto-detects jj checkouts before falling back to git mode", () => {
+    const home = createTempDir("hunk-config-home-");
+    const jjRepo = createTempDir("hunk-config-jj-repo-");
+    const colocatedRepo = createTempDir("hunk-config-colocated-repo-");
+    const gitRepo = createTempDir("hunk-config-git-repo-");
+
+    createJjRepo(jjRepo);
+    createRepo(colocatedRepo);
+    createJjRepo(colocatedRepo);
+    createRepo(gitRepo);
+
+    const input = {
+      kind: "vcs",
+      staged: false,
+      options: {},
+    } satisfies CliInput;
+
+    expect(
+      resolveConfiguredCliInput(input, { cwd: jjRepo, env: { HOME: home } }).input.options.vcs,
+    ).toBe("jj");
+    expect(
+      resolveConfiguredCliInput(input, { cwd: colocatedRepo, env: { HOME: home } }).input.options
+        .vcs,
+    ).toBe("jj");
+    expect(
+      resolveConfiguredCliInput(input, { cwd: gitRepo, env: { HOME: home } }).input.options.vcs,
+    ).toBe("git");
+  });
+
+  test("explicit config overrides auto-detected jj mode", () => {
+    const home = createTempDir("hunk-config-home-");
+    const repo = createTempDir("hunk-config-jj-repo-");
+    createJjRepo(repo);
+
+    mkdirSync(join(repo, ".hunk"), { recursive: true });
+    writeFileSync(join(repo, ".hunk", "config.toml"), 'vcs = "git"\n');
+
+    const resolved = resolveConfiguredCliInput(
+      {
+        kind: "vcs",
+        staged: false,
+        options: {},
+      },
+      { cwd: repo, env: { HOME: home } },
+    );
+
+    expect(resolved.input.options.vcs).toBe("git");
   });
 
   test("loadAppBootstrap exposes resolved initial preferences to the UI", async () => {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -193,6 +193,7 @@ describe("config resolution", () => {
     const jjRepo = createTempDir("hunk-config-jj-repo-");
     const colocatedRepo = createTempDir("hunk-config-colocated-repo-");
     const gitRepo = createTempDir("hunk-config-git-repo-");
+    const plainDir = createTempDir("hunk-config-no-repo-");
 
     createJjRepo(jjRepo);
     createRepo(colocatedRepo);
@@ -214,6 +215,9 @@ describe("config resolution", () => {
     ).toBe("jj");
     expect(
       resolveConfiguredCliInput(input, { cwd: gitRepo, env: { HOME: home } }).input.options.vcs,
+    ).toBe("git");
+    expect(
+      resolveConfiguredCliInput(input, { cwd: plainDir, env: { HOME: home } }).input.options.vcs,
     ).toBe("git");
   });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -119,6 +119,15 @@ function findRepoRoot(cwd = process.cwd()) {
   }
 }
 
+/** Choose the VCS backend that best matches the discovered checkout. */
+function detectRepoVcsMode(repoRoot?: string): VcsMode {
+  if (repoRoot && fs.existsSync(join(repoRoot, ".jj"))) {
+    return "jj";
+  }
+
+  return "git";
+}
+
 /** Parse one TOML config file into a plain object. */
 function readTomlRecord(path: string) {
   if (!fs.existsSync(path)) {
@@ -144,7 +153,7 @@ export function resolveConfiguredCliInput(
 
   let resolvedOptions: CommonOptions = {
     mode: DEFAULT_VIEW_PREFERENCES.mode,
-    vcs: "git",
+    vcs: detectRepoVcsMode(repoRoot),
     // Keep the built-in theme default explicit so stdin-backed startup paths do not depend on
     // renderer theme-mode detection for their initial palette.
     theme: "graphite",


### PR DESCRIPTION
## Summary

- Auto-detect `.jj` checkouts as Jujutsu-backed reviews by default
- Prefer jj mode for colocated jj/git workspaces unless explicit config overrides it
- Add config-resolution coverage for jj-only, colocated jj/git, git-only, and override cases

## Testing

- `bun test src/core/config.test.ts`
- `bun run typecheck`
- `bun run format:check`

*This PR description was generated by Pi using OpenAI GPT-5*
