### PR TITLE
fix(loaders): normalize mnemonic pager prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed `hunk pager` parsing for Git diffs emitted with `diff.mnemonicPrefix=true` so file paths do not keep `i/`, `w/`, `c/`, `1/`, or `2/` side prefixes.
 - Fixed large tracked and untracked file handling so very large diffs render as skipped placeholders instead of slowing startup or overflowing the JavaScript call stack.
 
 ## [0.11.0] - 2026-05-09

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -1082,6 +1082,88 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.changeset.files[0]?.stats.additions).toBe(1);
   });
 
+  test("loads patch text emitted with diff.mnemonicPrefix=true (e.g. from `hunk pager` stdin)", async () => {
+    const dir = createTempRepo("hunk-patch-mnemonic-prefix-");
+
+    writeFileSync(join(dir, "example.ts"), "export const value = 1;\n");
+    git(dir, "add", ".");
+    git(dir, "commit", "-m", "initial");
+
+    writeFileSync(join(dir, "example.ts"), "export const value = 2;\n");
+    const patchText = git(dir, "-c", "diff.mnemonicPrefix=true", "diff", "--", "example.ts");
+
+    expect(patchText).toContain("diff --git i/example.ts w/example.ts");
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: patchText,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]).toMatchObject({
+      path: "example.ts",
+      metadata: { name: "example.ts", type: "change" },
+    });
+    expect(bootstrap.changeset.files[0]?.stats).toEqual({ additions: 1, deletions: 1 });
+  });
+
+  test("loads renamed patch text emitted with diff.mnemonicPrefix=true", async () => {
+    const dir = createTempRepo("hunk-patch-mnemonic-rename-");
+
+    writeFileSync(join(dir, "old.ts"), "export const value = 1;\n");
+    git(dir, "add", ".");
+    git(dir, "commit", "-m", "initial");
+
+    git(dir, "mv", "old.ts", "new.ts");
+    const patchText = git(dir, "-c", "diff.mnemonicPrefix=true", "diff", "--cached");
+
+    expect(patchText).toContain("diff --git c/old.ts i/new.ts");
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: patchText,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]).toMatchObject({
+      path: "new.ts",
+      previousPath: "old.ts",
+      metadata: { type: "rename-pure" },
+    });
+    expect(bootstrap.changeset.files[0]?.patch).toContain("diff --git a/old.ts b/new.ts");
+  });
+
+  test("does not strip real directories that look like mnemonic prefixes in noprefix renames", async () => {
+    const dir = createTempRepo("hunk-patch-noprefix-mnemonic-dir-");
+
+    mkdirSync(join(dir, "c"));
+    writeFileSync(join(dir, "c/foo.ts"), "export const value = 1;\n");
+    git(dir, "add", ".");
+    git(dir, "commit", "-m", "initial");
+
+    mkdirSync(join(dir, "w"));
+    git(dir, "mv", "c/foo.ts", "w/bar.ts");
+    const patchText = git(dir, "-c", "diff.noprefix=true", "diff", "--cached");
+
+    expect(patchText).toContain("diff --git c/foo.ts w/bar.ts");
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: patchText,
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]).toMatchObject({
+      path: "w/bar.ts",
+      previousPath: "c/foo.ts",
+      metadata: { type: "rename-pure" },
+    });
+    expect(bootstrap.changeset.files[0]?.patch).toContain("diff --git a/c/foo.ts b/w/bar.ts");
+  });
+
   test("loads noprefix rename patches by recovering the rename pair from the headers", async () => {
     const bootstrap = await loadAppBootstrap({
       kind: "patch",

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -267,78 +267,162 @@ function buildDiffFile(
  * SQL/Lua/Haskell comment, which becomes `--- foo` on disk) is not mistaken for a file
  * header inside the hunk body.
  */
+type GitHeaderRewriteMode = "add" | "strip";
+
 function normalizeGitPatchPrefixes(patchText: string) {
   if (!patchText.includes("diff --git ")) {
     return patchText;
   }
 
-  let blockNeedsPrefix = false;
+  const lines = patchText.split("\n");
+  const normalizedLines: string[] = [];
+  let blockLines: string[] = [];
 
-  return patchText
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("diff --git ")) {
-        const result = rewriteGitDiffHeader(line);
-        blockNeedsPrefix = result.changed;
-        return result.line;
-      }
+  const flushBlock = () => {
+    if (blockLines.length === 0) {
+      return;
+    }
 
-      if (blockNeedsPrefix && line.startsWith("--- ")) {
-        return rewriteUnifiedFileLine(line, "--- ", "a/");
-      }
+    for (const line of rewriteGitPatchBlock(blockLines)) {
+      normalizedLines.push(line);
+    }
+    blockLines = [];
+  };
 
-      if (blockNeedsPrefix && line.startsWith("+++ ")) {
-        blockNeedsPrefix = false;
-        return rewriteUnifiedFileLine(line, "+++ ", "b/");
-      }
+  for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      flushBlock();
+      blockLines.push(line);
+      continue;
+    }
 
-      return line;
-    })
-    .join("\n");
+    if (blockLines.length > 0) {
+      blockLines.push(line);
+    } else {
+      normalizedLines.push(line);
+    }
+  }
+
+  flushBlock();
+  return normalizedLines.join("\n");
 }
 
