### PR TITLE
Preserve auto theme across watch refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Preserved the resolved auto theme across `--watch` refreshes instead of falling back to the default dark theme.
 - Included the bundled Hunk review skill in standalone prebuilt release archives so `hunk skill path` works after extracting a tarball or installing via Homebrew.
 
 ## [0.12.0] - 2026-05-12

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -108,7 +108,7 @@ export function App({
       : resolveTheme(bootstrap.initialTheme, bootstrap.initialThemeMode ?? null).id,
   );
   // Soft reloads replace bootstrap without re-running startup terminal theme detection.
-  const detectedThemeMode = useRef(bootstrap.initialThemeMode).current;
+  const [detectedThemeMode] = useState(() => bootstrap.initialThemeMode);
   const [showAgentNotes, setShowAgentNotes] = useState(bootstrap.initialShowAgentNotes ?? false);
   const [showLineNumbers, setShowLineNumbers] = useState(bootstrap.initialShowLineNumbers ?? true);
   const [wrapLines, setWrapLines] = useState(bootstrap.initialWrapLines ?? false);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -107,6 +107,8 @@ export function App({
       ? "auto"
       : resolveTheme(bootstrap.initialTheme, bootstrap.initialThemeMode ?? null).id,
   );
+  // Soft reloads replace bootstrap without re-running startup terminal theme detection.
+  const detectedThemeMode = useRef(bootstrap.initialThemeMode).current;
   const [showAgentNotes, setShowAgentNotes] = useState(bootstrap.initialShowAgentNotes ?? false);
   const [showLineNumbers, setShowLineNumbers] = useState(bootstrap.initialShowLineNumbers ?? true);
   const [wrapLines, setWrapLines] = useState(bootstrap.initialWrapLines ?? false);
@@ -120,7 +122,7 @@ export function App({
   const [resizeDragOriginX, setResizeDragOriginX] = useState<number | null>(null);
   const [resizeStartWidth, setResizeStartWidth] = useState<number | null>(null);
 
-  const activeTheme = resolveTheme(themeId, bootstrap.initialThemeMode ?? null);
+  const activeTheme = resolveTheme(themeId, detectedThemeMode ?? null);
   const review = useReviewController({ files: bootstrap.changeset.files });
   const filteredFiles = review.visibleFiles;
   const selectedFile = review.selectedFile;

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -436,23 +436,16 @@ async function waitForFrame(
 
 /** Open the top-level Theme menu and wait for the expected active light theme marker. */
 async function openThemeMenu(setup: Awaited<ReturnType<typeof testRender>>) {
-  let opened = false;
+  await act(async () => {
+    await setup.mockInput.pressKey("F10");
+  });
 
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    await act(async () => {
-      await setup.mockInput.pressKey("F10");
-    });
-
-    const menuFrame = await waitForFrame(setup, (frame) =>
-      frame.includes("Toggle files/filter focus"),
-    );
-    if (menuFrame.includes("Toggle files/filter focus")) {
-      opened = true;
-      break;
-    }
-  }
-
-  expect(opened).toBe(true);
+  const openedFrame = await waitForFrame(
+    setup,
+    (frame) => frame.includes("Toggle files/filter focus"),
+    12,
+  );
+  expect(openedFrame).toContain("Toggle files/filter focus");
 
   for (let index = 0; index < 3; index += 1) {
     await act(async () => {

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -434,6 +434,36 @@ async function waitForFrame(
   return frame;
 }
 
+/** Open the top-level Theme menu and wait for the expected active light theme marker. */
+async function openThemeMenu(setup: Awaited<ReturnType<typeof testRender>>) {
+  let opened = false;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await act(async () => {
+      await setup.mockInput.pressKey("F10");
+    });
+
+    const menuFrame = await waitForFrame(setup, (frame) =>
+      frame.includes("Toggle files/filter focus"),
+    );
+    if (menuFrame.includes("Toggle files/filter focus")) {
+      opened = true;
+      break;
+    }
+  }
+
+  expect(opened).toBe(true);
+
+  for (let index = 0; index < 3; index += 1) {
+    await act(async () => {
+      await setup.mockInput.pressArrow("right");
+    });
+    await flush(setup);
+  }
+
+  return waitForFrame(setup, (frame) => frame.includes("[x] Paper"), 12);
+}
+
 async function pressHunkNavigationKey(
   setup: Awaited<ReturnType<typeof testRender>>,
   key: "]" | "[",
@@ -1247,6 +1277,55 @@ describe("App interactions", () => {
       }
 
       expect(refreshed).toBe(true);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test("watch mode preserves the resolved auto theme after refreshing the file diff", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-watch-theme-"));
+    const left = join(dir, "before.ts");
+    const right = join(dir, "after.ts");
+
+    writeFileSync(left, "export const answer = 41;\n");
+    writeFileSync(right, "export const answer = 42;\n");
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "diff",
+      left,
+      right,
+      options: {
+        mode: "split",
+        theme: "auto",
+        watch: true,
+      },
+    });
+    // loadAppBootstrap does not do startup-time terminal theme detection in tests.
+    bootstrap.initialThemeMode = "light";
+
+    const setup = await testRender(<AppHost bootstrap={bootstrap} />, {
+      width: 220,
+      height: 20,
+    });
+
+    try {
+      await flush(setup);
+
+      writeFileSync(right, "export const answer = 42;\nexport const added = true;\n");
+
+      const refreshedFrame = await waitForFrame(
+        setup,
+        (currentFrame) => currentFrame.includes("export const added = true;"),
+        40,
+      );
+      expect(refreshedFrame).toContain("export const added = true;");
+
+      const menuFrame = await openThemeMenu(setup);
+      expect(menuFrame).toContain("[x] Paper");
+      expect(menuFrame).toContain("[ ] Graphite");
     } finally {
       await act(async () => {
         setup.renderer.destroy();


### PR DESCRIPTION
## Summary

- Preserve the startup-detected terminal theme mode across soft `--watch` refreshes
- Keep `theme: auto` from falling back to the default dark theme after watched file diffs reload

## Solves the bug

When Hunk started with `--theme auto`, startup detected the terminal background once & stored the resolved terminal theme mode on the initial app bootstrap.

In `--watch` mode, file changes trigger a soft reload: the diff bootstrap is replaced, but the `App` component is intentionally not remounted so view state like selected theme, layout, and scroll position can survive. That meant `themeId` stayed as `"auto"`, but the replacement bootstrap no longer had the startup-only detected terminal theme mode.

As a result, `resolveTheme("auto", null)` fell back to the default dark theme, so users on light terminals could see Hunk switch from the light `Paper` theme to dark `Graphite` after the first watched refresh.

This fix snapshots the startup-detected theme mode for the lifetime of the mounted app, so soft reloads keep resolving `auto` consistently.