### PR TITLE
feat(ui): add g / G navigation in hunk diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
-- Added `gg` and `G` keyboard aliases for jump-to-top and jump-to-bottom review navigation.
+- Added `g` and `G` keyboard aliases for jump-to-top and jump-to-bottom review navigation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+- Added `gg` and `G` keyboard aliases for jump-to-top and jump-to-bottom review navigation.
+
 ### Changed
 
 ### Fixed

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -18,6 +18,9 @@ import { createTestDiffFile as buildTestDiffFile, lines } from "../../test/helpe
 const { loadAppBootstrap } = await import("../core/loaders");
 const { AppHost } = await import("./AppHost");
 
+const TEST_KEY_PAGE_UP = "\x1B[5~";
+const TEST_KEY_PAGE_DOWN = "\x1B[6~";
+
 function createTestDiffFile(
   id: string,
   path: string,
@@ -1604,7 +1607,7 @@ describe("App interactions", () => {
       setup.captureCharFrame();
 
       await act(async () => {
-        await setup.mockInput.pressKey("pageup");
+        await setup.mockInput.pressKey(TEST_KEY_PAGE_UP);
       });
       await flush(setup);
 
@@ -2294,7 +2297,7 @@ describe("App interactions", () => {
       let snapshot = getLatestSnapshot();
       for (let index = 0; index < 8; index += 1) {
         await act(async () => {
-          await setup.mockInput.pressKey("pagedown");
+          await setup.mockInput.pressKey(TEST_KEY_PAGE_DOWN);
         });
         await flush(setup);
 
@@ -2318,7 +2321,7 @@ describe("App interactions", () => {
 
       for (let index = 0; index < 8; index += 1) {
         await act(async () => {
-          await setup.mockInput.pressKey("pageup");
+          await setup.mockInput.pressKey(TEST_KEY_PAGE_UP);
         });
         await flush(setup);
 

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1690,6 +1690,74 @@ describe("App interactions", () => {
     }
   });
 
+  test("G jumps to the bottom and gg jumps back to the top", async () => {
+    const before =
+      Array.from(
+        { length: 120 },
+        (_, index) => `export const line${String(index + 1).padStart(2, "0")} = ${index + 1};`,
+      ).join("\n") + "\n";
+    const after =
+      Array.from(
+        { length: 120 },
+        (_, index) => `export const line${String(index + 1).padStart(2, "0")} = ${index + 1001};`,
+      ).join("\n") + "\n";
+
+    const bootstrap: AppBootstrap = {
+      input: {
+        kind: "vcs",
+        staged: false,
+        options: {
+          mode: "split",
+        },
+      },
+      changeset: {
+        id: "changeset:gg-capital-g",
+        sourceLabel: "repo",
+        title: "repo working tree",
+        files: [createTestDiffFile("gg", "gg.ts", before, after)],
+      },
+      initialMode: "split",
+      initialTheme: "midnight",
+    };
+
+    const setup = await testRender(<AppHost bootstrap={bootstrap} />, {
+      width: 220,
+      height: 12,
+      otherModifiersMode: true,
+    });
+
+    try {
+      await flush(setup);
+      let frame = setup.captureCharFrame();
+      expect(frame).toContain("line01 = 1001");
+
+      await act(async () => {
+        await setup.mockInput.pressKey("g", { shift: true });
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("line120 = 1120");
+
+      await act(async () => {
+        await setup.mockInput.pressKey("g");
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("line120 = 1120");
+
+      await act(async () => {
+        await setup.mockInput.pressKey("g");
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("line01 = 1001");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("filter focus accepts typed input and narrows the visible file set", async () => {
     const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
       width: 240,

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1690,7 +1690,7 @@ describe("App interactions", () => {
     }
   });
 
-  test("G jumps to the bottom and gg jumps back to the top", async () => {
+  test("G jumps to the bottom and g jumps back to the top", async () => {
     const before =
       Array.from(
         { length: 120 },
@@ -1711,10 +1711,10 @@ describe("App interactions", () => {
         },
       },
       changeset: {
-        id: "changeset:gg-capital-g",
+        id: "changeset:g-capital-g",
         sourceLabel: "repo",
         title: "repo working tree",
-        files: [createTestDiffFile("gg", "gg.ts", before, after)],
+        files: [createTestDiffFile("g", "g.ts", before, after)],
       },
       initialMode: "split",
       initialTheme: "midnight",
@@ -1743,13 +1743,6 @@ describe("App interactions", () => {
       });
       await flush(setup);
       frame = setup.captureCharFrame();
-      expect(frame).toContain("line120 = 1120");
-
-      await act(async () => {
-        await setup.mockInput.pressKey("g");
-      });
-      await flush(setup);
-      frame = setup.captureCharFrame();
       expect(frame).toContain("line01 = 1001");
     } finally {
       await act(async () => {
@@ -1758,7 +1751,7 @@ describe("App interactions", () => {
     }
   });
 
-  test("pager mode also supports G and gg top/bottom jumps", async () => {
+  test("pager mode also supports G and g top/bottom jumps", async () => {
     const before =
       Array.from(
         { length: 120 },
@@ -1780,10 +1773,10 @@ describe("App interactions", () => {
         },
       },
       changeset: {
-        id: "changeset:pager-gg-capital-g",
+        id: "changeset:pager-g-capital-g",
         sourceLabel: "repo",
         title: "repo working tree",
-        files: [createTestDiffFile("pager-gg", "pager-gg.ts", before, after)],
+        files: [createTestDiffFile("pager-g", "pager-g.ts", before, after)],
       },
       initialMode: "split",
       initialTheme: "midnight",
@@ -1802,13 +1795,6 @@ describe("App interactions", () => {
 
       await act(async () => {
         await setup.mockInput.pressKey("g", { shift: true });
-      });
-      await flush(setup);
-      frame = setup.captureCharFrame();
-      expect(frame).toContain("line120 = 1120");
-
-      await act(async () => {
-        await setup.mockInput.pressKey("g");
       });
       await flush(setup);
       frame = setup.captureCharFrame();

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1758,6 +1758,75 @@ describe("App interactions", () => {
     }
   });
 
+  test("pager mode also supports G and gg top/bottom jumps", async () => {
+    const before =
+      Array.from(
+        { length: 120 },
+        (_, index) => `export const line${String(index + 1).padStart(2, "0")} = ${index + 1};`,
+      ).join("\n") + "\n";
+    const after =
+      Array.from(
+        { length: 120 },
+        (_, index) => `export const line${String(index + 1).padStart(2, "0")} = ${index + 1001};`,
+      ).join("\n") + "\n";
+
+    const bootstrap: AppBootstrap = {
+      input: {
+        kind: "vcs",
+        staged: false,
+        options: {
+          mode: "split",
+          pager: true,
+        },
+      },
+      changeset: {
+        id: "changeset:pager-gg-capital-g",
+        sourceLabel: "repo",
+        title: "repo working tree",
+        files: [createTestDiffFile("pager-gg", "pager-gg.ts", before, after)],
+      },
+      initialMode: "split",
+      initialTheme: "midnight",
+    };
+
+    const setup = await testRender(<AppHost bootstrap={bootstrap} />, {
+      width: 220,
+      height: 12,
+      otherModifiersMode: true,
+    });
+
+    try {
+      await flush(setup);
+      let frame = setup.captureCharFrame();
+      expect(frame).toContain("line01 = 1001");
+
+      await act(async () => {
+        await setup.mockInput.pressKey("g", { shift: true });
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("line120 = 1120");
+
+      await act(async () => {
+        await setup.mockInput.pressKey("g");
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("line120 = 1120");
+
+      await act(async () => {
+        await setup.mockInput.pressKey("g");
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("line01 = 1001");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("filter focus accepts typed input and narrows the visible file set", async () => {
     const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
       width: 240,

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -29,6 +29,7 @@ export function HelpDialog({
         ["{ / }", "previous / next comment"],
         ["← / →", "scroll code left / right (Shift = faster)"],
         ["Home / End", "jump to top / bottom"],
+        ["gg / G", "jump to top / bottom (Vim aliases)"],
       ],
     },
     {

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -29,7 +29,7 @@ export function HelpDialog({
         ["{ / }", "previous / next comment"],
         ["← / →", "scroll code left / right (Shift = faster)"],
         ["Home / End", "jump to top / bottom"],
-        ["gg / G", "jump to top / bottom (Vim aliases)"],
+        ["g / G", "jump to top / bottom (less-style)"],
       ],
     },
     {

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1608,7 +1608,7 @@ describe("UI components", () => {
       "{ / }           previous / next comment",
       "← / →           scroll code left / right (Shift = faster)",
       "Home / End      jump to top / bottom",
-      "gg / G          jump to top / bottom (Vim aliases)",
+      "g / G           jump to top / bottom (less-style)",
       "Mouse",
       "Wheel           scroll vertically",
       "Shift+Wheel     scroll code horizontally",

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1608,6 +1608,7 @@ describe("UI components", () => {
       "{ / }           previous / next comment",
       "← / →           scroll code left / right (Shift = faster)",
       "Home / End      jump to top / bottom",
+      "gg / G          jump to top / bottom (Vim aliases)",
       "Mouse",
       "Wheel           scroll vertically",
       "Shift+Wheel     scroll code horizontally",

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -33,7 +33,8 @@ function isLowercaseGKey(key: KeyEvent) {
 
 function isUppercaseGKey(key: KeyEvent) {
   return (
-    key.sequence === "G" || (key.name === "g" && key.shift && !key.option && !key.ctrl && !key.meta)
+    (key.sequence === "G" && !key.option && !key.ctrl && !key.meta) ||
+    (key.name === "g" && key.shift && !key.option && !key.ctrl && !key.meta)
   );
 }
 

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -19,8 +19,9 @@ type ScrollUnit = "step" | "viewport" | "content" | "half";
 
 const FAST_CODE_HORIZONTAL_SCROLL_COLUMNS = 8;
 
-type JumpShortcut = "top" | "bottom" | "pending";
+type JumpShortcut = "top" | "bottom";
 
+/** Detect an unmodified lowercase g keypress. */
 function isLowercaseGKey(key: KeyEvent) {
   return (
     (key.name === "g" || key.sequence === "g") &&
@@ -31,6 +32,7 @@ function isLowercaseGKey(key: KeyEvent) {
   );
 }
 
+/** Detect an unmodified uppercase G keypress. */
 function isUppercaseGKey(key: KeyEvent) {
   return (
     (key.sequence === "G" && !key.option && !key.ctrl && !key.meta) ||
@@ -101,7 +103,6 @@ export function useAppKeyboardShortcuts({
   const activeMenuIdRef = useRef(activeMenuId);
   const focusAreaRef = useRef(focusArea);
   const pagerModeRef = useRef(pagerMode);
-  const pendingTopJumpRef = useRef(false);
   const showHelpRef = useRef(showHelp);
 
   activeMenuIdRef.current = activeMenuId;
@@ -111,21 +112,13 @@ export function useAppKeyboardShortcuts({
 
   const resolveJumpShortcut = (key: KeyEvent): JumpShortcut | null => {
     if (isUppercaseGKey(key)) {
-      pendingTopJumpRef.current = false;
       return "bottom";
     }
 
     if (isLowercaseGKey(key)) {
-      if (pendingTopJumpRef.current) {
-        pendingTopJumpRef.current = false;
-        return "top";
-      }
-
-      pendingTopJumpRef.current = true;
-      return "pending";
+      return "top";
     }
 
-    pendingTopJumpRef.current = false;
     return null;
   };
 
@@ -161,10 +154,6 @@ export function useAppKeyboardShortcuts({
 
     if (jumpShortcut === "bottom") {
       scrollDiff(1, "content");
-      return;
-    }
-
-    if (jumpShortcut === "pending") {
       return;
     }
 
@@ -303,10 +292,6 @@ export function useAppKeyboardShortcuts({
 
     if (jumpShortcut === "bottom") {
       scrollDiff(1, "content");
-      return;
-    }
-
-    if (jumpShortcut === "pending") {
       return;
     }
 
@@ -458,7 +443,6 @@ export function useAppKeyboardShortcuts({
 
   useKeyboard((key: KeyEvent) => {
     if (handleMenuToggleShortcut(key)) {
-      pendingTopJumpRef.current = false;
       return;
     }
 
@@ -468,17 +452,14 @@ export function useAppKeyboardShortcuts({
     }
 
     if (handleHelpShortcut(key)) {
-      pendingTopJumpRef.current = false;
       return;
     }
 
     if (handleMenuShortcut(key)) {
-      pendingTopJumpRef.current = false;
       return;
     }
 
     if (handleFilterShortcut(key)) {
-      pendingTopJumpRef.current = false;
       return;
     }
 

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -19,6 +19,24 @@ type ScrollUnit = "step" | "viewport" | "content" | "half";
 
 const FAST_CODE_HORIZONTAL_SCROLL_COLUMNS = 8;
 
+type JumpShortcut = "top" | "bottom" | "pending";
+
+function isLowercaseGKey(key: KeyEvent) {
+  return (
+    (key.name === "g" || key.sequence === "g") &&
+    !key.shift &&
+    !key.option &&
+    !key.ctrl &&
+    !key.meta
+  );
+}
+
+function isUppercaseGKey(key: KeyEvent) {
+  return (
+    key.sequence === "G" || (key.name === "g" && key.shift && !key.option && !key.ctrl && !key.meta)
+  );
+}
+
 export interface UseAppKeyboardShortcutsOptions {
   activeMenuId: MenuId | null;
   activateCurrentMenuItem: () => void;
@@ -82,12 +100,33 @@ export function useAppKeyboardShortcuts({
   const activeMenuIdRef = useRef(activeMenuId);
   const focusAreaRef = useRef(focusArea);
   const pagerModeRef = useRef(pagerMode);
+  const pendingTopJumpRef = useRef(false);
   const showHelpRef = useRef(showHelp);
 
   activeMenuIdRef.current = activeMenuId;
   focusAreaRef.current = focusArea;
   pagerModeRef.current = pagerMode;
   showHelpRef.current = showHelp;
+
+  const resolveJumpShortcut = (key: KeyEvent): JumpShortcut | null => {
+    if (isUppercaseGKey(key)) {
+      pendingTopJumpRef.current = false;
+      return "bottom";
+    }
+
+    if (isLowercaseGKey(key)) {
+      if (pendingTopJumpRef.current) {
+        pendingTopJumpRef.current = false;
+        return "top";
+      }
+
+      pendingTopJumpRef.current = true;
+      return "pending";
+    }
+
+    pendingTopJumpRef.current = false;
+    return null;
+  };
 
   const runAndCloseMenu = (action: () => void) => {
     action();
@@ -113,6 +152,21 @@ export function useAppKeyboardShortcuts({
   };
 
   const handlePagerShortcut = (key: KeyEvent) => {
+    const jumpShortcut = resolveJumpShortcut(key);
+    if (jumpShortcut === "top") {
+      scrollDiff(-1, "content");
+      return;
+    }
+
+    if (jumpShortcut === "bottom") {
+      scrollDiff(1, "content");
+      return;
+    }
+
+    if (jumpShortcut === "pending") {
+      return;
+    }
+
     if (key.name === "q" || isEscapeKey(key)) {
       requestQuit();
       return;
@@ -240,6 +294,21 @@ export function useAppKeyboardShortcuts({
   };
 
   const handleAppShortcut = (key: KeyEvent) => {
+    const jumpShortcut = resolveJumpShortcut(key);
+    if (jumpShortcut === "top") {
+      scrollDiff(-1, "content");
+      return;
+    }
+
+    if (jumpShortcut === "bottom") {
+      scrollDiff(1, "content");
+      return;
+    }
+
+    if (jumpShortcut === "pending") {
+      return;
+    }
+
     if (key.name === "q") {
       requestQuit();
       return;
@@ -388,6 +457,7 @@ export function useAppKeyboardShortcuts({
 
   useKeyboard((key: KeyEvent) => {
     if (handleMenuToggleShortcut(key)) {
+      pendingTopJumpRef.current = false;
       return;
     }
 
@@ -397,14 +467,17 @@ export function useAppKeyboardShortcuts({
     }
 
     if (handleHelpShortcut(key)) {
+      pendingTopJumpRef.current = false;
       return;
     }
 
     if (handleMenuShortcut(key)) {
+      pendingTopJumpRef.current = false;
       return;
     }
 
     if (handleFilterShortcut(key)) {
+      pendingTopJumpRef.current = false;
       return;
     }
 


### PR DESCRIPTION
## Summary

- add less-style navigation aliases to Hunk review controls:
  - `g` jumps to top (alias for Home)
  - `G` jumps to bottom (alias for End)
- support the aliases in both full app mode and pager mode
- update controls help copy to include the new aliases
- add interaction coverage for `G` -> bottom and `g` -> top behavior
- update page-key interaction tests to send real PageUp/PageDown escape sequences so lowercase `g` does not interfere with test-only key-name strings

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun test src/ui/AppHost.interactions.test.tsx src/ui/components/ui-components.test.tsx`

Closes #286