-/** Detect prefixed/noprefix `diff --git` lines and rewrite the noprefix form into `a/X b/Y`. */
-function rewriteGitDiffHeader(line: string): { line: string; changed: boolean } {
+/** Rewrite one `diff --git` block, keeping file-header rewrites out of hunk bodies. */
+function rewriteGitPatchBlock(blockLines: string[]) {
+  const firstLine = blockLines[0];
+  if (!firstLine?.startsWith("diff --git ")) {
+    return blockLines;
+  }
+
+  const result = rewriteGitDiffHeader(firstLine, blockLines);
+  let blockRewriteMode = result.rewriteMode;
+
+  const rewrittenLines = [result.line];
+
+  for (const line of blockLines.slice(1)) {
+    if (blockRewriteMode && line.startsWith("--- ")) {
+      rewrittenLines.push(rewriteUnifiedFileLine(line, "--- ", "a/", blockRewriteMode));
+      continue;
+    }
+
+    if (blockRewriteMode && line.startsWith("+++ ")) {
+      const rewriteMode = blockRewriteMode;
+      blockRewriteMode = null;
+      rewrittenLines.push(rewriteUnifiedFileLine(line, "+++ ", "b/", rewriteMode));
+      continue;
+    }
+
+    rewrittenLines.push(line);
+  }
+
+  return rewrittenLines;
+}
+
+/** Detect prefixed/noprefix `diff --git` lines and rewrite them into Pierre's `a/X b/Y` form. */
+function rewriteGitDiffHeader(
+  line: string,
+  blockLines: string[],
+): {
+  line: string;
+  rewriteMode: GitHeaderRewriteMode | null;
+} {
   const rest = line.slice("diff --git ".length).trimEnd();
 
   const quotedMatch = rest.match(/^"((?:\\.|[^"\\])*)" "((?:\\.|[^"\\])*)"$/);
   if (quotedMatch) {
     const [, oldPath = "", newPath = ""] = quotedMatch;
+    const pair = canonicalizeGitPathPair(oldPath, newPath, blockLines);
     // Pierre's git header parser does not currently handle the quoted `"a/..." "b/..."`
     // form, so canonicalize quoted paths to the unquoted form even when prefixes exist.
-    return {
-      line: `diff --git ${withGitPrefix(oldPath, "a/")} ${withGitPrefix(newPath, "b/")}`,
-      changed: true,
-    };
+    return { line: `diff --git ${pair.oldPath} ${pair.newPath}`, rewriteMode: pair.rewriteMode };
   }
 
   const tokens = rest.split(" ");
 
-  // Already prefixed: `a/X b/Y` (covers single-token and equally split multi-token paths).
-  if (tokens.length === 2 && tokens[0]?.startsWith("a/") && tokens[1]?.startsWith("b/")) {
-    return { line, changed: false };
-  }
   if (tokens.length >= 2 && tokens.length % 2 === 0) {
     const half = tokens.length / 2;
     const firstHalf = tokens.slice(0, half).join(" ");
     const secondHalf = tokens.slice(half).join(" ");
-    if (firstHalf.startsWith("a/") && secondHalf.startsWith("b/")) {
-      return { line, changed: false };
+    const knownPair = canonicalizeKnownGitPathPair(firstHalf, secondHalf, blockLines);
+
+    if (knownPair?.changed) {
+      return {
+        line: `diff --git ${knownPair.oldPath} ${knownPair.newPath}`,
+        rewriteMode: knownPair.rewriteMode,
+      };
     }
+
+    // Already prefixed: `a/X b/Y` (covers single-token and equally split multi-token paths).
+    if (knownPair?.isCanonical) {
+      return { line, rewriteMode: null };
+    }
+
     // Non-rename noprefix: identical halves regardless of whether the path contains spaces.
     if (firstHalf === secondHalf && firstHalf.length > 0) {
-      return { line: `diff --git a/${firstHalf} b/${secondHalf}`, changed: true };
+      return { line: `diff --git a/${firstHalf} b/${secondHalf}`, rewriteMode: "add" };
     }
   }
 
   // Two-token rename without prefix and without spaces in either path.
   if (tokens.length === 2 && tokens[0] && tokens[1]) {
-    return { line: `diff --git a/${tokens[0]} b/${tokens[1]}`, changed: true };
+    return { line: `diff --git a/${tokens[0]} b/${tokens[1]}`, rewriteMode: "add" };
   }
 
   // Genuinely ambiguous (rename with spaces and no quoting). Leave untouched and let the
   // parser surface the existing failure rather than guess at the path split.
-  return { line, changed: false };
+  return { line, rewriteMode: null };
+}
+
+const GIT_MNEMONIC_PREFIXES = new Set(["c", "i", "o", "w", "1", "2"]);
+
+/** Return one Git mnemonic side prefix from a path, if present. */
+function splitGitMnemonicPrefix(path: string) {
+  const [prefix, ...rest] = path.split("/");
+  if (!prefix || rest.length === 0 || !GIT_MNEMONIC_PREFIXES.has(prefix)) {
+    return null;
+  }
+
+  return { prefix, path: rest.join("/") };
+}
+
+/** Remove Git's outer quotes from one path-like metadata value. */
+function stripGitPathQuotes(path: string) {
+  return path.match(/^"((?:\\.|[^"\\])*)"$/)?.[1] ?? path;
+}
+
+/** Return rename metadata, which Git writes without mnemonic side prefixes. */
+function findRenameMetadata(blockLines: string[]) {
+  const oldPath = blockLines.find((line) => line.startsWith("rename from "));
+  const newPath = blockLines.find((line) => line.startsWith("rename to "));
+
+  if (!oldPath || !newPath) {
+    return null;
+  }
+
+  return {
+    oldPath: stripGitPathQuotes(oldPath.slice("rename from ".length)),
+    newPath: stripGitPathQuotes(newPath.slice("rename to ".length)),
+  };
 }
 
 /** Return a path with the expected Git side prefix while avoiding double-prefixing. */
