### PR TITLE
fix(cli): expose hunkdiff npm exec alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "url": "git+https://github.com/modem-dev/hunk.git"
   },
   "bin": {
-    "hunk": "./bin/hunk.cjs"
+    "hunk": "./bin/hunk.cjs",
+    "hunkdiff": "./bin/hunk.cjs"
   },
   "workspaces": [
     "packages/*"

--- a/scripts/stage-prebuilt-npm.ts
+++ b/scripts/stage-prebuilt-npm.ts
@@ -95,6 +95,7 @@ function stageMetaPackage(
     description: rootPackage.description,
     bin: {
       hunk: "./bin/hunk.cjs",
+      hunkdiff: "./bin/hunk.cjs",
     },
     files: ["bin", "dist/npm", "skills", "README.md", "LICENSE"],
     type: rootPackage.type,

--- a/test/cli/entrypoint.test.ts
+++ b/test/cli/entrypoint.test.ts
@@ -167,6 +167,14 @@ describe("CLI entrypoint contracts", () => {
     expect(existsSync(resolvedPath)).toBe(true);
   });
 
+  test("package manifest exposes hunkdiff as an npm exec alias", () => {
+    const packageJson = require("../../package.json");
+    expect(packageJson.bin).toEqual({
+      hunk: "./bin/hunk.cjs",
+      hunkdiff: "./bin/hunk.cjs",
+    });
+  });
+
   test("bin wrapper fails clearly when the bundled skill is missing", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "hunk-wrapper-skill-missing-"));
     const tempBinDir = join(tempDir, "bin");


### PR DESCRIPTION
## Summary

- add `hunkdiff` as a second bin alias pointing at the existing wrapper
- keep the staged prebuilt meta-package manifest in sync so published release artifacts expose the same alias
- add a regression test that locks the package manifest to both `hunk` and `hunkdiff`

Fixes #276.

## Verification

- `npx -y hunkdiff@0.11.1 --version` currently fails with `sh: 1: hunk: not found` (reproduced locally against the published package)
- packed a minimal local tarball with the updated manifest and confirmed `npm exec --package=./hunkdiff-0.12.0-beta.2.tgz hunkdiff -- skill path` resolves successfully
- full Bun test suite not run here because Bun is not installed in this environment