### PR TITLE
fix(ui): remove inline note spacer row

### DIFF
--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -199,38 +199,3 @@ export function AgentInlineNote({
     </box>
   );
 }
-
-/** Render the small cap shown after the last diff row in a note's range. */
-export function AgentInlineNoteGuideCap({
-  side,
-  theme,
-  width,
-}: {
-  side: "old" | "new";
-  theme: AppTheme;
-  width: number;
-}) {
-  return (
-    <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
-      {side === "old" ? (
-        <>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder}>╵</text>
-          </box>
-          <box style={{ width: Math.max(0, width - 1), height: 1, backgroundColor: theme.panel }}>
-            <text>{" ".repeat(Math.max(0, width - 1))}</text>
-          </box>
-        </>
-      ) : (
-        <>
-          <box style={{ width: Math.max(0, width - 1), height: 1, backgroundColor: theme.panel }}>
-            <text>{" ".repeat(Math.max(0, width - 1))}</text>
-          </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder}>╵</text>
-          </box>
-        </>
-      )}
-    </box>
-  );
-}

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { DiffFile, LayoutMode } from "../../core/types";
-import { AgentInlineNote, AgentInlineNoteGuideCap } from "../components/panes/AgentInlineNote";
+import { AgentInlineNote } from "../components/panes/AgentInlineNote";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import type { DiffSectionGeometry } from "../lib/diffSectionGeometry";
 import { reviewRowId } from "../lib/ids";
@@ -165,14 +165,6 @@ export function PierreDiffView({
                 theme={theme}
                 width={width}
               />
-            </box>
-          );
-        }
-
-        if (plannedRow.kind === "note-guide-cap") {
-          return (
-            <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
-              <AgentInlineNoteGuideCap side={plannedRow.side} theme={theme} width={width} />
             </box>
           );
         }

--- a/src/ui/diff/plannedReviewRows.ts
+++ b/src/ui/diff/plannedReviewRows.ts
@@ -45,10 +45,6 @@ export function plannedReviewRowHeight(
     });
   }
 
-  if (row.kind === "note-guide-cap") {
-    return 1;
-  }
-
   if (row.row.type === "hunk-header") {
     return showHunkHeaders ? 1 : 0;
   }

