### PR TITLE
fix(diff): skip huge file rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed large tracked and untracked file handling so very large diffs render as skipped placeholders instead of slowing startup or overflowing the JavaScript call stack.
+
 ## [0.11.0] - 2026-05-09
 
 ### Added

--- a/scripts/test-large-untracked-render.tsx
+++ b/scripts/test-large-untracked-render.tsx
@@ -1,0 +1,94 @@
+import { testRender } from "@opentui/react/test-utils";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { act } from "react";
+import { loadAppBootstrap } from "../src/core/loaders";
+import { AppHost } from "../src/ui/AppHost";
+
+function runGit(cwd: string, ...args: string[]) {
+  const proc = Bun.spawnSync(["git", ...args], {
+    cwd,
+    stderr: "pipe",
+    stdin: "ignore",
+    stdout: "pipe",
+  });
+
+  if (proc.exitCode !== 0) {
+    throw new Error(Buffer.from(proc.stderr).toString("utf8").trim());
+  }
+}
+
+/** Generate a large untracked file that stays small on disk for manual render checks. */
+function createLargeFileBody(lineCount: number) {
+  return (
+    Array.from({ length: lineCount }, (_, index) => {
+      if (index === 0) {
+        return "visible-first-line";
+      }
+      if (index === lineCount - 1) {
+        return "the widest generated line";
+      }
+      return "x";
+    }).join("\n") + "\n"
+  );
+}
+
+const lineCount = Number.parseInt(process.argv[2] ?? "100000", 10);
+const fixtureKind = process.argv[3] === "tracked" ? "tracked" : "untracked";
+if (!Number.isFinite(lineCount) || lineCount <= 0) {
+  throw new Error("Usage: bun run scripts/test-large-untracked-render.tsx [line-count] [tracked]");
+}
+
+const repo = mkdtempSync(join(tmpdir(), "hunk-large-untracked-render-"));
+try {
+  runGit(repo, "init", "--initial-branch", "main");
+  runGit(repo, "config", "user.name", "Test User");
+  runGit(repo, "config", "user.email", "test@example.com");
+  const largePath = fixtureKind === "tracked" ? "large-tracked.txt" : "large-untracked.txt";
+  writeFileSync(join(repo, "tracked.txt"), "tracked\n");
+  if (fixtureKind === "tracked") {
+    writeFileSync(join(repo, largePath), "original\n");
+  }
+  runGit(repo, "add", ".");
+  runGit(repo, "commit", "-m", "initial");
+  writeFileSync(join(repo, largePath), createLargeFileBody(lineCount));
+
+  const bootstrap = await loadAppBootstrap(
+    { kind: "vcs", staged: false, options: { mode: "stack" } },
+    { cwd: repo },
+  );
+  const setup = await testRender(<AppHost bootstrap={bootstrap} />, { width: 120, height: 30 });
+
+  try {
+    await act(async () => {
+      await setup.renderOnce();
+    });
+
+    const frame = setup.captureCharFrame();
+    console.log(
+      JSON.stringify(
+        {
+          containsHeader: frame.includes(`@@ -0,0 +1,${lineCount} @@`),
+          containsPath: frame.includes(largePath),
+          containsSkippedLargeMessage: frame.includes("File too large to render"),
+          containsVisibleLine: frame.includes("visible-first-line"),
+          fileCount: bootstrap.changeset.files.length,
+          firstFileStats: bootstrap.changeset.files[0]?.stats,
+          firstFileStatsTruncated: bootstrap.changeset.files[0]?.statsTruncated,
+          fixtureKind,
+          lineCount,
+          renderedFrameBytes: Buffer.byteLength(frame),
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await act(async () => {
+      setup.renderer.destroy();
+    });
+  }
+} finally {
+  rmSync(repo, { force: true, recursive: true });
+}

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -49,8 +49,33 @@ function withNormalizedDiffPrefixes(args: string[]) {
 }
 
 /** Build the exact `git diff` arguments used for the shared working-tree and range review path. */
-export function buildGitDiffArgs(input: VcsCommandInput) {
+export function buildGitDiffArgs(input: VcsCommandInput, excludedPathspecs: string[] = []) {
   const args = ["diff", "--no-ext-diff", "--find-renames", "--no-color"];
+
+  if (input.staged) {
+    args.push("--staged");
+  }
+
+  if (input.range) {
+    args.push(input.range);
+  }
+
+  if (excludedPathspecs.length > 0) {
+    args.push(
+      "--",
+      ...(input.pathspecs ?? []),
+      ...excludedPathspecs.map((path) => `:(exclude)${path}`),
+    );
+  } else {
+    appendGitPathspecs(args, input.pathspecs);
+  }
+
+  return withNormalizedDiffPrefixes(args);
+}
+
+/** Build the cheap tracked-file stats query used to skip huge file diffs before patch output. */
+export function buildGitDiffNumstatArgs(input: VcsCommandInput) {
+  const args = ["diff", "--no-ext-diff", "--find-renames", "--no-color", "--numstat", "-z"];
 
   if (input.staged) {
     args.push("--staged");

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -297,6 +297,71 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.changeset.files[1]?.patch).toContain("new file mode");
   });
 
+  test("keeps generated large tracked diffs as skipped placeholders", async () => {
+    const dir = createTempRepo("hunk-git-large-tracked-");
+
+    writeFileSync(join(dir, "large.txt"), "original\n");
+    git(dir, "add", "large.txt");
+    git(dir, "commit", "-m", "initial");
+    writeFileSync(join(dir, "large.txt"), `${"x\n".repeat(100_000)}widest generated line\n`);
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]?.path).toBe("large.txt");
+    expect(bootstrap.changeset.files[0]?.isTooLarge).toBe(true);
+    expect(bootstrap.changeset.files[0]?.stats).toEqual({ additions: 100_001, deletions: 1 });
+    expect(bootstrap.changeset.files[0]?.metadata.hunks).toHaveLength(0);
+  });
+
+  test("keeps generated large untracked files as skipped placeholders", async () => {
+    const dir = createTempRepo("hunk-git-large-untracked-");
+
+    writeFileSync(join(dir, "tracked.ts"), "export const value = 1;\n");
+    git(dir, "add", "tracked.ts");
+    git(dir, "commit", "-m", "initial");
+    writeFileSync(join(dir, "large.txt"), `${"x\n".repeat(100_000)}widest generated line\n`);
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]?.path).toBe("large.txt");
+    expect(bootstrap.changeset.files[0]?.isTooLarge).toBe(true);
+    expect(bootstrap.changeset.files[0]?.stats).toEqual({ additions: 100_001, deletions: 0 });
+    expect(bootstrap.changeset.files[0]?.statsTruncated).toBe(false);
+    expect(bootstrap.changeset.files[0]?.metadata.hunks).toHaveLength(0);
+  });
+
+  test("caps skipped untracked-file stats when byte-size detection would require a full huge read", async () => {
+    const dir = createTempRepo("hunk-git-byte-large-untracked-");
+
+    writeFileSync(join(dir, "tracked.ts"), "export const value = 1;\n");
+    git(dir, "add", "tracked.ts");
+    git(dir, "commit", "-m", "initial");
+    writeFileSync(join(dir, "large-single-line.txt"), "x".repeat(1_000_001));
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]?.path).toBe("large-single-line.txt");
+    expect(bootstrap.changeset.files[0]?.isTooLarge).toBe(true);
+    expect(bootstrap.changeset.files[0]?.stats).toEqual({ additions: 1, deletions: 0 });
+    expect(bootstrap.changeset.files[0]?.statsTruncated).toBe(true);
+    expect(bootstrap.changeset.files[0]?.metadata.hunks).toHaveLength(0);
+  });
+
   test("skips untracked symlinks to directories while loading the rest of the review", async () => {
     const dir = createTempRepo("hunk-git-untracked-dir-symlink-");
 

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -6,13 +6,15 @@ import {
   type FileDiffMetadata,
 } from "@pierre/diffs";
 import { createTwoFilesPatch } from "diff";
-import { resolve as resolvePath } from "node:path";
+import fs from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
 import { findAgentFileContext, loadAgentContext } from "./agent";
 import { createSkippedBinaryMetadata, isProbablyBinaryFile, patchLooksBinary } from "./binary";
 import { normalizeDiffMetadataPaths, normalizeDiffPath } from "./diffPaths";
 import { HunkUserError } from "./errors";
 import {
   buildGitDiffArgs,
+  buildGitDiffNumstatArgs,
   buildGitShowArgs,
   buildGitStashShowArgs,
   listGitUntrackedFiles,
@@ -44,6 +46,10 @@ import type {
 interface LoadAppBootstrapOptions {
   cwd?: string;
 }
+
+const LARGE_DIFF_FILE_MAX_BYTES = 1_000_000;
+const LARGE_DIFF_FILE_MAX_LINES = 20_000;
+const LARGE_DIFF_FILE_SNIFF_BYTES = 256 * 1024;
 
 /** Return the final path segment for display-oriented labels. */
 function basename(path: string) {
@@ -205,6 +211,9 @@ interface BuildDiffFileOptions {
   isUntracked?: boolean;
   previousPath?: string;
   isBinary?: boolean;
+  isTooLarge?: boolean;
+  stats?: DiffFile["stats"];
+  statsTruncated?: boolean;
 }
 
 /** Build the normalized per-file model used by the UI regardless of input mode. */
@@ -214,7 +223,14 @@ function buildDiffFile(
   index: number,
   sourcePrefix: string,
   agentContext: AgentContext | null,
-  { isUntracked, previousPath, isBinary }: BuildDiffFileOptions = {},
+  {
+    isUntracked,
+    previousPath,
+    isBinary,
+    isTooLarge,
+    stats,
+    statsTruncated,
+  }: BuildDiffFileOptions = {},
 ): DiffFile {
   const normalizedMetadata = normalizeDiffMetadataPaths(metadata);
   const path = normalizedMetadata.name;
@@ -226,11 +242,13 @@ function buildDiffFile(
     previousPath: resolvedPreviousPath,
     patch,
     language: getFiletypeFromFileName(path) ?? undefined,
-    stats: countDiffStats(normalizedMetadata),
+    stats: stats ?? countDiffStats(normalizedMetadata),
     metadata: normalizedMetadata,
     agent: findAgentFileContext(agentContext, path, resolvedPreviousPath),
     isUntracked,
     isBinary: isBinary ?? patchLooksBinary(patch),
+    isTooLarge,
+    statsTruncated,
   };
 }
 
@@ -266,6 +284,162 @@ function normalizeUntrackedPatchHeaders(patchText: string, filePath: string) {
       return line;
     })
     .join("\n");
+}
+
+interface CountedLines {
+  complete: boolean;
+  lines: number;
+}
+
+/** Count text lines with a byte cap so huge skipped-file stats do not block startup. */
+function countLinesInFile(path: string, maxBytes: number, size: number): CountedLines {
+  let fd: number | undefined;
+
+  try {
+    fd = fs.openSync(path, "r");
+    const buffer = Buffer.alloc(Math.min(64 * 1024, maxBytes));
+    let position = 0;
+    let lineCount = 0;
+    let lastByte: number | undefined;
+
+    while (position < maxBytes) {
+      const bytesToRead = Math.min(buffer.length, maxBytes - position);
+      const bytesRead = fs.readSync(fd, buffer, 0, bytesToRead, position);
+      if (bytesRead === 0) {
+        break;
+      }
+
+      position += bytesRead;
+      for (let index = 0; index < bytesRead; index += 1) {
+        lastByte = buffer[index];
+        if (lastByte === 0x0a) {
+          lineCount += 1;
+        }
+      }
+    }
+
+    return {
+      complete: position >= size,
+      lines: lastByte !== undefined && lastByte !== 0x0a ? lineCount + 1 : lineCount,
+    };
+  } catch {
+    return { complete: true, lines: 0 };
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
+  }
+}
+
+interface LargeUntrackedFileCheck {
+  shouldSkip: boolean;
+  stats?: DiffFile["stats"];
+  statsTruncated?: boolean;
+}
+
+/** Return whether an untracked file is too large to synthesize into a full in-memory patch. */
+function inspectLargeUntrackedFile(repoRoot: string, filePath: string): LargeUntrackedFileCheck {
+  const absolutePath = join(repoRoot, filePath);
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(absolutePath);
+  } catch {
+    return { shouldSkip: false };
+  }
+
+  const byteLimit =
+    stat.size > LARGE_DIFF_FILE_MAX_BYTES ? LARGE_DIFF_FILE_MAX_BYTES : LARGE_DIFF_FILE_SNIFF_BYTES;
+  const counted = countLinesInFile(absolutePath, byteLimit, stat.size);
+  const shouldSkip =
+    stat.size > LARGE_DIFF_FILE_MAX_BYTES || counted.lines > LARGE_DIFF_FILE_MAX_LINES;
+
+  return {
+    shouldSkip,
+    stats: shouldSkip ? { additions: counted.lines, deletions: 0 } : undefined,
+    statsTruncated: shouldSkip ? !counted.complete : undefined,
+  };
+}
+
+/** Build placeholder metadata for a file whose full diff would be too expensive. */
+function createSkippedLargeMetadata(
+  filePath: string,
+  type: FileDiffMetadata["type"],
+): FileDiffMetadata {
+  return {
+    name: filePath,
+    type,
+    hunks: [],
+    splitLineCount: 0,
+    unifiedLineCount: 0,
+    isPartial: true,
+    additionLines: [],
+    deletionLines: [],
+    cacheKey: `${filePath}:large-diff-skipped`,
+  };
+}
+
+interface GitNumstatFile {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+/** Parse `git diff --numstat -z` output for normal path entries. */
+function parseGitNumstat(text: string): GitNumstatFile[] {
+  return text
+    .split("\0")
+    .filter(Boolean)
+    .flatMap((entry) => {
+      const [additionsText, deletionsText, path] = entry.split("\t");
+      if (!additionsText || !deletionsText || !path) {
+        return [];
+      }
+
+      const additions = Number.parseInt(additionsText, 10);
+      const deletions = Number.parseInt(deletionsText, 10);
+      if (!Number.isFinite(additions) || !Number.isFinite(deletions)) {
+        return [];
+      }
+
+      return [{ path, additions, deletions }];
+    });
+}
+
+/** Return whether tracked diff stats are too large to render by default. */
+function shouldSkipLargeTrackedDiff(file: GitNumstatFile, repoRoot: string) {
+  if (file.additions + file.deletions > LARGE_DIFF_FILE_MAX_LINES) {
+    return true;
+  }
+
+  try {
+    return fs.statSync(join(repoRoot, file.path)).size > LARGE_DIFF_FILE_MAX_BYTES;
+  } catch {
+    return false;
+  }
+}
+
+/** Build a tracked placeholder for a file whose diff would be too expensive to render. */
+function buildSkippedLargeTrackedDiffFile(
+  file: GitNumstatFile,
+  index: number,
+  sourcePrefix: string,
+  agentContext: AgentContext | null,
+) {
+  return buildDiffFile(
+    createSkippedLargeMetadata(file.path, "change"),
+    "",
+    index,
+    sourcePrefix,
+    agentContext,
+    {
+      isTooLarge: true,
+      stats: {
+        additions: file.additions,
+        deletions: file.deletions,
+      },
+    },
+  );
 }
 
 /** Parse one synthetic untracked-file patch and reattach the real path after header normalization. */
@@ -305,6 +479,23 @@ function buildUntrackedDiffFile(
   sourcePrefix: string,
   agentContext: AgentContext | null,
 ) {
+  const largeFileCheck = inspectLargeUntrackedFile(repoRoot, filePath);
+  if (largeFileCheck.shouldSkip) {
+    return buildDiffFile(
+      createSkippedLargeMetadata(filePath, "new"),
+      "",
+      index,
+      sourcePrefix,
+      agentContext,
+      {
+        isTooLarge: true,
+        isUntracked: true,
+        stats: largeFileCheck.stats,
+        statsTruncated: largeFileCheck.statsTruncated,
+      },
+    );
+  }
+
   const patch = normalizeUntrackedPatchHeaders(
     runGitUntrackedFileDiffText(input, filePath, { repoRoot }),
     filePath,
@@ -527,17 +718,40 @@ async function loadGitChangeset(
     : input.range
       ? `${repoName} ${input.range}`
       : `${repoName} working tree`;
+  const largeTrackedFiles = parseGitNumstat(
+    runGitText({ input, args: buildGitDiffNumstatArgs(input), cwd }),
+  ).filter((file) => shouldSkipLargeTrackedDiff(file, repoRoot));
   const trackedChangeset = normalizePatchChangeset(
-    runGitText({ input, args: buildGitDiffArgs(input), cwd }),
+    runGitText({
+      input,
+      args: buildGitDiffArgs(
+        input,
+        largeTrackedFiles.map((file) => file.path),
+      ),
+      cwd,
+    }),
     title,
     repoRoot,
     agentContext,
   );
-  const trackedFiles = trackedChangeset.files;
+  const trackedFiles = [
+    ...trackedChangeset.files,
+    ...largeTrackedFiles.map((file, index) =>
+      buildSkippedLargeTrackedDiffFile(
+        file,
+        trackedChangeset.files.length + index,
+        repoRoot,
+        agentContext,
+      ),
+    ),
+  ];
   const untrackedFiles = listGitUntrackedFiles(input, { cwd, repoRoot });
 
   if (untrackedFiles.length === 0) {
-    return trackedChangeset;
+    return {
+      ...trackedChangeset,
+      files: trackedFiles,
+    } satisfies Changeset;
   }
 
   return {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -42,6 +42,8 @@ export interface DiffFile {
   agent: AgentFileContext | null;
   isUntracked?: boolean;
   isBinary?: boolean;
+  isTooLarge?: boolean;
+  statsTruncated?: boolean;
 }
 
 export interface Changeset {

--- a/src/ui/components/panes/DiffFileHeaderRow.tsx
+++ b/src/ui/components/panes/DiffFileHeaderRow.tsx
@@ -19,7 +19,7 @@ export function DiffFileHeaderRow({
   theme,
   onSelect,
 }: DiffFileHeaderRowProps) {
-  const additionsText = `+${file.stats.additions}`;
+  const additionsText = `+${file.stats.additions}${file.statsTruncated ? "+" : ""}`;
   const deletionsText = `-${file.stats.deletions}`;
   const { filename, stateLabel } = fileLabelParts(file);
 

--- a/src/ui/diff/codeColumns.test.ts
+++ b/src/ui/diff/codeColumns.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import type { DiffFile } from "../../core/types";
+import { maxFileCodeLineWidth } from "./codeColumns";
+
+/** Generate a large diff metadata fixture without checking a huge file into the repo. */
+function createLargeLineFixture(lineCount: number, widestLine: string): DiffFile {
+  const additionLines = Array.from({ length: lineCount }, (_, index) =>
+    index === lineCount - 1 ? widestLine : "x",
+  );
+
+  return {
+    agent: null,
+    id: "large-untracked",
+    metadata: {
+      additionLines,
+      deletionLines: [],
+      hunks: [],
+    } as unknown as DiffFile["metadata"],
+    patch: "",
+    path: "large-untracked.txt",
+    stats: { additions: lineCount, deletions: 0 },
+  };
+}
+
+describe("code column measurement", () => {
+  test("measures large generated fixtures without overflowing the call stack", () => {
+    const file = createLargeLineFixture(100_000, "the widest generated line");
+
+    expect(maxFileCodeLineWidth(file)).toBe("the widest generated line".length);
+  });
+});

--- a/src/ui/diff/codeColumns.ts
+++ b/src/ui/diff/codeColumns.ts
@@ -19,11 +19,17 @@ export function maxFileCodeLineWidth(file: DiffFile) {
   const deletionLines = file.metadata.deletionLines ?? [];
   const additionLines = file.metadata.additionLines ?? [];
 
-  return Math.max(
-    0,
-    ...deletionLines.map(measureRenderedCodeLineWidth),
-    ...additionLines.map(measureRenderedCodeLineWidth),
-  );
+  let maxWidth = 0;
+
+  for (const line of deletionLines) {
+    maxWidth = Math.max(maxWidth, measureRenderedCodeLineWidth(line));
+  }
+
+  for (const line of additionLines) {
+    maxWidth = Math.max(maxWidth, measureRenderedCodeLineWidth(line));
+  }
+
+  return maxWidth;
 }
 
 /** Find the widest line-number gutter needed for one file. */

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -543,6 +543,10 @@ export function diffMessage(file: DiffFile) {
     return "Binary file skipped";
   }
 
+  if (file.isTooLarge) {
+    return "File too large to render automatically.";
+  }
+
   if (file.metadata.type === "new") {
     return "No textual hunks. The file is marked as new.";
   }

--- a/src/ui/lib/files.ts
+++ b/src/ui/lib/files.ts
@@ -37,8 +37,8 @@ function sidebarFileName(file: DiffFile) {
 }
 
 /** Hide zero-value file stats so the sidebar only shows real line deltas. */
-function formatSidebarStat(prefix: "+" | "-", value: number) {
-  return value > 0 ? `${prefix}${value}` : null;
+function formatSidebarStat(prefix: "+" | "-", value: number, truncated = false) {
+  return value > 0 ? `${prefix}${value}${truncated ? "+" : ""}` : null;
 }
 
 /** Build the visible stats badges for one sidebar row.
@@ -144,7 +144,7 @@ export function buildSidebarEntries(files: DiffFile[]): SidebarEntry[] {
       id: file.id,
       name: sidebarFileName(file),
       agentCommentsText: agentCommentCount > 0 ? `*${agentCommentCount}` : null,
-      additionsText: formatSidebarStat("+", file.stats.additions),
+      additionsText: formatSidebarStat("+", file.stats.additions, file.statsTruncated),
       deletionsText: formatSidebarStat("-", file.stats.deletions),
       changeType: file.metadata.type,
       isUntracked: file.isUntracked ?? false,


### PR DESCRIPTION
## Summary

- Skip very large tracked and untracked file diffs before rendering them as full patch rows.
- Render skipped large files as review-stream placeholders while preserving exact tracked stats and bounded/lower-bound untracked stats when a full count would be expensive.
- Exclude skipped tracked files from the generated `git diff` patch so large changes do not slow startup.
- Replace spread-based width measurement so large metadata arrays cannot overflow the JS call stack.
- Add generated 100k-line regression coverage and a manual render-check script for large tracked/untracked files.

Fixes #218.

## Testing

```sh
bun run format:check
bun run typecheck
bun run lint
bun test src/core/loaders.test.ts src/ui/diff/codeColumns.test.ts src/ui/lib/ui-lib.test.ts
bun run scripts/test-large-untracked-render.tsx 700000
bun run scripts/test-large-untracked-render.tsx 700000 tracked
```

*This PR description was generated by Pi using OpenAI GPT-5*
