### PR TITLE
chore: require aged Bun package releases

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+# Only install packages published at least 7 days ago.
+minimumReleaseAge = 604800


### PR DESCRIPTION
## Summary

- Add a root `bunfig.toml` that requires Bun installs to use packages published at least 7 days ago.

## Testing

- `bun install --frozen-lockfile`

*This PR description was generated by Pi using OpenAI GPT-5*