@@ -346,8 +430,74 @@ function withGitPrefix(path: string, prefix: "a/" | "b/") {
   return path.startsWith(prefix) ? path : `${prefix}${path}`;
 }
 
+/** Decide whether a mnemonic-looking path pair is real mnemonic output or a noprefix rename. */
+function shouldStripMnemonicPair(oldPath: string, newPath: string, blockLines: string[]) {
+  const oldMnemonic = splitGitMnemonicPrefix(oldPath);
+  const newMnemonic = splitGitMnemonicPrefix(newPath);
+
+  if (!oldMnemonic || !newMnemonic || oldMnemonic.prefix === newMnemonic.prefix) {
+    return null;
+  }
+
+  const rename = findRenameMetadata(blockLines);
+  if (!rename) {
+    return true;
+  }
+
+  if (rename.oldPath === oldPath && rename.newPath === newPath) {
+    return false;
+  }
+
+  if (rename.oldPath === oldMnemonic.path && rename.newPath === newMnemonic.path) {
+    return true;
+  }
+
+  return true;
+}
+
+/** Convert already-prefixed or mnemonic-prefixed path pairs into Pierre's canonical shape. */
+function canonicalizeKnownGitPathPair(oldPath: string, newPath: string, blockLines: string[]) {
+  const oldMnemonic = splitGitMnemonicPrefix(oldPath);
+  const newMnemonic = splitGitMnemonicPrefix(newPath);
+  const isCanonical = oldPath.startsWith("a/") && newPath.startsWith("b/");
+
+  if (isCanonical) {
+    return { oldPath, newPath, rewriteMode: "add" as const, changed: false, isCanonical: true };
+  }
+
+  if (oldMnemonic && newMnemonic && shouldStripMnemonicPair(oldPath, newPath, blockLines)) {
+    return {
+      oldPath: `a/${oldMnemonic.path}`,
+      newPath: `b/${newMnemonic.path}`,
+      rewriteMode: "strip" as const,
+      changed: true,
+      isCanonical: false,
+    };
+  }
+
+  return null;
+}
+
+/** Convert one quoted `diff --git` path pair into Pierre's canonical side-prefix shape. */
+function canonicalizeGitPathPair(oldPath: string, newPath: string, blockLines: string[]) {
+  return (
+    canonicalizeKnownGitPathPair(oldPath, newPath, blockLines) ?? {
+      oldPath: withGitPrefix(oldPath, "a/"),
+      newPath: withGitPrefix(newPath, "b/"),
+      rewriteMode: "add" as const,
+      changed: true,
+      isCanonical: false,
+    }
+  );
+}
+
 /** Insert the canonical `a/` or `b/` prefix on a unified-diff header that is missing it. */
