### PR TITLE
fix(session): preserve live comments across daemon-driven reloads

### DIFF
--- a/src/hunk-session/bridge.test.ts
+++ b/src/hunk-session/bridge.test.ts
@@ -116,7 +116,11 @@ describe("createHunkSessionBridge", () => {
       type: "command",
       requestId: "reload-1",
       command: "reload_session",
-      input: { sessionId: "session-1", nextInput: { kind: "vcs", staged: false, options: {} } },
+      input: {
+        sessionId: "session-1",
+        nextInput: { kind: "vcs", staged: false, options: {} },
+        sourcePath: "/repo",
+      },
     });
     await bridge.dispatchCommand({
       type: "command",
@@ -133,6 +137,10 @@ describe("createHunkSessionBridge", () => {
 
     expect(handlers.navigateToLocation).toHaveBeenCalledTimes(1);
     expect(handlers.reloadSession).toHaveBeenCalledTimes(1);
+    expect(handlers.reloadSession).toHaveBeenCalledWith(
+      { kind: "vcs", staged: false, options: {} },
+      { resetApp: false, sourcePath: "/repo" },
+    );
     expect(handlers.removeLiveComment).toHaveBeenCalledTimes(1);
     expect(handlers.clearLiveComments).toHaveBeenCalledTimes(1);
   });

--- a/src/hunk-session/bridge.ts
+++ b/src/hunk-session/bridge.ts
@@ -30,7 +30,7 @@ export interface HunkSessionBridgeHandlers {
       HunkSessionServerMessage,
       { command: "reload_session" }
     >["input"]["nextInput"],
-    options?: { sourcePath?: string },
+    options?: { resetApp?: boolean; sourcePath?: string },
   ) => Promise<ReloadedSessionResult>;
   removeLiveComment: (commentId: string) => RemovedCommentResult;
 }
@@ -68,6 +68,7 @@ export function createHunkSessionBridge(handlers: HunkSessionBridgeHandlers) {
           return handlers.navigateToLocation(message.input);
         case "reload_session":
           return handlers.reloadSession(message.input.nextInput, {
+            resetApp: false,
             sourcePath: message.input.sourcePath,
           });
         case "remove_comment":

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -72,6 +72,13 @@ function createMockHostClient() {
         latestSnapshot = snapshot.state;
       },
     } as unknown as HunkSessionBrokerClient,
+    dispatchCommand: async (message: HunkSessionServerMessage) => {
+      if (!bridge) {
+        throw new Error("Expected App to register a bridge before running the test command.");
+      }
+
+      return bridge.dispatchCommand(message);
+    },
     getBridge: () => bridge,
     getLatestSnapshot: () => latestSnapshot,
     navigateToHunk: async (
@@ -1102,6 +1109,90 @@ describe("App interactions", () => {
       }
 
       expect(refreshed).toBe(true);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test("session reload preserves live comments while refreshing the file diff", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-session-reload-"));
+    const left = join(dir, "before.ts");
+    const right = join(dir, "after.ts");
+    const reviewNote = "Keep this daemon review note";
+
+    writeFileSync(left, "export const answer = 41;\n");
+    writeFileSync(right, "export const answer = 42;\n");
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "diff",
+      left,
+      right,
+      options: {
+        mode: "split",
+      },
+    });
+    const { dispatchCommand, hostClient } = createMockHostClient();
+
+    const setup = await testRender(<AppHost bootstrap={bootstrap} hostClient={hostClient} />, {
+      width: 220,
+      height: 20,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await dispatchCommand({
+          type: "command",
+          requestId: "comment-1",
+          command: "comment",
+          input: {
+            sessionId: "session-1",
+            filePath: "after.ts",
+            side: "new",
+            line: 1,
+            summary: reviewNote,
+            reveal: true,
+          },
+        });
+      });
+
+      let frame = await waitForFrame(setup, (currentFrame) => currentFrame.includes(reviewNote));
+      expect(frame).toContain(reviewNote);
+
+      writeFileSync(right, "export const answer = 42;\nexport const added = true;\n");
+
+      await act(async () => {
+        await dispatchCommand({
+          type: "command",
+          requestId: "reload-1",
+          command: "reload_session",
+          input: {
+            sessionId: "session-1",
+            nextInput: {
+              kind: "diff",
+              left,
+              right,
+              options: {
+                mode: "split",
+              },
+            },
+            sourcePath: dir,
+          },
+        });
+      });
+
+      frame = await waitForFrame(
+        setup,
+        (currentFrame) => currentFrame.includes("export const added = true;"),
+        20,
+      );
+
+      expect(frame).toContain("export const added = true;");
+      expect(frame).toContain(reviewNote);
     } finally {
       await act(async () => {
         setup.renderer.destroy();


### PR DESCRIPTION
## Summary

`hunk session reload` (the daemon-driven reload path) was wiping the in-memory live-comment state. After this PR, daemon reloads preserve live comments the same way the `r` keystroke and watch-mode auto-reload already do.

## Why this matters

Per #212, after an agent annotates the diff with hunk-level comments, calling `hunk session reload` (from a second terminal or from another agent message on the same session) reloaded the diff and dropped every annotation the user was actively reviewing. The maintainer confirmed the behavior in [the issue comment](https://github.com/modem-dev/hunk/issues/212#issuecomment-4330296427): "Thanks for sharing. This is definitely a problem."

The root cause is in `src/hunk-session/bridge.ts:70`: the `reload_session` handler forwarded `sourcePath` but not `resetApp`. `AppHost.tsx:63` treats undefined `resetApp` as truthy (`options?.resetApp !== false` is `true`), which increments `appVersion`, remounts `<App />`, and discards the React state in `useReviewController` -- including `liveCommentsByFileId`. The interactive `r` reload and watch-mode reload both pass `resetApp: false` (see `App.tsx:354`), so they preserve state; only the daemon path didn't.

## Changes

- `src/hunk-session/bridge.ts`: the `reload_session` handler now passes `resetApp: false` alongside `sourcePath`, matching the contract `App.tsx:354` already uses. The handler type now also accepts `resetApp` so future opt-in-to-hard-reset is a one-line addition.
- `src/hunk-session/bridge.test.ts`: extended the existing dispatch test with an exact-match assertion via `toHaveBeenCalledWith({ resetApp: false, sourcePath: "/repo" })` -- exact match so accidental regression to the old `undefined`-passing behavior is caught.
- `src/ui/AppHost.interactions.test.tsx`: new higher-level test that writes a live comment, dispatches a `reload_session` after rewriting the right-hand file, and asserts both the new content and the original review note appear in the rendered frame.

## Testing

- `bun run typecheck` -- clean
- `bun run format:check` -- clean
- `bun run lint` -- clean (0 warnings)
- `bun test ./src/hunk-session/bridge.test.ts ./src/ui/AppHost.interactions.test.tsx` -- 45 pass, 0 fail
- Manual smoke: start `hunk diff` in one terminal, write a live comment via the session bridge, run `hunk session reload` from a second terminal -- the comment persists across the reload.

Residual risk: an agent that explicitly wanted a hard reset on `reload_session` loses that capability. The handler type now accepts `resetApp`, so an explicit opt-in wire flag is a follow-up if anyone needs it.

Fixes #212

AI was used for assistance.
