### PR TITLE
fix(ui): only show add-note affordance after pointer movement

### DIFF
--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -52,7 +52,6 @@ import type { VisibleBodyBounds } from "../../diff/rowWindowing";
 import { prefetchHighlightedDiff } from "../../diff/useHighlightedDiff";
 
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
-const ADD_NOTE_SCROLL_SUPPRESS_DELAY_MS = 160;
 
 /**
  * Clamp one vertical scroll target into the currently reachable review-stream extent.
@@ -219,28 +218,13 @@ export function DiffPane({
     () => createReviewMouseWheelScrollAcceleration(),
     [],
   );
-  const addNoteHoverSuppressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [addNoteHoverSuppressed, setAddNoteHoverSuppressed] = useState(false);
+  const [addNoteHoverClearSignal, setAddNoteHoverClearSignal] = useState(0);
 
-  /** Temporarily hide hover-only row controls during wheel scrolling so they do not flicker row-by-row. */
-  const suppressAddNoteHoverForMouseScroll = useCallback(() => {
-    setAddNoteHoverSuppressed(true);
-    if (addNoteHoverSuppressTimeoutRef.current) {
-      clearTimeout(addNoteHoverSuppressTimeoutRef.current);
-    }
-    addNoteHoverSuppressTimeoutRef.current = setTimeout(() => {
-      setAddNoteHoverSuppressed(false);
-      addNoteHoverSuppressTimeoutRef.current = null;
-    }, ADD_NOTE_SCROLL_SUPPRESS_DELAY_MS);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (addNoteHoverSuppressTimeoutRef.current) {
-        clearTimeout(addNoteHoverSuppressTimeoutRef.current);
-      }
-    };
-  }, []);
+  /** Hide hover-only row controls when content scrolls under a stationary mouse pointer. */
+  const clearAddNoteHoverForScroll = useCallback(() => {
+    setAddNoteHoverClearSignal((current) => current + 1);
+    onActiveAddNoteAffordanceChange?.(null);
+  }, [onActiveAddNoteAffordanceChange]);
 
   const adjacentPrefetchFileIds = useMemo(
     () => buildAdjacentPrefetchFileIds(files, selectedFileId),
@@ -256,7 +240,7 @@ export function DiffPane({
         return;
       }
 
-      suppressAddNoteHoverForMouseScroll();
+      clearAddNoteHoverForScroll();
 
       if (!scrollBox || wrapLines) {
         return;
@@ -302,7 +286,7 @@ export function DiffPane({
       event.preventDefault();
       event.stopPropagation();
     },
-    [onScrollCodeHorizontally, scrollRef, suppressAddNoteHoverForMouseScroll, wrapLines],
+    [clearAddNoteHoverForScroll, onScrollCodeHorizontally, scrollRef, wrapLines],
   );
 
   const allAgentNotesByFile = useMemo(() => {
@@ -438,9 +422,11 @@ export function DiffPane({
       const nextTop = scrollBox.scrollTop ?? 0;
       const nextHeight = scrollBox.viewport.height ?? 0;
 
-      // Detect scroll activity and show scrollbar.
+      // Detect scroll activity, show scrollbar, and clear hover-only controls. The pointer may
+      // now sit over a different row, but only an actual mouse move should reveal row actions.
       if (nextTop !== prevScrollTopRef.current) {
         scrollbarRef.current?.show();
+        clearAddNoteHoverForScroll();
         prevScrollTopRef.current = nextTop;
       }
 
@@ -488,7 +474,7 @@ export function DiffPane({
       scrollBox.viewport.off("layout-changed", handleViewportChange);
       scrollBox.viewport.off("resized", handleViewportChange);
     };
-  }, [files.length, scrollRef]);
+  }, [clearAddNoteHoverForScroll, files.length, scrollRef]);
 
   const sectionHeaderHeights = useMemo(() => buildInStreamFileHeaderHeights(files), [files]);
 
@@ -1324,14 +1310,14 @@ export function DiffPane({
                       wrapLines={wrapLines}
                       theme={theme}
                       hoverActive={hoveredFileId === null || hoveredFileId === file.id}
-                      hoverSuppressed={addNoteHoverSuppressed}
+                      hoverClearSignal={addNoteHoverClearSignal}
                       viewWidth={diffContentWidth}
                       visibleAgentNotes={
                         visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
                       }
                       visibleBodyBounds={visibleBodyBoundsByFile.get(file.id)}
                       onHover={() => setHoveredFileId(file.id)}
-                      onMouseScroll={suppressAddNoteHoverForMouseScroll}
+                      onMouseScroll={clearAddNoteHoverForScroll}
                       onActiveAddNoteAffordanceChange={(affordance) =>
                         onActiveAddNoteAffordanceChange?.(
                           affordance ? { ...affordance, fileId: file.id } : null,

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -29,7 +29,7 @@ interface DiffSectionProps {
   visibleBodyBounds?: VisibleBodyBounds;
   viewWidth: number;
   hoverActive?: boolean;
-  hoverSuppressed?: boolean;
+  hoverClearSignal?: number;
   onHover: () => void;
   onMouseScroll?: () => void;
   onActiveAddNoteAffordanceChange?: (affordance: ActiveAddNoteAffordance | null) => void;
@@ -58,7 +58,7 @@ function DiffSectionComponent({
   visibleBodyBounds,
   viewWidth,
   hoverActive = true,
-  hoverSuppressed = false,
+  hoverClearSignal = 0,
   onHover,
   onMouseScroll,
   onActiveAddNoteAffordanceChange,
@@ -112,7 +112,7 @@ function DiffSectionComponent({
         width={viewWidth}
         visibleAgentNotes={visibleAgentNotes}
         hoverActive={hoverActive}
-        hoverSuppressed={hoverSuppressed}
+        hoverClearSignal={hoverClearSignal}
         onHover={onHover}
         onActiveAddNoteAffordanceChange={onActiveAddNoteAffordanceChange}
         onStartUserNoteAtHunk={onStartUserNoteAtHunk}
@@ -146,7 +146,7 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
     previous.showHeader === next.showHeader &&
     previous.showSeparator === next.showSeparator &&
     previous.hoverActive === next.hoverActive &&
-    previous.hoverSuppressed === next.hoverSuppressed &&
+    previous.hoverClearSignal === next.hoverClearSignal &&
     previous.onMouseScroll === next.onMouseScroll &&
     previous.theme === next.theme &&
     previous.visibleAgentNotes === next.visibleAgentNotes &&

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -556,11 +556,13 @@ describe("UI components", () => {
     }
   });
 
-  test("DiffPane hides the hover add-note affordance during mouse-wheel scrolling", async () => {
+  test("DiffPane only shows the add-note affordance after pointer movement", async () => {
     const files = createWindowingFiles(6);
     const theme = resolveTheme("midnight", null);
+    const scrollRef = createRef<ScrollBoxRenderable>();
     const props = createDiffPaneProps(files, theme, {
       diffContentWidth: 88,
+      scrollRef,
       onStartUserNoteAtHunk: () => {},
       separatorWidth: 84,
       width: 92,
@@ -588,8 +590,27 @@ describe("UI components", () => {
       frame = await waitForFrame(setup, (nextFrame) => !nextFrame.includes("[+]"), 12);
       expect(frame).not.toContain("[+]");
 
-      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("[+]"), 16);
+      await act(async () => {
+        await Bun.sleep(250);
+        await setup.renderOnce();
+      });
+      frame = setup.captureCharFrame();
+      expect(frame).not.toContain("[+]");
+
+      await act(async () => {
+        await setup.mockMouse.moveTo(34, 4);
+        await setup.renderOnce();
+      });
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("[+]"), 12);
       expect(frame).toContain("[+]");
+
+      await act(async () => {
+        scrollRef.current?.scrollTo({ x: 0, y: 2 });
+        await Bun.sleep(0);
+        await setup.renderOnce();
+      });
+      frame = await waitForFrame(setup, (nextFrame) => !nextFrame.includes("[+]"), 12);
+      expect(frame).not.toContain("[+]");
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -65,7 +65,7 @@ export function PierreDiffView({
   theme,
   visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
   hoverActive = true,
-  hoverSuppressed = false,
+  hoverClearSignal = 0,
   width,
   selectedHunkIndex,
   sectionGeometry,
@@ -85,7 +85,7 @@ export function PierreDiffView({
   theme: AppTheme;
   visibleAgentNotes?: VisibleAgentNote[];
   hoverActive?: boolean;
-  hoverSuppressed?: boolean;
+  hoverClearSignal?: number;
   width: number;
   selectedHunkIndex: number;
   sectionGeometry?: DiffSectionGeometry;
@@ -96,9 +96,7 @@ export function PierreDiffView({
   const renderer = useRenderer();
   const [hoveredRowKey, setHoveredRowKey] = useState<string | null>(null);
   const hoverIdleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const hoverIdleDeadlineRef = useRef<number | null>(null);
-  const lastHoveredRowKeyRef = useRef<string | null>(null);
-  const previousHoverSuppressedRef = useRef(hoverSuppressed);
+  const previousHoverClearSignalRef = useRef(hoverClearSignal);
 
   const clearHoverIdleTimeout = useCallback(() => {
     if (hoverIdleTimeoutRef.current) {
@@ -109,54 +107,22 @@ export function PierreDiffView({
 
   const clearHoveredRow = useCallback(() => {
     clearHoverIdleTimeout();
-    hoverIdleDeadlineRef.current = null;
-    lastHoveredRowKeyRef.current = null;
     setHoveredRowKey(null);
     onActiveAddNoteAffordanceChange?.(null);
   }, [clearHoverIdleTimeout, onActiveAddNoteAffordanceChange]);
 
-  const scheduleHoverIdleHide = useCallback(
-    (rowKey: string, clearCurrentRow: boolean) => {
+  const activateHoveredRow = useCallback(
+    (rowKey: string, affordance: ActiveAddNoteAffordance) => {
+      setHoveredRowKey(rowKey);
+      onActiveAddNoteAffordanceChange?.(affordance);
       clearHoverIdleTimeout();
-      const deadline = Date.now() + ADD_NOTE_IDLE_HIDE_DELAY_MS;
-      hoverIdleDeadlineRef.current = deadline;
       hoverIdleTimeoutRef.current = setTimeout(() => {
-        if (hoverIdleDeadlineRef.current !== deadline) {
-          return;
-        }
-
-        if (clearCurrentRow || lastHoveredRowKeyRef.current === rowKey) {
-          lastHoveredRowKeyRef.current = null;
-          setHoveredRowKey(null);
-          onActiveAddNoteAffordanceChange?.(null);
-        }
-        hoverIdleDeadlineRef.current = null;
+        setHoveredRowKey((current) => (current === rowKey ? null : current));
+        onActiveAddNoteAffordanceChange?.(null);
         hoverIdleTimeoutRef.current = null;
       }, ADD_NOTE_IDLE_HIDE_DELAY_MS);
     },
     [clearHoverIdleTimeout, onActiveAddNoteAffordanceChange],
-  );
-
-  const activateHoveredRow = useCallback(
-    (rowKey: string, affordance: ActiveAddNoteAffordance) => {
-      if (hoverSuppressed) {
-        lastHoveredRowKeyRef.current = rowKey;
-        setHoveredRowKey(rowKey);
-        onActiveAddNoteAffordanceChange?.(affordance);
-        if ((hoverIdleDeadlineRef.current ?? 0) <= Date.now()) {
-          // Keep one idle deadline during scroll suppression, but let it clear whichever row
-          // ended up under the mouse after scroll-induced hover churn settles.
-          scheduleHoverIdleHide(rowKey, true);
-        }
-        return;
-      }
-
-      lastHoveredRowKeyRef.current = rowKey;
-      setHoveredRowKey(rowKey);
-      onActiveAddNoteAffordanceChange?.(affordance);
-      scheduleHoverIdleHide(rowKey, false);
-    },
-    [hoverSuppressed, onActiveAddNoteAffordanceChange, scheduleHoverIdleHide],
   );
 
   useEffect(() => {
@@ -166,12 +132,13 @@ export function PierreDiffView({
   }, [clearHoveredRow, hoverActive]);
 
   useEffect(() => {
-    const wasSuppressed = previousHoverSuppressedRef.current;
-    previousHoverSuppressedRef.current = hoverSuppressed;
-    if (wasSuppressed && !hoverSuppressed && (hoverIdleDeadlineRef.current ?? 0) > Date.now()) {
-      setHoveredRowKey(lastHoveredRowKeyRef.current);
+    if (previousHoverClearSignalRef.current === hoverClearSignal) {
+      return;
     }
-  }, [hoverSuppressed]);
+
+    previousHoverClearSignalRef.current = hoverClearSignal;
+    clearHoveredRow();
+  }, [clearHoveredRow, hoverClearSignal]);
 
   useEffect(() => {
     /** Hide hover-only affordances when terminal focus leaves Hunk. */
@@ -309,15 +276,7 @@ export function PierreDiffView({
         }
 
         return (
-          <box
-            key={plannedRow.key}
-            id={rowId}
-            style={{ width: "100%", flexDirection: "column" }}
-            onMouseOver={() => {
-              onHover?.();
-              activateHoveredRow(plannedRow.key, addNoteAffordanceForRow(plannedRow.row));
-            }}
-          >
+          <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
             <DiffRowView
               row={plannedRow.row}
               width={width}
@@ -330,11 +289,7 @@ export function PierreDiffView({
               selected={plannedRow.row.hunkIndex === selectedHunkIndex}
               anchorId={plannedRow.anchorId}
               noteGuideSide={plannedRow.noteGuideSide}
-              showAddNoteBadge={
-                !hoverSuppressed &&
-                hoveredRowKey === plannedRow.key &&
-                Boolean(onStartUserNoteAtHunk)
-              }
+              showAddNoteBadge={hoveredRowKey === plannedRow.key && Boolean(onStartUserNoteAtHunk)}
               onHoverRow={() => {
                 onHover?.();
                 activateHoveredRow(plannedRow.key, addNoteAffordanceForRow(plannedRow.row));

--- a/test/pty/ui-integration.test.ts
+++ b/test/pty/ui-integration.test.ts
@@ -531,6 +531,53 @@ describe("live UI integration", () => {
     }
   });
 
+  test("add-note affordance appears only after mouse movement in a real PTY", async () => {
+    const fixture = harness.createScrollableFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      cols: 120,
+      rows: 12,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      await moveMouse(session, 8, 5);
+      await session.waitForText(/\[\+\]/, { timeout: 5_000 });
+
+      await session.scrollDown(2);
+      const afterWheel = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("[+]"),
+        5_000,
+      );
+      expect(afterWheel).not.toContain("[+]");
+
+      await sleep(250);
+      const afterWheelIdle = await session.text({ immediate: true });
+      expect(afterWheelIdle).not.toContain("[+]");
+
+      await moveMouse(session, 9, 5);
+      await session.waitForText(/\[\+\]/, { timeout: 5_000 });
+
+      await session.press("down");
+      const afterKeyboard = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("[+]"),
+        5_000,
+      );
+      expect(afterKeyboard).not.toContain("[+]");
+
+      await sleep(250);
+      const afterKeyboardIdle = await session.text({ immediate: true });
+      expect(afterKeyboardIdle).not.toContain("[+]");
+    } finally {
+      session.close();
+    }
+  });
+
   test("clicking diff add-note affordances can cancel and save draft notes", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Summary
- clear the hover-only `[+]` affordance whenever review content scrolls under the pointer
- stop row `onMouseOver` from activating `[+]`; only `onMouseMove` now activates it
- keep `[+]` hidden after wheel, keyboard, or programmatic scroll until the pointer actually moves again

## Tests
- bun run typecheck
- bun test src/ui/components/ui-components.test.tsx
- bun test src/ui/components/ui-components.test.tsx -t "DiffPane only shows"
- bun run lint