### PR TITLE
feat: add Homebrew tap distribution

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -225,15 +225,19 @@ jobs:
 
       - name: Update Homebrew formula
         if: ${{ !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           bun run update:homebrew-formula -- \
-            --tag "${{ github.ref_name }}" \
+            --tag "$TAG_NAME" \
             --asset-root dist/release/github \
             --output-root dist/release/homebrew-tap
 
       - name: Commit Homebrew formula update
         if: ${{ !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
         working-directory: dist/release/homebrew-tap
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -241,6 +245,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "Homebrew formula already up to date."
           else
-            git commit -m "hunk ${{ github.ref_name }}"
+            git commit -m "hunk $TAG_NAME"
             git push
           fi

--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -174,6 +174,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.10
+
       - name: Download platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -208,4 +213,34 @@ jobs:
               --generate-notes \
               "${prerelease_args[@]}" \
               dist/release/github/*
+          fi
+
+      - name: Check out Homebrew tap
+        if: ${{ !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: modem-dev/homebrew-tap
+          path: dist/release/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Update Homebrew formula
+        if: ${{ !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
+        run: |
+          bun run update:homebrew-formula -- \
+            --tag "${{ github.ref_name }}" \
+            --asset-root dist/release/github \
+            --output-root dist/release/homebrew-tap
+
+      - name: Commit Homebrew formula update
+        if: ${{ !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc') }}
+        working-directory: dist/release/homebrew-tap
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/hunk.rb
+          if git diff --cached --quiet; then
+            echo "Homebrew formula already up to date."
+          else
+            git commit -m "hunk ${{ github.ref_name }}"
+            git push
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+- Added Homebrew tap release automation and Homebrew-aware startup update notices.
+
 ### Changed
 
 - Auto-detect Jujutsu checkouts for `hunk diff` and `hunk show`, while keeping explicit `vcs` config overrides.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Hunk is a review-first terminal diff viewer for agent-authored changesets, built
 npm i -g hunkdiff
 ```
 
+Or with Homebrew:
+
+```bash
+brew install modem-dev/tap/hunk
+```
+
 Requirements:
 
 - Node.js 18+

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "check:prebuilt-pack": "bun run ./scripts/check-prebuilt-pack.ts",
     "smoke:prebuilt-install": "bun run ./scripts/smoke-prebuilt-install.ts",
     "publish:prebuilt:npm": "bun run ./scripts/publish-prebuilt-npm.ts",
+    "update:homebrew-formula": "bun run ./scripts/update-homebrew-formula.ts",
     "prepack": "bun run build:npm",
     "bench:bootstrap-load": "bun run benchmarks/bootstrap-load.ts",
     "bench:highlight-prefetch": "bun run benchmarks/highlight-prefetch.ts",

--- a/scripts/update-homebrew-formula.test.ts
+++ b/scripts/update-homebrew-formula.test.ts
@@ -18,6 +18,38 @@ function createTestAssets(assetRoot: string) {
 }
 
 describe("update-homebrew-formula", () => {
+  test("rejects unsafe repository slugs before writing Ruby formula URLs", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "hunk-homebrew-formula-"));
+    const assetRoot = path.join(root, "assets");
+    const outputRoot = path.join(root, "tap");
+
+    try {
+      mkdirSync(assetRoot, { recursive: true });
+      createTestAssets(assetRoot);
+      const proc = Bun.spawnSync(
+        [
+          "bun",
+          "run",
+          path.resolve(import.meta.dir, "update-homebrew-formula.ts"),
+          "--tag",
+          "v1.2.3",
+          "--asset-root",
+          assetRoot,
+          "--output-root",
+          outputRoot,
+          "--repo",
+          'modem-dev/hunk"; system("echo owned") #',
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+
+      expect(proc.exitCode).not.toBe(0);
+      expect(proc.stderr.toString()).toContain("Invalid GitHub repository slug");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test("writes a formula that installs the binary through the Homebrew update-notice wrapper", () => {
     const root = mkdtempSync(path.join(tmpdir(), "hunk-homebrew-formula-"));
     const assetRoot = path.join(root, "assets");

--- a/scripts/update-homebrew-formula.test.ts
+++ b/scripts/update-homebrew-formula.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const ASSETS = [
+  "hunkdiff-darwin-arm64.tar.gz",
+  "hunkdiff-darwin-x64.tar.gz",
+  "hunkdiff-linux-arm64.tar.gz",
+  "hunkdiff-linux-x64.tar.gz",
+] as const;
+
+/** Create minimal release asset placeholders for formula checksum generation. */
+function createTestAssets(assetRoot: string) {
+  for (const asset of ASSETS) {
+    writeFileSync(path.join(assetRoot, asset), `contents for ${asset}`);
+  }
+}
+
+describe("update-homebrew-formula", () => {
+  test("writes a formula that installs the binary through the Homebrew update-notice wrapper", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "hunk-homebrew-formula-"));
+    const assetRoot = path.join(root, "assets");
+    const outputRoot = path.join(root, "tap");
+
+    try {
+      mkdirSync(assetRoot, { recursive: true });
+      createTestAssets(assetRoot);
+      const proc = Bun.spawnSync(
+        [
+          "bun",
+          "run",
+          path.resolve(import.meta.dir, "update-homebrew-formula.ts"),
+          "--tag",
+          "v1.2.3",
+          "--asset-root",
+          assetRoot,
+          "--output-root",
+          outputRoot,
+        ],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+
+      expect(proc.exitCode).toBe(0);
+      const formula = readFileSync(path.join(outputRoot, "Formula", "hunk.rb"), "utf8");
+      expect(formula).toContain('version "1.2.3"');
+      expect(formula).toContain("hunkdiff-darwin-arm64.tar.gz");
+      expect(formula).toContain("hunkdiff-linux-x64.tar.gz");
+      expect(formula).toContain('chmod 0755, "hunk"');
+      expect(formula).toContain('libexec.install "hunk"');
+      expect(formula).toContain(
+        '(bin/"hunk").write_env_script libexec/"hunk", HUNK_INSTALL_SOURCE: "homebrew"',
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/update-homebrew-formula.ts
+++ b/scripts/update-homebrew-formula.ts
@@ -87,6 +87,12 @@ function versionFromTag(tag: string) {
   return version;
 }
 
+function assertSafeRepoSlug(repo: string) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error(`Invalid GitHub repository slug: ${repo}`);
+  }
+}
+
 function sha256(file: string) {
   return createHash("sha256").update(readFileSync(file)).digest("hex");
 }
@@ -97,6 +103,7 @@ function assetUrl(repo: string, tag: string, assetName: string) {
 
 function formulaContent(options: Options) {
   const version = versionFromTag(options.tag);
+  assertSafeRepoSlug(options.repo);
   const checksums = Object.fromEntries(
     Object.entries(RELEASE_ASSET_NAMES).map(([key, assetName]) => {
       const assetPath = path.join(options.assetRoot, assetName);

--- a/scripts/update-homebrew-formula.ts
+++ b/scripts/update-homebrew-formula.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+const FORMULA_RELATIVE_PATH = path.join("Formula", "hunk.rb");
+const RELEASE_ASSET_NAMES = {
+  darwinArm64: "hunkdiff-darwin-arm64.tar.gz",
+  darwinX64: "hunkdiff-darwin-x64.tar.gz",
+  linuxArm64: "hunkdiff-linux-arm64.tar.gz",
+  linuxX64: "hunkdiff-linux-x64.tar.gz",
+} as const;
+
+interface Options {
+  assetRoot: string;
+  outputRoot: string;
+  repo: string;
+  tag: string;
+}
+
+function parseArgs(argv: string[]): Options {
+  const repoRoot = path.resolve(import.meta.dir, "..");
+  const options: Options = {
+    assetRoot: path.join(repoRoot, "dist", "release", "github"),
+    outputRoot: repoRoot,
+    repo: "modem-dev/hunk",
+    tag: "",
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+
+    if (argument === "--asset-root") {
+      if (!value) {
+        throw new Error("Missing value for --asset-root.");
+      }
+      options.assetRoot = path.resolve(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--output-root") {
+      if (!value) {
+        throw new Error("Missing value for --output-root.");
+      }
+      options.outputRoot = path.resolve(value);
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--repo") {
+      if (!value) {
+        throw new Error("Missing value for --repo.");
+      }
+      options.repo = value;
+      index += 1;
+      continue;
+    }
+
+    if (argument === "--tag") {
+      if (!value) {
+        throw new Error("Missing value for --tag.");
+      }
+      options.tag = value;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  if (!options.tag) {
+    throw new Error("Missing required --tag vX.Y.Z argument.");
+  }
+
+  return options;
+}
+
+function versionFromTag(tag: string) {
+  const version = tag.startsWith("v") ? tag.slice(1) : tag;
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Homebrew formula updates only support stable semver tags, got ${tag}.`);
+  }
+
+  return version;
+}
+
+function sha256(file: string) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function assetUrl(repo: string, tag: string, assetName: string) {
+  return `https://github.com/${repo}/releases/download/${tag}/${assetName}`;
+}
+
+function formulaContent(options: Options) {
+  const version = versionFromTag(options.tag);
+  const checksums = Object.fromEntries(
+    Object.entries(RELEASE_ASSET_NAMES).map(([key, assetName]) => {
+      const assetPath = path.join(options.assetRoot, assetName);
+      if (!existsSync(assetPath)) {
+        const found = existsSync(options.assetRoot)
+          ? readdirSync(options.assetRoot).join(", ")
+          : "";
+        throw new Error(`Missing release asset ${assetPath}. Found: ${found}`);
+      }
+
+      return [key, sha256(assetPath)];
+    }),
+  ) as Record<keyof typeof RELEASE_ASSET_NAMES, string>;
+
+  return `class Hunk < Formula
+  desc "Desktop-inspired terminal diff viewer for agent-authored changesets"
+  homepage "https://github.com/modem-dev/hunk"
+  version "${version}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "${assetUrl(options.repo, options.tag, RELEASE_ASSET_NAMES.darwinArm64)}"
+      sha256 "${checksums.darwinArm64}"
+    else
+      url "${assetUrl(options.repo, options.tag, RELEASE_ASSET_NAMES.darwinX64)}"
+      sha256 "${checksums.darwinX64}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "${assetUrl(options.repo, options.tag, RELEASE_ASSET_NAMES.linuxArm64)}"
+      sha256 "${checksums.linuxArm64}"
+    else
+      url "${assetUrl(options.repo, options.tag, RELEASE_ASSET_NAMES.linuxX64)}"
+      sha256 "${checksums.linuxX64}"
+    end
+  end
+
+  def install
+    chmod 0755, "hunk"
+    libexec.install "hunk"
+    (bin/"hunk").write_env_script libexec/"hunk", HUNK_INSTALL_SOURCE: "homebrew"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hunk --version")
+  end
+end
+`;
+}
+
+const options = parseArgs(process.argv.slice(2));
+const formulaPath = path.join(options.outputRoot, FORMULA_RELATIVE_PATH);
+mkdirSync(path.dirname(formulaPath), { recursive: true });
+writeFileSync(formulaPath, formulaContent(options));
+console.log(`Updated ${formulaPath}`);

--- a/src/core/updateNotice.test.ts
+++ b/src/core/updateNotice.test.ts
@@ -39,7 +39,7 @@ describe("startup update notice", () => {
     });
   });
 
-  test("falls back to beta for stable installs when latest is not newer", async () => {
+  test("falls back to beta for npm stable installs when latest is not newer", async () => {
     await withTempStatePath(async (statePath) => {
       await expect(
         resolveStartupUpdateNotice({
@@ -54,7 +54,7 @@ describe("startup update notice", () => {
     });
   });
 
-  test("beta installs choose the higher newer version between latest and beta", async () => {
+  test("npm beta installs choose the higher newer version between latest and beta", async () => {
     await withTempStatePath(async (statePath) => {
       await expect(
         resolveStartupUpdateNotice({
@@ -65,6 +65,51 @@ describe("startup update notice", () => {
       ).resolves.toEqual({
         key: "beta:0.8.1-beta.1",
         message: "Update available: 0.8.1-beta.1 (beta) • npm i -g hunkdiff@beta",
+      });
+    });
+  });
+
+  test("uses the Homebrew upgrade command for Homebrew installs", async () => {
+    await withTempStatePath(async (statePath) => {
+      await expect(
+        resolveStartupUpdateNotice({
+          fetchImpl: async () => createDistTagsResponse({ latest: "0.7.1", beta: "0.8.0-beta.1" }),
+          resolveInstalledVersion: () => "0.7.0",
+          resolveInstallSource: () => "homebrew",
+          statePath,
+        }),
+      ).resolves.toEqual({
+        key: "latest:0.7.1",
+        message: "Update available: 0.7.1 (latest) • brew update && brew upgrade hunk",
+      });
+    });
+  });
+
+  test("ignores beta updates for Homebrew installs", async () => {
+    await withTempStatePath(async (statePath) => {
+      await expect(
+        resolveStartupUpdateNotice({
+          fetchImpl: async () => createDistTagsResponse({ latest: "0.7.0", beta: "0.8.0-beta.1" }),
+          resolveInstalledVersion: () => "0.7.0",
+          resolveInstallSource: () => "homebrew",
+          statePath,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
+  test("detects Homebrew installs from the HUNK_INSTALL_SOURCE environment variable", async () => {
+    await withTempStatePath(async (statePath) => {
+      await expect(
+        resolveStartupUpdateNotice({
+          env: { HUNK_INSTALL_SOURCE: "homebrew" },
+          fetchImpl: async () => createDistTagsResponse({ latest: "0.7.1" }),
+          resolveInstalledVersion: () => "0.7.0",
+          statePath,
+        }),
+      ).resolves.toEqual({
+        key: "latest:0.7.1",
+        message: "Update available: 0.7.1 (latest) • brew update && brew upgrade hunk",
       });
     });
   });

--- a/src/core/updateNotice.ts
+++ b/src/core/updateNotice.ts
@@ -8,6 +8,7 @@ const STABLE_SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
 const PRERELEASE_SEMVER_PATTERN = /^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/;
 const DEFAULT_UPDATE_NOTICE_FETCH_TIMEOUT_MS = 5_000;
 const DISABLE_STARTUP_UPDATE_NOTICE_ENV = "HUNK_DISABLE_UPDATE_NOTICE";
+const INSTALL_SOURCE_ENV = "HUNK_INSTALL_SOURCE";
 const STARTUP_STATE_VERSION = 1;
 
 interface PersistedStartupState {
@@ -16,6 +17,7 @@ interface PersistedStartupState {
 }
 
 export type UpdateChannel = "latest" | "beta";
+export type InstallSource = "npm" | "homebrew";
 
 export interface UpdateNotice {
   key: string;
@@ -34,6 +36,7 @@ export interface UpdateNoticeDeps {
   fetchImpl?: FetchImpl;
   fetchTimeoutMs?: number;
   resolveInstalledVersion?: () => string;
+  resolveInstallSource?: () => InstallSource;
   statePath?: string;
 }
 
@@ -69,14 +72,27 @@ function isNewerVersion(current: string, candidate: string) {
   }
 }
 
+/** Resolve which package manager installed this binary, defaulting to the npm package path. */
+function resolveInstallSourceFromEnv(env: NodeJS.ProcessEnv = process.env): InstallSource {
+  return env[INSTALL_SOURCE_ENV] === "homebrew" ? "homebrew" : "npm";
+}
+
 /** Build the install command shown in the transient notice for one channel. */
-function commandForChannel(channel: UpdateChannel) {
+function commandForChannel(channel: UpdateChannel, installSource: InstallSource) {
+  if (installSource === "homebrew") {
+    return "brew update && brew upgrade hunk";
+  }
+
   return channel === "latest" ? "npm i -g hunkdiff" : "npm i -g hunkdiff@beta";
 }
 
 /** Build the session-local notice payload for the chosen version and channel. */
-function createUpdateNotice(version: string, channel: UpdateChannel): UpdateNotice {
-  const command = commandForChannel(channel);
+function createUpdateNotice(
+  version: string,
+  channel: UpdateChannel,
+  installSource: InstallSource,
+): UpdateNotice {
+  const command = commandForChannel(channel, installSource);
   return {
     key: `${channel}:${version}`,
     message: `Update available: ${version} (${channel}) • ${command}`,
@@ -96,6 +112,7 @@ function isComparableInstalledVersion(version: string) {
 function selectUpdateNotice(
   installedVersion: string,
   distTags: ParsedDistTags,
+  installSource: InstallSource,
 ): UpdateNotice | null {
   if (!isComparableInstalledVersion(installedVersion)) {
     return null;
@@ -103,16 +120,19 @@ function selectUpdateNotice(
 
   const validLatest =
     distTags.latest && isStableVersion(distTags.latest) ? distTags.latest : undefined;
-  const validBeta = distTags.beta && isPrereleaseVersion(distTags.beta) ? distTags.beta : undefined;
+  const validBeta =
+    installSource === "npm" && distTags.beta && isPrereleaseVersion(distTags.beta)
+      ? distTags.beta
+      : undefined;
   const installedIsStable = isStableVersion(installedVersion);
 
   if (installedIsStable) {
     if (validLatest && isNewerVersion(installedVersion, validLatest)) {
-      return createUpdateNotice(validLatest, "latest");
+      return createUpdateNotice(validLatest, "latest", installSource);
     }
 
     if (validBeta && isNewerVersion(installedVersion, validBeta)) {
-      return createUpdateNotice(validBeta, "beta");
+      return createUpdateNotice(validBeta, "beta", installSource);
     }
 
     return null;
@@ -135,7 +155,7 @@ function selectUpdateNotice(
     isNewerVersion(best.version, candidate.version) ? candidate : best,
   );
 
-  return createUpdateNotice(selected.version, selected.channel);
+  return createUpdateNotice(selected.version, selected.channel, installSource);
 }
 
 /** Build one fetch timeout signal for the dist-tag lookup, if supported by the runtime. */
@@ -248,6 +268,8 @@ export async function resolveStartupUpdateNotice(
   const fetchImpl = deps.fetchImpl ?? fetch;
   const fetchTimeoutMs = deps.fetchTimeoutMs ?? DEFAULT_UPDATE_NOTICE_FETCH_TIMEOUT_MS;
   const resolveInstalledVersion = deps.resolveInstalledVersion ?? resolveCliVersion;
+  const resolveInstallSource =
+    deps.resolveInstallSource ?? (() => resolveInstallSourceFromEnv(env));
   const { signal, dispose } = createFetchTimeoutSignal(fetchTimeoutMs);
 
   try {
@@ -257,7 +279,7 @@ export async function resolveStartupUpdateNotice(
     }
 
     const parsedPayload = parseDistTags(await response.json());
-    return selectUpdateNotice(resolveInstalledVersion(), parsedPayload);
+    return selectUpdateNotice(resolveInstalledVersion(), parsedPayload, resolveInstallSource());
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
## Summary

- add a Homebrew formula generator for the `modem-dev/homebrew-tap` release flow
- update stable release automation to push formula updates to the tap
- make startup update notices show `brew update && brew upgrade hunk` for Homebrew installs
- document `brew install modem-dev/tap/hunk`

Closes #219

## Testing

- `bun test src/core/updateNotice.test.ts scripts/update-homebrew-formula.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- Docker smoke: `brew install modem-dev/tap/hunk && hunk --version && brew test modem-dev/tap/hunk`

*This PR description was generated by Pi using OpenAI GPT-5 Codex*
