### PR TITLE
fix(ui): exit cleanly on Ctrl-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed Ctrl-C in the live TUI so it exits through Hunk's full shutdown path instead of only destroying the renderer.
+
 ## [0.12.0-beta.1] - 2026-05-10
 
 ### Added

--- a/src/core/jobControl.test.ts
+++ b/src/core/jobControl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
-import { installJobControlSuspendSupport } from "./jobControl";
+import { installJobControlInterruptSupport, installJobControlSuspendSupport } from "./jobControl";
 
 function createTestKey(overrides: Partial<KeyEvent> = {}) {
   let defaultPrevented = false;
@@ -104,6 +104,41 @@ function createSignalHarness() {
     removed,
   };
 }
+
+describe("installJobControlInterruptSupport", () => {
+  test("routes Ctrl-C through the provided shutdown callback", () => {
+    const renderer = createMockRenderer();
+    let interruptCalls = 0;
+
+    installJobControlInterruptSupport(renderer, () => {
+      interruptCalls += 1;
+    });
+
+    const ctrlC = createTestKey({ ctrl: true, name: "c" });
+    renderer.emitKeypress(ctrlC);
+
+    expect(ctrlC.defaultPrevented).toBe(true);
+    expect(ctrlC.propagationStopped).toBe(true);
+    expect(interruptCalls).toBe(1);
+  });
+
+  test("ignores non-Ctrl-C keys and removes its listener on dispose", () => {
+    const renderer = createMockRenderer();
+    let interruptCalls = 0;
+    const support = installJobControlInterruptSupport(renderer, () => {
+      interruptCalls += 1;
+    });
+
+    renderer.emitKeypress(createTestKey({ ctrl: true, name: "z" }));
+    expect(interruptCalls).toBe(0);
+
+    support.dispose();
+    expect(renderer.keypressListeners.size).toBe(0);
+
+    renderer.emitKeypress(createTestKey({ ctrl: true, name: "c" }));
+    expect(interruptCalls).toBe(0);
+  });
+});
 
 describe("installJobControlSuspendSupport", () => {
   test("does not install keypress listeners on Windows", () => {

--- a/src/core/jobControl.test.ts
+++ b/src/core/jobControl.test.ts
@@ -138,6 +138,23 @@ describe("installJobControlInterruptSupport", () => {
     renderer.emitKeypress(createTestKey({ ctrl: true, name: "c" }));
     expect(interruptCalls).toBe(0);
   });
+
+  test("ignores Ctrl-C after the renderer has already been destroyed", () => {
+    const renderer = createMockRenderer();
+    let interruptCalls = 0;
+
+    installJobControlInterruptSupport(renderer, () => {
+      interruptCalls += 1;
+    });
+
+    renderer.isDestroyed = true;
+    const ctrlC = createTestKey({ ctrl: true, name: "c" });
+    renderer.emitKeypress(ctrlC);
+
+    expect(ctrlC.defaultPrevented).toBe(false);
+    expect(ctrlC.propagationStopped).toBe(false);
+    expect(interruptCalls).toBe(0);
+  });
 });
 
 describe("installJobControlSuspendSupport", () => {

--- a/src/core/jobControl.ts
+++ b/src/core/jobControl.ts
@@ -25,9 +25,46 @@ export interface JobControlSuspendSupport {
   dispose: () => void;
 }
 
+export interface JobControlInterruptSupport {
+  /** Remove listeners installed for the lifetime of one app renderer. */
+  dispose: () => void;
+}
+
+/** Match the parsed Ctrl-C shortcut that should quit the app in raw mode. */
+function isCtrlC(key: KeyEvent) {
+  return key.ctrl && !key.meta && !key.shift && key.name === "c";
+}
+
 /** Match the parsed Ctrl-Z shortcut that opencode binds to its terminal suspend command. */
 function isCtrlZ(key: KeyEvent) {
   return key.ctrl && !key.meta && !key.shift && key.name === "z";
+}
+
+/** Install Ctrl-C handling that routes through the app's full shutdown path. */
+export function installJobControlInterruptSupport(
+  renderer: Pick<JobControlRenderer, "isDestroyed" | "keyInput">,
+  onInterrupt: () => void,
+): JobControlInterruptSupport {
+  let disposed = false;
+
+  const keypressListener: KeypressListener = (key) => {
+    if (disposed || renderer.isDestroyed || !isCtrlC(key)) {
+      return;
+    }
+
+    key.preventDefault();
+    key.stopPropagation();
+    onInterrupt();
+  };
+
+  renderer.keyInput.on("keypress", keypressListener);
+
+  return {
+    dispose: () => {
+      disposed = true;
+      renderer.keyInput.off("keypress", keypressListener);
+    },
+  };
 }
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,12 @@
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
 import { formatCliError } from "./core/errors";
-import { installJobControlSuspendSupport } from "./core/jobControl";
+import {
+  installJobControlInterruptSupport,
+  installJobControlSuspendSupport,
+  type JobControlInterruptSupport,
+  type JobControlSuspendSupport,
+} from "./core/jobControl";
 import { pagePlainText } from "./core/pager";
 import { shutdownSession } from "./core/shutdown";
 import { renderStaticDiffPager } from "./ui/staticDiffPager";
@@ -79,15 +84,17 @@ async function main() {
       hasControllingTerminal: Boolean(controllingTerminal),
     }),
     useAlternateScreen: true,
-    exitOnCtrlC: true,
+    exitOnCtrlC: false,
     openConsoleOnError: true,
     onDestroy: () => controllingTerminal?.close(),
   });
 
   const appRenderer = renderer;
-  const jobControlSuspendSupport = installJobControlSuspendSupport(appRenderer);
   const root = createRoot(appRenderer);
+  const shutdownSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
   let shuttingDown = false;
+  let jobControlSuspendSupport: JobControlSuspendSupport = { dispose: () => undefined };
+  let jobControlInterruptSupport: JobControlInterruptSupport = { dispose: () => undefined };
 
   /** Tear down the renderer before exit so the primary terminal screen comes back cleanly. */
   function shutdown() {
@@ -96,10 +103,20 @@ async function main() {
     }
 
     shuttingDown = true;
+    for (const signal of shutdownSignals) {
+      process.off(signal, shutdown);
+    }
+    jobControlInterruptSupport.dispose();
     jobControlSuspendSupport.dispose();
     hostClient.stop();
     shutdownSession({ root, renderer: appRenderer });
   }
+
+  for (const signal of shutdownSignals) {
+    process.once(signal, shutdown);
+  }
+  jobControlInterruptSupport = installJobControlInterruptSupport(appRenderer, shutdown);
+  jobControlSuspendSupport = installJobControlSuspendSupport(appRenderer);
 
   // The app owns the full alternate screen session from this point on.
   root.render(


### PR DESCRIPTION
## Summary

- Route Ctrl-C through Hunk's full shutdown path instead of OpenTUI's renderer-only destroy path.
- Add SIGINT/SIGTERM shutdown handling alongside raw-mode Ctrl-C handling.
- Cover the new interrupt handler with unit tests and document the fix in the changelog.

## Tests

- `bun test src/core/jobControl.test.ts`
- `bun run typecheck`

*This PR description was generated by Pi using OpenAI GPT-5.1 Codex*