--- a/src/ui/diff/reviewRenderPlan.test.ts
+++ b/src/ui/diff/reviewRenderPlan.test.ts
@@ -113,12 +113,6 @@ describe("review render plan", () => {
     }
 
     expect(guidedSplitLineNumbers(plannedRows, "new")).toEqual([2, 3]);
-
-    const cap = plannedRows.find((row) => row.kind === "note-guide-cap");
-    expect(cap?.kind).toBe("note-guide-cap");
-    if (cap?.kind === "note-guide-cap") {
-      expect(cap.side).toBe("new");
-    }
   });
 
   test("anchors deletion-only notes to old-side rows and guides the old column", () => {
@@ -164,12 +158,6 @@ describe("review render plan", () => {
     }
 
     expect(guidedSplitLineNumbers(plannedRows, "old")).toEqual([1]);
-
-    const cap = plannedRows.find((row) => row.kind === "note-guide-cap");
-    expect(cap?.kind).toBe("note-guide-cap");
-    if (cap?.kind === "note-guide-cap") {
-      expect(cap.side).toBe("old");
-    }
   });
 
   test("assigns hunk anchor ids from the first visible row for every hunk when hunk headers are hidden", () => {
@@ -259,7 +247,6 @@ describe("review render plan", () => {
       expect(note.anchorSide).toBeUndefined();
     }
 
-    expect(plannedRows.some((row) => row.kind === "note-guide-cap")).toBe(false);
     expect(
       plannedRows.some((row) => row.kind === "diff-row" && row.noteGuideSide !== undefined),
     ).toBe(false);

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -11,7 +11,6 @@ type DiffLineRow = Extract<DiffRow, { type: "split-line" | "stack-line" }>;
 interface InlineVisibleNotePlacement {
   anchorKey: string;
   anchorSide?: "old" | "new";
-  endGuideAfterKey?: string;
   guidedRowKeys: Set<string>;
   hunkIndex: number;
   note: VisibleAgentNote;
@@ -42,14 +41,6 @@ export type PlannedReviewRow =
       anchorSide?: "old" | "new";
       noteCount: number;
       noteIndex: number;
-    }
-  | {
-      kind: "note-guide-cap";
-      key: string;
-      stableKey: string;
-      fileId: string;
-      hunkIndex: number;
-      side: "old" | "new";
     };
 
 function lineRows(rows: DiffRow[]) {
@@ -153,23 +144,6 @@ function diffRowStableKeys(row: DiffRow) {
   ]);
 }
 
-/** Pick the stable anchor that best matches one old/new-side guide row. */
-function diffRowStableKeyForSide(row: DiffRow, side: "old" | "new") {
-  if (row.type === "split-line") {
-    return side === "new"
-      ? newLineStableKey(row.hunkIndex, row.right.lineNumber)
-      : oldLineStableKey(row.hunkIndex, row.left.lineNumber);
-  }
-
-  if (row.type === "stack-line") {
-    return side === "new"
-      ? newLineStableKey(row.hunkIndex, row.cell.newLineNumber)
-      : oldLineStableKey(row.hunkIndex, row.cell.oldLineNumber);
-  }
-
-  return diffRowStableKeys(row)[0];
-}
-
 /** Check whether a rendered diff row visually covers the note anchor line. */
 function rowMatchesNote(row: DiffLineRow, annotation: AgentAnnotation) {
   const anchor = annotationAnchor(annotation);
@@ -250,7 +224,6 @@ function buildInlineVisibleNotePlacements(rows: DiffRow[], visibleAgentNotes: Vi
     anchorPlacements.push({
       anchorKey: anchorRow.key,
       anchorSide,
-      endGuideAfterKey: guideRows.at(-1)?.key,
       guidedRowKeys:
         guideRows.length > 0 ? new Set(guideRows.map((row) => row.key)) : EMPTY_ROW_KEYS,
       hunkIndex: anchorRow.hunkIndex,
@@ -291,24 +264,6 @@ function buildNoteGuideSideByRowKey(placementsByAnchor: Map<string, InlineVisibl
   return guideSideByRowKey;
 }
 
-function buildGuideCapsByRowKey(placementsByAnchor: Map<string, InlineVisibleNotePlacement[]>) {
-  const guideCapsByRowKey = new Map<string, Set<"old" | "new">>();
-
-  for (const placements of placementsByAnchor.values()) {
-    for (const placement of placements) {
-      if (!placement.anchorSide || !placement.endGuideAfterKey) {
-        continue;
-      }
-
-      const rowCaps = guideCapsByRowKey.get(placement.endGuideAfterKey) ?? new Set<"old" | "new">();
-      rowCaps.add(placement.anchorSide);
-      guideCapsByRowKey.set(placement.endGuideAfterKey, rowCaps);
-    }
-  }
-
-  return guideCapsByRowKey;
-}
-
 function rowCanAnchorHunk(row: DiffRow, showHunkHeaders: boolean) {
   if (showHunkHeaders) {
     return row.type === "hunk-header";
@@ -319,8 +274,8 @@ function rowCanAnchorHunk(row: DiffRow, showHunkHeaders: boolean) {
 
 /**
  * Build the explicit presentational row plan for one file diff body.
- * The plan always preserves diff-row order and may insert inline notes plus
- * trailing guide caps for every visible note anchored in this file.
+ * The plan always preserves diff-row order and may insert inline notes for every visible note
+ * anchored in this file.
  */
 export function buildReviewRenderPlan({
   fileId,
@@ -337,7 +292,6 @@ export function buildReviewRenderPlan({
 }) {
   const placementsByAnchor = buildInlineVisibleNotePlacements(rows, visibleAgentNotes);
   const noteGuideSideByRowKey = buildNoteGuideSideByRowKey(placementsByAnchor);
-  const guideCapsByRowKey = buildGuideCapsByRowKey(placementsByAnchor);
   const plannedRows: PlannedReviewRow[] = [];
   const anchoredHunks = new Set<number>();
 
@@ -380,20 +334,6 @@ export function buildReviewRenderPlan({
       anchorId,
       noteGuideSide: noteGuideSideByRowKey.get(row.key),
     });
-
-    const guideCaps = guideCapsByRowKey.get(row.key);
-    if (guideCaps) {
-      Array.from(guideCaps).forEach((side) => {
-        plannedRows.push({
-          kind: "note-guide-cap",
-          key: `note-guide-cap:${row.key}:${side}`,
-          stableKey: `note-guide-cap:${side}:${diffRowStableKeyForSide(row, side) ?? diffStableKey}`,
-          fileId,
-          hunkIndex: row.hunkIndex,
-          side,
-        });
-      });
-    }
   }
 
   return plannedRows;

--- a/src/ui/lib/diffSectionGeometry.ts
+++ b/src/ui/lib/diffSectionGeometry.ts
@@ -68,10 +68,6 @@ function plannedRowHeight(
     });
   }
 
-  if (row.kind === "note-guide-cap") {
-    return 1;
-  }
-
   return measureRenderedRowHeight(
     row.row,
     width,


### PR DESCRIPTION
## Summary

- Remove the standalone inline-note guide-cap row that rendered as an extra blank spacer after note ranges
- Drop the now-unused guide-cap planning, rendering, and height-measurement code
- Keep existing guide highlighting on covered diff rows without adding a trailing row

## Testing

- bun run format:check
- bun run lint
- bun run typecheck
- bun test src/ui/diff/reviewRenderPlan.test.ts src/ui/components/ui-components.test.tsx src/ui/lib/diffSectionGeometry.test.ts
- bun test

*This PR description was generated by Pi using OpenAI GPT-5*
