### PR TITLE
docs: migrate sponsor link to canonical UTM convention (GTM-32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ For source setup, tests, packaging checks, and repo architecture, see [CONTRIBUT
 
 ## Sponsor
 
-Sponsored by [Modem](https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=hunk).
+Sponsored by [Modem](https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=oss_hunk&utm_content=readme_footer).
 
-<a href="https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=hunk">
+<a href="https://modem.dev?utm_source=github&utm_medium=oss&utm_campaign=oss_hunk&utm_content=readme_footer">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://modem.dev/images/logo/svg/modem-combined-white.svg">
     <source media="(prefers-color-scheme: light)" srcset="https://modem.dev/images/logo/svg/modem-combined-black.svg">


### PR DESCRIPTION
## Summary

Migrates the README sponsor link's UTM params to the canonical "Modem-owned repo README" row in the GTM [UTM Tagging Strategy](https://www.notion.so/UTM-Tagging-Strategy-3642c5842de0816cacfdd83ac1d4d6e7) (updated 2026-05-18):

- `utm_campaign`: `hunk` → `oss_hunk`
- `utm_content`: (none) → `readme_footer`

Aligns with the convention applied to newly-shipped sponsor blocks in `modem-dev/baudbot` (GTM-29) and `modem-dev/glance-agent-plugins` (GTM-30). Companion PRs land in `modem-dev/slop-scan` and `modem-dev/podguy` on the same branch name.

## Linear

[GTM-32](https://linear.app/modem-dev/issue/GTM-32) — Migrate slop-scan, hunk, podguy sponsor links to canonical UTM convention

## Changes

- Update both occurrences of the sponsor link (text + `<a href>` wrapping the `<picture>`)

## Testing

- [x] README renders correctly in GitHub markdown preview
- [ ] After merge: confirm `$pageview` with `utm_campaign=oss_hunk` lands in PostHog within ~24h (hunk is the highest-traffic of the three, fastest to verify)

## Related

- UTM Generator (Notion) row needs `Campaign`/`Content` updated to match after merge