### PR TITLE
fix(release): include bundled skill in prebuilt archives

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -191,6 +191,19 @@ jobs:
           mkdir -p dist/release/github
           while IFS= read -r -d '' directory; do
             package_name="$(basename "$directory")"
+            binary="$directory/hunk"
+            if [ ! -f "$binary" ] && [ -f "$directory/hunk.exe" ]; then
+              binary="$directory/hunk.exe"
+            fi
+            if [ ! -f "$binary" ]; then
+              echo "Missing release binary in $directory" >&2
+              exit 1
+            fi
+            if [ ! -f "$directory/skills/hunk-review/SKILL.md" ]; then
+              echo "Missing bundled Hunk review skill in $directory" >&2
+              exit 1
+            fi
+            chmod 0755 "$binary"
             tar -C "$(dirname "$directory")" -czf "dist/release/github/${package_name}.tar.gz" "$package_name"
           done < <(find dist/release/artifacts -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
           find dist/release/github -maxdepth 1 -type f | sort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Included the bundled Hunk review skill in standalone prebuilt release archives so `hunk skill path` works after extracting a tarball or installing via Homebrew.
+
 ## [0.12.0] - 2026-05-12
 
 ### Added

--- a/scripts/build-prebuilt-artifact.test.ts
+++ b/scripts/build-prebuilt-artifact.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { stagePrebuiltArtifact } from "./build-prebuilt-artifact";
+import { binaryFilenameForSpec, getHostPlatformPackageSpec } from "./prebuilt-package-helpers";
+
+let tempRoot: string | undefined;
+
+/** Create a disposable repository shape for release artifact staging tests. */
+function createTestRepo() {
+  tempRoot = mkdtempSync(path.join(os.tmpdir(), "hunk-prebuilt-artifact-"));
+  const repoRoot = path.join(tempRoot, "repo");
+  const spec = getHostPlatformPackageSpec();
+  const binaryName = binaryFilenameForSpec(spec);
+
+  mkdirSync(path.join(repoRoot, "dist"), { recursive: true });
+  mkdirSync(path.join(repoRoot, "skills", "hunk-review"), { recursive: true });
+  writeFileSync(path.join(repoRoot, "dist", binaryName), "#!/bin/sh\necho hunk\n", {
+    mode: 0o600,
+  });
+  writeFileSync(path.join(repoRoot, "skills", "hunk-review", "SKILL.md"), "# Hunk review\n");
+
+  return { repoRoot, spec, binaryName };
+}
+
+afterEach(() => {
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+    tempRoot = undefined;
+  }
+});
+
+describe("stagePrebuiltArtifact", () => {
+  test("rejects missing skills directory with an actionable error", () => {
+    const { repoRoot } = createTestRepo();
+    rmSync(path.join(repoRoot, "skills"), { recursive: true, force: true });
+
+    expect(() => stagePrebuiltArtifact({ repoRoot })).toThrow("Missing skills directory");
+  });
+
+  test("rejects missing bundled Hunk review skill with an actionable error", () => {
+    const { repoRoot } = createTestRepo();
+    rmSync(path.join(repoRoot, "skills", "hunk-review", "SKILL.md"), { force: true });
+
+    expect(() => stagePrebuiltArtifact({ repoRoot })).toThrow("Missing bundled Hunk review skill");
+  });
+
+  test("includes the bundled skill next to standalone release binaries", () => {
+    const { repoRoot, spec, binaryName } = createTestRepo();
+    const outputRoot = path.join(tempRoot!, "artifacts");
+
+    const outputDir = stagePrebuiltArtifact({ repoRoot, outputRoot });
+
+    expect(outputDir).toBe(path.join(outputRoot, spec.packageName));
+    expect(existsSync(path.join(outputDir, binaryName))).toBe(true);
+    expect(existsSync(path.join(outputDir, "metadata.json"))).toBe(true);
+    expect(existsSync(path.join(outputDir, "skills", "hunk-review", "SKILL.md"))).toBe(true);
+
+    if (process.platform !== "win32") {
+      expect(statSync(path.join(outputDir, binaryName)).mode & 0o111).not.toBe(0);
+    }
+  });
+});

