### PR TITLE
fix(ui): hide add-note affordance while scrolling

### DIFF
--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -52,6 +52,7 @@ import type { VisibleBodyBounds } from "../../diff/rowWindowing";
 import { prefetchHighlightedDiff } from "../../diff/useHighlightedDiff";
 
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
+const ADD_NOTE_SCROLL_SUPPRESS_DELAY_MS = 160;
 
 /**
  * Clamp one vertical scroll target into the currently reachable review-stream extent.
@@ -218,6 +219,28 @@ export function DiffPane({
     () => createReviewMouseWheelScrollAcceleration(),
     [],
   );
+  const addNoteHoverSuppressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [addNoteHoverSuppressed, setAddNoteHoverSuppressed] = useState(false);
+
+  /** Temporarily hide hover-only row controls during wheel scrolling so they do not flicker row-by-row. */
+  const suppressAddNoteHoverForMouseScroll = useCallback(() => {
+    setAddNoteHoverSuppressed(true);
+    if (addNoteHoverSuppressTimeoutRef.current) {
+      clearTimeout(addNoteHoverSuppressTimeoutRef.current);
+    }
+    addNoteHoverSuppressTimeoutRef.current = setTimeout(() => {
+      setAddNoteHoverSuppressed(false);
+      addNoteHoverSuppressTimeoutRef.current = null;
+    }, ADD_NOTE_SCROLL_SUPPRESS_DELAY_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (addNoteHoverSuppressTimeoutRef.current) {
+        clearTimeout(addNoteHoverSuppressTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const adjacentPrefetchFileIds = useMemo(
     () => buildAdjacentPrefetchFileIds(files, selectedFileId),
@@ -229,7 +252,13 @@ export function DiffPane({
     (event: TuiMouseEvent) => {
       const scrollBox = scrollRef.current;
       const direction = event.scroll?.direction;
-      if (!direction || !scrollBox || wrapLines) {
+      if (!direction) {
+        return;
+      }
+
+      suppressAddNoteHoverForMouseScroll();
+
+      if (!scrollBox || wrapLines) {
         return;
       }
 
@@ -273,7 +302,7 @@ export function DiffPane({
       event.preventDefault();
       event.stopPropagation();
     },
-    [onScrollCodeHorizontally, scrollRef, wrapLines],
+    [onScrollCodeHorizontally, scrollRef, suppressAddNoteHoverForMouseScroll, wrapLines],
   );
 
   const allAgentNotesByFile = useMemo(() => {
@@ -1295,12 +1324,14 @@ export function DiffPane({
                       wrapLines={wrapLines}
                       theme={theme}
                       hoverActive={hoveredFileId === null || hoveredFileId === file.id}
+                      hoverSuppressed={addNoteHoverSuppressed}
                       viewWidth={diffContentWidth}
                       visibleAgentNotes={
                         visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
                       }
                       visibleBodyBounds={visibleBodyBoundsByFile.get(file.id)}
                       onHover={() => setHoveredFileId(file.id)}
+                      onMouseScroll={suppressAddNoteHoverForMouseScroll}
                       onActiveAddNoteAffordanceChange={(affordance) =>
                         onActiveAddNoteAffordanceChange?.(
                           affordance ? { ...affordance, fileId: file.id } : null,

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -29,7 +29,9 @@ interface DiffSectionProps {
   visibleBodyBounds?: VisibleBodyBounds;
   viewWidth: number;
   hoverActive?: boolean;
+  hoverSuppressed?: boolean;
   onHover: () => void;
+  onMouseScroll?: () => void;
   onActiveAddNoteAffordanceChange?: (affordance: ActiveAddNoteAffordance | null) => void;
   onStartUserNoteAtHunk?: (hunkIndex: number, target?: UserNoteLineTarget) => void;
   onSelect: () => void;
@@ -56,7 +58,9 @@ function DiffSectionComponent({
   visibleBodyBounds,
   viewWidth,
   hoverActive = true,
+  hoverSuppressed = false,
   onHover,
+  onMouseScroll,
   onActiveAddNoteAffordanceChange,
   onStartUserNoteAtHunk,
   onSelect,
@@ -65,6 +69,7 @@ function DiffSectionComponent({
     <box
       id={diffSectionId(file.id)}
       onMouseOver={onHover}
+      onMouseScroll={onMouseScroll}
       style={{
         width: "100%",
         flexDirection: "column",
@@ -107,6 +112,7 @@ function DiffSectionComponent({
         width={viewWidth}
         visibleAgentNotes={visibleAgentNotes}
         hoverActive={hoverActive}
+        hoverSuppressed={hoverSuppressed}
         onHover={onHover}
         onActiveAddNoteAffordanceChange={onActiveAddNoteAffordanceChange}
         onStartUserNoteAtHunk={onStartUserNoteAtHunk}
@@ -140,6 +146,8 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
     previous.showHeader === next.showHeader &&
     previous.showSeparator === next.showSeparator &&
     previous.hoverActive === next.hoverActive &&
+    previous.hoverSuppressed === next.hoverSuppressed &&
+    previous.onMouseScroll === next.onMouseScroll &&
     previous.theme === next.theme &&
     previous.visibleAgentNotes === next.visibleAgentNotes &&
     previous.visibleBodyBounds === next.visibleBodyBounds &&

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -556,6 +556,47 @@ describe("UI components", () => {
     }
   });
 
+  test("DiffPane hides the hover add-note affordance during mouse-wheel scrolling", async () => {
+    const files = createWindowingFiles(6);
+    const theme = resolveTheme("midnight", null);
+    const props = createDiffPaneProps(files, theme, {
+      diffContentWidth: 88,
+      onStartUserNoteAtHunk: () => {},
+      separatorWidth: 84,
+      width: 92,
+    });
+    const setup = await testRender(<DiffPane {...props} />, {
+      width: 96,
+      height: 12,
+    });
+
+    try {
+      await settleDiffPane(setup);
+
+      await act(async () => {
+        await setup.mockMouse.moveTo(32, 4);
+        await setup.renderOnce();
+      });
+      let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("[+]"), 12);
+      expect(frame).toContain("[+]");
+
+      await act(async () => {
+        await setup.mockMouse.scroll(32, 4, "down");
+        await Bun.sleep(0);
+        await setup.renderOnce();
+      });
+      frame = await waitForFrame(setup, (nextFrame) => !nextFrame.includes("[+]"), 12);
+      expect(frame).not.toContain("[+]");
+
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("[+]"), 16);
+      expect(frame).toContain("[+]");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("DiffPane scrolls a later selected file into view in the windowed path", async () => {
     const files = createWindowingFiles(6);
     const theme = resolveTheme("midnight", null);

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -65,6 +65,7 @@ export function PierreDiffView({
   theme,
   visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
   hoverActive = true,
+  hoverSuppressed = false,
   width,
   selectedHunkIndex,
   sectionGeometry,
@@ -84,6 +85,7 @@ export function PierreDiffView({
   theme: AppTheme;
   visibleAgentNotes?: VisibleAgentNote[];
   hoverActive?: boolean;
+  hoverSuppressed?: boolean;
   width: number;
   selectedHunkIndex: number;
   sectionGeometry?: DiffSectionGeometry;
@@ -94,6 +96,9 @@ export function PierreDiffView({
   const renderer = useRenderer();
   const [hoveredRowKey, setHoveredRowKey] = useState<string | null>(null);
   const hoverIdleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hoverIdleDeadlineRef = useRef<number | null>(null);
+  const lastHoveredRowKeyRef = useRef<string | null>(null);
+  const previousHoverSuppressedRef = useRef(hoverSuppressed);
 
   const clearHoverIdleTimeout = useCallback(() => {
     if (hoverIdleTimeoutRef.current) {
@@ -104,22 +109,54 @@ export function PierreDiffView({
 
   const clearHoveredRow = useCallback(() => {
     clearHoverIdleTimeout();
+    hoverIdleDeadlineRef.current = null;
+    lastHoveredRowKeyRef.current = null;
     setHoveredRowKey(null);
     onActiveAddNoteAffordanceChange?.(null);
   }, [clearHoverIdleTimeout, onActiveAddNoteAffordanceChange]);
 
-  const activateHoveredRow = useCallback(
-    (rowKey: string, affordance: ActiveAddNoteAffordance) => {
-      setHoveredRowKey(rowKey);
-      onActiveAddNoteAffordanceChange?.(affordance);
+  const scheduleHoverIdleHide = useCallback(
+    (rowKey: string, clearCurrentRow: boolean) => {
       clearHoverIdleTimeout();
+      const deadline = Date.now() + ADD_NOTE_IDLE_HIDE_DELAY_MS;
+      hoverIdleDeadlineRef.current = deadline;
       hoverIdleTimeoutRef.current = setTimeout(() => {
-        setHoveredRowKey((current) => (current === rowKey ? null : current));
-        onActiveAddNoteAffordanceChange?.(null);
+        if (hoverIdleDeadlineRef.current !== deadline) {
+          return;
+        }
+
+        if (clearCurrentRow || lastHoveredRowKeyRef.current === rowKey) {
+          lastHoveredRowKeyRef.current = null;
+          setHoveredRowKey(null);
+          onActiveAddNoteAffordanceChange?.(null);
+        }
+        hoverIdleDeadlineRef.current = null;
         hoverIdleTimeoutRef.current = null;
       }, ADD_NOTE_IDLE_HIDE_DELAY_MS);
     },
     [clearHoverIdleTimeout, onActiveAddNoteAffordanceChange],
+  );
+
+  const activateHoveredRow = useCallback(
+    (rowKey: string, affordance: ActiveAddNoteAffordance) => {
+      if (hoverSuppressed) {
+        lastHoveredRowKeyRef.current = rowKey;
+        setHoveredRowKey(rowKey);
+        onActiveAddNoteAffordanceChange?.(affordance);
+        if ((hoverIdleDeadlineRef.current ?? 0) <= Date.now()) {
+          // Keep one idle deadline during scroll suppression, but let it clear whichever row
+          // ended up under the mouse after scroll-induced hover churn settles.
+          scheduleHoverIdleHide(rowKey, true);
+        }
+        return;
+      }
+
+      lastHoveredRowKeyRef.current = rowKey;
+      setHoveredRowKey(rowKey);
+      onActiveAddNoteAffordanceChange?.(affordance);
+      scheduleHoverIdleHide(rowKey, false);
+    },
+    [hoverSuppressed, onActiveAddNoteAffordanceChange, scheduleHoverIdleHide],
   );
 
   useEffect(() => {
@@ -127,6 +164,14 @@ export function PierreDiffView({
       clearHoveredRow();
     }
   }, [clearHoveredRow, hoverActive]);
+
+  useEffect(() => {
+    const wasSuppressed = previousHoverSuppressedRef.current;
+    previousHoverSuppressedRef.current = hoverSuppressed;
+    if (wasSuppressed && !hoverSuppressed && (hoverIdleDeadlineRef.current ?? 0) > Date.now()) {
+      setHoveredRowKey(lastHoveredRowKeyRef.current);
+    }
+  }, [hoverSuppressed]);
 
   useEffect(() => {
     /** Hide hover-only affordances when terminal focus leaves Hunk. */
@@ -285,7 +330,11 @@ export function PierreDiffView({
               selected={plannedRow.row.hunkIndex === selectedHunkIndex}
               anchorId={plannedRow.anchorId}
               noteGuideSide={plannedRow.noteGuideSide}
-              showAddNoteBadge={hoveredRowKey === plannedRow.key && Boolean(onStartUserNoteAtHunk)}
+              showAddNoteBadge={
+                !hoverSuppressed &&
+                hoveredRowKey === plannedRow.key &&
+                Boolean(onStartUserNoteAtHunk)
+              }
               onHoverRow={() => {
                 onHover?.();
                 activateHoveredRow(plannedRow.key, addNoteAffordanceForRow(plannedRow.row));


### PR DESCRIPTION
## Summary
- hide the hover-only `[+]` add-note badge during mouse wheel scrolling
- restore the badge after the short scroll suppression window if the hover idle timeout is still active
- keep the active add-note target updated while the badge is visually suppressed

## Tests
- bun run typecheck
- bun test src/ui/components/ui-components.test.tsx
- bun test src/ui/components/ui-components.test.tsx -t "DiffPane hides the hover add-note"
- bun run lint