### PR TITLE
fix(release): ignore staged npm artifact when archiving

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Download platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: hunkdiff-*
           path: dist/release/artifacts
 
       - name: Archive release assets
@@ -205,7 +206,7 @@ jobs:
             fi
             chmod 0755 "$binary"
             tar -C "$(dirname "$directory")" -czf "dist/release/github/${package_name}.tar.gz" "$package_name"
-          done < <(find dist/release/artifacts -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+          done < <(find dist/release/artifacts -mindepth 1 -maxdepth 1 -type d -name 'hunkdiff-*' -print0 | sort -z)
           find dist/release/github -maxdepth 1 -type f | sort
 
       - name: Create or update GitHub release


### PR DESCRIPTION
## Summary
- limit the GitHub release job download to `hunkdiff-*` platform artifacts
- filter the archive loop to platform artifact directories so staged npm release artifacts are ignored

## Why
The 0.13.0-beta.0 release workflow downloaded `staged-prebuilt-npm-release` alongside binary artifacts and tried to archive it as if it contained a top-level `hunk` binary.

## Tests
- `git diff --check`
- local shell simulation with an extra `staged-prebuilt-npm-release` directory