### PR TITLE
fix(pager): render static diffs in captured pagers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Made `hunk pager` emit static highlighted diff output for captured pager contexts like LazyGit, and pass diff input through unchanged when stdout is non-interactive.
 - Fixed `hunk pager` parsing for Git diffs emitted with `diff.mnemonicPrefix=true` so file paths do not keep `i/`, `w/`, `c/`, `1/`, or `2/` side prefixes.
 - Fixed large tracked and untracked file handling so very large diffs render as skipped placeholders instead of slowing startup or overflowing the JavaScript call stack.
 

--- a/src/core/startup.test.ts
+++ b/src/core/startup.test.ts
@@ -173,6 +173,11 @@ describe("startup planning", () => {
       looksLikePatchInputImpl: () => true,
       stdoutIsTTY: true,
       env: { TERM: "dumb", LV: "-c" },
+      resolveRuntimeCliInputImpl: (input) => input,
+      resolveConfiguredCliInputImpl: (input) =>
+        ({
+          input: { ...input, options: { ...input.options, lineNumbers: false, theme: "paper" } },
+        }) as never,
       loadAppBootstrapImpl: async () => {
         loaded = true;
         throw new Error("unreachable");
@@ -182,7 +187,7 @@ describe("startup planning", () => {
     expect(plan).toEqual({
       kind: "static-diff-pager",
       text: patchText,
-      options: { theme: "paper" },
+      options: { theme: "paper", pager: true, lineNumbers: false },
     });
     expect(loaded).toBe(false);
   });
@@ -197,6 +202,8 @@ describe("startup planning", () => {
       looksLikePatchInputImpl: () => true,
       stdoutIsTTY: true,
       env: { TERM: "xterm-256color" },
+      resolveRuntimeCliInputImpl: (input) => input,
+      resolveConfiguredCliInputImpl: (input) => ({ input }) as never,
       openControllingTerminalImpl: () => null,
       loadAppBootstrapImpl: async () => {
         loaded = true;
@@ -204,7 +211,11 @@ describe("startup planning", () => {
       },
     });
 
-    expect(plan).toEqual({ kind: "static-diff-pager", text: patchText, options: {} });
+    expect(plan).toEqual({
+      kind: "static-diff-pager",
+      text: patchText,
+      options: { pager: true },
+    });
     expect(loaded).toBe(false);
   });
 

--- a/src/core/startup.test.ts
+++ b/src/core/startup.test.ts
@@ -143,7 +143,27 @@ describe("startup planning", () => {
     expect(loaded).toBe(false);
   });
 
-  test("routes diff-like pager stdin to static output when the host advertises a dumb terminal", async () => {
+  test("passes diff-like pager stdin through for a plain dumb terminal", async () => {
+    let loaded = false;
+    const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
+      parseCliImpl: async () => ({ kind: "pager", options: {} }),
+      readStdinText: async () => patchText,
+      looksLikePatchInputImpl: () => true,
+      stdoutIsTTY: true,
+      env: { TERM: "dumb" },
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({ kind: "passthrough", text: patchText });
+    expect(loaded).toBe(false);
+  });
+
+  test("routes diff-like pager stdin to static output when the host advertises a captured pager", async () => {
     let loaded = false;
     const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
 
@@ -152,7 +172,7 @@ describe("startup planning", () => {
       readStdinText: async () => patchText,
       looksLikePatchInputImpl: () => true,
       stdoutIsTTY: true,
-      env: { TERM: "dumb" },
+      env: { TERM: "dumb", LV: "-c" },
       loadAppBootstrapImpl: async () => {
         loaded = true;
         throw new Error("unreachable");

--- a/src/core/startup.test.ts
+++ b/src/core/startup.test.ts
@@ -89,6 +89,9 @@ describe("startup planning", () => {
       parseCliImpl: async () => ({ kind: "pager", options: { theme: "paper" } }),
       readStdinText: async () => "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n",
       looksLikePatchInputImpl: () => true,
+      stdoutIsTTY: true,
+      env: { TERM: "xterm-256color" },
+      openControllingTerminalImpl: () => ({ stdin: {} as never, close: () => {} }),
       resolveRuntimeCliInputImpl(input) {
         seenInputs.push(input);
         return input;
@@ -119,6 +122,70 @@ describe("startup planning", () => {
       },
     });
     expect(seenInputs).toHaveLength(3);
+  });
+
+  test("passes diff-like pager stdin through when stdout is not interactive", async () => {
+    let loaded = false;
+    const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
+      parseCliImpl: async () => ({ kind: "pager", options: {} }),
+      readStdinText: async () => patchText,
+      looksLikePatchInputImpl: () => true,
+      stdoutIsTTY: false,
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({ kind: "passthrough", text: patchText });
+    expect(loaded).toBe(false);
+  });
+
+  test("routes diff-like pager stdin to static output when the host advertises a dumb terminal", async () => {
+    let loaded = false;
+    const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
+      parseCliImpl: async () => ({ kind: "pager", options: { theme: "paper" } }),
+      readStdinText: async () => patchText,
+      looksLikePatchInputImpl: () => true,
+      stdoutIsTTY: true,
+      env: { TERM: "dumb" },
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: "static-diff-pager",
+      text: patchText,
+      options: { theme: "paper" },
+    });
+    expect(loaded).toBe(false);
+  });
+
+  test("routes diff-like pager stdin to static output when no controlling terminal is available", async () => {
+    let loaded = false;
+    const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
+      parseCliImpl: async () => ({ kind: "pager", options: {} }),
+      readStdinText: async () => patchText,
+      looksLikePatchInputImpl: () => true,
+      stdoutIsTTY: true,
+      env: { TERM: "xterm-256color" },
+      openControllingTerminalImpl: () => null,
+      loadAppBootstrapImpl: async () => {
+        loaded = true;
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(plan).toEqual({ kind: "static-diff-pager", text: patchText, options: {} });
+    expect(loaded).toBe(false);
   });
 
   test("rejects watch mode for stdin-backed patch inputs", async () => {

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -108,6 +108,27 @@ export async function prepareStartupPlan(
 
   if (parsedCliInput.kind === "pager") {
     const stdinText = await readStdinText();
+    const pagerOptions = parsedCliInput.options;
+    const staticPagerPlan = () => {
+      const staticPatchInput: CliInput = {
+        kind: "patch",
+        file: "-",
+        text: stdinText,
+        options: {
+          ...pagerOptions,
+          pager: true,
+        },
+      };
+      const configuredStaticInput = resolveConfiguredCliInputImpl(
+        resolveRuntimeCliInputImpl(staticPatchInput),
+      ).input;
+
+      return {
+        kind: "static-diff-pager" as const,
+        text: stdinText,
+        options: configuredStaticInput.options,
+      };
+    };
 
     if (!looksLikePatchInputImpl(stdinText)) {
       return {
@@ -133,20 +154,12 @@ export async function prepareStartupPlan(
     // Captured pager hosts like LazyGit can provide a PTY while advertising TERM=dumb.
     // In that mode, emit static colored diff output instead of launching the TUI.
     if (isCapturedPagerHost(env)) {
-      return {
-        kind: "static-diff-pager",
-        text: stdinText,
-        options: parsedCliInput.options,
-      };
+      return staticPagerPlan();
     }
 
     controllingTerminal = openControllingTerminalImpl();
     if (!controllingTerminal) {
-      return {
-        kind: "static-diff-pager",
-        text: stdinText,
-        options: parsedCliInput.options,
-      };
+      return staticPagerPlan();
     }
 
     parsedCliInput = {

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -44,6 +44,15 @@ export type StartupPlan =
       controllingTerminal: ControllingTerminal | null;
     };
 
+function isCapturedPagerHost(env: NodeJS.ProcessEnv) {
+  return (
+    env.TERM === "dumb" &&
+    (env.LV === "-c" ||
+      Boolean(env.GIT_PAGER) ||
+      Object.keys(env).some((key) => key.startsWith("LAZYGIT")))
+  );
+}
+
 export interface StartupDeps {
   parseCliImpl?: (argv: string[]) => Promise<ParsedCliInput>;
   readStdinText?: () => Promise<string>;
@@ -114,9 +123,16 @@ export async function prepareStartupPlan(
       };
     }
 
+    if (env.TERM === "dumb" && !isCapturedPagerHost(env)) {
+      return {
+        kind: "passthrough",
+        text: stdinText,
+      };
+    }
+
     // Captured pager hosts like LazyGit can provide a PTY while advertising TERM=dumb.
     // In that mode, emit static colored diff output instead of launching the TUI.
-    if (env.TERM === "dumb") {
+    if (isCapturedPagerHost(env)) {
       return {
         kind: "static-diff-pager",
         text: stdinText,

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -29,6 +29,15 @@ export type StartupPlan =
       text: string;
     }
   | {
+      kind: "passthrough";
+      text: string;
+    }
+  | {
+      kind: "static-diff-pager";
+      text: string;
+      options: CliInput["options"];
+    }
+  | {
       kind: "app";
       bootstrap: AppBootstrap;
       cliInput: CliInput;
@@ -44,6 +53,8 @@ export interface StartupDeps {
   loadAppBootstrapImpl?: typeof loadAppBootstrap;
   usesPipedPatchInputImpl?: typeof usesPipedPatchInput;
   openControllingTerminalImpl?: typeof openControllingTerminal;
+  stdoutIsTTY?: boolean;
+  env?: NodeJS.ProcessEnv;
 }
 
 /** Normalize startup work so help, pager, and app-bootstrap paths can be tested directly. */
@@ -60,8 +71,11 @@ export async function prepareStartupPlan(
   const loadAppBootstrapImpl = deps.loadAppBootstrapImpl ?? loadAppBootstrap;
   const usesPipedPatchInputImpl = deps.usesPipedPatchInputImpl ?? usesPipedPatchInput;
   const openControllingTerminalImpl = deps.openControllingTerminalImpl ?? openControllingTerminal;
+  const stdoutIsTTY = deps.stdoutIsTTY ?? Boolean(process.stdout.isTTY);
+  const env = deps.env ?? process.env;
 
   let parsedCliInput = await parseCliImpl(argv);
+  let controllingTerminal: ControllingTerminal | null = null;
 
   if (parsedCliInput.kind === "help") {
     return {
@@ -93,6 +107,32 @@ export async function prepareStartupPlan(
       };
     }
 
+    if (!stdoutIsTTY) {
+      return {
+        kind: "passthrough",
+        text: stdinText,
+      };
+    }
+
+    // Captured pager hosts like LazyGit can provide a PTY while advertising TERM=dumb.
+    // In that mode, emit static colored diff output instead of launching the TUI.
+    if (env.TERM === "dumb") {
+      return {
+        kind: "static-diff-pager",
+        text: stdinText,
+        options: parsedCliInput.options,
+      };
+    }
+
+    controllingTerminal = openControllingTerminalImpl();
+    if (!controllingTerminal) {
+      return {
+        kind: "static-diff-pager",
+        text: stdinText,
+        options: parsedCliInput.options,
+      };
+    }
+
     parsedCliInput = {
       kind: "patch",
       file: "-",
@@ -117,10 +157,15 @@ export async function prepareStartupPlan(
     );
   }
 
-  const bootstrap = await loadAppBootstrapImpl(cliInput);
-  const controllingTerminal = usesPipedPatchInputImpl(cliInput)
-    ? openControllingTerminalImpl()
-    : null;
+  let bootstrap: AppBootstrap;
+  try {
+    bootstrap = await loadAppBootstrapImpl(cliInput);
+  } catch (error) {
+    controllingTerminal?.close();
+    throw error;
+  }
+
+  controllingTerminal ??= usesPipedPatchInputImpl(cliInput) ? openControllingTerminalImpl() : null;
 
   return {
     kind: "app",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "@opentui/react";
 import { formatCliError } from "./core/errors";
 import { pagePlainText } from "./core/pager";
 import { shutdownSession } from "./core/shutdown";
+import { renderStaticDiffPager } from "./ui/staticDiffPager";
 import { prepareStartupPlan } from "./core/startup";
 import { shouldUseMouseForApp } from "./core/terminal";
 import { resolveStartupUpdateNotice } from "./core/updateNotice";
@@ -44,6 +45,16 @@ async function main() {
 
   if (startupPlan.kind === "plain-text-pager") {
     await pagePlainText(startupPlan.text);
+    process.exit(0);
+  }
+
+  if (startupPlan.kind === "passthrough") {
+    process.stdout.write(startupPlan.text);
+    process.exit(0);
+  }
+
+  if (startupPlan.kind === "static-diff-pager") {
+    process.stdout.write(await renderStaticDiffPager(startupPlan.text, startupPlan.options));
     process.exit(0);
   }
 

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -7,7 +7,17 @@ import {
   resolveStackCellGeometry,
 } from "./codeColumns";
 import type { DiffRow, RenderSpan, SplitLineCell, StackLineCell } from "./pierre";
-import { blendHex } from "../lib/color";
+import {
+  diffRailMarker,
+  dimRailColor,
+  neutralRailColor,
+  splitCellPalette,
+  splitLeftRailColor,
+  splitRightRailColor,
+  stackCellPalette,
+  stackGutterText,
+  stackRailColor,
+} from "./rowStyle";
 
 /** Clamp a label to one terminal row with an ellipsis. */
 export function fitText(text: string, width: number) {
@@ -80,114 +90,7 @@ function sliceSpansWindow(spans: RenderSpan[], offset: number, width: number) {
   };
 }
 
-const INACTIVE_RAIL_BLEND = 0.35;
-
-/** Dim a rail color for inactive hunks by blending toward the panel background. */
-function dimRailColor(color: string, theme: AppTheme) {
-  return blendHex(color, theme.panel, INACTIVE_RAIL_BLEND);
-}
-
-/** The rail marker is always visible. */
-function marker() {
-  return "▌";
-}
-
-/** Return the neutral active-hunk rail color for the current theme. */
-function neutralRailColor(theme: AppTheme) {
-  return theme.lineNumberFg;
-}
-
-/** Pick the stack-view rail color for one rendered row. */
-function stackRailColor(kind: StackLineCell["kind"], theme: AppTheme, selected: boolean) {
-  let color: string;
-
-  if (kind === "addition") {
-    color = theme.addedSignColor;
-  } else if (kind === "deletion") {
-    color = theme.removedSignColor;
-  } else {
-    color = neutralRailColor(theme);
-  }
-
-  return selected ? color : dimRailColor(color, theme);
-}
-
-/** Pick the left split-view rail color from the old-side cell state. */
-function splitLeftRailColor(kind: SplitLineCell["kind"], theme: AppTheme, selected: boolean) {
-  const color = kind === "deletion" ? theme.removedSignColor : neutralRailColor(theme);
-  return selected ? color : dimRailColor(color, theme);
-}
-
-/** Pick the right split-view rail color from the new-side cell state. */
-function splitRightRailColor(kind: SplitLineCell["kind"], theme: AppTheme, selected: boolean) {
-  const color = kind === "addition" ? theme.addedSignColor : neutralRailColor(theme);
-  return selected ? color : dimRailColor(color, theme);
-}
-
-/** Pick split-view colors from the semantic diff cell kind. */
-function splitCellPalette(kind: SplitLineCell["kind"], theme: AppTheme) {
-  if (kind === "addition") {
-    return {
-      gutterBg: theme.addedBg,
-      contentBg: theme.addedBg,
-      signColor: theme.addedSignColor,
-      numberColor: theme.addedSignColor,
-    };
-  }
-
-  if (kind === "deletion") {
-    return {
-      gutterBg: theme.removedBg,
-      contentBg: theme.removedBg,
-      signColor: theme.removedSignColor,
-      numberColor: theme.removedSignColor,
-    };
-  }
-
-  if (kind === "empty") {
-    return {
-      gutterBg: theme.lineNumberBg,
-      contentBg: theme.panelAlt,
-      signColor: theme.muted,
-      numberColor: theme.lineNumberFg,
-    };
-  }
-
-  return {
-    gutterBg: theme.lineNumberBg,
-    contentBg: theme.contextBg,
-    signColor: theme.muted,
-    numberColor: theme.lineNumberFg,
-  };
-}
-
-/** Pick stack-view colors from the semantic diff cell kind. */
-function stackCellPalette(kind: StackLineCell["kind"], theme: AppTheme) {
-  if (kind === "addition") {
-    return {
-      gutterBg: theme.addedBg,
-      contentBg: theme.addedBg,
-      signColor: theme.addedSignColor,
-      numberColor: theme.addedSignColor,
-    };
-  }
-
-  if (kind === "deletion") {
-    return {
-      gutterBg: theme.removedBg,
-      contentBg: theme.removedBg,
-      signColor: theme.removedSignColor,
-      numberColor: theme.removedSignColor,
-    };
-  }
-
-  return {
-    gutterBg: theme.lineNumberBg,
-    contentBg: theme.contextBg,
-    signColor: theme.muted,
-    numberColor: theme.lineNumberFg,
-  };
-}
+const marker = diffRailMarker;
 
 /** Render a fixed-width inline span sequence for one diff cell. */
 function renderInlineSpans(
@@ -342,15 +245,9 @@ function buildWrappedStackCell(
     showLineNumbers,
     prefixWidth,
   );
-  const oldNumber = cell.oldLineNumber
-    ? String(cell.oldLineNumber).padStart(lineNumberDigits, " ")
-    : " ".repeat(lineNumberDigits);
-  const newNumber = cell.newLineNumber
-    ? String(cell.newLineNumber).padStart(lineNumberDigits, " ")
-    : " ".repeat(lineNumberDigits);
-  const firstGutterText = (
-    showLineNumbers ? `${oldNumber} ${newNumber} ${cell.sign}` : `${cell.sign} `
-  ).padEnd(gutterWidth);
+  const firstGutterText = stackGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(
+    gutterWidth,
+  );
   const wrappedSpans = wrapSpans(cell.spans, contentWidth);
 
   return {
@@ -438,13 +335,6 @@ function renderStackCell(
     prefixWidth,
   );
 
-  const oldNumber = cell.oldLineNumber
-    ? String(cell.oldLineNumber).padStart(lineNumberDigits, " ")
-    : " ".repeat(lineNumberDigits);
-  const newNumber = cell.newLineNumber
-    ? String(cell.newLineNumber).padStart(lineNumberDigits, " ")
-    : " ".repeat(lineNumberDigits);
-
   return (
     <>
       {prefix ? (
@@ -453,9 +343,7 @@ function renderStackCell(
         </span>
       ) : null}
       <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
-        {(showLineNumbers ? `${oldNumber} ${newNumber} ${cell.sign}` : `${cell.sign} `).padEnd(
-          gutterWidth,
-        )}
+        {stackGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth)}
       </span>
       {renderInlineSpans(
         cell.spans,

--- a/src/ui/diff/rowStyle.ts
+++ b/src/ui/diff/rowStyle.ts
@@ -1,0 +1,140 @@
+import type { AppTheme } from "../themes";
+import { blendHex } from "../lib/color";
+import type { SplitLineCell, StackLineCell } from "./pierre";
+
+const INACTIVE_RAIL_BLEND = 0.35;
+
+/** The diff rail marker is always visible in Hunk stack and split rows. */
+export function diffRailMarker() {
+  return "▌";
+}
+
+/** Return the neutral active-hunk rail color for the current theme. */
+export function neutralRailColor(theme: AppTheme) {
+  return theme.lineNumberFg;
+}
+
+/** Dim a rail color for inactive hunks by blending toward the panel background. */
+export function dimRailColor(color: string, theme: AppTheme) {
+  return blendHex(color, theme.panel, INACTIVE_RAIL_BLEND);
+}
+
+/** Pick the stack-view rail color for one rendered row. */
+export function stackRailColor(kind: StackLineCell["kind"], theme: AppTheme, selected: boolean) {
+  let color: string;
+
+  if (kind === "addition") {
+    color = theme.addedSignColor;
+  } else if (kind === "deletion") {
+    color = theme.removedSignColor;
+  } else {
+    color = neutralRailColor(theme);
+  }
+
+  return selected ? color : dimRailColor(color, theme);
+}
+
+/** Pick the left split-view rail color from the old-side cell state. */
+export function splitLeftRailColor(
+  kind: SplitLineCell["kind"],
+  theme: AppTheme,
+  selected: boolean,
+) {
+  const color = kind === "deletion" ? theme.removedSignColor : neutralRailColor(theme);
+  return selected ? color : dimRailColor(color, theme);
+}
+
+/** Pick the right split-view rail color from the new-side cell state. */
+export function splitRightRailColor(
+  kind: SplitLineCell["kind"],
+  theme: AppTheme,
+  selected: boolean,
+) {
+  const color = kind === "addition" ? theme.addedSignColor : neutralRailColor(theme);
+  return selected ? color : dimRailColor(color, theme);
+}
+
+/** Pick split-view colors from the semantic diff cell kind. */
+export function splitCellPalette(kind: SplitLineCell["kind"], theme: AppTheme) {
+  if (kind === "addition") {
+    return {
+      gutterBg: theme.addedBg,
+      contentBg: theme.addedBg,
+      signColor: theme.addedSignColor,
+      numberColor: theme.addedSignColor,
+    };
+  }
+
+  if (kind === "deletion") {
+    return {
+      gutterBg: theme.removedBg,
+      contentBg: theme.removedBg,
+      signColor: theme.removedSignColor,
+      numberColor: theme.removedSignColor,
+    };
+  }
+
+  if (kind === "empty") {
+    return {
+      gutterBg: theme.lineNumberBg,
+      contentBg: theme.panelAlt,
+      signColor: theme.muted,
+      numberColor: theme.lineNumberFg,
+    };
+  }
+
+  return {
+    gutterBg: theme.lineNumberBg,
+    contentBg: theme.contextBg,
+    signColor: theme.muted,
+    numberColor: theme.lineNumberFg,
+  };
+}
+
+/** Pick stack-view colors from the semantic diff cell kind. */
+export function stackCellPalette(kind: StackLineCell["kind"], theme: AppTheme) {
+  if (kind === "addition") {
+    return {
+      gutterBg: theme.addedBg,
+      contentBg: theme.addedBg,
+      signColor: theme.addedSignColor,
+      numberColor: theme.addedSignColor,
+    };
+  }
+
+  if (kind === "deletion") {
+    return {
+      gutterBg: theme.removedBg,
+      contentBg: theme.removedBg,
+      signColor: theme.removedSignColor,
+      numberColor: theme.removedSignColor,
+    };
+  }
+
+  return {
+    gutterBg: theme.lineNumberBg,
+    contentBg: theme.contextBg,
+    signColor: theme.muted,
+    numberColor: theme.lineNumberFg,
+  };
+}
+
+/** Format one optional line number for a fixed-width diff gutter. */
+export function diffLineNumberText(value: number | undefined, width: number) {
+  return value === undefined ? " ".repeat(width) : String(value).padStart(width, " ");
+}
+
+/** Build the stack-view gutter text shared by the TUI and static pager renderers. */
+export function stackGutterText(
+  cell: StackLineCell,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+) {
+  if (!showLineNumbers) {
+    return `${cell.sign} `;
+  }
+
+  const oldNumber = diffLineNumberText(cell.oldLineNumber, lineNumberDigits);
+  const newNumber = diffLineNumberText(cell.newLineNumber, lineNumberDigits);
+  return `${oldNumber} ${newNumber} ${cell.sign}`;
+}

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -39,9 +39,25 @@ describe("static diff pager", () => {
     expect(plain).not.toContain("index 0000000");
   });
 
-  test("falls back to original text when the patch cannot be parsed", async () => {
+  test("falls back to original text with a diagnostic when the patch cannot be parsed", async () => {
     const text = "diff --git incomplete\n";
+    let warning = "";
 
-    await expect(renderStaticDiffPager(text)).resolves.toBe(text);
+    await expect(
+      renderStaticDiffPager(
+        text,
+        {},
+        {
+          stderr: {
+            write: (chunk) => {
+              warning += String(chunk);
+              return true;
+            },
+          },
+        },
+      ),
+    ).resolves.toBe(text);
+    expect(warning).toContain("hunk: static pager render failed");
+    expect(warning).toContain("falling back to raw diff");
   });
 });

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -22,6 +22,19 @@ describe("static diff pager", () => {
     expect(output).not.toContain("\x1b[?1049h");
   });
 
+  test("honors configured hidden line numbers and hunk headers", async () => {
+    const patchText =
+      "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-const value = 1;\n+const value = 2;\n";
+
+    const plain = stripAnsi(
+      await renderStaticDiffPager(patchText, { lineNumbers: false, hunkHeaders: false }),
+    );
+
+    expect(plain).not.toContain("@@ -1 +1 @@");
+    expect(plain).toContain("▌- const value = 1;");
+    expect(plain).toContain("▌+ const value = 2;");
+  });
+
   test("shows semantic file metadata without raw patch headers", async () => {
     const patchText = [
       "diff --git a/new.txt b/new.txt",

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -15,7 +15,9 @@ describe("static diff pager", () => {
     const plain = stripAnsi(output);
 
     expect(plain).toContain("a.ts modified +1 -1");
-    expect(plain).toContain("const value = 2;");
+    expect(plain).toContain("▌@@ -1 +1 @@\n");
+    expect(plain).toContain("▌1   -  const value = 1;");
+    expect(plain).toContain("▌  1 +  const value = 2;");
     expect(output).toContain("\x1b[38;2;");
     expect(output).not.toContain("\x1b[?1049h");
   });

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { renderStaticDiffPager } from "./staticDiffPager";
+
+function stripAnsi(text: string) {
+  return text.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+describe("static diff pager", () => {
+  test("renders diff-like stdin as non-interactive ANSI output", async () => {
+    const patchText =
+      "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-const value = 1;\n+const value = 2;\n";
+
+    const output = await renderStaticDiffPager(patchText);
+
+    const plain = stripAnsi(output);
+
+    expect(plain).toContain("a.ts modified +1 -1");
+    expect(plain).toContain("const value = 2;");
+    expect(output).toContain("\x1b[38;2;");
+    expect(output).not.toContain("\x1b[?1049h");
+  });
+
+  test("shows semantic file metadata without raw patch headers", async () => {
+    const patchText = [
+      "diff --git a/new.txt b/new.txt",
+      "new file mode 100644",
+      "index 0000000..587be6b",
+      "--- /dev/null",
+      "+++ b/new.txt",
+      "@@ -0,0 +1 @@",
+      "+hello",
+      "",
+    ].join("\n");
+
+    const plain = stripAnsi(await renderStaticDiffPager(patchText));
+
+    expect(plain).toContain("new.txt new file 100644 +1 -0");
+    expect(plain).not.toContain("diff --git");
+    expect(plain).not.toContain("index 0000000");
+  });
+
+  test("falls back to original text when the patch cannot be parsed", async () => {
+    const text = "diff --git incomplete\n";
+
+    await expect(renderStaticDiffPager(text)).resolves.toBe(text);
+  });
+});

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -1,3 +1,19 @@
+/**
+ * Non-interactive `hunk pager` renderer for captured pager hosts.
+ *
+ * Hunk's normal pager integration is a full-screen interactive TUI: Git pipes patch text on stdin,
+ * and Hunk opens the controlling terminal for keyboard/mouse input. That works for `core.pager`,
+ * but tools such as LazyGit invoke custom pagers inside their own diff panel and advertise a
+ * constrained environment (notably `TERM=dumb`). Launching the TUI there either hangs, corrupts the
+ * host panel with alternate-screen control sequences, or leaves no usable diff output.
+ *
+ * This module is the fallback output adapter for those contexts. It intentionally reuses Hunk's
+ * normal parse/highlight/render planning stack (`loadAppBootstrap`, Pierre metadata,
+ * `loadHighlightedDiff`, and `buildStackRows`) and only serializes the resulting stack rows to ANSI
+ * text. Keep it as a thin adapter: do not introduce a second diff parser or a parallel review model
+ * here. If the static renderer cannot parse or render safely, callers fall back to the original patch
+ * text so pager pipelines keep working.
+ */
 import { loadAppBootstrap } from "../core/loaders";
 import type { CommonOptions, DiffFile } from "../core/types";
 import { buildStackRows, loadHighlightedDiff, type DiffRow, type RenderSpan } from "./diff/pierre";

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -62,14 +62,31 @@ function renderHeaderLikeRow(text: string, fg: string, bg: string, theme: AppThe
   return `${colorText(marker(), neutralRailColor(theme), bg)}${colorText(text.trimEnd(), fg, bg)}`;
 }
 
+function staticStackGutterText(
+  cell: Extract<DiffRow, { type: "stack-line" }>["cell"],
+  lineNumberWidth: number,
+  showLineNumbers: boolean,
+) {
+  return stackGutterText(cell, lineNumberWidth, showLineNumbers).padEnd(
+    showLineNumbers ? lineNumberWidth * 2 + 5 : 2,
+  );
+}
+
 /** Render one non-interactive stacked diff row as ANSI text. */
-function renderStaticRow(row: DiffRow, theme: AppTheme, lineNumberWidth: number) {
+function renderStaticRow(
+  row: DiffRow,
+  theme: AppTheme,
+  lineNumberWidth: number,
+  options: CommonOptions,
+) {
   if (row.type === "collapsed") {
     return renderHeaderLikeRow(`··· ${row.text} ···`, theme.muted, theme.panelAlt, theme);
   }
 
   if (row.type === "hunk-header") {
-    return renderHeaderLikeRow(row.text, theme.badgeNeutral, theme.panelAlt, theme);
+    return options.hunkHeaders === false
+      ? ""
+      : renderHeaderLikeRow(row.text, theme.badgeNeutral, theme.panelAlt, theme);
   }
 
   if (row.type !== "stack-line") {
@@ -79,7 +96,7 @@ function renderStaticRow(row: DiffRow, theme: AppTheme, lineNumberWidth: number)
   const { cell } = row;
   const palette = stackCellPalette(cell.kind, theme);
   return `${colorText(marker(), stackRailColor(cell.kind, theme, true), theme.panel)}${colorText(
-    stackGutterText(cell, lineNumberWidth, true).padEnd(lineNumberWidth * 2 + 5),
+    staticStackGutterText(cell, lineNumberWidth, options.lineNumbers !== false),
     palette.numberColor,
     palette.gutterBg,
   )}${serializeSpans(cell.spans, palette.contentBg)}`;
@@ -152,7 +169,7 @@ function fileModeText(file: DiffFile) {
 }
 
 /** Format one parsed diff file for static pager hosts like LazyGit's diff panel. */
-async function renderStaticFile(file: DiffFile, theme: AppTheme) {
+async function renderStaticFile(file: DiffFile, theme: AppTheme, options: CommonOptions) {
   const highlighted =
     file.isBinary || file.isTooLarge ? null : await loadHighlightedDiff(file, theme.appearance);
   const rows = buildStackRows(file, highlighted, theme);
@@ -170,7 +187,10 @@ async function renderStaticFile(file: DiffFile, theme: AppTheme) {
     return [header, colorText(message, theme.muted)].join("\n");
   }
 
-  return [header, ...rows.map((row) => renderStaticRow(row, theme, lineNumberWidth))].join("\n");
+  return [
+    header,
+    ...rows.map((row) => renderStaticRow(row, theme, lineNumberWidth, options)).filter(Boolean),
+  ].join("\n");
 }
 
 function fallbackMessage(error: unknown) {
@@ -207,7 +227,7 @@ export async function renderStaticDiffPager(
     });
     const theme = resolveTheme(options.theme, null);
     const rendered = await Promise.all(
-      bootstrap.changeset.files.map((file) => renderStaticFile(file, theme)),
+      bootstrap.changeset.files.map((file) => renderStaticFile(file, theme, options)),
     );
 
     if (rendered.length === 0) {

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -174,8 +174,28 @@ async function renderStaticFile(file: DiffFile, theme: AppTheme) {
   return [header, ...rows.map((row) => renderStaticRow(row, theme, lineNumberWidth))].join("\n");
 }
 
+function fallbackMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return String(error || "unknown error");
+}
+
+export interface StaticDiffPagerDeps {
+  stderr?: Pick<NodeJS.WriteStream, "write">;
+}
+
+function warnFallback(deps: StaticDiffPagerDeps, reason: string) {
+  deps.stderr?.write(`hunk: static pager render failed; falling back to raw diff (${reason}).\n`);
+}
+
 /** Render diff-like pager stdin as colored static output, falling back to the original patch on failure. */
-export async function renderStaticDiffPager(text: string, options: CommonOptions = {}) {
+export async function renderStaticDiffPager(
+  text: string,
+  options: CommonOptions = {},
+  deps: StaticDiffPagerDeps = { stderr: process.stderr },
+) {
   try {
     const bootstrap = await loadAppBootstrap({
       kind: "patch",
@@ -191,8 +211,14 @@ export async function renderStaticDiffPager(text: string, options: CommonOptions
       bootstrap.changeset.files.map((file) => renderStaticFile(file, theme)),
     );
 
-    return rendered.length > 0 ? `${rendered.join("\n\n")}\n` : text;
-  } catch {
+    if (rendered.length === 0) {
+      warnFallback(deps, "no files rendered");
+      return text;
+    }
+
+    return `${rendered.join("\n\n")}\n`;
+  } catch (error) {
+    warnFallback(deps, fallbackMessage(error));
     return text;
   }
 }

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -49,29 +49,64 @@ function serializeSpans(spans: RenderSpan[], rowBg: string) {
   return spans.map((span) => colorText(span.text, span.fg, span.bg ?? rowBg)).join("");
 }
 
-function lineColor(kind: "context" | "addition" | "deletion", theme: AppTheme) {
-  switch (kind) {
-    case "addition":
-      return { fg: theme.addedSignColor, bg: theme.addedBg };
-    case "deletion":
-      return { fg: theme.removedSignColor, bg: theme.removedBg };
-    case "context":
-      return { fg: theme.muted, bg: theme.contextBg };
+function neutralRailColor(theme: AppTheme) {
+  return theme.lineNumberFg;
+}
+
+function marker() {
+  return "▌";
+}
+
+/** Keep the static stack gutter visually aligned with DiffRowView's stack renderer. */
+function stackPalette(kind: "context" | "addition" | "deletion", theme: AppTheme) {
+  if (kind === "addition") {
+    return {
+      railColor: theme.addedSignColor,
+      gutterBg: theme.addedBg,
+      contentBg: theme.addedBg,
+      numberColor: theme.addedSignColor,
+    };
   }
+
+  if (kind === "deletion") {
+    return {
+      railColor: theme.removedSignColor,
+      gutterBg: theme.removedBg,
+      contentBg: theme.removedBg,
+      numberColor: theme.removedSignColor,
+    };
+  }
+
+  return {
+    railColor: neutralRailColor(theme),
+    gutterBg: theme.lineNumberBg,
+    contentBg: theme.contextBg,
+    numberColor: theme.lineNumberFg,
+  };
 }
 
 function lineNumberText(value: number | undefined, width: number) {
   return value === undefined ? " ".repeat(width) : String(value).padStart(width, " ");
 }
 
+function stackGutterText(cell: Extract<DiffRow, { type: "stack-line" }>["cell"], width: number) {
+  const oldLine = lineNumberText(cell.oldLineNumber, width);
+  const newLine = lineNumberText(cell.newLineNumber, width);
+  return `${oldLine} ${newLine} ${cell.sign}`.padEnd(width * 2 + 5);
+}
+
+function renderHeaderLikeRow(text: string, fg: string, bg: string, theme: AppTheme) {
+  return `${colorText(marker(), neutralRailColor(theme), bg)}${colorText(text.trimEnd(), fg, bg)}`;
+}
+
 /** Render one non-interactive stacked diff row as ANSI text. */
 function renderStaticRow(row: DiffRow, theme: AppTheme, lineNumberWidth: number) {
   if (row.type === "collapsed") {
-    return colorText(`  ${row.text}`, theme.muted);
+    return renderHeaderLikeRow(`··· ${row.text} ···`, theme.muted, theme.panelAlt, theme);
   }
 
   if (row.type === "hunk-header") {
-    return colorText(`  ${row.text}`, theme.accent);
+    return renderHeaderLikeRow(row.text, theme.badgeNeutral, theme.panelAlt, theme);
   }
 
   if (row.type !== "stack-line") {
@@ -79,11 +114,12 @@ function renderStaticRow(row: DiffRow, theme: AppTheme, lineNumberWidth: number)
   }
 
   const { cell } = row;
-  const colors = lineColor(cell.kind, theme);
-  const oldLine = lineNumberText(cell.oldLineNumber, lineNumberWidth);
-  const newLine = lineNumberText(cell.newLineNumber, lineNumberWidth);
-  const prefix = `${cell.sign} ${oldLine} ${newLine} │ `;
-  return `${colorText(prefix, colors.fg, colors.bg)}${serializeSpans(cell.spans, colors.bg)}`;
+  const palette = stackPalette(cell.kind, theme);
+  return `${colorText(marker(), palette.railColor, theme.panel)}${colorText(
+    stackGutterText(cell, lineNumberWidth),
+    palette.numberColor,
+    palette.gutterBg,
+  )}${serializeSpans(cell.spans, palette.contentBg)}`;
 }
 
 function maxLineNumberWidth(file: DiffFile, rows: DiffRow[]) {

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -17,6 +17,13 @@
 import { loadAppBootstrap } from "../core/loaders";
 import type { CommonOptions, DiffFile } from "../core/types";
 import { buildStackRows, loadHighlightedDiff, type DiffRow, type RenderSpan } from "./diff/pierre";
+import {
+  diffRailMarker,
+  neutralRailColor,
+  stackCellPalette,
+  stackGutterText,
+  stackRailColor,
+} from "./diff/rowStyle";
 import { resolveTheme, type AppTheme } from "./themes";
 
 const RESET = "\x1b[0m";
@@ -49,51 +56,7 @@ function serializeSpans(spans: RenderSpan[], rowBg: string) {
   return spans.map((span) => colorText(span.text, span.fg, span.bg ?? rowBg)).join("");
 }
 
-function neutralRailColor(theme: AppTheme) {
-  return theme.lineNumberFg;
-}
-
-function marker() {
-  return "▌";
-}
-
-/** Keep the static stack gutter visually aligned with DiffRowView's stack renderer. */
-function stackPalette(kind: "context" | "addition" | "deletion", theme: AppTheme) {
-  if (kind === "addition") {
-    return {
-      railColor: theme.addedSignColor,
-      gutterBg: theme.addedBg,
-      contentBg: theme.addedBg,
-      numberColor: theme.addedSignColor,
-    };
-  }
-
-  if (kind === "deletion") {
-    return {
-      railColor: theme.removedSignColor,
-      gutterBg: theme.removedBg,
-      contentBg: theme.removedBg,
-      numberColor: theme.removedSignColor,
-    };
-  }
-
-  return {
-    railColor: neutralRailColor(theme),
-    gutterBg: theme.lineNumberBg,
-    contentBg: theme.contextBg,
-    numberColor: theme.lineNumberFg,
-  };
-}
-
-function lineNumberText(value: number | undefined, width: number) {
-  return value === undefined ? " ".repeat(width) : String(value).padStart(width, " ");
-}
-
-function stackGutterText(cell: Extract<DiffRow, { type: "stack-line" }>["cell"], width: number) {
-  const oldLine = lineNumberText(cell.oldLineNumber, width);
-  const newLine = lineNumberText(cell.newLineNumber, width);
-  return `${oldLine} ${newLine} ${cell.sign}`.padEnd(width * 2 + 5);
-}
+const marker = diffRailMarker;
 
 function renderHeaderLikeRow(text: string, fg: string, bg: string, theme: AppTheme) {
   return `${colorText(marker(), neutralRailColor(theme), bg)}${colorText(text.trimEnd(), fg, bg)}`;
@@ -114,9 +77,9 @@ function renderStaticRow(row: DiffRow, theme: AppTheme, lineNumberWidth: number)
   }
 
   const { cell } = row;
-  const palette = stackPalette(cell.kind, theme);
-  return `${colorText(marker(), palette.railColor, theme.panel)}${colorText(
-    stackGutterText(cell, lineNumberWidth),
+  const palette = stackCellPalette(cell.kind, theme);
+  return `${colorText(marker(), stackRailColor(cell.kind, theme, true), theme.panel)}${colorText(
+    stackGutterText(cell, lineNumberWidth, true).padEnd(lineNumberWidth * 2 + 5),
     palette.numberColor,
     palette.gutterBg,
   )}${serializeSpans(cell.spans, palette.contentBg)}`;

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -1,0 +1,182 @@
+import { loadAppBootstrap } from "../core/loaders";
+import type { CommonOptions, DiffFile } from "../core/types";
+import { buildStackRows, loadHighlightedDiff, type DiffRow, type RenderSpan } from "./diff/pierre";
+import { resolveTheme, type AppTheme } from "./themes";
+
+const RESET = "\x1b[0m";
+
+/** Convert a six-digit hex color into one ANSI truecolor code. */
+function ansiColor(kind: "fg" | "bg", hex: string | undefined) {
+  const normalized = hex?.replace(/^#/, "");
+  if (!normalized || !/^[0-9a-f]{6}$/i.test(normalized)) {
+    return "";
+  }
+
+  const red = Number.parseInt(normalized.slice(0, 2), 16);
+  const green = Number.parseInt(normalized.slice(2, 4), 16);
+  const blue = Number.parseInt(normalized.slice(4, 6), 16);
+  return `\x1b[${kind === "fg" ? 38 : 48};2;${red};${green};${blue}m`;
+}
+
+/** Wrap one terminal text fragment in ANSI colors. */
+function colorText(text: string, fg?: string, bg?: string) {
+  if (!text) {
+    return "";
+  }
+
+  const prefix = `${ansiColor("fg", fg)}${ansiColor("bg", bg)}`;
+  return prefix ? `${prefix}${text}${RESET}` : text;
+}
+
+/** Serialize highlighted code spans into ANSI text, preserving a row background when present. */
+function serializeSpans(spans: RenderSpan[], rowBg: string) {
+  return spans.map((span) => colorText(span.text, span.fg, span.bg ?? rowBg)).join("");
+}
+
+function lineColor(kind: "context" | "addition" | "deletion", theme: AppTheme) {
+  switch (kind) {
+    case "addition":
+      return { fg: theme.addedSignColor, bg: theme.addedBg };
+    case "deletion":
+      return { fg: theme.removedSignColor, bg: theme.removedBg };
+    case "context":
+      return { fg: theme.muted, bg: theme.contextBg };
+  }
+}
+
+function lineNumberText(value: number | undefined, width: number) {
+  return value === undefined ? " ".repeat(width) : String(value).padStart(width, " ");
+}
+
+/** Render one non-interactive stacked diff row as ANSI text. */
+function renderStaticRow(row: DiffRow, theme: AppTheme, lineNumberWidth: number) {
+  if (row.type === "collapsed") {
+    return colorText(`  ${row.text}`, theme.muted);
+  }
+
+  if (row.type === "hunk-header") {
+    return colorText(`  ${row.text}`, theme.accent);
+  }
+
+  if (row.type !== "stack-line") {
+    return "";
+  }
+
+  const { cell } = row;
+  const colors = lineColor(cell.kind, theme);
+  const oldLine = lineNumberText(cell.oldLineNumber, lineNumberWidth);
+  const newLine = lineNumberText(cell.newLineNumber, lineNumberWidth);
+  const prefix = `${cell.sign} ${oldLine} ${newLine} │ `;
+  return `${colorText(prefix, colors.fg, colors.bg)}${serializeSpans(cell.spans, colors.bg)}`;
+}
+
+function maxLineNumberWidth(file: DiffFile, rows: DiffRow[]) {
+  let max = 1;
+  for (const row of rows) {
+    if (row.type !== "stack-line") {
+      continue;
+    }
+
+    max = Math.max(
+      max,
+      row.cell.oldLineNumber ? String(row.cell.oldLineNumber).length : 1,
+      row.cell.newLineNumber ? String(row.cell.newLineNumber).length : 1,
+    );
+  }
+
+  return Math.max(max, String(file.metadata.additionLines.length).length);
+}
+
+/** Describe the file-level change without exposing raw patch transport headers. */
+function fileStatusLabel(file: DiffFile) {
+  if (file.isTooLarge) {
+    return "skipped large file";
+  }
+
+  if (file.isBinary) {
+    return "binary";
+  }
+
+  switch (file.metadata.type) {
+    case "new":
+      return file.isUntracked ? "untracked" : "new file";
+    case "deleted":
+      return "deleted";
+    case "rename-pure":
+      return "renamed";
+    case "rename-changed":
+      return "renamed modified";
+    case "change":
+    default:
+      return file.metadata.prevMode && file.metadata.prevMode !== file.metadata.mode
+        ? "mode changed"
+        : "modified";
+  }
+}
+
+/** Use an arrow label for renamed files so static output keeps important path metadata. */
+function fileDisplayPath(file: DiffFile) {
+  const previousPath = file.previousPath ?? file.metadata.prevName;
+  return previousPath && previousPath !== file.path ? `${previousPath} → ${file.path}` : file.path;
+}
+
+function fileModeText(file: DiffFile) {
+  if (
+    file.metadata.prevMode &&
+    file.metadata.mode &&
+    file.metadata.prevMode !== file.metadata.mode
+  ) {
+    return ` ${file.metadata.prevMode}→${file.metadata.mode}`;
+  }
+
+  if ((file.metadata.type === "new" || file.metadata.type === "deleted") && file.metadata.mode) {
+    return ` ${file.metadata.mode}`;
+  }
+
+  return "";
+}
+
+/** Format one parsed diff file for static pager hosts like LazyGit's diff panel. */
+async function renderStaticFile(file: DiffFile, theme: AppTheme) {
+  const highlighted =
+    file.isBinary || file.isTooLarge ? null : await loadHighlightedDiff(file, theme.appearance);
+  const rows = buildStackRows(file, highlighted, theme);
+  const lineNumberWidth = maxLineNumberWidth(file, rows);
+  const stats = `${colorText(`+${file.stats.additions}${file.statsTruncated ? "+" : ""}`, theme.badgeAdded)} ${colorText(`-${file.stats.deletions}`, theme.badgeRemoved)}`;
+  const status = colorText(`${fileStatusLabel(file)}${fileModeText(file)}`, theme.muted);
+  const header = `${colorText(fileDisplayPath(file), theme.text)} ${status} ${stats}`;
+
+  if (rows.length === 0) {
+    const message = file.isTooLarge
+      ? "  Skipped because the file is too large to render."
+      : file.isBinary
+        ? "  Binary file."
+        : "  No textual changes.";
+    return [header, colorText(message, theme.muted)].join("\n");
+  }
+
+  return [header, ...rows.map((row) => renderStaticRow(row, theme, lineNumberWidth))].join("\n");
+}
+
+/** Render diff-like pager stdin as colored static output, falling back to the original patch on failure. */
+export async function renderStaticDiffPager(text: string, options: CommonOptions = {}) {
+  try {
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      file: "-",
+      text,
+      options: {
+        ...options,
+        pager: true,
+      },
+    });
+    const theme = resolveTheme(options.theme, null);
+    const rendered = await Promise.all(
+      bootstrap.changeset.files.map((file) => renderStaticFile(file, theme)),
+    );
+
+    return rendered.length > 0 ? `${rendered.join("\n\n")}\n` : text;
+  } catch {
+    return text;
+  }
+}

--- a/test/cli/entrypoint.test.ts
+++ b/test/cli/entrypoint.test.ts
@@ -216,6 +216,25 @@ describe("CLI entrypoint contracts", () => {
     expect(stdout).not.toContain("\u001b[?1049h");
   });
 
+  test("general pager mode passes diff stdin through when stdout is not a terminal", () => {
+    const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
+    const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "pager"], {
+      cwd: process.cwd(),
+      stdin: Buffer.from(patchText),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: process.env,
+    });
+
+    const stdout = Buffer.from(proc.stdout).toString("utf8");
+    const stderr = Buffer.from(proc.stderr).toString("utf8");
+
+    expect(proc.exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(patchText);
+    expect(stdout).not.toContain("\u001b[?1049h");
+  });
+
   test("prints a friendly git-repo error without a Bun stack trace", () => {
     const nonRepoDir = mkdtempSync(join(tmpdir(), "hunk-nonrepo-"));
     const sourceEntrypoint = join(process.cwd(), "src/main.tsx");


### PR DESCRIPTION
## Summary

- Add a static ANSI diff renderer for `hunk pager` when it is launched by captured pager hosts such as LazyGit.
- Keep normal interactive pager behavior when Hunk can attach to a terminal, and preserve raw passthrough for non-TTY stdout/pipelines or plain `TERM=dumb` terminals.
- Reuse Hunk/Pierre parsing, highlighting, row planning, and shared row styling helpers so static output stays visually aligned with the TUI.
- Include semantic file metadata in static headers without exposing raw patch transport headers.
- Apply Hunk config to static output for supported view options such as theme, line numbers, and hunk headers.
- Emit a diagnostic before falling back to raw diff if static rendering fails.

## Verification

- `bun test src/ui/staticDiffPager.test.ts src/core/startup.test.ts test/cli/entrypoint.test.ts`
- `bun run typecheck`
- Manual LazyGit check with `git.pagers[].pager = "bun /home/bentlegen/Projects/hunk-b/src/main.tsx pager"`

*This PR description was generated by Pi using OpenAI GPT-5*
