### PR TITLE
feat(ui): add Catppuccin themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+- Added Catppuccin Latte and Mocha as built-in themes.
 - Added mouse-drag text selection in diff views that copies selected rows to the system clipboard via OSC 52. A `View > Copy decorations` toggle (or `copy_decorations` config) controls whether the clipboard includes diff rails, gutters, and file headers or only the changed code.
 - Added inline expansion for collapsed unchanged file content. Click an unchanged-context row (`▾ N unchanged lines` when expandable, otherwise the static `··· N unchanged lines ···` form) or press `e` while a hunk is selected to reveal surrounding and trailing file lines without leaving the review. The affordance is shown only for input modes that have reachable source content (`hunk diff`, `show`, `stash show`, file-pair `diff` and `difftool`, untracked files); raw `hunk patch` input still renders as before. Failed and in-flight loads surface a one-line status ("Loading…", "Could not load N unchanged lines") on the gap row. Expanded context rows use the same syntax highlighting as the surrounding diff.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can persist preferences to a config file:
 Example:
 
 ```toml
-theme = "graphite"   # graphite, midnight, paper, ember, custom
+theme = "graphite"   # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha, custom
 mode = "auto"        # auto, split, stack
 vcs = "git"          # git, jj
 watch = false
@@ -137,7 +137,7 @@ Custom themes can inherit from any built-in base theme and override only the col
 theme = "custom"
 
 [custom_theme]
-base = "graphite"    # graphite, midnight, paper, ember
+base = "graphite"    # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha
 label = "My Theme"
 accent = "#7fd1ff"
 panel = "#10161d"

--- a/docs/opentui-component.md
+++ b/docs/opentui-component.md
@@ -190,19 +190,19 @@ If you need direct access to Pierre's parser, `parsePatchFiles(...)` is still re
 
 ## Common props
 
-| Prop                 | Type                                             | Default      | Notes                                                                               |
-| -------------------- | ------------------------------------------------ | ------------ | ----------------------------------------------------------------------------------- |
-| `layout`             | `"split" \| "stack"`                             | `"split"`    | Chooses side-by-side or stacked rendering.                                          |
-| `width`              | `number`                                         | —            | Required content width in terminal columns.                                         |
-| `theme`              | `"graphite" \| "midnight" \| "paper" \| "ember"` | `"graphite"` | Matches Hunk's built-in themes.                                                     |
-| `showLineNumbers`    | `boolean`                                        | `true`       | Toggles line-number columns.                                                        |
-| `showHunkHeaders`    | `boolean`                                        | `true`       | Toggles `@@ ... @@` hunk header rows.                                               |
-| `showFileSeparators` | `boolean`                                        | `true`       | Toggles separator rows between files in `HunkReviewStream`.                         |
-| `wrapLines`          | `boolean`                                        | `false`      | Wraps long lines instead of clipping horizontally.                                  |
-| `horizontalOffset`   | `number`                                         | `0`          | Scroll offset for non-wrapped code rows.                                            |
-| `highlight`          | `boolean`                                        | `true`       | Enables syntax highlighting.                                                        |
-| `selectedHunkIndex`  | `number`                                         | `0`          | Highlights one hunk as the active target for single-file components.                |
-| `scrollable`         | `boolean`                                        | `true`       | `HunkDiffView` only; primitives should be wrapped in OpenTUI scrollbox when needed. |
+| Prop                 | Type                                                                                         | Default      | Notes                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `layout`             | `"split" \| "stack"`                                                                         | `"split"`    | Chooses side-by-side or stacked rendering.                                          |
+| `width`              | `number`                                                                                     | —            | Required content width in terminal columns.                                         |
+| `theme`              | `"graphite" \| "midnight" \| "paper" \| "ember" \| "catppuccin-latte" \| "catppuccin-mocha"` | `"graphite"` | Matches Hunk's built-in themes.                                                     |
+| `showLineNumbers`    | `boolean`                                                                                    | `true`       | Toggles line-number columns.                                                        |
+| `showHunkHeaders`    | `boolean`                                                                                    | `true`       | Toggles `@@ ... @@` hunk header rows.                                               |
+| `showFileSeparators` | `boolean`                                                                                    | `true`       | Toggles separator rows between files in `HunkReviewStream`.                         |
+| `wrapLines`          | `boolean`                                                                                    | `false`      | Wraps long lines instead of clipping horizontally.                                  |
+| `horizontalOffset`   | `number`                                                                                     | `0`          | Scroll offset for non-wrapped code rows.                                            |
+| `highlight`          | `boolean`                                                                                    | `true`       | Enables syntax highlighting.                                                        |
+| `selectedHunkIndex`  | `number`                                                                                     | `0`          | Highlights one hunk as the active target for single-file components.                |
+| `scrollable`         | `boolean`                                                                                    | `true`       | `HunkDiffView` only; primitives should be wrapped in OpenTUI scrollbox when needed. |
 
 ## Other exports
 

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -155,6 +155,13 @@ describe("OpenTUI public components", () => {
   });
 
   test("exports the documented built-in theme names", () => {
-    expect(HUNK_DIFF_THEME_NAMES).toEqual(["graphite", "midnight", "paper", "ember"]);
+    expect(HUNK_DIFF_THEME_NAMES).toEqual([
+      "graphite",
+      "midnight",
+      "paper",
+      "ember",
+      "catppuccin-latte",
+      "catppuccin-mocha",
+    ]);
   });
 });

--- a/src/opentui/themes.ts
+++ b/src/opentui/themes.ts
@@ -1,3 +1,10 @@
-export const HUNK_DIFF_THEME_NAMES = ["graphite", "midnight", "paper", "ember"] as const;
+export const HUNK_DIFF_THEME_NAMES = [
+  "graphite",
+  "midnight",
+  "paper",
+  "ember",
+  "catppuccin-latte",
+  "catppuccin-mocha",
+] as const;
 
 export type HunkDiffThemeName = (typeof HUNK_DIFF_THEME_NAMES)[number];

--- a/src/ui/diff/pierre.test.ts
+++ b/src/ui/diff/pierre.test.ts
@@ -327,7 +327,7 @@ describe("Pierre diff rows", () => {
   test("remaps Pierre markdown reds and greens away from diff-semantic hues", async () => {
     const file = createMarkdownDiffFile();
 
-    for (const themeId of ["midnight", "paper"] as const) {
+    for (const themeId of ["midnight", "paper", "catppuccin-latte", "catppuccin-mocha"] as const) {
       const theme = resolveTheme(themeId, null);
       const highlighted = await loadHighlightedDiff(file, theme.appearance);
       const rows = buildStackRows(file, highlighted, theme).filter(
@@ -453,7 +453,7 @@ describe("Pierre diff rows", () => {
     const file = createMarkdownDiffFile();
     const highlighted = await loadHighlightedDiff(file, "dark");
 
-    for (const themeId of ["graphite", "midnight", "ember"] as const) {
+    for (const themeId of ["graphite", "midnight", "ember", "catppuccin-mocha"] as const) {
       const theme = resolveTheme(themeId, null);
       const rows = buildStackRows(file, highlighted, theme).filter(
         (row): row is Extract<DiffRow, { type: "stack-line" }> =>

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -191,7 +191,7 @@ describe("ui helpers", () => {
       menus.theme
         .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
         .map((entry) => entry.label),
-    ).toEqual(["Graphite", "Midnight", "Paper", "Ember"]);
+    ).toEqual(["Graphite", "Midnight", "Paper", "Ember", "Catppuccin Latte", "Catppuccin Mocha"]);
     expect(
       menus.theme.some(
         (entry) => entry.kind === "item" && entry.label === "Graphite" && entry.checked,
@@ -238,7 +238,15 @@ describe("ui helpers", () => {
       menus.theme
         .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
         .map((entry) => entry.label),
-    ).toEqual(["Graphite", "Midnight", "Paper", "Ember", "My Theme"]);
+    ).toEqual([
+      "Graphite",
+      "Midnight",
+      "Paper",
+      "Ember",
+      "Catppuccin Latte",
+      "Catppuccin Mocha",
+      "My Theme",
+    ]);
     expect(
       menus.theme.some(
         (entry) => entry.kind === "item" && entry.label === "My Theme" && entry.checked,
@@ -457,5 +465,7 @@ describe("ui helpers", () => {
     expect(missingCustom.id).toBe("graphite");
     expect(resolveTheme("ember", null).syntaxStyle).toBeDefined();
     expect(custom.syntaxStyle).toBeDefined();
+    expect(resolveTheme("catppuccin-latte", null).syntaxStyle).toBeDefined();
+    expect(resolveTheme("catppuccin-mocha", null).syntaxStyle).toBeDefined();
   });
 });

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { blendHex, hexColorDistance } from "./lib/color";
+import { CATPPUCCIN_PALETTES, resolveTheme } from "./themes";
+
+describe("themes", () => {
+  test("resolves Catppuccin Latte and Mocha by theme id", () => {
+    const latte = resolveTheme("catppuccin-latte", null);
+    const mocha = resolveTheme("catppuccin-mocha", null);
+
+    expect(latte.id).toBe("catppuccin-latte");
+    expect(latte.label).toBe("Catppuccin Latte");
+    expect(latte.appearance).toBe("light");
+    expect(mocha.id).toBe("catppuccin-mocha");
+    expect(mocha.label).toBe("Catppuccin Mocha");
+    expect(mocha.appearance).toBe("dark");
+  });
+
+  test("keeps official Catppuccin sentinel colors in source", () => {
+    expect(CATPPUCCIN_PALETTES.latte.base).toBe("#eff1f5");
+    expect(CATPPUCCIN_PALETTES.latte.mauve).toBe("#8839ef");
+    expect(CATPPUCCIN_PALETTES.latte.green).toBe("#40a02b");
+    expect(CATPPUCCIN_PALETTES.latte.red).toBe("#d20f39");
+    expect(CATPPUCCIN_PALETTES.mocha.base).toBe("#1e1e2e");
+    expect(CATPPUCCIN_PALETTES.mocha.mauve).toBe("#cba6f7");
+    expect(CATPPUCCIN_PALETTES.mocha.green).toBe("#a6e3a1");
+    expect(CATPPUCCIN_PALETTES.mocha.red).toBe("#f38ba8");
+  });
+
+  test("derives Catppuccin diff backgrounds from official semantic tokens", () => {
+    const latte = resolveTheme("catppuccin-latte", null);
+    const mocha = resolveTheme("catppuccin-mocha", null);
+
+    expect(latte.addedBg).toBe(blendHex(CATPPUCCIN_PALETTES.latte.green, latte.contextBg, 0.15));
+    expect(latte.removedBg).toBe(blendHex(CATPPUCCIN_PALETTES.latte.red, latte.contextBg, 0.15));
+    expect(latte.addedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.latte.green, latte.contextBg, 0.25),
+    );
+    expect(latte.removedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.latte.red, latte.contextBg, 0.25),
+    );
+    expect(mocha.addedBg).toBe(blendHex(CATPPUCCIN_PALETTES.mocha.green, mocha.contextBg, 0.15));
+    expect(mocha.removedBg).toBe(blendHex(CATPPUCCIN_PALETTES.mocha.red, mocha.contextBg, 0.15));
+    expect(mocha.addedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.mocha.green, mocha.contextBg, 0.25),
+    );
+    expect(mocha.removedContentBg).toBe(
+      blendHex(CATPPUCCIN_PALETTES.mocha.red, mocha.contextBg, 0.25),
+    );
+  });
+
+  test("keeps Catppuccin add and remove rows semantically distinct", () => {
+    for (const theme of [
+      resolveTheme("catppuccin-latte", null),
+      resolveTheme("catppuccin-mocha", null),
+    ]) {
+      expect(theme.addedBg).not.toBe(theme.removedBg);
+      expect(hexColorDistance(theme.addedBg, theme.contextBg)).toBeGreaterThan(0);
+      expect(hexColorDistance(theme.removedBg, theme.contextBg)).toBeGreaterThan(0);
+      expect(hexColorDistance(theme.addedContentBg, theme.contextBg)).toBeGreaterThan(
+        hexColorDistance(theme.addedBg, theme.contextBg),
+      );
+      expect(hexColorDistance(theme.removedContentBg, theme.contextBg)).toBeGreaterThan(
+        hexColorDistance(theme.removedBg, theme.contextBg),
+      );
+    }
+  });
+
+  test("maps Catppuccin syntax roles to documented editor tokens", () => {
+    const latte = resolveTheme("catppuccin-latte", null);
+    const mocha = resolveTheme("catppuccin-mocha", null);
+
+    expect(latte.syntaxColors).toMatchObject({
+      keyword: CATPPUCCIN_PALETTES.latte.mauve,
+      string: CATPPUCCIN_PALETTES.latte.green,
+      comment: CATPPUCCIN_PALETTES.latte.overlay2,
+      number: CATPPUCCIN_PALETTES.latte.peach,
+      function: CATPPUCCIN_PALETTES.latte.blue,
+      property: CATPPUCCIN_PALETTES.latte.blue,
+      type: CATPPUCCIN_PALETTES.latte.yellow,
+      punctuation: CATPPUCCIN_PALETTES.latte.overlay2,
+    });
+    expect(mocha.syntaxColors).toMatchObject({
+      keyword: CATPPUCCIN_PALETTES.mocha.mauve,
+      string: CATPPUCCIN_PALETTES.mocha.green,
+      comment: CATPPUCCIN_PALETTES.mocha.overlay2,
+      number: CATPPUCCIN_PALETTES.mocha.peach,
+      function: CATPPUCCIN_PALETTES.mocha.blue,
+      property: CATPPUCCIN_PALETTES.mocha.blue,
+      type: CATPPUCCIN_PALETTES.mocha.yellow,
+      punctuation: CATPPUCCIN_PALETTES.mocha.overlay2,
+    });
+  });
+});

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -1,5 +1,6 @@
 import { RGBA, SyntaxStyle, type ThemeMode } from "@opentui/core";
 import type { CustomThemeConfig } from "../core/types";
+import { blendHex } from "./lib/color";
 
 export interface AppTheme {
   id: string;
@@ -53,6 +54,99 @@ type SyntaxColors = {
 };
 
 type ThemeBase = Omit<AppTheme, "syntaxColors" | "syntaxStyle">;
+
+type CatppuccinPalette = {
+  rosewater: string;
+  flamingo: string;
+  pink: string;
+  mauve: string;
+  red: string;
+  maroon: string;
+  peach: string;
+  yellow: string;
+  green: string;
+  teal: string;
+  sky: string;
+  sapphire: string;
+  blue: string;
+  lavender: string;
+  text: string;
+  subtext1: string;
+  subtext0: string;
+  overlay2: string;
+  overlay1: string;
+  overlay0: string;
+  surface2: string;
+  surface1: string;
+  surface0: string;
+  base: string;
+  mantle: string;
+  crust: string;
+};
+
+// Source: https://github.com/catppuccin/palette/blob/main/palette.json
+// Cross-check reference: https://catppuccin.com/palette/
+// Semantic guidance: https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md
+export const CATPPUCCIN_PALETTES = {
+  latte: {
+    rosewater: "#dc8a78",
+    flamingo: "#dd7878",
+    pink: "#ea76cb",
+    mauve: "#8839ef",
+    red: "#d20f39",
+    maroon: "#e64553",
+    peach: "#fe640b",
+    yellow: "#df8e1d",
+    green: "#40a02b",
+    teal: "#179299",
+    sky: "#04a5e5",
+    sapphire: "#209fb5",
+    blue: "#1e66f5",
+    lavender: "#7287fd",
+    text: "#4c4f69",
+    subtext1: "#5c5f77",
+    subtext0: "#6c6f85",
+    overlay2: "#7c7f93",
+    overlay1: "#8c8fa1",
+    overlay0: "#9ca0b0",
+    surface2: "#acb0be",
+    surface1: "#bcc0cc",
+    surface0: "#ccd0da",
+    base: "#eff1f5",
+    mantle: "#e6e9ef",
+    crust: "#dce0e8",
+  },
+  mocha: {
+    rosewater: "#f5e0dc",
+    flamingo: "#f2cdcd",
+    pink: "#f5c2e7",
+    mauve: "#cba6f7",
+    red: "#f38ba8",
+    maroon: "#eba0ac",
+    peach: "#fab387",
+    yellow: "#f9e2af",
+    green: "#a6e3a1",
+    teal: "#94e2d5",
+    sky: "#89dceb",
+    sapphire: "#74c7ec",
+    blue: "#89b4fa",
+    lavender: "#b4befe",
+    text: "#cdd6f4",
+    subtext1: "#bac2de",
+    subtext0: "#a6adc8",
+    overlay2: "#9399b2",
+    overlay1: "#7f849c",
+    overlay0: "#6c7086",
+    surface2: "#585b70",
+    surface1: "#45475a",
+    surface0: "#313244",
+    base: "#1e1e2e",
+    mantle: "#181825",
+    crust: "#11111b",
+  },
+} as const satisfies Record<"latte" | "mocha", CatppuccinPalette>;
+
+type CatppuccinFlavor = keyof typeof CATPPUCCIN_PALETTES;
 
 /** Build the syntax palette OpenTUI should use for in-terminal code rendering. */
 function createSyntaxStyle(colors: SyntaxColors) {
@@ -155,6 +249,66 @@ export function availableThemeIds(customTheme?: CustomThemeConfig): string[] {
 /** Return the menu/cycle themes, adding the config-defined custom theme only when available. */
 export function availableThemes(customTheme?: CustomThemeConfig): AppTheme[] {
   return customTheme ? [...THEMES, buildCustomTheme(customTheme)] : THEMES;
+}
+
+/** Map official Catppuccin palette tokens into Hunk's semantic theme slots. */
+function createCatppuccinTheme(flavor: CatppuccinFlavor) {
+  const palette = CATPPUCCIN_PALETTES[flavor];
+  const label = flavor === "latte" ? "Catppuccin Latte" : "Catppuccin Mocha";
+  const appearance: AppTheme["appearance"] = flavor === "latte" ? "light" : "dark";
+  const panel = flavor === "latte" ? palette.base : palette.mantle;
+  const panelAlt = flavor === "latte" ? palette.mantle : palette.base;
+  const contextBg = palette.base;
+
+  return withLazySyntaxStyle(
+    {
+      id: `catppuccin-${flavor}`,
+      label,
+      appearance,
+      background: palette.crust,
+      panel,
+      panelAlt,
+      border: palette.surface1,
+      accent: palette.mauve,
+      accentMuted: blendHex(palette.mauve, panel, 0.2),
+      text: palette.text,
+      muted: palette.subtext0,
+      addedBg: blendHex(palette.green, contextBg, 0.15),
+      removedBg: blendHex(palette.red, contextBg, 0.15),
+      contextBg,
+      addedContentBg: blendHex(palette.green, contextBg, 0.25),
+      removedContentBg: blendHex(palette.red, contextBg, 0.25),
+      contextContentBg: contextBg,
+      addedSignColor: palette.green,
+      removedSignColor: palette.red,
+      lineNumberBg: palette.mantle,
+      lineNumberFg: palette.overlay1,
+      selectedHunk: blendHex(palette.overlay2, contextBg, 0.25),
+      badgeAdded: palette.green,
+      badgeRemoved: palette.red,
+      badgeNeutral: palette.overlay2,
+      fileNew: palette.green,
+      fileDeleted: palette.red,
+      fileRenamed: palette.yellow,
+      fileModified: palette.mauve,
+      fileUntracked: palette.sky,
+      noteBorder: palette.mauve,
+      noteBackground: blendHex(palette.mauve, panel, 0.12),
+      noteTitleBackground: blendHex(palette.mauve, panel, 0.22),
+      noteTitleText: palette.text,
+    },
+    {
+      default: palette.text,
+      keyword: palette.mauve,
+      string: palette.green,
+      comment: palette.overlay2,
+      number: palette.peach,
+      function: palette.blue,
+      property: palette.blue,
+      type: palette.yellow,
+      punctuation: palette.overlay2,
+    },
+  );
 }
 
 export const THEMES: AppTheme[] = [
@@ -354,6 +508,8 @@ export const THEMES: AppTheme[] = [
       punctuation: "#a17d69",
     },
   ),
+  createCatppuccinTheme("latte"),
+  createCatppuccinTheme("mocha"),
 ];
 
 /** Resolve a named theme, including explicit terminal-background auto mode and custom themes, or fall back to Hunk's explicit built-in default. */


### PR DESCRIPTION
## Summary

- Add built-in Catppuccin Latte and Mocha themes.
- Wire the new theme ids through app and OpenTUI theme resolution.
- Update docs, changelog, and theme coverage tests.

Closes #304.

## Testing

- `bun run typecheck`
- `bun test`