### PR TITLE
chore(release): prepare 0.13.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.13.0-beta.0] - 2026-05-16
+
+### Added
+
 - Added an `e` shortcut to open the selected diff file in `$EDITOR`.
 - Added `g` and `G` keyboard aliases for jump-to-top and jump-to-bottom review navigation.
 - Added session-persistent user-authored inline notes with `c` to draft/save notes.
@@ -323,7 +331,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Stabilized diff repainting, active-hunk scrolling, syntax highlighting, pager stdin patch handling, and terminal cleanup on exit.
 
-[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.13.0-beta.0...HEAD
+[0.13.0-beta.0]: https://github.com/modem-dev/hunk/compare/v0.12.0...v0.13.0-beta.0
 [0.12.0]: https://github.com/modem-dev/hunk/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/modem-dev/hunk/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/modem-dev/hunk/compare/v0.10.0...v0.11.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.12.0",
+  "version": "0.13.0-beta.0",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary
- bump package version to 0.13.0-beta.0
- move current unreleased changelog entries into 0.13.0-beta.0
- reset Unreleased and update changelog comparison links

## Tests
- bun run typecheck
- bun test