-function rewriteUnifiedFileLine(line: string, marker: "--- " | "+++ ", prefix: "a/" | "b/") {
+function rewriteUnifiedFileLine(
+  line: string,
+  marker: "--- " | "+++ ",
+  prefix: "a/" | "b/",
+  mode: GitHeaderRewriteMode,
+) {
   const path = line.slice(marker.length);
   const quotedPath = path.match(/^"((?:\\.|[^"\\])*)"(.*)$/);
   const pathName = quotedPath?.[1] ?? path;
@@ -357,7 +507,10 @@ function rewriteUnifiedFileLine(line: string, marker: "--- " | "+++ ", prefix: "
     return line;
   }
 
-  return `${marker}${withGitPrefix(pathName, prefix)}${suffix}`;
+  const normalizedPath =
+    mode === "strip" ? (splitGitMnemonicPrefix(pathName)?.path ?? pathName) : pathName;
+
+  return `${marker}${withGitPrefix(normalizedPath, prefix)}${suffix}`;
 }
 
 /** Escape only the filename characters that break unified-diff header parsing. */


### PR DESCRIPTION
## Summary

Fixes `hunk pager` / `hunk patch` handling for Git patch input emitted with `diff.mnemonicPrefix=true`.

Git emits mnemonic side prefixes like `i/`, `w/`, `c/`, `1/`, and `2/` instead of the parser-friendly `a/` / `b/` prefixes. After #240, those patches can parse, but file paths keep the side prefix (for example `w/example.ts`). This normalizes mnemonic prefix pairs back to Pierre's expected `a/... b/...` shape before parsing so the review path is `example.ts`.

Fixes #265.

## Tests

- [x] `bun test src/core/loaders.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`

*This PR description was generated by Pi using OpenAI GPT-5*
