### PR TITLE
test(ui): fix broken plannedReviewRows test on main

### DIFF
--- a/src/ui/diff/plannedReviewRows.test.ts
+++ b/src/ui/diff/plannedReviewRows.test.ts
@@ -91,20 +91,49 @@ function inlineNote(key: string, hunkIndex: number): PlannedReviewRow {
       summary: "Explain why this branch changed.",
       rationale: "The note should reserve space in the hunk bounds.",
     },
+    note: {
+      id: "note-1",
+      annotation: {
+        id: "note-1",
+        newRange: [1, 1],
+        summary: "Explain why this branch changed.",
+        rationale: "The note should reserve space in the hunk bounds.",
+      },
+    },
     anchorSide: "new",
     noteCount: 1,
     noteIndex: 0,
   };
 }
 
+// Inline notes were unified into the diff-row stream, so the standalone "note-guide-cap" row
+// kind is gone: a guide cap is now a regular diff-row that carries a noteGuideSide marker.
 function guideCap(key: string, hunkIndex: number): PlannedReviewRow {
   return {
-    kind: "note-guide-cap",
+    kind: "diff-row",
     key,
     stableKey: key,
     fileId: "file-1",
     hunkIndex,
-    side: "new",
+    noteGuideSide: "new",
+    row: {
+      type: "split-line",
+      key,
+      fileId: "file-1",
+      hunkIndex,
+      left: {
+        kind: "deletion",
+        sign: "-",
+        lineNumber: 1,
+        spans: [{ text: "old" }],
+      },
+      right: {
+        kind: "addition",
+        sign: "+",
+        lineNumber: 1,
+        spans: [{ text: "new" }],
+      },
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

`main` currently fails `tsc` (and therefore the Typecheck + Test + Smoke CI job) independently of any open PR.

PR #317 (`feat: unify inline notes and expand behavior coverage`) unified inline notes into the diff-row stream:
- `inline-note` rows now require a `note: VisibleAgentNote` field
- the standalone `note-guide-cap` row kind was removed (a guide cap is now a `diff-row` carrying `noteGuideSide`)

But its colocated `src/ui/diff/plannedReviewRows.test.ts` still constructed the old shapes, so `tsc` fails on `main`:

```
plannedReviewRows.test.ts(81,3): error TS2322: Property 'note' is missing ... PlannedReviewRow
plannedReviewRows.test.ts(102,5): error TS2322: Type '"note-guide-cap"' is not assignable to type '"diff-row" | "inline-note"'
```

## Changes

Test-only. Update the two stale helpers to the current `PlannedReviewRow` model:
- `inlineNote()` now includes the required `note` field
- `guideCap()` now returns a `diff-row` with `noteGuideSide: "new"` (the unified representation)

No assertions changed — a guide cap is still a 1-height row that contributes to hunk bounds, so all three geometry tests pass with their original expected values.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun test src/ui/diff/plannedReviewRows.test.ts` — 3 pass

No CHANGELOG entry: test-only, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)