### PR TITLE
feat(ui): add comma and period shortcuts to move between files

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -125,6 +125,7 @@ export function App({
   const selectedHunkIndex = review.selectedHunkIndex;
   const moveToAnnotatedFile = review.moveToAnnotatedFile;
   const moveToAnnotatedHunk = review.moveToAnnotatedHunk;
+  const moveToFile = review.moveToFile;
 
   const jumpToFile = useCallback(
     (fileId: string, nextHunkIndex = 0, options?: { alignFileHeaderTop?: boolean }) => {
@@ -548,6 +549,7 @@ export function App({
     focusArea,
     focusFilter,
     moveToAnnotatedHunk,
+    moveToFile,
     moveToHunk: review.moveToHunk,
     moveMenuItem,
     openMenu,

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -2033,6 +2033,80 @@ describe("App interactions", () => {
     }
   });
 
+  test("file navigation shortcuts jump between visible files outside filter focus", async () => {
+    const { getLatestSnapshot, hostClient } = createMockHostClient();
+    const setup = await testRender(
+      <AppHost bootstrap={createTwoFileHunkBootstrap()} hostClient={hostClient} />,
+      {
+        width: 220,
+        height: 10,
+      },
+    );
+
+    try {
+      await flush(setup);
+
+      for (let index = 0; index < 10; index += 1) {
+        await act(async () => {
+          await setup.mockInput.pressArrow("down");
+        });
+        await flush(setup);
+      }
+
+      await act(async () => {
+        await setup.mockInput.typeText(".");
+      });
+      await flush(setup);
+
+      let snapshot = await waitForSnapshot(
+        setup,
+        getLatestSnapshot,
+        (nextSnapshot) => nextSnapshot.selectedFileId === "second",
+        24,
+      );
+      expect(snapshot?.selectedFileId).toBe("second");
+      expect(snapshot?.selectedHunkIndex).toBe(0);
+
+      let frame = await waitForFrame(
+        setup,
+        (nextFrame) =>
+          nextFrame.includes("second.ts") && (nextFrame.match(/first\.ts/g) ?? []).length === 1,
+        24,
+      );
+      expect(frame).toContain("second.ts");
+
+      await act(async () => {
+        await setup.mockInput.typeText(",");
+      });
+      await flush(setup);
+
+      snapshot = await waitForSnapshot(
+        setup,
+        getLatestSnapshot,
+        (nextSnapshot) => nextSnapshot.selectedFileId === "first",
+        24,
+      );
+      expect(snapshot?.selectedFileId).toBe("first");
+
+      await act(async () => {
+        await setup.mockInput.pressTab();
+      });
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText(".");
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("filter:");
+      expect(getLatestSnapshot()?.selectedFileId).toBe("first");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("forward cross-file hunk navigation keeps the destination file owning the review pane", async () => {
     const setup = await testRender(
       <AppHost bootstrap={createCrossFileHunkNavigationBootstrap()} />,

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -26,6 +26,7 @@ export function HelpDialog({
         ["Shift+Space", "page up (alt)"],
         ["d / u", "half page down / up"],
         ["[ / ]", "previous / next hunk"],
+        [", / .", "previous / next file"],
         ["{ / }", "previous / next comment"],
         ["← / →", "scroll code left / right (Shift = faster)"],
         ["Home / End", "jump to top / bottom"],

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -29,6 +29,7 @@ export interface UseAppKeyboardShortcutsOptions {
   focusArea: FocusArea;
   focusFilter: () => void;
   moveToAnnotatedHunk: (delta: number) => void;
+  moveToFile: (delta: number) => void;
   moveToHunk: (delta: number) => void;
   moveMenuItem: (delta: number) => void;
   openMenu: (menuId: MenuId) => void;
@@ -60,6 +61,7 @@ export function useAppKeyboardShortcuts({
   focusArea,
   focusFilter,
   moveToAnnotatedHunk,
+  moveToFile,
   moveToHunk,
   moveMenuItem,
   openMenu,
@@ -373,6 +375,16 @@ export function useAppKeyboardShortcuts({
 
     if (key.name === "]") {
       runAndCloseMenu(() => moveToHunk(1));
+      return;
+    }
+
+    if (key.name === "," || key.sequence === ",") {
+      runAndCloseMenu(() => moveToFile(-1));
+      return;
+    }
+
+    if (key.name === "." || key.sequence === ".") {
+      runAndCloseMenu(() => moveToFile(1));
       return;
     }
 

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -198,6 +198,97 @@ describe("useReviewController", () => {
     }
   });
 
+  test("moves through visible files with clamped file-header alignment", async () => {
+    const controllerRef: { current: ReviewController | null } = { current: null };
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[
+          createTwoHunkFile(),
+          createDiffFile("beta", "beta.ts", "export const beta = 1;\n", "export const beta = 2;\n"),
+          createDiffFile(
+            "gamma",
+            "gamma.ts",
+            "export const gamma = 1;\n",
+            "export const gamma = 2;\n",
+          ),
+        ]}
+        onController={(nextController) => {
+          controllerRef.current = nextController;
+        }}
+      />,
+      { width: 80, height: 4 },
+    );
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        expectValue(controllerRef.current).selectHunk("alpha", 1);
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(1);
+      });
+      await flush(setup);
+
+      let controller = expectValue(controllerRef.current);
+      expect(controller.selectedFile?.path).toBe("beta.ts");
+      expect(controller.selectedHunkIndex).toBe(0);
+      expect(controller.selectedFileTopAlignRequestId).toBe(1);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(1);
+      });
+      await flush(setup);
+
+      controller = expectValue(controllerRef.current);
+      expect(controller.selectedFile?.path).toBe("gamma.ts");
+      expect(controller.selectedFileTopAlignRequestId).toBe(2);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(1);
+      });
+      await flush(setup);
+
+      controller = expectValue(controllerRef.current);
+      expect(controller.selectedFile?.path).toBe("gamma.ts");
+      expect(controller.selectedFileTopAlignRequestId).toBe(2);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(-1);
+      });
+      await flush(setup);
+
+      controller = expectValue(controllerRef.current);
+      expect(controller.selectedFile?.path).toBe("beta.ts");
+      expect(controller.selectedFileTopAlignRequestId).toBe(3);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(-1);
+      });
+      await flush(setup);
+
+      controller = expectValue(controllerRef.current);
+      expect(controller.selectedFile?.path).toBe("alpha.ts");
+      expect(controller.selectedFileTopAlignRequestId).toBe(4);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(-1);
+      });
+      await flush(setup);
+
+      controller = expectValue(controllerRef.current);
+      expect(controller.selectedFile?.path).toBe("alpha.ts");
+      expect(controller.selectedFileTopAlignRequestId).toBe(4);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("live comment mutations update annotated navigation without remounting the app", async () => {
     const controllerRef: { current: ReviewController | null } = { current: null };
     const setup = await testRender(

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -60,6 +60,7 @@ export interface ReviewController {
   liveCommentsByFileId: Record<string, LiveComment[]>;
   moveToAnnotatedFile: (delta: number) => void;
   moveToAnnotatedHunk: (delta: number) => void;
+  moveToFile: (delta: number) => void;
   moveToHunk: (delta: number) => void;
   scrollToNote: boolean;
   selectedFile: DiffFile | undefined;
@@ -243,6 +244,29 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
       }
 
       selectFile(nextFile.id);
+    },
+    [selectFile, selectedFile?.id, visibleFiles],
+  );
+
+  /** Move through all currently visible files without wrapping past either end. */
+  const moveToFile = useCallback(
+    (delta: number) => {
+      const currentIndex = visibleFiles.findIndex((file) => file.id === selectedFile?.id);
+      if (currentIndex < 0) {
+        return;
+      }
+
+      const nextIndex = clamp(currentIndex + delta, 0, visibleFiles.length - 1);
+      if (nextIndex === currentIndex) {
+        return;
+      }
+
+      const nextFile = visibleFiles[nextIndex];
+      if (!nextFile) {
+        return;
+      }
+
+      selectFile(nextFile.id, 0, { alignFileHeaderTop: true });
     },
     [selectFile, selectedFile?.id, visibleFiles],
   );
@@ -504,6 +528,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     clearLiveComments,
     moveToAnnotatedFile,
     moveToAnnotatedHunk,
+    moveToFile,
     moveToHunk,
     navigateToLocation,
     removeLiveComment,


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts to move between files in the current diff -- `,` for previous file, `.` for next file. Mirrors how `[`/`]` walks hunks, but at the file level.

## Why this matters

Per [#212 your suggestion](https://github.com/modem-dev/hunk/issues/255#issuecomment-4415425057): "If the purpose is to just scroll up/down on the file list, what if I just added a keyboard shortcut for file up/down?" This PR ships exactly that -- a global shortcut that works from the diff pane without needing a sidebar-focus state machine.

`moveToAnnotatedFile` (useReviewController.ts:238) was the architecturally analogous existing function -- it walks `annotatedFiles` and calls `selectFile`. This PR adds `moveToFile` next to it. Two deliberate divergences vs. `moveToAnnotatedFile`:

- Walks `visibleFiles` (all files, not just annotated). The whole point of the shortcut is to reach every file.
- Clamps at the boundaries rather than wrapping. Wrap is fine for a small annotated-file set; for arbitrary file lists, clamp matches scroll semantics and avoids surprise when the cursor leaves the visible range and reappears at the other end. Happy to switch to wrap if you'd prefer consistency with `moveToAnnotatedFile`.
- Calls `selectFile(nextFile.id, 0, { alignFileHeaderTop: true })` so the diff pane aligns the file header to the top, matching the mouse-click behavior the original issue described as `jumpToFile(fileId, 0, { alignFileHeaderTop: true })`.

## Key binding choice

Picked `,` and `.` because both `f` and `j`/`k` are already taken (page-down and step-down/up respectively per keyboard.ts:13-35). The comma/period pair is unbound and reads naturally as prev/next in many TUIs.

If you'd prefer a different pair, let me know -- changing the binding is a one-line tweak.

## Changes

- `src/ui/hooks/useReviewController.ts`: new `moveToFile(delta)` method. Clamps to `[0, visibleFiles.length - 1]`; no-op at boundaries (no re-fire of `selectFile`).
- `src/ui/hooks/useAppKeyboardShortcuts.ts`: binds `,` → `moveToFile(-1)` and `.` → `moveToFile(1)` inside `handleAppShortcut`, so the filter-area short-circuit at lines 228-240 automatically prevents firing while typing in the filter.
- `src/ui/App.tsx`: threads `moveToFile` from the review controller into the keyboard shortcuts hook (mirrors `moveToHunk`).
- `src/ui/components/chrome/HelpDialog.tsx`: new row `[", / ."]` → `"previous / next file"`, placed next to the existing `[ / ]` hunk row.
- `src/ui/hooks/useReviewController.test.tsx`: unit tests covering mid-list step, clamp at first file (no-op), clamp at last file (no-op), and that `selectFile` is called with `alignFileHeaderTop: true`.
- `src/ui/AppHost.interactions.test.tsx`: integration test that exercises the key bindings end-to-end through the renderer.

## Testing

- `bun run typecheck` -- clean
- `bun run format:check` -- clean
- `bun run lint` -- clean (0 warnings)
- `bun test ./src/ui/hooks/useReviewController.test.tsx ./src/ui/AppHost.interactions.test.tsx` -- 48 pass, 0 fail
- Verified no collision: `,` and `.` are not bound anywhere in `keyboard.ts` or `useAppKeyboardShortcuts.ts`. Existing shortcuts `[`/`]`, `j`/`k`, `f`, `Space`, etc. behave unchanged.

Existing CONTRIBUTING.md rule honored: "Selecting a file should jump within the main stream, not collapse the review to one file." This PR jumps within the main stream (no view-mode change).

Fixes #255

AI was used for assistance.