--- a/scripts/build-prebuilt-artifact.ts
+++ b/scripts/build-prebuilt-artifact.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import {
   binaryFilenameForSpec,
@@ -32,45 +32,76 @@ function parseArgs(argv: string[]) {
   return { outputRoot, expectedPackage };
 }
 
-const repoRoot = path.resolve(import.meta.dir, "..");
-const options = parseArgs(process.argv.slice(2));
-const spec = getHostPlatformPackageSpec();
-const binaryName = binaryFilenameForSpec(spec);
-const compiledBinaryCandidates = [
-  path.join(repoRoot, "dist", binaryName),
-  path.join(repoRoot, "dist", "hunk"),
-];
-const compiledBinary = compiledBinaryCandidates.find((candidate) => existsSync(candidate));
-const outputRoot = path.resolve(options.outputRoot ?? releaseArtifactsDir(repoRoot));
-const outputDir = path.join(outputRoot, spec.packageName);
-
-if (options.expectedPackage && options.expectedPackage !== spec.packageName) {
-  throw new Error(
-    `Host build resolved to ${spec.packageName}, but the workflow expected ${options.expectedPackage}.`,
-  );
+export interface StagePrebuiltArtifactOptions {
+  repoRoot?: string;
+  outputRoot?: string;
+  expectedPackage?: string;
 }
 
-if (!compiledBinary) {
-  throw new Error(
-    `Missing compiled binary at ${compiledBinaryCandidates.join(" or ")}. Run \`bun run build:bin\` first.`,
+/** Stage one standalone prebuilt release artifact for the current host. */
+export function stagePrebuiltArtifact(options: StagePrebuiltArtifactOptions = {}) {
+  const repoRoot = path.resolve(options.repoRoot ?? path.resolve(import.meta.dir, ".."));
+  const spec = getHostPlatformPackageSpec();
+  const binaryName = binaryFilenameForSpec(spec);
+  const compiledBinaryCandidates = [
+    path.join(repoRoot, "dist", binaryName),
+    path.join(repoRoot, "dist", "hunk"),
+  ];
+  const compiledBinary = compiledBinaryCandidates.find((candidate) => existsSync(candidate));
+  const outputRoot = path.resolve(options.outputRoot ?? releaseArtifactsDir(repoRoot));
+  const outputDir = path.join(outputRoot, spec.packageName);
+
+  if (options.expectedPackage && options.expectedPackage !== spec.packageName) {
+    throw new Error(
+      `Host build resolved to ${spec.packageName}, but the workflow expected ${options.expectedPackage}.`,
+    );
+  }
+
+  if (!compiledBinary) {
+    throw new Error(
+      `Missing compiled binary at ${compiledBinaryCandidates.join(" or ")}. Run \`bun run build:bin\` first.`,
+    );
+  }
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(outputDir, { recursive: true });
+
+  const stagedBinary = path.join(outputDir, binaryName);
+  cpSync(compiledBinary, stagedBinary);
+  if (spec.os !== "windows") {
+    chmodSync(stagedBinary, 0o755);
+  }
+
+  const skillsSource = path.join(repoRoot, "skills");
+  if (!existsSync(skillsSource)) {
+    throw new Error(`Missing skills directory at ${skillsSource}.`);
+  }
+
+  const hunkReviewSkill = path.join(skillsSource, "hunk-review", "SKILL.md");
+  if (!existsSync(hunkReviewSkill)) {
+    throw new Error(`Missing bundled Hunk review skill at ${hunkReviewSkill}.`);
+  }
+
+  cpSync(skillsSource, path.join(outputDir, "skills"), { recursive: true });
+  writeFileSync(
+    path.join(outputDir, "metadata.json"),
+    `${JSON.stringify(
+      {
+        packageName: spec.packageName,
+        os: spec.os,
+        cpu: spec.cpu,
+        binaryName,
+      },
+      null,
+      2,
+    )}\n`,
   );
+
+  return outputDir;
 }
 
-rmSync(outputDir, { recursive: true, force: true });
-mkdirSync(outputDir, { recursive: true });
-cpSync(compiledBinary, path.join(outputDir, binaryName));
-writeFileSync(
-  path.join(outputDir, "metadata.json"),
-  `${JSON.stringify(
-    {
-      packageName: spec.packageName,
-      os: spec.os,
-      cpu: spec.cpu,
-      binaryName,
-    },
-    null,
-    2,
-  )}\n`,
-);
-
-console.log(`Prepared prebuilt artifact in ${outputDir}`);
+if (import.meta.main) {
+  const options = parseArgs(process.argv.slice(2));
+  const outputDir = stagePrebuiltArtifact(options);
+  console.log(`Prepared prebuilt artifact in ${outputDir}`);
+}

--- a/scripts/update-homebrew-formula.test.ts
+++ b/scripts/update-homebrew-formula.test.ts
@@ -80,6 +80,7 @@ describe("update-homebrew-formula", () => {
       expect(formula).toContain("hunkdiff-linux-x64.tar.gz");
       expect(formula).toContain('chmod 0755, "hunk"');
       expect(formula).toContain('libexec.install "hunk"');
+      expect(formula).toContain('libexec.install "skills"');
       expect(formula).toContain(
         '(bin/"hunk").write_env_script libexec/"hunk", HUNK_INSTALL_SOURCE: "homebrew"',
       );

--- a/scripts/update-homebrew-formula.ts
+++ b/scripts/update-homebrew-formula.ts
@@ -147,6 +147,7 @@ function formulaContent(options: Options) {
   def install
     chmod 0755, "hunk"
     libexec.install "hunk"
+    libexec.install "skills"
     (bin/"hunk").write_env_script libexec/"hunk", HUNK_INSTALL_SOURCE: "homebrew"
   end
 


### PR DESCRIPTION
## Summary

- Include the bundled `skills/` directory in standalone prebuilt release artifacts.
- Verify GitHub release archives contain the Hunk review skill and restore binary execute bits before tarring.
- Install `skills/` through the generated Homebrew formula so `hunk skill path` works from Brew installs.

Closes #299

## Tests

- `bun test ./scripts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`

*This PR description was generated by Pi using OpenAI GPT-5*
