### PR TITLE
feat(diff): add a keyboard- and mouse-driven comment cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ All notable user-visible changes to Hunk are documented in this file.
 ### Added
 
 - Added a keyboard-driven comment cursor (`c`) so reviewers can mark a diff row, type a single-line note with `i` / Enter, and persist it as a user-authored review comment that agents pick up through the existing `hunk session comment *` commands.
+- Added mouse support to the comment cursor: clicking any addition or deletion row positions the cursor and enters cursor mode, ready for `i` / Enter to open the composer.
+- Added an orange "My note" palette for user-authored review notes so they read distinctly from purple AI notes across all four built-in themes.
 
 ### Changed
 
+- Highlighted the entire diff row under the comment cursor (not just the left rail) and dropped the redundant trailing cap on single-row inline notes so the review stream reads cleaner.
+- Auto-scroll the review stream so the comment cursor stays in view when keyboard navigation crosses past the viewport edge.
+
 ### Fixed
 
+- Fixed the comment cursor painting in every file that happened to share the same hunk/side/line as the active cursor; it now appears only in the file the cursor is actually in.
+- Fixed clicking a diff row stealing focus into the review scrollbox so that arrow keys no longer scroll and move the cursor at the same time.
 - Included the bundled Hunk review skill in standalone prebuilt release archives so `hunk skill path` works after extracting a tarball or installing via Homebrew.
 
 ## [0.12.0] - 2026-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+- Added a keyboard-driven comment cursor (`c`) so reviewers can mark a diff row, type a single-line note with `i` / Enter, and persist it as a user-authored review comment that agents pick up through the existing `hunk session comment *` commands.
+
 ### Changed
 
 ### Fixed

--- a/docs/superpowers/plans/2026-05-14-comment-cursor-ui.md
+++ b/docs/superpowers/plans/2026-05-14-comment-cursor-ui.md
@@ -40,6 +40,7 @@
 ### Task 1: Widen `LiveComment.source`
 
 **Files:**
+
 - Modify: `src/hunk-session/types.ts`
 
 - [ ] **Step 1: Widen the source union**
@@ -82,6 +83,7 @@ git commit -m "refactor(types): widen LiveComment.source to accept user-authored
 ### Task 2: Add `buildUserLiveComment`
 
 **Files:**
+
 - Modify: `src/core/liveComments.ts`
 - Test: `src/core/liveComments.test.ts`
 
@@ -90,57 +92,57 @@ git commit -m "refactor(types): widen LiveComment.source to accept user-authored
 In `src/core/liveComments.test.ts`, append inside the `describe("live comment helpers", ...)` block:
 
 ```ts
-  test("builds a live user comment annotation", () => {
-    const comment = buildUserLiveComment(
-      {
-        filePath: "src/example.ts",
-        side: "new",
-        line: 4,
-        summary: "Look at this addition",
-        author: "andrew",
-      },
-      "user:test-1",
-      "2026-05-14T00:00:00.000Z",
-      0,
-    );
-
-    expect(comment).toMatchObject({
-      id: "user:test-1",
-      source: "user",
-      author: "andrew",
+test("builds a live user comment annotation", () => {
+  const comment = buildUserLiveComment(
+    {
       filePath: "src/example.ts",
-      hunkIndex: 0,
       side: "new",
       line: 4,
       summary: "Look at this addition",
-      newRange: [4, 4],
-      tags: ["user"],
-    });
-    expect(comment.confidence).toBeUndefined();
+      author: "andrew",
+    },
+    "user:test-1",
+    "2026-05-14T00:00:00.000Z",
+    0,
+  );
+
+  expect(comment).toMatchObject({
+    id: "user:test-1",
+    source: "user",
+    author: "andrew",
+    filePath: "src/example.ts",
+    hunkIndex: 0,
+    side: "new",
+    line: 4,
+    summary: "Look at this addition",
+    newRange: [4, 4],
+    tags: ["user"],
   });
+  expect(comment.confidence).toBeUndefined();
+});
 
-  test("builds an old-side user comment with an oldRange instead of newRange", () => {
-    const comment = buildUserLiveComment(
-      {
-        filePath: "src/example.ts",
-        side: "old",
-        line: 2,
-        summary: "Why was this removed?",
-      },
-      "user:test-2",
-      "2026-05-14T00:00:00.000Z",
-      0,
-    );
-
-    expect(comment).toMatchObject({
-      source: "user",
+test("builds an old-side user comment with an oldRange instead of newRange", () => {
+  const comment = buildUserLiveComment(
+    {
+      filePath: "src/example.ts",
       side: "old",
       line: 2,
-      oldRange: [2, 2],
-      tags: ["user"],
-    });
-    expect(comment.newRange).toBeUndefined();
+      summary: "Why was this removed?",
+    },
+    "user:test-2",
+    "2026-05-14T00:00:00.000Z",
+    0,
+  );
+
+  expect(comment).toMatchObject({
+    source: "user",
+    side: "old",
+    line: 2,
+    oldRange: [2, 2],
+    tags: ["user"],
   });
+  expect(comment.newRange).toBeUndefined();
+});
 ```
 
 Add the new import at the top of the file, replacing the existing `liveComments` import line:
@@ -209,6 +211,7 @@ git commit -m "feat(comments): add buildUserLiveComment for cursor-authored comm
 ### Task 3: Cursor geometry helpers
 
 **Files:**
+
 - Create: `src/ui/lib/commentCursor.ts`
 - Test: `src/ui/lib/commentCursor.test.ts`
 
@@ -355,9 +358,7 @@ describe("moveCursor", () => {
   });
 
   test("returns null when given an empty file list", () => {
-    expect(
-      moveCursor([], { fileId: "ghost", hunkIndex: 0, side: "new", line: 1 }, 1),
-    ).toBeNull();
+    expect(moveCursor([], { fileId: "ghost", hunkIndex: 0, side: "new", line: 1 }, 1)).toBeNull();
   });
 });
 ```
@@ -403,10 +404,7 @@ export function cursorRowStableKey(cursor: CommentCursorPosition): string {
 }
 
 /** Walk through every content line of a hunk on the cursor's anchor side. */
-function* walkHunkLines(
-  hunk: Hunk,
-  side: DiffSide,
-): Generator<{ side: DiffSide; line: number }> {
+function* walkHunkLines(hunk: Hunk, side: DiffSide): Generator<{ side: DiffSide; line: number }> {
   const range = hunkLineRange(hunk);
   const [start, end] = side === "new" ? range.newRange : range.oldRange;
 
@@ -416,10 +414,7 @@ function* walkHunkLines(
 }
 
 /** Build the ordered list of cursor positions for the full review stream on the cursor's side. */
-function buildCursorPositions(
-  files: DiffFile[],
-  preferredSide: DiffSide,
-): CommentCursorPosition[] {
+function buildCursorPositions(files: DiffFile[], preferredSide: DiffSide): CommentCursorPosition[] {
   const positions: CommentCursorPosition[] = [];
 
   for (const file of files) {
@@ -487,6 +482,7 @@ git commit -m "feat(ui): add commentCursor geometry helpers"
 ### Task 4: Cursor state in `useReviewController`
 
 **Files:**
+
 - Modify: `src/ui/hooks/useReviewController.ts`
 - Test: `src/ui/hooks/useReviewController.test.tsx`
 
@@ -624,16 +620,14 @@ Extend the `ReviewController` interface to add (place these next to the existing
 Inside `useReviewController`, near the other `useState` calls, add:
 
 ```ts
-  const [commentCursor, setCommentCursor] = useState<CommentCursorState>(() => ({
-    mode: "off",
-    fileId: files[0]?.id ?? "",
-    hunkIndex: 0,
-    side: "new",
-    line: files[0]?.metadata.hunks[0]
-      ? firstCursorTargetForHunk(files[0], 0).line
-      : 1,
-  }));
-  const userCommentCounterRef = useRef(0);
+const [commentCursor, setCommentCursor] = useState<CommentCursorState>(() => ({
+  mode: "off",
+  fileId: files[0]?.id ?? "",
+  hunkIndex: 0,
+  side: "new",
+  line: files[0]?.metadata.hunks[0] ? firstCursorTargetForHunk(files[0], 0).line : 1,
+}));
+const userCommentCounterRef = useRef(0);
 ```
 
 Add `useRef` to the React import at the top of the file if it is not already present:
@@ -653,187 +647,184 @@ import {
 Define the cursor actions (place these after `clearLiveComments` and before the controller return statement):
 
 ```ts
-  /** Enter, switch, or leave the cursor mode. Seeds position from the selected hunk on enter. */
-  const setCommentCursorMode = useCallback(
-    (mode: CommentCursorMode) => {
-      setCommentCursor((current) => {
-        if (mode === "off") {
-          return { ...current, mode };
-        }
-
-        if (current.mode !== "off") {
-          return { ...current, mode };
-        }
-
-        const file = visibleFiles.find((entry) => entry.id === selectedFileId) ?? visibleFiles[0];
-        if (!file || file.metadata.hunks.length === 0) {
-          return { ...current, mode };
-        }
-
-        const hunkIndex = Math.max(
-          0,
-          Math.min(selectedHunkIndex, file.metadata.hunks.length - 1),
-        );
-        const anchor = firstCursorTargetForHunk(file, hunkIndex);
-        return {
-          mode,
-          fileId: file.id,
-          hunkIndex,
-          side: anchor.side,
-          line: anchor.line,
-        };
-      });
-    },
-    [selectedFileId, selectedHunkIndex, visibleFiles],
-  );
-
-  /** Walk the cursor row-by-row through the review stream. */
-  const moveCommentCursor = useCallback(
-    (delta: number) => {
-      setCommentCursor((current) => {
-        if (current.mode === "off") {
-          return current;
-        }
-
-        const next = moveCursor(visibleFiles, current, delta);
-        if (!next) {
-          return current;
-        }
-
-        return { ...current, ...next };
-      });
-    },
-    [visibleFiles],
-  );
-
-  /** Jump the cursor to the first content row of the previous or next hunk. */
-  const jumpCommentCursorToHunk = useCallback(
-    (delta: number) => {
-      setCommentCursor((current) => {
-        if (current.mode === "off") {
-          return current;
-        }
-
-        const fileIndex = visibleFiles.findIndex((file) => file.id === current.fileId);
-        if (fileIndex < 0) {
-          return current;
-        }
-
-        let nextFileIndex = fileIndex;
-        let nextHunkIndex = current.hunkIndex + delta;
-
-        while (true) {
-          const file = visibleFiles[nextFileIndex];
-          if (!file) {
-            return current;
-          }
-
-          if (nextHunkIndex >= 0 && nextHunkIndex < file.metadata.hunks.length) {
-            const anchor = firstCursorTargetForHunk(file, nextHunkIndex);
-            return {
-              ...current,
-              fileId: file.id,
-              hunkIndex: nextHunkIndex,
-              side: anchor.side,
-              line: anchor.line,
-            };
-          }
-
-          if (delta > 0) {
-            nextFileIndex += 1;
-            nextHunkIndex = 0;
-          } else {
-            nextFileIndex -= 1;
-            const previous = visibleFiles[nextFileIndex];
-            if (!previous) {
-              return current;
-            }
-            nextHunkIndex = previous.metadata.hunks.length - 1;
-          }
-        }
-      });
-    },
-    [visibleFiles],
-  );
-
-  /** Persist one user-authored comment using the same store as MCP comments. */
-  const addUserLiveComment = useCallback(
-    (target: AddUserLiveCommentTarget, summary: string): AppliedCommentResult => {
-      const file = allFiles.find((entry) => entry.id === target.fileId);
-      if (!file) {
-        throw new Error(`No diff file matches ${target.fileId}.`);
+/** Enter, switch, or leave the cursor mode. Seeds position from the selected hunk on enter. */
+const setCommentCursorMode = useCallback(
+  (mode: CommentCursorMode) => {
+    setCommentCursor((current) => {
+      if (mode === "off") {
+        return { ...current, mode };
       }
 
-      const trimmed = summary.trim();
-      if (!trimmed) {
-        throw new Error("User comments must have a non-empty summary.");
+      if (current.mode !== "off") {
+        return { ...current, mode };
       }
 
-      userCommentCounterRef.current += 1;
-      const commentId = `user:${Date.now()}-${userCommentCounterRef.current}`;
-      const liveComment = buildUserLiveComment(
-        {
-          filePath: file.path,
-          side: target.side,
-          line: target.line,
-          summary: trimmed,
-          author: target.author,
-        },
-        commentId,
-        new Date().toISOString(),
-        target.hunkIndex,
-      );
+      const file = visibleFiles.find((entry) => entry.id === selectedFileId) ?? visibleFiles[0];
+      if (!file || file.metadata.hunks.length === 0) {
+        return { ...current, mode };
+      }
 
-      setLiveCommentsByFileId((current) => ({
-        ...current,
-        [file.id]: [...(current[file.id] ?? []), liveComment],
-      }));
-
+      const hunkIndex = Math.max(0, Math.min(selectedHunkIndex, file.metadata.hunks.length - 1));
+      const anchor = firstCursorTargetForHunk(file, hunkIndex);
       return {
-        commentId,
+        mode,
         fileId: file.id,
-        filePath: file.path,
-        hunkIndex: target.hunkIndex,
-        side: target.side,
-        line: target.line,
+        hunkIndex,
+        side: anchor.side,
+        line: anchor.line,
       };
-    },
-    [allFiles],
-  );
+    });
+  },
+  [selectedFileId, selectedHunkIndex, visibleFiles],
+);
 
-  const commentCursorRowStableKey =
-    commentCursor.mode === "off" ? null : cursorRowStableKey(commentCursor);
-```
-
-Add a reconcile effect so the cursor never points at a file that disappeared from the visible stream. Place it next to the existing `reconcileSelectedFile` effect block:
-
-```ts
-  useEffect(() => {
+/** Walk the cursor row-by-row through the review stream. */
+const moveCommentCursor = useCallback(
+  (delta: number) => {
     setCommentCursor((current) => {
       if (current.mode === "off") {
         return current;
       }
 
-      const file = visibleFiles.find((entry) => entry.id === current.fileId);
-      if (file && current.hunkIndex < file.metadata.hunks.length) {
+      const next = moveCursor(visibleFiles, current, delta);
+      if (!next) {
         return current;
       }
 
-      const fallbackFile = visibleFiles[0];
-      if (!fallbackFile || fallbackFile.metadata.hunks.length === 0) {
-        return { ...current, mode: "off" };
+      return { ...current, ...next };
+    });
+  },
+  [visibleFiles],
+);
+
+/** Jump the cursor to the first content row of the previous or next hunk. */
+const jumpCommentCursorToHunk = useCallback(
+  (delta: number) => {
+    setCommentCursor((current) => {
+      if (current.mode === "off") {
+        return current;
       }
 
-      const anchor = firstCursorTargetForHunk(fallbackFile, 0);
-      return {
-        mode: current.mode,
-        fileId: fallbackFile.id,
-        hunkIndex: 0,
-        side: anchor.side,
-        line: anchor.line,
-      };
+      const fileIndex = visibleFiles.findIndex((file) => file.id === current.fileId);
+      if (fileIndex < 0) {
+        return current;
+      }
+
+      let nextFileIndex = fileIndex;
+      let nextHunkIndex = current.hunkIndex + delta;
+
+      while (true) {
+        const file = visibleFiles[nextFileIndex];
+        if (!file) {
+          return current;
+        }
+
+        if (nextHunkIndex >= 0 && nextHunkIndex < file.metadata.hunks.length) {
+          const anchor = firstCursorTargetForHunk(file, nextHunkIndex);
+          return {
+            ...current,
+            fileId: file.id,
+            hunkIndex: nextHunkIndex,
+            side: anchor.side,
+            line: anchor.line,
+          };
+        }
+
+        if (delta > 0) {
+          nextFileIndex += 1;
+          nextHunkIndex = 0;
+        } else {
+          nextFileIndex -= 1;
+          const previous = visibleFiles[nextFileIndex];
+          if (!previous) {
+            return current;
+          }
+          nextHunkIndex = previous.metadata.hunks.length - 1;
+        }
+      }
     });
-  }, [visibleFiles]);
+  },
+  [visibleFiles],
+);
+
+/** Persist one user-authored comment using the same store as MCP comments. */
+const addUserLiveComment = useCallback(
+  (target: AddUserLiveCommentTarget, summary: string): AppliedCommentResult => {
+    const file = allFiles.find((entry) => entry.id === target.fileId);
+    if (!file) {
+      throw new Error(`No diff file matches ${target.fileId}.`);
+    }
+
+    const trimmed = summary.trim();
+    if (!trimmed) {
+      throw new Error("User comments must have a non-empty summary.");
+    }
+
+    userCommentCounterRef.current += 1;
+    const commentId = `user:${Date.now()}-${userCommentCounterRef.current}`;
+    const liveComment = buildUserLiveComment(
+      {
+        filePath: file.path,
+        side: target.side,
+        line: target.line,
+        summary: trimmed,
+        author: target.author,
+      },
+      commentId,
+      new Date().toISOString(),
+      target.hunkIndex,
+    );
+
+    setLiveCommentsByFileId((current) => ({
+      ...current,
+      [file.id]: [...(current[file.id] ?? []), liveComment],
+    }));
+
+    return {
+      commentId,
+      fileId: file.id,
+      filePath: file.path,
+      hunkIndex: target.hunkIndex,
+      side: target.side,
+      line: target.line,
+    };
+  },
+  [allFiles],
+);
+
+const commentCursorRowStableKey =
+  commentCursor.mode === "off" ? null : cursorRowStableKey(commentCursor);
+```
+
+Add a reconcile effect so the cursor never points at a file that disappeared from the visible stream. Place it next to the existing `reconcileSelectedFile` effect block:
+
+```ts
+useEffect(() => {
+  setCommentCursor((current) => {
+    if (current.mode === "off") {
+      return current;
+    }
+
+    const file = visibleFiles.find((entry) => entry.id === current.fileId);
+    if (file && current.hunkIndex < file.metadata.hunks.length) {
+      return current;
+    }
+
+    const fallbackFile = visibleFiles[0];
+    if (!fallbackFile || fallbackFile.metadata.hunks.length === 0) {
+      return { ...current, mode: "off" };
+    }
+
+    const anchor = firstCursorTargetForHunk(fallbackFile, 0);
+    return {
+      mode: current.mode,
+      fileId: fallbackFile.id,
+      hunkIndex: 0,
+      side: anchor.side,
+      line: anchor.line,
+    };
+  });
+}, [visibleFiles]);
 ```
 
 Add the new fields to the `return` block at the bottom of `useReviewController`:
@@ -869,6 +860,7 @@ git commit -m "feat(review): own comment cursor state and addUserLiveComment in 
 ### Task 5: `CommentComposer` component
 
 **Files:**
+
 - Create: `src/ui/components/panes/CommentComposer.tsx`
 
 - [ ] **Step 1: Write the component**
@@ -1023,6 +1015,7 @@ git commit -m "feat(ui): add CommentComposer card for inline cursor-driven comme
 ### Task 6: `comment-composer` planned row kind
 
 **Files:**
+
 - Modify: `src/ui/diff/reviewRenderPlan.ts`
 
 - [ ] **Step 1: Extend the planned-row type and insertion logic**
@@ -1180,6 +1173,7 @@ git commit -m "feat(diff): add comment-composer planned row kind for inline comm
 ### Task 7: Composer row geometry
 
 **Files:**
+
 - Modify: `src/ui/lib/diffSectionGeometry.ts`
 
 - [ ] **Step 1: Plumb the composer through geometry and measure its height**
@@ -1302,9 +1296,10 @@ export function measureDiffSectionGeometry(
     };
   }
 
-  const composerKey = composer && composer.fileId === file.id
-    ? `${composer.hunkIndex}:${composer.side}:${composer.line}`
-    : "none";
+  const composerKey =
+    composer && composer.fileId === file.id
+      ? `${composer.hunkIndex}:${composer.side}:${composer.line}`
+      : "none";
   const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}:${composerKey}`;
   if (visibleAgentNotes.length > 0) {
     const cachedByNotes = NOTE_AWARE_SECTION_GEOMETRY_CACHE.get(visibleAgentNotes);
@@ -1425,6 +1420,7 @@ git commit -m "feat(diff): measure the comment composer row in diff section geom
 ### Task 8: Render the cursor highlight and composer in the diff view
 
 **Files:**
+
 - Modify: `src/ui/diff/renderRows.tsx`
 - Modify: `src/ui/diff/PierreDiffView.tsx`
 
@@ -1437,49 +1433,49 @@ Locate `renderRow` and update its parameter list to include `isCursor: boolean =
 Find these lines inside the split-line branch:
 
 ```ts
-    const leftPrefix = {
-      text: guideOnOldSide ? "│" : marker(),
-      fg: guideOnOldSide ? theme.noteBorder : splitLeftRailColor(row.left.kind, theme, selected),
-      bg: theme.panel,
-    };
+const leftPrefix = {
+  text: guideOnOldSide ? "│" : marker(),
+  fg: guideOnOldSide ? theme.noteBorder : splitLeftRailColor(row.left.kind, theme, selected),
+  bg: theme.panel,
+};
 ```
 
 Replace with:
 
 ```ts
-    const leftPrefix = {
-      text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
-      fg: guideOnOldSide
-        ? theme.noteBorder
-        : isCursor
-          ? theme.noteTitleText
-          : splitLeftRailColor(row.left.kind, theme, selected),
-      bg: isCursor ? theme.noteTitleBackground : theme.panel,
-    };
+const leftPrefix = {
+  text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
+  fg: guideOnOldSide
+    ? theme.noteBorder
+    : isCursor
+      ? theme.noteTitleText
+      : splitLeftRailColor(row.left.kind, theme, selected),
+  bg: isCursor ? theme.noteTitleBackground : theme.panel,
+};
 ```
 
 Find these lines inside the stack-line branch:
 
 ```ts
-    const prefix = {
-      text: guideOnOldSide ? "│" : marker(),
-      fg: guideOnOldSide ? theme.noteBorder : stackRailColor(row.cell.kind, theme, selected),
-      bg: theme.panel,
-    };
+const prefix = {
+  text: guideOnOldSide ? "│" : marker(),
+  fg: guideOnOldSide ? theme.noteBorder : stackRailColor(row.cell.kind, theme, selected),
+  bg: theme.panel,
+};
 ```
 
 Replace with:
 
 ```ts
-    const prefix = {
-      text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
-      fg: guideOnOldSide
-        ? theme.noteBorder
-        : isCursor
-          ? theme.noteTitleText
-          : stackRailColor(row.cell.kind, theme, selected),
-      bg: isCursor ? theme.noteTitleBackground : theme.panel,
-    };
+const prefix = {
+  text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
+  fg: guideOnOldSide
+    ? theme.noteBorder
+    : isCursor
+      ? theme.noteTitleText
+      : stackRailColor(row.cell.kind, theme, selected),
+  bg: isCursor ? theme.noteTitleBackground : theme.panel,
+};
 ```
 
 Add `isCursor` to the `renderRow` parameter list. Find:
@@ -1665,19 +1661,19 @@ export function PierreDiffView({
 Update the `plannedRows` `useMemo` to pass the composer through to `buildReviewRenderPlan`:
 
 ```ts
-  const plannedRows = useMemo(
-    () =>
-      file
-        ? buildReviewRenderPlan({
-            fileId: file.id,
-            rows,
-            showHunkHeaders,
-            visibleAgentNotes,
-            composer: composer ?? null,
-          })
-        : [],
-    [composer, file, rows, showHunkHeaders, visibleAgentNotes],
-  );
+const plannedRows = useMemo(
+  () =>
+    file
+      ? buildReviewRenderPlan({
+          fileId: file.id,
+          rows,
+          showHunkHeaders,
+          visibleAgentNotes,
+          composer: composer ?? null,
+        })
+      : [],
+  [composer, file, rows, showHunkHeaders, visibleAgentNotes],
+);
 ```
 
 Inside the row-mapping branch, add a render case for the `comment-composer` row before the existing diff-row return. Replace:
@@ -1796,6 +1792,7 @@ git commit -m "feat(diff): render the cursor highlight and inline composer in Pi
 ### Task 9: Plumb the cursor through `DiffPane` and `DiffSection`
 
 **Files:**
+
 - Modify: `src/ui/components/panes/DiffPane.tsx`
 - Modify: `src/ui/components/panes/DiffSection.tsx`
 
@@ -1894,28 +1891,28 @@ Forward the new props to `PierreDiffView`. Replace the `<PierreDiffView ... />` 
 Extend the memo comparator. Replace the existing comparator's return expression with:
 
 ```ts
-  return (
-    previous.codeHorizontalOffset === next.codeHorizontalOffset &&
-    previous.commentCursorRowStableKey === next.commentCursorRowStableKey &&
-    previous.composer === next.composer &&
-    previous.file === next.file &&
-    previous.headerLabelWidth === next.headerLabelWidth &&
-    previous.headerStatsWidth === next.headerStatsWidth &&
-    previous.layout === next.layout &&
-    previous.selectedHunkIndex === next.selectedHunkIndex &&
-    previous.shouldLoadHighlight === next.shouldLoadHighlight &&
-    previous.sectionGeometry === next.sectionGeometry &&
-    previous.separatorWidth === next.separatorWidth &&
-    previous.showLineNumbers === next.showLineNumbers &&
-    previous.showHunkHeaders === next.showHunkHeaders &&
-    previous.wrapLines === next.wrapLines &&
-    previous.showHeader === next.showHeader &&
-    previous.showSeparator === next.showSeparator &&
-    previous.theme === next.theme &&
-    previous.visibleAgentNotes === next.visibleAgentNotes &&
-    previous.visibleBodyBounds === next.visibleBodyBounds &&
-    previous.viewWidth === next.viewWidth
-  );
+return (
+  previous.codeHorizontalOffset === next.codeHorizontalOffset &&
+  previous.commentCursorRowStableKey === next.commentCursorRowStableKey &&
+  previous.composer === next.composer &&
+  previous.file === next.file &&
+  previous.headerLabelWidth === next.headerLabelWidth &&
+  previous.headerStatsWidth === next.headerStatsWidth &&
+  previous.layout === next.layout &&
+  previous.selectedHunkIndex === next.selectedHunkIndex &&
+  previous.shouldLoadHighlight === next.shouldLoadHighlight &&
+  previous.sectionGeometry === next.sectionGeometry &&
+  previous.separatorWidth === next.separatorWidth &&
+  previous.showLineNumbers === next.showLineNumbers &&
+  previous.showHunkHeaders === next.showHunkHeaders &&
+  previous.wrapLines === next.wrapLines &&
+  previous.showHeader === next.showHeader &&
+  previous.showSeparator === next.showSeparator &&
+  previous.theme === next.theme &&
+  previous.visibleAgentNotes === next.visibleAgentNotes &&
+  previous.visibleBodyBounds === next.visibleBodyBounds &&
+  previous.viewWidth === next.viewWidth
+);
 ```
 
 - [ ] **Step 2: Accept cursor + composer props in `DiffPane`**
@@ -1946,40 +1943,40 @@ after `codeHorizontalOffset`. Add them to the prop type as well:
 When `DiffPane` measures `sectionGeometry` for the selected file, pass the composer through so the composer row contributes to the file's body height. Locate the `measureDiffSectionGeometry` call inside the `sectionGeometry` `useMemo` and update it to pass `composer` as the ninth argument. Replace the relevant `useMemo` block (the one assigned to `sectionGeometry`) with:
 
 ```ts
-  const sectionGeometry = useMemo(
-    () =>
-      files.map((file, index) => {
-        const notes = allAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES;
-        const fileComposer = composer && composer.fileId === file.id ? composer : null;
-        if (notes.length === 0 && !fileComposer) {
-          return baseSectionGeometry[index]!;
-        }
+const sectionGeometry = useMemo(
+  () =>
+    files.map((file, index) => {
+      const notes = allAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES;
+      const fileComposer = composer && composer.fileId === file.id ? composer : null;
+      if (notes.length === 0 && !fileComposer) {
+        return baseSectionGeometry[index]!;
+      }
 
-        return measureDiffSectionGeometry(
-          file,
-          layout,
-          showHunkHeaders,
-          theme,
-          notes,
-          diffContentWidth,
-          showLineNumbers,
-          wrapLines,
-          fileComposer,
-        );
-      }),
-    [
-      allAgentNotesByFile,
-      baseSectionGeometry,
-      composer,
-      diffContentWidth,
-      files,
-      layout,
-      showHunkHeaders,
-      showLineNumbers,
-      theme,
-      wrapLines,
-    ],
-  );
+      return measureDiffSectionGeometry(
+        file,
+        layout,
+        showHunkHeaders,
+        theme,
+        notes,
+        diffContentWidth,
+        showLineNumbers,
+        wrapLines,
+        fileComposer,
+      );
+    }),
+  [
+    allAgentNotesByFile,
+    baseSectionGeometry,
+    composer,
+    diffContentWidth,
+    files,
+    layout,
+    showHunkHeaders,
+    showLineNumbers,
+    theme,
+    wrapLines,
+  ],
+);
 ```
 
 Forward `commentCursorRowStableKey`, `composer`, and the composer callbacks to each `<DiffSection ... />` in the render branch. Inside the `files.map(...)` block, replace the `<DiffSection key={file.id} ... />` element with:
@@ -2042,6 +2039,7 @@ git commit -m "feat(diff): plumb the comment cursor and composer through DiffPan
 ### Task 10: `handleCursorShortcut` in the keyboard router
 
 **Files:**
+
 - Modify: `src/ui/hooks/useAppKeyboardShortcuts.ts`
 
 - [ ] **Step 1: Extend the options interface**
@@ -2064,95 +2062,95 @@ Pull those fields out of the function parameters next to the existing ones.
 Add this helper inside `useAppKeyboardShortcuts`, between `handleMenuShortcut` and `handleFilterShortcut`:
 
 ```ts
-  const commentCursorModeRef = useRef(commentCursorMode);
-  commentCursorModeRef.current = commentCursorMode;
+const commentCursorModeRef = useRef(commentCursorMode);
+commentCursorModeRef.current = commentCursorMode;
 
-  const handleCursorShortcut = (key: KeyEvent) => {
-    const mode = commentCursorModeRef.current;
+const handleCursorShortcut = (key: KeyEvent) => {
+  const mode = commentCursorModeRef.current;
 
-    if (mode === "off") {
-      return false;
-    }
-
-    if (mode === "composing") {
-      // The focused composer input owns its own keys; the router stays out of its way.
-      return true;
-    }
-
-    if (isEscapeKey(key) || key.name === "c" || key.sequence === "c") {
-      exitCommentCursor();
-      return true;
-    }
-
-    if (key.name === "return" || key.name === "enter" || key.name === "i" || key.sequence === "i") {
-      openCommentComposer();
-      return true;
-    }
-
-    if (isStepUpKey(key)) {
-      moveCommentCursor(-1);
-      return true;
-    }
-
-    if (isStepDownKey(key)) {
-      moveCommentCursor(1);
-      return true;
-    }
-
-    if (key.name === "[") {
-      jumpCommentCursorToHunk(-1);
-      return true;
-    }
-
-    if (key.name === "]") {
-      jumpCommentCursorToHunk(1);
-      return true;
-    }
-
+  if (mode === "off") {
     return false;
-  };
+  }
+
+  if (mode === "composing") {
+    // The focused composer input owns its own keys; the router stays out of its way.
+    return true;
+  }
+
+  if (isEscapeKey(key) || key.name === "c" || key.sequence === "c") {
+    exitCommentCursor();
+    return true;
+  }
+
+  if (key.name === "return" || key.name === "enter" || key.name === "i" || key.sequence === "i") {
+    openCommentComposer();
+    return true;
+  }
+
+  if (isStepUpKey(key)) {
+    moveCommentCursor(-1);
+    return true;
+  }
+
+  if (isStepDownKey(key)) {
+    moveCommentCursor(1);
+    return true;
+  }
+
+  if (key.name === "[") {
+    jumpCommentCursorToHunk(-1);
+    return true;
+  }
+
+  if (key.name === "]") {
+    jumpCommentCursorToHunk(1);
+    return true;
+  }
+
+  return false;
+};
 ```
 
-Add cursor entry to `handleAppShortcut`. Find the block that begins with `if (key.name === "a") {` and insert this new branch *before* it:
+Add cursor entry to `handleAppShortcut`. Find the block that begins with `if (key.name === "a") {` and insert this new branch _before_ it:
 
 ```ts
-    if (key.name === "c" || key.sequence === "c") {
-      runAndCloseMenu(enterCommentCursor);
-      return;
-    }
+if (key.name === "c" || key.sequence === "c") {
+  runAndCloseMenu(enterCommentCursor);
+  return;
+}
 ```
 
 Wire the new handler into the `useKeyboard` callback. Replace the existing callback body with:
 
 ```ts
-  useKeyboard((key: KeyEvent) => {
-    if (handleMenuToggleShortcut(key)) {
-      return;
-    }
+useKeyboard((key: KeyEvent) => {
+  if (handleMenuToggleShortcut(key)) {
+    return;
+  }
 
-    if (pagerModeRef.current) {
-      handlePagerShortcut(key);
-      return;
-    }
+  if (pagerModeRef.current) {
+    handlePagerShortcut(key);
+    return;
+  }
 
-    if (handleHelpShortcut(key)) {
-      return;
-    }
+  if (handleHelpShortcut(key)) {
+    return;
+  }
 
-    if (handleMenuShortcut(key)) {
-      return;
-    }
+  if (handleMenuShortcut(key)) {
+    return;
+  }
 
-    if (handleCursorShortcut(key)) {
-      return;
-    }
+  if (handleCursorShortcut(key)) {
+    return;
+  }
 
-    if (handleFilterShortcut(key)) {
-      return;
-    }
+  if (handleFilterShortcut(key)) {
+    return;
+  }
 
-    handleAppShortcut(key);
-  });
+  handleAppShortcut(key);
+});
 ```
 
 - [ ] **Step 3: Run typecheck**
@@ -2172,6 +2170,7 @@ git commit -m "feat(keys): add cursor-mode handler to the app keyboard router"
 ### Task 11: Wire cursor state into `App.tsx`
 
 **Files:**
+
 - Modify: `src/ui/App.tsx`
 - Modify: `src/ui/lib/appMenus.ts`
 
@@ -2180,12 +2179,12 @@ git commit -m "feat(keys): add cursor-mode handler to the app keyboard router"
 In `src/ui/App.tsx`, near the existing `review.*` destructure (around line 124-130), add:
 
 ```ts
-  const commentCursor = review.commentCursor;
-  const commentCursorRowStableKey = review.commentCursorRowStableKey;
-  const addUserLiveComment = review.addUserLiveComment;
-  const setCommentCursorMode = review.setCommentCursorMode;
-  const moveCommentCursor = review.moveCommentCursor;
-  const jumpCommentCursorToHunk = review.jumpCommentCursorToHunk;
+const commentCursor = review.commentCursor;
+const commentCursorRowStableKey = review.commentCursorRowStableKey;
+const addUserLiveComment = review.addUserLiveComment;
+const setCommentCursorMode = review.setCommentCursorMode;
+const moveCommentCursor = review.moveCommentCursor;
+const jumpCommentCursorToHunk = review.jumpCommentCursorToHunk;
 ```
 
 - [ ] **Step 2: Build the composer descriptor and callbacks**
@@ -2193,59 +2192,59 @@ In `src/ui/App.tsx`, near the existing `review.*` destructure (around line 124-1
 Below the destructure above, add:
 
 ```ts
-  const composerDescriptor =
-    commentCursor.mode === "composing"
-      ? {
+const composerDescriptor =
+  commentCursor.mode === "composing"
+    ? {
+        fileId: commentCursor.fileId,
+        hunkIndex: commentCursor.hunkIndex,
+        side: commentCursor.side,
+        line: commentCursor.line,
+      }
+    : null;
+
+const enterCommentCursor = useCallback(() => {
+  setCommentCursorMode(commentCursor.mode === "off" ? "navigating" : "off");
+}, [commentCursor.mode, setCommentCursorMode]);
+
+const exitCommentCursor = useCallback(() => {
+  setCommentCursorMode("off");
+}, [setCommentCursorMode]);
+
+const openCommentComposer = useCallback(() => {
+  setCommentCursorMode("composing");
+}, [setCommentCursorMode]);
+
+const cancelCommentComposer = useCallback(() => {
+  setCommentCursorMode("navigating");
+}, [setCommentCursorMode]);
+
+const submitCommentComposer = useCallback(
+  (summary: string) => {
+    try {
+      addUserLiveComment(
+        {
           fileId: commentCursor.fileId,
           hunkIndex: commentCursor.hunkIndex,
           side: commentCursor.side,
           line: commentCursor.line,
-        }
-      : null;
-
-  const enterCommentCursor = useCallback(() => {
-    setCommentCursorMode(commentCursor.mode === "off" ? "navigating" : "off");
-  }, [commentCursor.mode, setCommentCursorMode]);
-
-  const exitCommentCursor = useCallback(() => {
-    setCommentCursorMode("off");
-  }, [setCommentCursorMode]);
-
-  const openCommentComposer = useCallback(() => {
-    setCommentCursorMode("composing");
-  }, [setCommentCursorMode]);
-
-  const cancelCommentComposer = useCallback(() => {
-    setCommentCursorMode("navigating");
-  }, [setCommentCursorMode]);
-
-  const submitCommentComposer = useCallback(
-    (summary: string) => {
-      try {
-        addUserLiveComment(
-          {
-            fileId: commentCursor.fileId,
-            hunkIndex: commentCursor.hunkIndex,
-            side: commentCursor.side,
-            line: commentCursor.line,
-          },
-          summary,
-        );
-      } catch (error) {
-        console.error("Failed to add user comment.", error);
-      } finally {
-        setCommentCursorMode("navigating");
-      }
-    },
-    [
-      addUserLiveComment,
-      commentCursor.fileId,
-      commentCursor.hunkIndex,
-      commentCursor.line,
-      commentCursor.side,
-      setCommentCursorMode,
-    ],
-  );
+        },
+        summary,
+      );
+    } catch (error) {
+      console.error("Failed to add user comment.", error);
+    } finally {
+      setCommentCursorMode("navigating");
+    }
+  },
+  [
+    addUserLiveComment,
+    commentCursor.fileId,
+    commentCursor.hunkIndex,
+    commentCursor.line,
+    commentCursor.side,
+    setCommentCursorMode,
+  ],
+);
 ```
 
 - [ ] **Step 3: Pass cursor and composer through to `DiffPane`**
@@ -2359,6 +2358,7 @@ git commit -m "feat(app): wire the comment cursor into App, DiffPane, and the vi
 ### Task 12: AppHost interaction tests
 
 **Files:**
+
 - Modify: `src/ui/AppHost.interactions.test.tsx`
 
 - [ ] **Step 1: Add the failing tests**
@@ -2479,6 +2479,7 @@ git commit -m "test(app): cover the comment cursor toggle, composer, and save fl
 ### Task 13: PTY integration coverage
 
 **Files:**
+
 - Create: `test/pty/comment-cursor-integration.test.ts`
 
 - [ ] **Step 1: Write the integration test**
@@ -2562,6 +2563,7 @@ git commit -m "test(pty): cover the comment cursor end-to-end through a real PTY
 ### Task 14: Changelog entry
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 
 - [ ] **Step 1: Record the feature**

--- a/docs/superpowers/plans/2026-05-14-comment-cursor-ui.md
+++ b/docs/superpowers/plans/2026-05-14-comment-cursor-ui.md
@@ -1,0 +1,2632 @@
+# Comment cursor UI implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a keyboard-driven cursor that lets a developer attach a single-line review comment to any diff row from inside the Hunk TUI, reusing the existing `LiveComment` store so agents pick up user comments through the same `hunk session comment *` commands they already use.
+
+**Architecture:** Cursor state lives in `useReviewController` next to the existing selection state. Cursor geometry is computed by a new pure helper module. The composer is mounted as a new planned-row kind that flows through the existing diff render plan, geometry layer, and row renderer. The user-authored `LiveComment` reuses every existing storage and render path with only `source: "user"` as the discriminator.
+
+**Tech Stack:** Bun, React, OpenTUI (built-in `<input>` element only — no new packages), TypeScript, `@pierre/diffs`, `bun:test`, `tuistory` PTY harness.
+
+**Source spec:** `docs/superpowers/specs/2026-05-14-comment-cursor-ui-design.md`
+
+---
+
+## Files
+
+- Create: `src/ui/lib/commentCursor.ts` — pure cursor geometry helpers
+- Create: `src/ui/lib/commentCursor.test.ts` — colocated unit tests for the helpers
+- Create: `src/ui/components/panes/CommentComposer.tsx` — inline composer card
+- Create: `test/pty/comment-cursor-integration.test.ts` — PTY-backed integration test
+- Modify: `src/hunk-session/types.ts` — widen `LiveComment.source` to `"mcp" | "user"`
+- Modify: `src/core/liveComments.ts` — add `buildUserLiveComment`
+- Modify: `src/core/liveComments.test.ts` — extend coverage for the new builder
+- Modify: `src/ui/hooks/useReviewController.ts` — own cursor state and `addUserLiveComment`
+- Modify: `src/ui/hooks/useReviewController.test.tsx` — extend coverage for cursor state and `addUserLiveComment`
+- Modify: `src/ui/diff/reviewRenderPlan.ts` — add the `comment-composer` planned row kind
+- Modify: `src/ui/lib/diffSectionGeometry.ts` — measure composer row height
+- Modify: `src/ui/diff/PierreDiffView.tsx` — accept cursor stable key, render the composer planned-row kind
+- Modify: `src/ui/diff/renderRows.tsx` — apply cursor highlight when a row matches the cursor stable key
+- Modify: `src/ui/components/panes/DiffPane.tsx` — accept and plumb cursor state
+- Modify: `src/ui/components/panes/DiffSection.tsx` — accept and plumb cursor state
+- Modify: `src/ui/hooks/useAppKeyboardShortcuts.ts` — new mode handler `handleCursorShortcut`
+- Modify: `src/ui/App.tsx` — wire cursor state, pass to DiffPane and keyboard hook, add View menu entry
+- Modify: `src/ui/lib/appMenus.ts` — add the `Toggle comment cursor (c)` View menu entry
+- Modify: `src/ui/AppHost.interactions.test.tsx` — interaction coverage of the cursor flow
+- Modify: `CHANGELOG.md` — record the user-visible addition
+
+---
+
+### Task 1: Widen `LiveComment.source`
+
+**Files:**
+- Modify: `src/hunk-session/types.ts`
+
+- [ ] **Step 1: Widen the source union**
+
+In `src/hunk-session/types.ts`, find:
+
+```ts
+export interface LiveComment extends AgentAnnotation {
+  id: string;
+  source: "mcp";
+```
+
+Change to:
+
+```ts
+export interface LiveComment extends AgentAnnotation {
+  id: string;
+  source: "mcp" | "user";
+```
+
+- [ ] **Step 2: Run typecheck to verify nothing else relied on the literal**
+
+Run: `bun run typecheck`
+Expected: PASS. Every existing call site sets `source: "mcp"`, which is still in the widened union.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hunk-session/types.ts
+git commit -m "refactor(types): widen LiveComment.source to accept user-authored comments"
+```
+
+---
+
+### Task 2: Add `buildUserLiveComment`
+
+**Files:**
+- Modify: `src/core/liveComments.ts`
+- Test: `src/core/liveComments.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+In `src/core/liveComments.test.ts`, append inside the `describe("live comment helpers", ...)` block:
+
+```ts
+  test("builds a live user comment annotation", () => {
+    const comment = buildUserLiveComment(
+      {
+        filePath: "src/example.ts",
+        side: "new",
+        line: 4,
+        summary: "Look at this addition",
+        author: "andrew",
+      },
+      "user:test-1",
+      "2026-05-14T00:00:00.000Z",
+      0,
+    );
+
+    expect(comment).toMatchObject({
+      id: "user:test-1",
+      source: "user",
+      author: "andrew",
+      filePath: "src/example.ts",
+      hunkIndex: 0,
+      side: "new",
+      line: 4,
+      summary: "Look at this addition",
+      newRange: [4, 4],
+      tags: ["user"],
+    });
+    expect(comment.confidence).toBeUndefined();
+  });
+
+  test("builds an old-side user comment with an oldRange instead of newRange", () => {
+    const comment = buildUserLiveComment(
+      {
+        filePath: "src/example.ts",
+        side: "old",
+        line: 2,
+        summary: "Why was this removed?",
+      },
+      "user:test-2",
+      "2026-05-14T00:00:00.000Z",
+      0,
+    );
+
+    expect(comment).toMatchObject({
+      source: "user",
+      side: "old",
+      line: 2,
+      oldRange: [2, 2],
+      tags: ["user"],
+    });
+    expect(comment.newRange).toBeUndefined();
+  });
+```
+
+Add the new import at the top of the file, replacing the existing `liveComments` import line:
+
+```ts
+import {
+  buildLiveComment,
+  buildUserLiveComment,
+  findDiffFileByPath,
+  findHunkIndexForLine,
+  firstCommentTargetForHunk,
+  hunkLineRange,
+  resolveCommentTarget,
+} from "./liveComments";
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bun test src/core/liveComments.test.ts`
+Expected: FAIL with `buildUserLiveComment is not a function` (or `Cannot find name 'buildUserLiveComment'`).
+
+- [ ] **Step 3: Implement `buildUserLiveComment`**
+
+In `src/core/liveComments.ts`, append after the existing `buildLiveComment` function:
+
+```ts
+/** Convert one cursor-driven user comment into a live annotation. */
+export function buildUserLiveComment(
+  input: CommentTargetInput & { side: DiffSide; line: number },
+  commentId: string,
+  createdAt: string,
+  hunkIndex: number,
+): LiveComment {
+  return {
+    id: commentId,
+    source: "user",
+    author: input.author,
+    createdAt,
+    filePath: input.filePath,
+    hunkIndex,
+    side: input.side,
+    line: input.line,
+    summary: input.summary,
+    rationale: input.rationale,
+    oldRange: input.side === "old" ? [input.line, input.line] : undefined,
+    newRange: input.side === "new" ? [input.line, input.line] : undefined,
+    tags: ["user"],
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test src/core/liveComments.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/liveComments.ts src/core/liveComments.test.ts
+git commit -m "feat(comments): add buildUserLiveComment for cursor-authored comments"
+```
+
+---
+
+### Task 3: Cursor geometry helpers
+
+**Files:**
+- Create: `src/ui/lib/commentCursor.ts`
+- Test: `src/ui/lib/commentCursor.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/ui/lib/commentCursor.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import {
+  cursorRowStableKey,
+  firstCursorTargetForHunk,
+  moveCursor,
+  type CommentCursorPosition,
+} from "./commentCursor";
+
+const beforeLines = Array.from({ length: 12 }, (_, index) => `line${index + 1}`);
+const afterLines = [...beforeLines];
+afterLines[0] = "LINE1";
+afterLines[10] = "LINE11";
+
+function createTwoHunkFile() {
+  return createTestDiffFile({
+    id: "alpha",
+    path: "alpha.ts",
+    before: lines(...beforeLines),
+    after: lines(...afterLines),
+    context: 1,
+  });
+}
+
+function createSingleHunkFile() {
+  const before = lines("a", "b", "c");
+  const after = lines("a", "B", "c");
+  return createTestDiffFile({
+    id: "beta",
+    path: "beta.ts",
+    before,
+    after,
+    context: 1,
+  });
+}
+
+describe("firstCursorTargetForHunk", () => {
+  test("prefers the first added line", () => {
+    const file = createTwoHunkFile();
+
+    const target = firstCursorTargetForHunk(file, 0);
+    expect(target).toEqual({ side: "new", line: 1 });
+  });
+});
+
+describe("cursorRowStableKey", () => {
+  test("formats a stable key matching the diff render plan", () => {
+    const key = cursorRowStableKey({
+      fileId: "alpha",
+      hunkIndex: 2,
+      side: "new",
+      line: 42,
+    });
+
+    expect(key).toBe("line:2:new:42");
+  });
+});
+
+describe("moveCursor", () => {
+  test("steps forward through diff rows within a hunk", () => {
+    const file = createTwoHunkFile();
+    const start: CommentCursorPosition = {
+      fileId: "alpha",
+      hunkIndex: 0,
+      ...firstCursorTargetForHunk(file, 0),
+    };
+
+    const next = moveCursor([file], start, 1);
+    expect(next).not.toBeNull();
+    expect(next?.fileId).toBe("alpha");
+  });
+
+  test("crosses hunk boundaries when stepping past the last row of a hunk", () => {
+    const file = createTwoHunkFile();
+    const lastHunkIndex = file.metadata.hunks.length - 1;
+    const lastHunk = file.metadata.hunks[lastHunkIndex]!;
+    const start: CommentCursorPosition = {
+      fileId: "alpha",
+      hunkIndex: lastHunkIndex,
+      ...firstCursorTargetForHunk(file, lastHunkIndex),
+    };
+
+    let cursor: CommentCursorPosition | null = start;
+    for (let step = 0; step < 200 && cursor !== null; step += 1) {
+      const next = moveCursor([file], cursor, 1);
+      if (!next || next.hunkIndex !== cursor.hunkIndex) {
+        break;
+      }
+      cursor = next;
+    }
+
+    // Either we landed in a later hunk, or clamped at the end of the only hunk.
+    expect(cursor).not.toBeNull();
+    expect(cursor!.hunkIndex).toBeGreaterThanOrEqual(0);
+    expect(lastHunk).toBeDefined();
+  });
+
+  test("crosses file boundaries when stepping past the last row of the last hunk", () => {
+    const fileA = createSingleHunkFile();
+    const fileB = createTestDiffFile({
+      id: "gamma",
+      path: "gamma.ts",
+      before: lines("g1", "g2", "g3"),
+      after: lines("g1", "G2", "g3"),
+      context: 1,
+    });
+    const startInA: CommentCursorPosition = {
+      fileId: "beta",
+      hunkIndex: 0,
+      ...firstCursorTargetForHunk(fileA, 0),
+    };
+
+    let cursor: CommentCursorPosition | null = startInA;
+    for (let step = 0; step < 200 && cursor !== null; step += 1) {
+      const next = moveCursor([fileA, fileB], cursor, 1);
+      if (!next || next.fileId !== cursor.fileId) {
+        cursor = next;
+        break;
+      }
+      cursor = next;
+    }
+
+    expect(cursor?.fileId).toBe("gamma");
+  });
+
+  test("clamps at the first row of the first hunk when stepping backwards from the start", () => {
+    const file = createSingleHunkFile();
+    const start: CommentCursorPosition = {
+      fileId: "beta",
+      hunkIndex: 0,
+      ...firstCursorTargetForHunk(file, 0),
+    };
+
+    const previous = moveCursor([file], start, -1);
+    expect(previous).toEqual(start);
+  });
+
+  test("returns null when given an empty file list", () => {
+    expect(
+      moveCursor([], { fileId: "ghost", hunkIndex: 0, side: "new", line: 1 }, 1),
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test src/ui/lib/commentCursor.test.ts`
+Expected: FAIL because the module does not exist.
+
+- [ ] **Step 3: Implement the cursor helpers**
+
+Create `src/ui/lib/commentCursor.ts`:
+
+```ts
+import type { Hunk } from "@pierre/diffs";
+import type { DiffFile } from "../../core/types";
+import { firstCommentTargetForHunk, hunkLineRange } from "../../core/liveComments";
+import type { DiffSide } from "../../hunk-session/types";
+
+export interface CommentCursorPosition {
+  fileId: string;
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+}
+
+/** Return the cursor anchor for one hunk — first addition, then deletion, then context. */
+export function firstCursorTargetForHunk(
+  file: DiffFile,
+  hunkIndex: number,
+): { side: DiffSide; line: number } {
+  const hunk = file.metadata.hunks[hunkIndex];
+  if (!hunk) {
+    return { side: "new", line: 1 };
+  }
+
+  return firstCommentTargetForHunk(hunk);
+}
+
+/** Build the file-scoped stable row key used by reviewRenderPlan for a cursor position. */
+export function cursorRowStableKey(cursor: CommentCursorPosition): string {
+  return `line:${cursor.hunkIndex}:${cursor.side}:${cursor.line}`;
+}
+
+/** Walk through every content line of a hunk on the cursor's anchor side. */
+function* walkHunkLines(
+  hunk: Hunk,
+  side: DiffSide,
+): Generator<{ side: DiffSide; line: number }> {
+  const range = hunkLineRange(hunk);
+  const [start, end] = side === "new" ? range.newRange : range.oldRange;
+
+  for (let line = start; line <= end; line += 1) {
+    yield { side, line };
+  }
+}
+
+/** Build the ordered list of cursor positions for the full review stream on the cursor's side. */
+function buildCursorPositions(
+  files: DiffFile[],
+  preferredSide: DiffSide,
+): CommentCursorPosition[] {
+  const positions: CommentCursorPosition[] = [];
+
+  for (const file of files) {
+    file.metadata.hunks.forEach((hunk, hunkIndex) => {
+      for (const step of walkHunkLines(hunk, preferredSide)) {
+        positions.push({
+          fileId: file.id,
+          hunkIndex,
+          side: step.side,
+          line: step.line,
+        });
+      }
+    });
+  }
+
+  return positions;
+}
+
+/** Move the cursor forward or backward through the review stream by one row. */
+export function moveCursor(
+  files: DiffFile[],
+  current: CommentCursorPosition,
+  delta: number,
+): CommentCursorPosition | null {
+  const positions = buildCursorPositions(files, current.side);
+  if (positions.length === 0) {
+    return null;
+  }
+
+  const index = positions.findIndex(
+    (position) =>
+      position.fileId === current.fileId &&
+      position.hunkIndex === current.hunkIndex &&
+      position.line === current.line,
+  );
+
+  if (index < 0) {
+    return delta >= 0 ? positions[0]! : positions[positions.length - 1]!;
+  }
+
+  const nextIndex = Math.max(0, Math.min(positions.length - 1, index + delta));
+  return positions[nextIndex]!;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test src/ui/lib/commentCursor.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/lib/commentCursor.ts src/ui/lib/commentCursor.test.ts
+git commit -m "feat(ui): add commentCursor geometry helpers"
+```
+
+---
+
+### Task 4: Cursor state in `useReviewController`
+
+**Files:**
+- Modify: `src/ui/hooks/useReviewController.ts`
+- Test: `src/ui/hooks/useReviewController.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/ui/hooks/useReviewController.test.tsx`, append inside the top-level `describe(...)` block (or add a new one near the end of the file). First add the new import next to the existing controller import:
+
+```ts
+import { useReviewController, type ReviewController } from "./useReviewController";
+```
+
+Then add the new test block:
+
+```ts
+describe("useReviewController cursor state", () => {
+  test("turning cursor on seeds it from the currently selected hunk", async () => {
+    let controllerRef: ReviewController | null = null;
+    const file = createTwoHunkFile();
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[file]}
+        onController={(controller) => {
+          controllerRef = controller;
+        }}
+      />,
+    );
+
+    try {
+      await flush(setup);
+      const controller = expectValue(controllerRef);
+      expect(controller.commentCursor.mode).toBe("off");
+
+      await act(async () => {
+        controller.setCommentCursorMode("navigating");
+      });
+      await flush(setup);
+
+      const next = expectValue(controllerRef);
+      expect(next.commentCursor.mode).toBe("navigating");
+      expect(next.commentCursor.fileId).toBe(file.id);
+      expect(next.commentCursor.hunkIndex).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("addUserLiveComment stores a user comment that surfaces in liveCommentSummaries", async () => {
+    let controllerRef: ReviewController | null = null;
+    const file = createTwoHunkFile();
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[file]}
+        onController={(controller) => {
+          controllerRef = controller;
+        }}
+      />,
+    );
+
+    try {
+      await flush(setup);
+      const controller = expectValue(controllerRef);
+
+      await act(async () => {
+        controller.addUserLiveComment(
+          { fileId: file.id, hunkIndex: 0, side: "new", line: 1 },
+          "Needs a follow-up",
+        );
+      });
+      await flush(setup);
+
+      const after = expectValue(controllerRef);
+      expect(after.liveCommentCount).toBe(1);
+      expect(after.liveCommentSummaries[0]?.summary).toBe("Needs a follow-up");
+      expect(after.liveCommentSummaries[0]?.filePath).toBe(file.path);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test src/ui/hooks/useReviewController.test.tsx`
+Expected: FAIL — `setCommentCursorMode is not a function` (or similar missing property).
+
+- [ ] **Step 3: Extend the controller interface and implementation**
+
+In `src/ui/hooks/useReviewController.ts`, add imports next to the existing ones:
+
+```ts
+import {
+  cursorRowStableKey,
+  firstCursorTargetForHunk,
+  moveCursor,
+  type CommentCursorPosition,
+} from "../lib/commentCursor";
+import { buildUserLiveComment } from "../../core/liveComments";
+import type { DiffSide } from "../../hunk-session/types";
+```
+
+Add new types above `ReviewController`:
+
+```ts
+export type CommentCursorMode = "off" | "navigating" | "composing";
+
+export interface CommentCursorState extends CommentCursorPosition {
+  mode: CommentCursorMode;
+}
+
+export interface AddUserLiveCommentTarget {
+  fileId: string;
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+  author?: string;
+}
+```
+
+Extend the `ReviewController` interface to add (place these next to the existing actions, in alphabetical-ish order matching the file's style):
+
+```ts
+  commentCursor: CommentCursorState;
+  commentCursorRowStableKey: string | null;
+  addUserLiveComment: (target: AddUserLiveCommentTarget, summary: string) => AppliedCommentResult;
+  setCommentCursorMode: (mode: CommentCursorMode) => void;
+  moveCommentCursor: (delta: number) => void;
+  jumpCommentCursorToHunk: (delta: number) => void;
+```
+
+Inside `useReviewController`, near the other `useState` calls, add:
+
+```ts
+  const [commentCursor, setCommentCursor] = useState<CommentCursorState>(() => ({
+    mode: "off",
+    fileId: files[0]?.id ?? "",
+    hunkIndex: 0,
+    side: "new",
+    line: files[0]?.metadata.hunks[0]
+      ? firstCursorTargetForHunk(files[0], 0).line
+      : 1,
+  }));
+  const userCommentCounterRef = useRef(0);
+```
+
+Add `useRef` to the React import at the top of the file if it is not already present:
+
+```ts
+import {
+  startTransition,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+```
+
+Define the cursor actions (place these after `clearLiveComments` and before the controller return statement):
+
+```ts
+  /** Enter, switch, or leave the cursor mode. Seeds position from the selected hunk on enter. */
+  const setCommentCursorMode = useCallback(
+    (mode: CommentCursorMode) => {
+      setCommentCursor((current) => {
+        if (mode === "off") {
+          return { ...current, mode };
+        }
+
+        if (current.mode !== "off") {
+          return { ...current, mode };
+        }
+
+        const file = visibleFiles.find((entry) => entry.id === selectedFileId) ?? visibleFiles[0];
+        if (!file || file.metadata.hunks.length === 0) {
+          return { ...current, mode };
+        }
+
+        const hunkIndex = Math.max(
+          0,
+          Math.min(selectedHunkIndex, file.metadata.hunks.length - 1),
+        );
+        const anchor = firstCursorTargetForHunk(file, hunkIndex);
+        return {
+          mode,
+          fileId: file.id,
+          hunkIndex,
+          side: anchor.side,
+          line: anchor.line,
+        };
+      });
+    },
+    [selectedFileId, selectedHunkIndex, visibleFiles],
+  );
+
+  /** Walk the cursor row-by-row through the review stream. */
+  const moveCommentCursor = useCallback(
+    (delta: number) => {
+      setCommentCursor((current) => {
+        if (current.mode === "off") {
+          return current;
+        }
+
+        const next = moveCursor(visibleFiles, current, delta);
+        if (!next) {
+          return current;
+        }
+
+        return { ...current, ...next };
+      });
+    },
+    [visibleFiles],
+  );
+
+  /** Jump the cursor to the first content row of the previous or next hunk. */
+  const jumpCommentCursorToHunk = useCallback(
+    (delta: number) => {
+      setCommentCursor((current) => {
+        if (current.mode === "off") {
+          return current;
+        }
+
+        const fileIndex = visibleFiles.findIndex((file) => file.id === current.fileId);
+        if (fileIndex < 0) {
+          return current;
+        }
+
+        let nextFileIndex = fileIndex;
+        let nextHunkIndex = current.hunkIndex + delta;
+
+        while (true) {
+          const file = visibleFiles[nextFileIndex];
+          if (!file) {
+            return current;
+          }
+
+          if (nextHunkIndex >= 0 && nextHunkIndex < file.metadata.hunks.length) {
+            const anchor = firstCursorTargetForHunk(file, nextHunkIndex);
+            return {
+              ...current,
+              fileId: file.id,
+              hunkIndex: nextHunkIndex,
+              side: anchor.side,
+              line: anchor.line,
+            };
+          }
+
+          if (delta > 0) {
+            nextFileIndex += 1;
+            nextHunkIndex = 0;
+          } else {
+            nextFileIndex -= 1;
+            const previous = visibleFiles[nextFileIndex];
+            if (!previous) {
+              return current;
+            }
+            nextHunkIndex = previous.metadata.hunks.length - 1;
+          }
+        }
+      });
+    },
+    [visibleFiles],
+  );
+
+  /** Persist one user-authored comment using the same store as MCP comments. */
+  const addUserLiveComment = useCallback(
+    (target: AddUserLiveCommentTarget, summary: string): AppliedCommentResult => {
+      const file = allFiles.find((entry) => entry.id === target.fileId);
+      if (!file) {
+        throw new Error(`No diff file matches ${target.fileId}.`);
+      }
+
+      const trimmed = summary.trim();
+      if (!trimmed) {
+        throw new Error("User comments must have a non-empty summary.");
+      }
+
+      userCommentCounterRef.current += 1;
+      const commentId = `user:${Date.now()}-${userCommentCounterRef.current}`;
+      const liveComment = buildUserLiveComment(
+        {
+          filePath: file.path,
+          side: target.side,
+          line: target.line,
+          summary: trimmed,
+          author: target.author,
+        },
+        commentId,
+        new Date().toISOString(),
+        target.hunkIndex,
+      );
+
+      setLiveCommentsByFileId((current) => ({
+        ...current,
+        [file.id]: [...(current[file.id] ?? []), liveComment],
+      }));
+
+      return {
+        commentId,
+        fileId: file.id,
+        filePath: file.path,
+        hunkIndex: target.hunkIndex,
+        side: target.side,
+        line: target.line,
+      };
+    },
+    [allFiles],
+  );
+
+  const commentCursorRowStableKey =
+    commentCursor.mode === "off" ? null : cursorRowStableKey(commentCursor);
+```
+
+Add a reconcile effect so the cursor never points at a file that disappeared from the visible stream. Place it next to the existing `reconcileSelectedFile` effect block:
+
+```ts
+  useEffect(() => {
+    setCommentCursor((current) => {
+      if (current.mode === "off") {
+        return current;
+      }
+
+      const file = visibleFiles.find((entry) => entry.id === current.fileId);
+      if (file && current.hunkIndex < file.metadata.hunks.length) {
+        return current;
+      }
+
+      const fallbackFile = visibleFiles[0];
+      if (!fallbackFile || fallbackFile.metadata.hunks.length === 0) {
+        return { ...current, mode: "off" };
+      }
+
+      const anchor = firstCursorTargetForHunk(fallbackFile, 0);
+      return {
+        mode: current.mode,
+        fileId: fallbackFile.id,
+        hunkIndex: 0,
+        side: anchor.side,
+        line: anchor.line,
+      };
+    });
+  }, [visibleFiles]);
+```
+
+Add the new fields to the `return` block at the bottom of `useReviewController`:
+
+```ts
+    commentCursor,
+    commentCursorRowStableKey,
+    addUserLiveComment,
+    setCommentCursorMode,
+    moveCommentCursor,
+    jumpCommentCursorToHunk,
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test src/ui/hooks/useReviewController.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/hooks/useReviewController.ts src/ui/hooks/useReviewController.test.tsx
+git commit -m "feat(review): own comment cursor state and addUserLiveComment in the review controller"
+```
+
+---
+
+### Task 5: `CommentComposer` component
+
+**Files:**
+- Create: `src/ui/components/panes/CommentComposer.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Create `src/ui/components/panes/CommentComposer.tsx`:
+
+```ts
+import { useState } from "react";
+import type { KeyEvent } from "@opentui/core";
+import { isEscapeKey } from "../../lib/keyboard";
+import { fitText, padText } from "../../lib/text";
+import type { AppTheme } from "../../themes";
+
+/** Render the inline composer card the user types a single review comment into. */
+export function CommentComposer({
+  filePath,
+  hunkIndex,
+  line,
+  side,
+  theme,
+  width,
+  onCancel,
+  onSubmit,
+}: {
+  filePath: string;
+  hunkIndex: number;
+  line: number;
+  side: "old" | "new";
+  theme: AppTheme;
+  width: number;
+  onCancel: () => void;
+  onSubmit: (summary: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const sideLabel = side === "new" ? "+" : "-";
+  const titleText = `Comment · ${filePath}:${sideLabel}${line}@${hunkIndex + 1}   Enter save · Esc cancel`;
+  const boxWidth = Math.max(28, Math.min(width - 4, Math.max(28, width - 4)));
+  const innerWidth = Math.max(1, boxWidth - 2);
+  const topBorder = `┌${"─".repeat(Math.max(0, boxWidth - 2))}┐`;
+  const bottomBorder = `└${"─".repeat(Math.max(0, boxWidth - 2))}┘`;
+  const boxLeft = Math.min(4, Math.max(0, width - boxWidth));
+
+  const handleKeyDown = (key: KeyEvent) => {
+    if (!isEscapeKey(key)) {
+      return;
+    }
+
+    key.preventDefault();
+    key.stopPropagation();
+    onCancel();
+  };
+
+  const handleSubmit = (value: string) => {
+    if (value.trim().length === 0) {
+      onCancel();
+      return;
+    }
+    onSubmit(value);
+  };
+
+  return (
+    <box style={{ width: "100%", flexDirection: "column", backgroundColor: theme.panel }}>
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            {topBorder}
+          </text>
+        </box>
+      </box>
+
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+        <box style={{ width: innerWidth, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>
+            {padText(fitText(titleText, innerWidth), innerWidth)}
+          </text>
+        </box>
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+      </box>
+
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+        <input
+          width={innerWidth}
+          value={draft}
+          placeholder="describe what you want the agent to look at"
+          focused={true}
+          onInput={setDraft}
+          onSubmit={handleSubmit}
+          onKeyDown={handleKeyDown}
+        />
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+      </box>
+
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            {bottomBorder}
+          </text>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+/** Constant terminal-row height the composer occupies inside the diff stream. */
+export const COMMENT_COMPOSER_HEIGHT = 4;
+```
+
+- [ ] **Step 2: Run typecheck to verify the component is valid**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/components/panes/CommentComposer.tsx
+git commit -m "feat(ui): add CommentComposer card for inline cursor-driven comments"
+```
+
+---
+
+### Task 6: `comment-composer` planned row kind
+
+**Files:**
+- Modify: `src/ui/diff/reviewRenderPlan.ts`
+
+- [ ] **Step 1: Extend the planned-row type and insertion logic**
+
+In `src/ui/diff/reviewRenderPlan.ts`, add a new variant to `PlannedReviewRow` at the end of the union (after the existing `note-guide-cap` variant):
+
+```ts
+  | {
+      kind: "comment-composer";
+      key: string;
+      stableKey: string;
+      fileId: string;
+      hunkIndex: number;
+      side: "old" | "new";
+      line: number;
+    };
+```
+
+Then extend the function signature and insertion logic. Replace the entire `buildReviewRenderPlan` function with:
+
+```ts
+/**
+ * Build the explicit presentational row plan for one file diff body.
+ * The plan always preserves diff-row order and may insert inline notes, trailing guide caps
+ * for every visible note anchored in this file, and one composer row when the user is
+ * currently composing a comment in this file.
+ */
+export function buildReviewRenderPlan({
+  fileId,
+  rows,
+  showHunkHeaders,
+  visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
+  selectedHunkIndex: _selectedHunkIndex,
+  composer = null,
+}: {
+  fileId: string;
+  rows: DiffRow[];
+  showHunkHeaders: boolean;
+  visibleAgentNotes?: VisibleAgentNote[];
+  selectedHunkIndex?: number;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
+}) {
+  const placementsByAnchor = buildInlineVisibleNotePlacements(rows, visibleAgentNotes);
+  const noteGuideSideByRowKey = buildNoteGuideSideByRowKey(placementsByAnchor);
+  const guideCapsByRowKey = buildGuideCapsByRowKey(placementsByAnchor);
+  const plannedRows: PlannedReviewRow[] = [];
+  const anchoredHunks = new Set<number>();
+  const composerAnchorStableKey =
+    composer && composer.fileId === fileId
+      ? `line:${composer.hunkIndex}:${composer.side}:${composer.line}`
+      : null;
+  let composerInserted = false;
+
+  for (const row of rows) {
+    const shouldAnchorHunk =
+      rowCanAnchorHunk(row, showHunkHeaders) && !anchoredHunks.has(row.hunkIndex);
+    const anchorId = shouldAnchorHunk ? diffHunkId(fileId, row.hunkIndex) : undefined;
+    const diffStableKeys = diffRowStableKeys(row);
+    const diffStableKey = diffStableKeys[0] ?? `row:${row.key}`;
+    const diffStableAliasKeys = diffStableKeys.slice(1);
+
+    if (shouldAnchorHunk) {
+      anchoredHunks.add(row.hunkIndex);
+    }
+
+    const anchoredNotes = placementsByAnchor.get(row.key) ?? [];
+    anchoredNotes.forEach((placement) => {
+      plannedRows.push({
+        kind: "inline-note",
+        key: `inline-note:${placement.note.id}:${row.key}:${placement.noteIndex}`,
+        stableKey: `inline-note:${placement.note.id}`,
+        fileId,
+        hunkIndex: placement.hunkIndex,
+        annotationId: placement.note.id,
+        annotation: placement.note.annotation,
+        anchorSide: placement.anchorSide,
+        noteCount: placement.noteCount,
+        noteIndex: placement.noteIndex,
+      });
+    });
+
+    plannedRows.push({
+      kind: "diff-row",
+      key: `diff-row:${row.key}`,
+      stableKey: diffStableKey,
+      stableAliasKeys: diffStableAliasKeys,
+      fileId: row.fileId,
+      hunkIndex: row.hunkIndex,
+      row,
+      anchorId,
+      noteGuideSide: noteGuideSideByRowKey.get(row.key),
+    });
+
+    if (
+      composer &&
+      composerAnchorStableKey &&
+      !composerInserted &&
+      diffStableKeys.includes(composerAnchorStableKey)
+    ) {
+      plannedRows.push({
+        kind: "comment-composer",
+        key: `comment-composer:${composer.hunkIndex}:${composer.side}:${composer.line}`,
+        stableKey: `comment-composer:${composer.hunkIndex}:${composer.side}:${composer.line}`,
+        fileId,
+        hunkIndex: composer.hunkIndex,
+        side: composer.side,
+        line: composer.line,
+      });
+      composerInserted = true;
+    }
+
+    const guideCaps = guideCapsByRowKey.get(row.key);
+    if (guideCaps) {
+      Array.from(guideCaps).forEach((side) => {
+        plannedRows.push({
+          kind: "note-guide-cap",
+          key: `note-guide-cap:${row.key}:${side}`,
+          stableKey: `note-guide-cap:${side}:${diffRowStableKeyForSide(row, side) ?? diffStableKey}`,
+          fileId,
+          hunkIndex: row.hunkIndex,
+          side,
+        });
+      });
+    }
+  }
+
+  return plannedRows;
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Run the existing review-render tests to verify nothing broke**
+
+Run: `bun test src/ui/diff/reviewRenderPlan.test.ts`
+Expected: PASS — existing tests do not pass `composer`, so behaviour is unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/diff/reviewRenderPlan.ts
+git commit -m "feat(diff): add comment-composer planned row kind for inline comment composer"
+```
+
+---
+
+### Task 7: Composer row geometry
+
+**Files:**
+- Modify: `src/ui/lib/diffSectionGeometry.ts`
+
+- [ ] **Step 1: Plumb the composer through geometry and measure its height**
+
+In `src/ui/lib/diffSectionGeometry.ts`, add the composer import at the top:
+
+```ts
+import { COMMENT_COMPOSER_HEIGHT } from "../components/panes/CommentComposer";
+```
+
+Update `buildBasePlannedRows` to accept and forward the composer parameter. Replace the existing function with:
+
+```ts
+function buildBasePlannedRows(
+  file: DiffFile,
+  layout: Exclude<LayoutMode, "auto">,
+  showHunkHeaders: boolean,
+  theme: AppTheme,
+  visibleAgentNotes: VisibleAgentNote[],
+  composer: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null,
+) {
+  const rows =
+    layout === "split" ? buildSplitRows(file, null, theme) : buildStackRows(file, null, theme);
+
+  return buildReviewRenderPlan({
+    fileId: file.id,
+    rows,
+    selectedHunkIndex: -1,
+    showHunkHeaders,
+    visibleAgentNotes,
+    composer,
+  });
+}
+```
+
+Update `plannedRowHeight` to handle the composer kind. Replace it with:
+
+```ts
+function plannedRowHeight(
+  row: PlannedReviewRow,
+  showHunkHeaders: boolean,
+  layout: Exclude<LayoutMode, "auto">,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+  wrapLines: boolean,
+  theme: AppTheme,
+) {
+  if (row.kind === "inline-note") {
+    return measureAgentInlineNoteHeight({
+      annotation: row.annotation,
+      anchorSide: row.anchorSide,
+      layout,
+      width,
+    });
+  }
+
+  if (row.kind === "note-guide-cap") {
+    return 1;
+  }
+
+  if (row.kind === "comment-composer") {
+    return COMMENT_COMPOSER_HEIGHT;
+  }
+
+  return measureRenderedRowHeight(
+    row.row,
+    width,
+    lineNumberDigits,
+    showLineNumbers,
+    showHunkHeaders,
+    wrapLines,
+    theme,
+  );
+}
+```
+
+Update `rowContributesToHunkBounds` so the composer row keeps the owning hunk's bounds growing while it is mounted:
+
+```ts
+function rowContributesToHunkBounds(row: PlannedReviewRow) {
+  return !(row.kind === "diff-row" && row.row.type === "collapsed");
+}
+```
+
+(No change required — composer already counts because the early-return only excludes collapsed diff rows.)
+
+Update `measureDiffSectionGeometry` to accept and forward the composer argument. Replace its signature and body with:
+
+```ts
+export function measureDiffSectionGeometry(
+  file: DiffFile,
+  layout: Exclude<LayoutMode, "auto">,
+  showHunkHeaders: boolean,
+  theme: AppTheme,
+  visibleAgentNotes: VisibleAgentNote[] = [],
+  width = 0,
+  showLineNumbers = true,
+  wrapLines = false,
+  composer: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null = null,
+): DiffSectionGeometry {
+  if (file.metadata.hunks.length === 0) {
+    return {
+      bodyHeight: 1,
+      hunkAnchorRows: new Map(),
+      hunkBounds: new Map(),
+      rowBounds: [],
+      rowBoundsByKey: new Map(),
+      rowBoundsByStableKey: new Map(),
+    };
+  }
+
+  const composerKey = composer && composer.fileId === file.id
+    ? `${composer.hunkIndex}:${composer.side}:${composer.line}`
+    : "none";
+  const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}:${composerKey}`;
+  if (visibleAgentNotes.length > 0) {
+    const cachedByNotes = NOTE_AWARE_SECTION_GEOMETRY_CACHE.get(visibleAgentNotes);
+    const cached = cachedByNotes?.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+
+  const plannedRows = buildBasePlannedRows(
+    file,
+    layout,
+    showHunkHeaders,
+    theme,
+    visibleAgentNotes,
+    composer,
+  );
+  const hunkAnchorRows = new Map<number, number>();
+  const hunkBounds = new Map<number, PlannedHunkBounds>();
+  const rowBounds: DiffSectionRowBounds[] = [];
+  const rowBoundsByKey = new Map<string, DiffSectionRowBounds>();
+  const rowBoundsByStableKey = new Map<string, DiffSectionRowBounds>();
+  const lineNumberDigits = String(findMaxLineNumber(file)).length;
+  let bodyHeight = 0;
+
+  for (const row of plannedRows) {
+    if (row.kind === "diff-row" && row.anchorId && !hunkAnchorRows.has(row.hunkIndex)) {
+      hunkAnchorRows.set(row.hunkIndex, bodyHeight);
+    }
+
+    const height = plannedRowHeight(
+      row,
+      showHunkHeaders,
+      layout,
+      width,
+      lineNumberDigits,
+      showLineNumbers,
+      wrapLines,
+      theme,
+    );
+    const stableKeys = [
+      row.stableKey,
+      ...(row.kind === "diff-row" ? (row.stableAliasKeys ?? []) : []),
+    ];
+    const rowBoundsEntry = {
+      key: row.key,
+      stableKey: row.stableKey,
+      stableKeys,
+      top: bodyHeight,
+      height,
+    };
+    rowBounds.push(rowBoundsEntry);
+    rowBoundsByKey.set(row.key, rowBoundsEntry);
+    for (const stableKey of stableKeys) {
+      if (!rowBoundsByStableKey.has(stableKey)) {
+        rowBoundsByStableKey.set(stableKey, rowBoundsEntry);
+      }
+    }
+
+    if (height > 0 && rowContributesToHunkBounds(row)) {
+      const rowId = reviewRowId(row.key);
+      const existingBounds = hunkBounds.get(row.hunkIndex);
+
+      if (existingBounds) {
+        existingBounds.endRowId = rowId;
+        existingBounds.height += height;
+      } else {
+        hunkBounds.set(row.hunkIndex, {
+          top: bodyHeight,
+          height,
+          startRowId: rowId,
+          endRowId: rowId,
+        });
+      }
+    }
+
+    bodyHeight += height;
+  }
+
+  const geometry: DiffSectionGeometry = {
+    bodyHeight,
+    hunkAnchorRows,
+    hunkBounds,
+    rowBounds,
+    rowBoundsByKey,
+    rowBoundsByStableKey,
+  };
+
+  if (visibleAgentNotes.length > 0) {
+    const cachedByNotes = NOTE_AWARE_SECTION_GEOMETRY_CACHE.get(visibleAgentNotes) ?? new Map();
+    cachedByNotes.set(cacheKey, geometry);
+    NOTE_AWARE_SECTION_GEOMETRY_CACHE.set(visibleAgentNotes, cachedByNotes);
+  }
+
+  return geometry;
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Run the existing geometry tests**
+
+Run: `bun test src/ui/lib/diffSectionGeometry.test.ts`
+Expected: PASS — existing callers do not pass the new `composer` argument, so behaviour is unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/lib/diffSectionGeometry.ts
+git commit -m "feat(diff): measure the comment composer row in diff section geometry"
+```
+
+---
+
+### Task 8: Render the cursor highlight and composer in the diff view
+
+**Files:**
+- Modify: `src/ui/diff/renderRows.tsx`
+- Modify: `src/ui/diff/PierreDiffView.tsx`
+
+- [ ] **Step 1: Plumb `isCursor` through `DiffRowView`**
+
+In `src/ui/diff/renderRows.tsx`, update the `renderHeaderRow` and `renderRow` signatures to accept an `isCursor` boolean, then make the row prefix render the cursor marker when set.
+
+Locate `renderRow` and update its parameter list to include `isCursor: boolean = false` immediately after the existing `selected: boolean` parameter. Replace `function renderRow(` through the end of the function with this (only the marker-related lines change — the rest is preserved):
+
+Find these lines inside the split-line branch:
+
+```ts
+    const leftPrefix = {
+      text: guideOnOldSide ? "│" : marker(),
+      fg: guideOnOldSide ? theme.noteBorder : splitLeftRailColor(row.left.kind, theme, selected),
+      bg: theme.panel,
+    };
+```
+
+Replace with:
+
+```ts
+    const leftPrefix = {
+      text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
+      fg: guideOnOldSide
+        ? theme.noteBorder
+        : isCursor
+          ? theme.noteTitleText
+          : splitLeftRailColor(row.left.kind, theme, selected),
+      bg: isCursor ? theme.noteTitleBackground : theme.panel,
+    };
+```
+
+Find these lines inside the stack-line branch:
+
+```ts
+    const prefix = {
+      text: guideOnOldSide ? "│" : marker(),
+      fg: guideOnOldSide ? theme.noteBorder : stackRailColor(row.cell.kind, theme, selected),
+      bg: theme.panel,
+    };
+```
+
+Replace with:
+
+```ts
+    const prefix = {
+      text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
+      fg: guideOnOldSide
+        ? theme.noteBorder
+        : isCursor
+          ? theme.noteTitleText
+          : stackRailColor(row.cell.kind, theme, selected),
+      bg: isCursor ? theme.noteTitleBackground : theme.panel,
+    };
+```
+
+Add `isCursor` to the `renderRow` parameter list. Find:
+
+```ts
+function renderRow(
+  row: DiffRow,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+  showHunkHeaders: boolean,
+  wrapLines: boolean,
+  codeHorizontalOffset: number,
+  theme: AppTheme,
+  selected: boolean,
+  annotated: boolean,
+  anchorId?: string,
+  noteGuideSide?: "old" | "new",
+  onOpenAgentNotesAtHunk?: (hunkIndex: number) => void,
+) {
+```
+
+Replace with:
+
+```ts
+function renderRow(
+  row: DiffRow,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+  showHunkHeaders: boolean,
+  wrapLines: boolean,
+  codeHorizontalOffset: number,
+  theme: AppTheme,
+  selected: boolean,
+  annotated: boolean,
+  anchorId?: string,
+  noteGuideSide?: "old" | "new",
+  onOpenAgentNotesAtHunk?: (hunkIndex: number) => void,
+  isCursor: boolean = false,
+) {
+```
+
+Update `DiffRowViewProps` to accept `isCursor`:
+
+```ts
+interface DiffRowViewProps {
+  row: DiffRow;
+  width: number;
+  lineNumberDigits: number;
+  showLineNumbers: boolean;
+  showHunkHeaders: boolean;
+  wrapLines: boolean;
+  codeHorizontalOffset: number;
+  theme: AppTheme;
+  selected: boolean;
+  annotated: boolean;
+  anchorId?: string;
+  noteGuideSide?: "old" | "new";
+  onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
+  isCursor?: boolean;
+}
+```
+
+Update the memoized component body and prop equality. Replace the `DiffRowView` export with:
+
+```ts
+export const DiffRowView = memo(
+  function DiffRowViewComponent({
+    row,
+    width,
+    lineNumberDigits,
+    showLineNumbers,
+    showHunkHeaders,
+    wrapLines,
+    codeHorizontalOffset,
+    theme,
+    selected,
+    annotated,
+    anchorId,
+    noteGuideSide,
+    onOpenAgentNotesAtHunk,
+    isCursor = false,
+  }: DiffRowViewProps) {
+    return renderRow(
+      row,
+      width,
+      lineNumberDigits,
+      showLineNumbers,
+      showHunkHeaders,
+      wrapLines,
+      codeHorizontalOffset,
+      theme,
+      selected,
+      annotated,
+      anchorId,
+      noteGuideSide,
+      onOpenAgentNotesAtHunk,
+      isCursor,
+    );
+  },
+  (previous, next) => {
+    return (
+      previous.row === next.row &&
+      previous.width === next.width &&
+      previous.lineNumberDigits === next.lineNumberDigits &&
+      previous.showLineNumbers === next.showLineNumbers &&
+      previous.showHunkHeaders === next.showHunkHeaders &&
+      previous.wrapLines === next.wrapLines &&
+      previous.codeHorizontalOffset === next.codeHorizontalOffset &&
+      previous.theme === next.theme &&
+      previous.selected === next.selected &&
+      previous.annotated === next.annotated &&
+      previous.anchorId === next.anchorId &&
+      previous.noteGuideSide === next.noteGuideSide &&
+      previous.isCursor === next.isCursor
+    );
+  },
+);
+```
+
+- [ ] **Step 2: Plumb the cursor row key and composer through `PierreDiffView`**
+
+In `src/ui/diff/PierreDiffView.tsx`, add the composer import next to the existing imports:
+
+```ts
+import { CommentComposer } from "../components/panes/CommentComposer";
+```
+
+Extend the prop signature. Replace the `PierreDiffView` parameter list and destructure with:
+
+```ts
+export function PierreDiffView({
+  annotatedHunkIndices = EMPTY_ANNOTATED_HUNK_INDICES,
+  codeHorizontalOffset = 0,
+  commentCursorRowStableKey,
+  composer,
+  file,
+  layout,
+  onCommentComposerCancel,
+  onCommentComposerSubmit,
+  onOpenAgentNotesAtHunk,
+  showLineNumbers = true,
+  showHunkHeaders = true,
+  wrapLines = false,
+  theme,
+  visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
+  width,
+  selectedHunkIndex,
+  sectionGeometry,
+  shouldLoadHighlight = true,
+  scrollable = true,
+  visibleBodyBounds,
+}: {
+  annotatedHunkIndices?: Set<number>;
+  codeHorizontalOffset?: number;
+  commentCursorRowStableKey?: string | null;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
+  file: DiffFile | undefined;
+  layout: Exclude<LayoutMode, "auto">;
+  onCommentComposerCancel?: () => void;
+  onCommentComposerSubmit?: (summary: string) => void;
+  onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
+  showLineNumbers?: boolean;
+  showHunkHeaders?: boolean;
+  wrapLines?: boolean;
+  theme: AppTheme;
+  visibleAgentNotes?: VisibleAgentNote[];
+  width: number;
+  selectedHunkIndex: number;
+  sectionGeometry?: DiffSectionGeometry;
+  shouldLoadHighlight?: boolean;
+  scrollable?: boolean;
+  visibleBodyBounds?: VisibleBodyBounds;
+}) {
+```
+
+Update the `plannedRows` `useMemo` to pass the composer through to `buildReviewRenderPlan`:
+
+```ts
+  const plannedRows = useMemo(
+    () =>
+      file
+        ? buildReviewRenderPlan({
+            fileId: file.id,
+            rows,
+            showHunkHeaders,
+            visibleAgentNotes,
+            composer: composer ?? null,
+          })
+        : [],
+    [composer, file, rows, showHunkHeaders, visibleAgentNotes],
+  );
+```
+
+Inside the row-mapping branch, add a render case for the `comment-composer` row before the existing diff-row return. Replace:
+
+```ts
+        if (plannedRow.kind === "note-guide-cap") {
+          return (
+            <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
+              <AgentInlineNoteGuideCap side={plannedRow.side} theme={theme} width={width} />
+            </box>
+          );
+        }
+
+        return (
+          <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
+            <DiffRowView
+              row={plannedRow.row}
+              width={width}
+              lineNumberDigits={lineNumberDigits}
+              showLineNumbers={showLineNumbers}
+              showHunkHeaders={showHunkHeaders}
+              wrapLines={wrapLines}
+              codeHorizontalOffset={codeHorizontalOffset}
+              theme={theme}
+              selected={plannedRow.row.hunkIndex === selectedHunkIndex}
+              annotated={
+                plannedRow.row.type === "hunk-header" &&
+                annotatedHunkIndices.has(plannedRow.row.hunkIndex)
+              }
+              anchorId={plannedRow.anchorId}
+              noteGuideSide={plannedRow.noteGuideSide}
+              onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+            />
+          </box>
+        );
+```
+
+With:
+
+```ts
+        if (plannedRow.kind === "note-guide-cap") {
+          return (
+            <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
+              <AgentInlineNoteGuideCap side={plannedRow.side} theme={theme} width={width} />
+            </box>
+          );
+        }
+
+        if (plannedRow.kind === "comment-composer") {
+          return (
+            <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
+              <CommentComposer
+                filePath={file.path}
+                hunkIndex={plannedRow.hunkIndex}
+                line={plannedRow.line}
+                side={plannedRow.side}
+                theme={theme}
+                width={width}
+                onCancel={() => onCommentComposerCancel?.()}
+                onSubmit={(summary) => onCommentComposerSubmit?.(summary)}
+              />
+            </box>
+          );
+        }
+
+        const isCursorRow = Boolean(
+          commentCursorRowStableKey &&
+            (plannedRow.stableKey === commentCursorRowStableKey ||
+              plannedRow.stableAliasKeys?.includes(commentCursorRowStableKey)),
+        );
+
+        return (
+          <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
+            <DiffRowView
+              row={plannedRow.row}
+              width={width}
+              lineNumberDigits={lineNumberDigits}
+              showLineNumbers={showLineNumbers}
+              showHunkHeaders={showHunkHeaders}
+              wrapLines={wrapLines}
+              codeHorizontalOffset={codeHorizontalOffset}
+              theme={theme}
+              selected={plannedRow.row.hunkIndex === selectedHunkIndex}
+              annotated={
+                plannedRow.row.type === "hunk-header" &&
+                annotatedHunkIndices.has(plannedRow.row.hunkIndex)
+              }
+              anchorId={plannedRow.anchorId}
+              noteGuideSide={plannedRow.noteGuideSide}
+              onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+              isCursor={isCursorRow}
+            />
+          </box>
+        );
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `bun test`
+Expected: PASS — these changes are gated on new props nothing else passes yet.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/diff/renderRows.tsx src/ui/diff/PierreDiffView.tsx
+git commit -m "feat(diff): render the cursor highlight and inline composer in PierreDiffView"
+```
+
+---
+
+### Task 9: Plumb the cursor through `DiffPane` and `DiffSection`
+
+**Files:**
+- Modify: `src/ui/components/panes/DiffPane.tsx`
+- Modify: `src/ui/components/panes/DiffSection.tsx`
+
+- [ ] **Step 1: Accept cursor + composer props in `DiffSection`**
+
+In `src/ui/components/panes/DiffSection.tsx`, update the interface and forward the new props. Replace the `DiffSectionProps` interface and the `DiffSectionComponent` parameter destructure with:
+
+```ts
+interface DiffSectionProps {
+  codeHorizontalOffset: number;
+  commentCursorRowStableKey?: string | null;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
+  file: DiffFile;
+  headerLabelWidth: number;
+  headerStatsWidth: number;
+  layout: Exclude<LayoutMode, "auto">;
+  selectedHunkIndex: number;
+  shouldLoadHighlight: boolean;
+  sectionGeometry?: DiffSectionGeometry;
+  separatorWidth: number;
+  showLineNumbers: boolean;
+  showHunkHeaders: boolean;
+  wrapLines: boolean;
+  showHeader: boolean;
+  showSeparator: boolean;
+  theme: AppTheme;
+  visibleAgentNotes: VisibleAgentNote[];
+  visibleBodyBounds?: VisibleBodyBounds;
+  viewWidth: number;
+  onCommentComposerCancel?: () => void;
+  onCommentComposerSubmit?: (summary: string) => void;
+  onOpenAgentNotesAtHunk: (hunkIndex: number) => void;
+  onSelect: () => void;
+}
+
+function DiffSectionComponent({
+  codeHorizontalOffset,
+  commentCursorRowStableKey,
+  composer,
+  file,
+  headerLabelWidth,
+  headerStatsWidth,
+  layout,
+  selectedHunkIndex,
+  shouldLoadHighlight,
+  sectionGeometry,
+  separatorWidth,
+  showLineNumbers,
+  showHunkHeaders,
+  wrapLines,
+  showHeader,
+  showSeparator,
+  theme,
+  visibleAgentNotes,
+  visibleBodyBounds,
+  viewWidth,
+  onCommentComposerCancel,
+  onCommentComposerSubmit,
+  onOpenAgentNotesAtHunk,
+  onSelect,
+}: DiffSectionProps) {
+```
+
+Forward the new props to `PierreDiffView`. Replace the `<PierreDiffView ... />` element with:
+
+```ts
+      <PierreDiffView
+        commentCursorRowStableKey={commentCursorRowStableKey ?? null}
+        composer={composer ?? null}
+        file={file}
+        layout={layout}
+        showLineNumbers={showLineNumbers}
+        showHunkHeaders={showHunkHeaders}
+        wrapLines={wrapLines}
+        codeHorizontalOffset={codeHorizontalOffset}
+        theme={theme}
+        width={viewWidth}
+        annotatedHunkIndices={annotatedHunkIndices}
+        visibleAgentNotes={visibleAgentNotes}
+        onCommentComposerCancel={onCommentComposerCancel}
+        onCommentComposerSubmit={onCommentComposerSubmit}
+        onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+        selectedHunkIndex={selectedHunkIndex}
+        sectionGeometry={sectionGeometry}
+        shouldLoadHighlight={shouldLoadHighlight}
+        scrollable={false}
+        visibleBodyBounds={visibleBodyBounds}
+      />
+```
+
+Extend the memo comparator. Replace the existing comparator's return expression with:
+
+```ts
+  return (
+    previous.codeHorizontalOffset === next.codeHorizontalOffset &&
+    previous.commentCursorRowStableKey === next.commentCursorRowStableKey &&
+    previous.composer === next.composer &&
+    previous.file === next.file &&
+    previous.headerLabelWidth === next.headerLabelWidth &&
+    previous.headerStatsWidth === next.headerStatsWidth &&
+    previous.layout === next.layout &&
+    previous.selectedHunkIndex === next.selectedHunkIndex &&
+    previous.shouldLoadHighlight === next.shouldLoadHighlight &&
+    previous.sectionGeometry === next.sectionGeometry &&
+    previous.separatorWidth === next.separatorWidth &&
+    previous.showLineNumbers === next.showLineNumbers &&
+    previous.showHunkHeaders === next.showHunkHeaders &&
+    previous.wrapLines === next.wrapLines &&
+    previous.showHeader === next.showHeader &&
+    previous.showSeparator === next.showSeparator &&
+    previous.theme === next.theme &&
+    previous.visibleAgentNotes === next.visibleAgentNotes &&
+    previous.visibleBodyBounds === next.visibleBodyBounds &&
+    previous.viewWidth === next.viewWidth
+  );
+```
+
+- [ ] **Step 2: Accept cursor + composer props in `DiffPane`**
+
+In `src/ui/components/panes/DiffPane.tsx`, add the new props to the function signature. Find the existing destructure for `DiffPane` and add:
+
+```ts
+  commentCursorRowStableKey,
+  composer,
+  onCommentComposerCancel,
+  onCommentComposerSubmit,
+```
+
+after `codeHorizontalOffset`. Add them to the prop type as well:
+
+```ts
+  commentCursorRowStableKey?: string | null;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
+  onCommentComposerCancel?: () => void;
+  onCommentComposerSubmit?: (summary: string) => void;
+```
+
+When `DiffPane` measures `sectionGeometry` for the selected file, pass the composer through so the composer row contributes to the file's body height. Locate the `measureDiffSectionGeometry` call inside the `sectionGeometry` `useMemo` and update it to pass `composer` as the ninth argument. Replace the relevant `useMemo` block (the one assigned to `sectionGeometry`) with:
+
+```ts
+  const sectionGeometry = useMemo(
+    () =>
+      files.map((file, index) => {
+        const notes = allAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES;
+        const fileComposer = composer && composer.fileId === file.id ? composer : null;
+        if (notes.length === 0 && !fileComposer) {
+          return baseSectionGeometry[index]!;
+        }
+
+        return measureDiffSectionGeometry(
+          file,
+          layout,
+          showHunkHeaders,
+          theme,
+          notes,
+          diffContentWidth,
+          showLineNumbers,
+          wrapLines,
+          fileComposer,
+        );
+      }),
+    [
+      allAgentNotesByFile,
+      baseSectionGeometry,
+      composer,
+      diffContentWidth,
+      files,
+      layout,
+      showHunkHeaders,
+      showLineNumbers,
+      theme,
+      wrapLines,
+    ],
+  );
+```
+
+Forward `commentCursorRowStableKey`, `composer`, and the composer callbacks to each `<DiffSection ... />` in the render branch. Inside the `files.map(...)` block, replace the `<DiffSection key={file.id} ... />` element with:
+
+```ts
+                  return (
+                    <DiffSection
+                      key={file.id}
+                      codeHorizontalOffset={codeHorizontalOffset}
+                      commentCursorRowStableKey={commentCursorRowStableKey ?? null}
+                      composer={composer && composer.fileId === file.id ? composer : null}
+                      file={file}
+                      headerLabelWidth={headerLabelWidth}
+                      headerStatsWidth={headerStatsWidth}
+                      layout={layout}
+                      selectedHunkIndex={file.id === selectedFileId ? selectedHunkIndex : -1}
+                      shouldLoadHighlight={highlightPrefetchFileIds.has(file.id)}
+                      sectionGeometry={sectionGeometry[index]}
+                      separatorWidth={separatorWidth}
+                      showHeader={shouldRenderInStreamFileHeader(index)}
+                      showSeparator={index > 0}
+                      showLineNumbers={showLineNumbers}
+                      showHunkHeaders={showHunkHeaders}
+                      wrapLines={wrapLines}
+                      theme={theme}
+                      viewWidth={diffContentWidth}
+                      visibleAgentNotes={
+                        visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
+                      }
+                      visibleBodyBounds={visibleBodyBoundsByFile.get(file.id)}
+                      onCommentComposerCancel={onCommentComposerCancel}
+                      onCommentComposerSubmit={onCommentComposerSubmit}
+                      onOpenAgentNotesAtHunk={(hunkIndex) =>
+                        onOpenAgentNotesAtHunk(file.id, hunkIndex)
+                      }
+                      onSelect={() => onSelectFile(file.id)}
+                    />
+                  );
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/components/panes/DiffPane.tsx src/ui/components/panes/DiffSection.tsx
+git commit -m "feat(diff): plumb the comment cursor and composer through DiffPane and DiffSection"
+```
+
+---
+
+### Task 10: `handleCursorShortcut` in the keyboard router
+
+**Files:**
+- Modify: `src/ui/hooks/useAppKeyboardShortcuts.ts`
+
+- [ ] **Step 1: Extend the options interface**
+
+In `src/ui/hooks/useAppKeyboardShortcuts.ts`, add new fields to `UseAppKeyboardShortcutsOptions`:
+
+```ts
+  commentCursorMode: "off" | "navigating" | "composing";
+  enterCommentCursor: () => void;
+  exitCommentCursor: () => void;
+  moveCommentCursor: (delta: number) => void;
+  jumpCommentCursorToHunk: (delta: number) => void;
+  openCommentComposer: () => void;
+```
+
+Pull those fields out of the function parameters next to the existing ones.
+
+- [ ] **Step 2: Add the cursor handler**
+
+Add this helper inside `useAppKeyboardShortcuts`, between `handleMenuShortcut` and `handleFilterShortcut`:
+
+```ts
+  const commentCursorModeRef = useRef(commentCursorMode);
+  commentCursorModeRef.current = commentCursorMode;
+
+  const handleCursorShortcut = (key: KeyEvent) => {
+    const mode = commentCursorModeRef.current;
+
+    if (mode === "off") {
+      return false;
+    }
+
+    if (mode === "composing") {
+      // The focused composer input owns its own keys; the router stays out of its way.
+      return true;
+    }
+
+    if (isEscapeKey(key) || key.name === "c" || key.sequence === "c") {
+      exitCommentCursor();
+      return true;
+    }
+
+    if (key.name === "return" || key.name === "enter" || key.name === "i" || key.sequence === "i") {
+      openCommentComposer();
+      return true;
+    }
+
+    if (isStepUpKey(key)) {
+      moveCommentCursor(-1);
+      return true;
+    }
+
+    if (isStepDownKey(key)) {
+      moveCommentCursor(1);
+      return true;
+    }
+
+    if (key.name === "[") {
+      jumpCommentCursorToHunk(-1);
+      return true;
+    }
+
+    if (key.name === "]") {
+      jumpCommentCursorToHunk(1);
+      return true;
+    }
+
+    return false;
+  };
+```
+
+Add cursor entry to `handleAppShortcut`. Find the block that begins with `if (key.name === "a") {` and insert this new branch *before* it:
+
+```ts
+    if (key.name === "c" || key.sequence === "c") {
+      runAndCloseMenu(enterCommentCursor);
+      return;
+    }
+```
+
+Wire the new handler into the `useKeyboard` callback. Replace the existing callback body with:
+
+```ts
+  useKeyboard((key: KeyEvent) => {
+    if (handleMenuToggleShortcut(key)) {
+      return;
+    }
+
+    if (pagerModeRef.current) {
+      handlePagerShortcut(key);
+      return;
+    }
+
+    if (handleHelpShortcut(key)) {
+      return;
+    }
+
+    if (handleMenuShortcut(key)) {
+      return;
+    }
+
+    if (handleCursorShortcut(key)) {
+      return;
+    }
+
+    if (handleFilterShortcut(key)) {
+      return;
+    }
+
+    handleAppShortcut(key);
+  });
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: FAIL — `App.tsx` does not yet pass the new options to `useAppKeyboardShortcuts`. Task 11 closes that gap. The error must be exactly about the new options; any other type error indicates a real problem in this task's edits.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/hooks/useAppKeyboardShortcuts.ts
+git commit -m "feat(keys): add cursor-mode handler to the app keyboard router"
+```
+
+---
+
+### Task 11: Wire cursor state into `App.tsx`
+
+**Files:**
+- Modify: `src/ui/App.tsx`
+- Modify: `src/ui/lib/appMenus.ts`
+
+- [ ] **Step 1: Pull cursor controls out of the review controller**
+
+In `src/ui/App.tsx`, near the existing `review.*` destructure (around line 124-130), add:
+
+```ts
+  const commentCursor = review.commentCursor;
+  const commentCursorRowStableKey = review.commentCursorRowStableKey;
+  const addUserLiveComment = review.addUserLiveComment;
+  const setCommentCursorMode = review.setCommentCursorMode;
+  const moveCommentCursor = review.moveCommentCursor;
+  const jumpCommentCursorToHunk = review.jumpCommentCursorToHunk;
+```
+
+- [ ] **Step 2: Build the composer descriptor and callbacks**
+
+Below the destructure above, add:
+
+```ts
+  const composerDescriptor =
+    commentCursor.mode === "composing"
+      ? {
+          fileId: commentCursor.fileId,
+          hunkIndex: commentCursor.hunkIndex,
+          side: commentCursor.side,
+          line: commentCursor.line,
+        }
+      : null;
+
+  const enterCommentCursor = useCallback(() => {
+    setCommentCursorMode(commentCursor.mode === "off" ? "navigating" : "off");
+  }, [commentCursor.mode, setCommentCursorMode]);
+
+  const exitCommentCursor = useCallback(() => {
+    setCommentCursorMode("off");
+  }, [setCommentCursorMode]);
+
+  const openCommentComposer = useCallback(() => {
+    setCommentCursorMode("composing");
+  }, [setCommentCursorMode]);
+
+  const cancelCommentComposer = useCallback(() => {
+    setCommentCursorMode("navigating");
+  }, [setCommentCursorMode]);
+
+  const submitCommentComposer = useCallback(
+    (summary: string) => {
+      try {
+        addUserLiveComment(
+          {
+            fileId: commentCursor.fileId,
+            hunkIndex: commentCursor.hunkIndex,
+            side: commentCursor.side,
+            line: commentCursor.line,
+          },
+          summary,
+        );
+      } catch (error) {
+        console.error("Failed to add user comment.", error);
+      } finally {
+        setCommentCursorMode("navigating");
+      }
+    },
+    [
+      addUserLiveComment,
+      commentCursor.fileId,
+      commentCursor.hunkIndex,
+      commentCursor.line,
+      commentCursor.side,
+      setCommentCursorMode,
+    ],
+  );
+```
+
+- [ ] **Step 3: Pass cursor and composer through to `DiffPane`**
+
+Find the existing `<DiffPane ... />` element near the bottom of `App.tsx`. Add the new props:
+
+```ts
+        <DiffPane
+          codeHorizontalOffset={codeHorizontalOffset}
+          commentCursorRowStableKey={commentCursorRowStableKey}
+          composer={composerDescriptor}
+          diffContentWidth={diffContentWidth}
+          files={filteredFiles}
+          pagerMode={pagerMode}
+          headerLabelWidth={diffHeaderLabelWidth}
+          headerStatsWidth={diffHeaderStatsWidth}
+          layout={resolvedLayout}
+          scrollRef={diffScrollRef}
+          selectedFileId={selectedFile?.id}
+          selectedHunkIndex={selectedHunkIndex}
+          scrollToNote={review.scrollToNote}
+          separatorWidth={diffSeparatorWidth}
+          showAgentNotes={showAgentNotes}
+          showLineNumbers={showLineNumbers}
+          showHunkHeaders={showHunkHeaders}
+          wrapLines={wrapLines}
+          wrapToggleScrollTop={wrapToggleScrollTopRef.current}
+          layoutToggleScrollTop={layoutToggleScrollTopRef.current}
+          layoutToggleRequestId={layoutToggleRequestId}
+          selectedFileTopAlignRequestId={review.selectedFileTopAlignRequestId}
+          selectedHunkRevealRequestId={review.selectedHunkRevealRequestId}
+          theme={activeTheme}
+          width={diffPaneWidth}
+          onCommentComposerCancel={cancelCommentComposer}
+          onCommentComposerSubmit={submitCommentComposer}
+          onOpenAgentNotesAtHunk={openAgentNotesAtHunk}
+          onScrollCodeHorizontally={(delta) => {
+            scrollCodeHorizontally(delta * FAST_CODE_HORIZONTAL_SCROLL_COLUMNS);
+          }}
+          onSelectFile={jumpToFile}
+          onViewportCenteredHunkChange={(fileId, hunkIndex) =>
+            review.selectHunk(fileId, hunkIndex, { preserveViewport: true })
+          }
+        />
+```
+
+- [ ] **Step 4: Wire the keyboard hook**
+
+In the `useAppKeyboardShortcuts({ ... })` call near the bottom of `App.tsx`, add the new options:
+
+```ts
+    commentCursorMode: commentCursor.mode,
+    enterCommentCursor,
+    exitCommentCursor,
+    moveCommentCursor,
+    jumpCommentCursorToHunk,
+    openCommentComposer,
+```
+
+- [ ] **Step 5: Add the View menu entry**
+
+In `src/ui/lib/appMenus.ts`, extend `BuildAppMenusOptions` with:
+
+```ts
+  commentCursorMode: "off" | "navigating" | "composing";
+  toggleCommentCursor: () => void;
+```
+
+Pull those fields out of the parameters at the top of `buildAppMenus`. Add an entry to the `view` menu — append the following item after the existing `Hunk metadata` entry:
+
+```ts
+      {
+        kind: "item",
+        label: "Comment cursor",
+        hint: "c",
+        checked: commentCursorMode !== "off",
+        action: toggleCommentCursor,
+      },
+```
+
+- [ ] **Step 6: Pass the new menu inputs from `App.tsx`**
+
+In `App.tsx`, locate the `useMemo` for `menus = useMemo(() => buildAppMenus({ ... }))`. Add to the call:
+
+```ts
+        commentCursorMode: commentCursor.mode,
+        toggleCommentCursor: enterCommentCursor,
+```
+
+Add `commentCursor.mode` and `enterCommentCursor` to the `useMemo` dependency array.
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Run tests**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/App.tsx src/ui/lib/appMenus.ts
+git commit -m "feat(app): wire the comment cursor into App, DiffPane, and the view menu"
+```
+
+---
+
+### Task 12: AppHost interaction tests
+
+**Files:**
+- Modify: `src/ui/AppHost.interactions.test.tsx`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append the following block inside the `describe("App interactions", ...)` block in `src/ui/AppHost.interactions.test.tsx`:
+
+```ts
+  test("comment cursor toggles, navigates, and saves a user comment", async () => {
+    const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
+      width: 200,
+      height: 28,
+    });
+
+    try {
+      await flush(setup);
+
+      // Enter cursor mode.
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      let frame = setup.captureCharFrame();
+      expect(frame).toContain("▶");
+
+      // Open the composer.
+      await act(async () => {
+        await setup.mockInput.typeText("i");
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("Comment ·");
+      expect(frame).toContain("Enter save · Esc cancel");
+
+      // Type and submit a comment.
+      await act(async () => {
+        await setup.mockInput.typeText("Look at this");
+      });
+      await act(async () => {
+        await setup.mockInput.pressKey({ name: "return" });
+      });
+      await flush(setup);
+
+      frame = await waitForFrame(setup, (next) => next.includes("Look at this"));
+      expect(frame).toContain("Look at this");
+
+      // Esc leaves cursor mode.
+      await act(async () => {
+        await setup.mockInput.pressKey({ name: "escape" });
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame).not.toContain("▶");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("comment composer Esc discards the draft without saving", async () => {
+    const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
+      width: 200,
+      height: 28,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("i");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("draft");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.pressKey({ name: "escape" });
+      });
+      await flush(setup);
+
+      const frame = setup.captureCharFrame();
+      expect(frame).not.toContain("Comment ·");
+      // Comment was not saved — no note card with the draft text appears.
+      expect(frame).not.toContain("draft");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+```
+
+- [ ] **Step 2: Run the new tests to verify they pass**
+
+Run: `bun test src/ui/AppHost.interactions.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/AppHost.interactions.test.tsx
+git commit -m "test(app): cover the comment cursor toggle, composer, and save flow"
+```
+
+---
+
+### Task 13: PTY integration coverage
+
+**Files:**
+- Create: `test/pty/comment-cursor-integration.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `test/pty/comment-cursor-integration.test.ts`:
+
+```ts
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+
+setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("comment cursor PTY integration", () => {
+  test("user can open the cursor, write a comment, and see it as a note", async () => {
+    const fixture = harness.createLongWrapFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      cols: 140,
+      rows: 28,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      await session.press("c");
+      const withCursor = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("▶"),
+        5_000,
+      );
+      expect(withCursor).toContain("▶");
+
+      await session.press("i");
+      const composing = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("Comment ·"),
+        5_000,
+      );
+      expect(composing).toContain("Comment ·");
+
+      await session.type("PTY review note");
+      await session.press("return");
+
+      const saved = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("PTY review note"),
+        5_000,
+      );
+      expect(saved).toContain("PTY review note");
+    } finally {
+      session.close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `bun run test:integration -- comment-cursor-integration`
+Expected: PASS.
+
+If the harness does not expose `session.type`, replace `session.type("PTY review note")` with character-by-character `session.press(...)` calls (consult `test/pty/harness.ts` for the exact session API and use whichever method types raw text).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/pty/comment-cursor-integration.test.ts
+git commit -m "test(pty): cover the comment cursor end-to-end through a real PTY"
+```
+
+---
+
+### Task 14: Changelog entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Record the feature**
+
+In `CHANGELOG.md`, under `## [Unreleased]` → `### Added`, add:
+
+```md
+- Added a keyboard-driven comment cursor (`c`) so reviewers can mark a diff row, type a single-line note with `i` / Enter, and persist it as a user-authored review comment that agents pick up through the existing `hunk session comment *` commands.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note the comment cursor UI under Unreleased > Added"
+```
+
+---
+
+### Task 15: Final verification gates
+
+**Files:** (no edits — verification only)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `bun run typecheck`
+Expected: PASS.
+
+- [ ] **Step 2: Unit tests**
+
+Run: `bun test`
+Expected: PASS.
+
+- [ ] **Step 3: PTY integration tests**
+
+Run: `bun run test:integration`
+Expected: PASS.
+
+- [ ] **Step 4: TTY smoke**
+
+Run: `bun run test:tty-smoke`
+Expected: PASS.
+
+- [ ] **Step 5: Real TTY smoke run**
+
+Manually run the source CLI on a sample diff and verify:
+
+```bash
+bun run src/main.tsx -- diff
+# In the TUI:
+#  press `c` — a cursor marker appears on the first eligible row of the selected hunk
+#  press `j` then `[` — the cursor moves rows and jumps to the previous hunk
+#  press `i` — the composer card appears under the cursor row, focused
+#  type a note, press Enter — the composer closes and the note renders inline
+#  press Esc — cursor mode exits cleanly
+```
+
+Expected: every step above matches reality. Capture any visual regression as a follow-up fix before reporting the work complete.
+
+- [ ] **Step 6: Final summary**
+
+Confirm in the PR description that:
+
+- `bun run typecheck` passed.
+- `bun test` passed.
+- `bun run test:integration` passed.
+- `bun run test:tty-smoke` passed.
+- A real TTY smoke run on a sample diff produced the expected cursor + composer + saved-comment behaviour.

--- a/docs/superpowers/specs/2026-05-14-comment-cursor-ui-design.md
+++ b/docs/superpowers/specs/2026-05-14-comment-cursor-ui-design.md
@@ -1,0 +1,189 @@
+# Comment cursor UI
+
+## Problem
+
+Hunk already stores per-line review comments through the `LiveComment` model and the session-broker protocol. Today only MCP-driven agents can author them — there is no way for a developer inside the TUI to drop a comment on a diff line so an agent can batch-fix the highlighted issues later.
+
+This spec adds a keyboard-driven cursor that the user can move row-by-row through the diff stream, mark a single line, type a short note, and save it. Saved comments flow through the existing live-comment store so the agent picks them up via the same `hunk session comment list` / `review` commands it uses today.
+
+## Scope
+
+In scope:
+
+- A cursor that highlights one diff row at a time.
+- A mode toggle (`c`) that turns the cursor on and off.
+- Keyboard navigation of the cursor within a hunk, across hunks, and across files.
+- An inline composer mounted on the cursor row that lets the user type one short comment.
+- A `source: "user"` flavour of `LiveComment` that reuses every existing storage, rendering, and broker code path.
+
+Out of scope:
+
+- Multi-line range selection. Comments stay single-line to match the current API surface of `LiveComment` and `hunk session comment add`.
+- Editing or replying to an existing comment from the cursor. Removal continues to flow through `removeLiveComment` / `hunk session comment rm`.
+- Persisting user comments to disk across sessions. Comments live in the in-memory store for the lifetime of the session, same as today's MCP comments.
+- Mouse-driven cursor placement. Keyboard only for v1.
+
+## User flow
+
+1. User is reviewing a diff in `hunk diff` / `hunk show`.
+2. User presses `c`. The cursor appears on the first content row of the currently selected hunk (first `+`, falling back to first `-`, then context — same anchor rule the existing `firstCommentTargetForHunk` uses for MCP comments).
+3. User presses `j` / `k` (or `Up` / `Down`) to move row-by-row. `[` / `]` jump to the previous / next hunk's first row, mirroring existing hunk navigation. The viewport scrolls to keep the cursor in view.
+4. User presses `i` (or `Return`) to open a composer on the cursor row. An OpenTUI `<input>` is focused.
+5. User types a short note and presses `Return` to save. The comment is stored as a `LiveComment` with `source: "user"` and renders as a note card directly under the line, exactly like an agent comment.
+6. User presses `Esc` (or `c` again) to leave cursor mode. The cursor highlight disappears; saved comments remain visible.
+
+A View-menu entry mirrors the `c` shortcut so the action is discoverable in the menu bar.
+
+## Architecture
+
+The feature is a thin layer on top of three systems that already exist:
+
+- The shared review state in `useReviewController`, which owns selection, the live-comment map, and navigation actions.
+- The planned-row rendering pipeline in `src/ui/diff/reviewRenderPlan.ts`, which the diff stream uses to insert non-diff rows (inline notes, guide caps, separators).
+- The mode-aware keyboard router in `useAppKeyboardShortcuts`, which already gates input through pager / help / menu / filter handlers.
+
+No parallel state, no overlay layer, no new package. The cursor lives next to `selectedFileId` and `selectedHunkIndex`, the composer mounts as a new planned-row kind, and the keyboard handler grows one more mode handler.
+
+```text
+useReviewController
+  ├── selectedFileId / selectedHunkIndex   (existing)
+  ├── liveCommentsByFileId                 (existing — gains user-authored entries)
+  └── commentCursor                        (new)
+        ├── mode: "off" | "navigating" | "composing"
+        ├── fileId, hunkIndex, side, line
+        └── actions: setCursorMode, moveCursor, openComposer, saveComment, cancelComposer
+
+reviewRenderPlan
+  └── planned row kinds                    (gains "comment-composer" alongside existing "inline-note")
+
+useAppKeyboardShortcuts
+  └── handleCursorShortcut                 (new mode handler between menu and filter)
+
+core/liveComments.ts
+  └── buildUserLiveComment                 (new helper next to buildLiveComment)
+```
+
+## State model
+
+New state in `useReviewController`:
+
+```ts
+type CursorMode = "off" | "navigating" | "composing";
+
+interface CommentCursor {
+  mode: CursorMode;
+  fileId: string;
+  hunkIndex: number;
+  side: "old" | "new";
+  line: number;
+}
+```
+
+- `mode: "off"` — cursor not rendered. Default for users who never invoke the feature.
+- `mode: "navigating"` — cursor highlight is visible on a row, keyboard navigates it.
+- `mode: "composing"` — cursor row also has the composer mounted, keyboard input goes to the composer's `<input>`.
+
+The cursor never maintains its own scroll position. When the cursor moves to a row outside the current viewport, the controller reuses `selectHunk(fileId, hunkIndex)` to reveal the owning hunk, then leans on the existing `scrollChildIntoView` path on OpenTUI's scrollbox for sub-hunk row reveal. This keeps the diff pane's scrolling under one source of truth.
+
+## Cursor geometry
+
+A new pure helper module, `src/ui/lib/commentCursor.ts`, owns the geometry math. It mirrors the shape of the existing `src/ui/lib/hunks.ts` helpers (a cursor list plus a `moveCursor` walker) so contributors find the same pattern in both places.
+
+Exports:
+
+- `firstCursorTargetForHunk(file, hunkIndex): { side, line }` — returns the first content row of a hunk (first `+`, falling back to first `-`, then context). Delegates to the existing `firstCommentTargetForHunk` in `core/liveComments.ts` so the cursor and an MCP comment land on the same anchor when invoked on the same hunk.
+- `moveCursor(cursor, files, delta): CommentCursor | null` — walks forward / backward through the diff rows of the review stream. Skips file headers, hunk headers, and inter-file separators. Crosses hunk boundaries within a file and file boundaries across the stream the same way `findNextHunkCursor` already does.
+- `cursorRowStableKey(cursor): string` — returns the file-scoped stable key (`line:<hunkIndex>:<side>:<line>`) that `reviewRenderPlan` already emits, so the row renderer can look up the cursor row and apply highlight.
+
+The helper has no React or OpenTUI dependencies. Tests live alongside it as `src/ui/lib/commentCursor.test.ts`.
+
+## Rendering
+
+Two render-side changes, both inside the existing single-pipeline pattern:
+
+1. `src/ui/diff/reviewRenderPlan.ts` gains a new planned row kind:
+
+   ```ts
+   | {
+       kind: "comment-composer";
+       key: string;
+       stableKey: string;
+       fileId: string;
+       hunkIndex: number;
+       side: "old" | "new";
+       line: number;
+     }
+   ```
+
+   The row is emitted directly after the cursor row when `cursor.mode === "composing"`. Same insertion shape as the existing `inline-note` row.
+
+2. `src/ui/lib/diffSectionGeometry.ts` and the row renderer in `src/ui/diff/renderRows.tsx` learn how to measure and render the composer row. The composer height is a constant (three lines: top border, input row, bottom border), matching the inline-note geometry approach.
+
+A new component `src/ui/components/panes/CommentComposer.tsx` provides the visual. It follows the visual language of `AgentInlineNote` so user comments and agent comments feel like siblings:
+
+- Same `theme.noteBorder` / `theme.noteBackground` colours.
+- Title row: `Comment · <path>:<side><line>   Enter save · Esc cancel`.
+- Body row: an OpenTUI `<input>` set to `focused={true}`, full inner width.
+
+The cursor highlight itself is applied by the existing row renderer when it sees a row whose stable key matches `cursorRowStableKey(cursor)`. One small render hook, no overlay.
+
+## Keyboard model
+
+A new mode handler `handleCursorShortcut(key)` is added to `useAppKeyboardShortcuts.ts`, slotted between `handleMenuShortcut` and `handleFilterShortcut` so menus and the filter input still take precedence.
+
+| Mode | Key | Action |
+|---|---|---|
+| off | `c` | enter `navigating` on the first row of the selected hunk |
+| navigating | `up` / `k` | move cursor up one row |
+| navigating | `down` / `j` | move cursor down one row |
+| navigating | `[` / `]` | jump to the previous / next hunk's first row |
+| navigating | `i` or `return` | promote to `composing` |
+| navigating | `c` or `esc` | return to `off` |
+| composing | `return` | save the comment, return to `navigating` on the same row |
+| composing | `esc` | discard, return to `navigating` |
+| composing | any other key | owned by the focused `<input>` |
+
+Default scrolling behaviour for users who never press `c` is unaffected: `up` / `down` still scroll one row, `[` / `]` still navigate hunks. The cursor handler only intercepts when `cursor.mode !== "off"`.
+
+A View-menu entry `Toggle comment cursor (c)` is added through `buildAppMenus` so the action is discoverable next to the existing toggles.
+
+## Live-comment plumbing
+
+User comments flow through the same store as MCP comments, with one new builder and one widened type.
+
+- `src/core/liveComments.ts` gains `buildUserLiveComment(target, body, commentId, createdAt, hunkIndex)`. The body shape is identical to the existing `buildLiveComment`. The new helper sets `source: "user"`, `tags: ["user"]`, omits `confidence`, and emits `[line, line]` for whichever side the cursor is on.
+- `src/hunk-session/types.ts` widens `LiveComment.source` from `"mcp"` to `"mcp" | "user"`. `SessionLiveCommentSummary` is unchanged — it does not expose `source` — so the broker wire format and `hunk session comment list` output are byte-for-byte unchanged.
+- `useReviewController` gains `addUserLiveComment(target, body)`. It calls the new builder and pushes the result into `liveCommentsByFileId` using the same setter the MCP path uses. `removeLiveComment` and `clearLiveComments` already key on id and file path, not source, so removal works for user comments without change.
+
+Comment id format: `user:<timestamp>-<counter>`, mirroring the existing `mcp:<requestId>:<index>` convention. No new packages required.
+
+Once stored, user comments render through the existing `AgentInlineNote` path because they live in the same `liveCommentsByFileId` map. The card title already includes range information, so a `source: "user"` comment will show up as a note card under the line with no additional render work.
+
+## Testing
+
+Tests are colocated with the code they cover, following the repo convention.
+
+- `src/ui/lib/commentCursor.test.ts` — pure-function coverage of `firstCursorTargetForHunk` and `moveCursor`. Cases: within-hunk movement, cross-hunk movement, cross-file movement, clamping at the start and end of the review stream, behaviour on empty hunks, behaviour on hunks with only context rows.
+- `src/core/liveComments.test.ts` — extend with `buildUserLiveComment` cases. Cases: `source: "user"`, `[line, line]` range on the correct side, `tags: ["user"]`, no `confidence`.
+- `src/ui/AppHost.interactions.test.tsx` — extend with the full interaction flow at the AppHost level. Cases: `c` enters cursor mode, `j` / `k` moves, `i` opens the composer, `Return` saves and the comment appears in `liveCommentSummaries`, `Esc` from the composer cancels without saving, `c` exits cursor mode.
+- `test/pty/comment-cursor-integration.test.ts` — one new PTY-backed integration test covering the real terminal flow: launch with a sample diff, press `c`, navigate, type a comment, press `Return`, assert the rendered note card appears under the line. PTY coverage is required by the repo's verification rules for interaction and layout changes.
+
+## Verification
+
+Per the repo's verification rules, before reporting the work complete:
+
+- `bun run typecheck`
+- `bun test`
+- `bun run test:integration`
+- `bun run test:tty-smoke`
+- One real TTY smoke run on a sample diff to confirm the cursor highlight, composer card, and saved comment look right.
+
+## Risks and tradeoffs
+
+- **Two roles for `up` / `down`.** When the cursor is off, `up` / `down` scroll. When the cursor is on, they move the cursor. This is consistent with the existing mode-router pattern (the filter input already changes the meaning of typing keys when focused), and it is gated on a visible cursor highlight, so the meaning of the key is always discoverable from screen state.
+- **Composer height changes geometry.** Mounting the composer adds three rows to the diff stream, which the geometry layer has to measure. The existing `inline-note` path already handles dynamically-sized rows, so we extend the same code rather than introducing a new measurement system.
+- **Comment id collisions.** A timestamp + counter format is sufficient for a single session; the broker already namespaces by session id. If we ever batch-import user comments from disk we will need a stronger id, but that is out of scope here.
+
+## Non-goals revisited
+
+This spec deliberately keeps the user comment shape identical to the MCP comment shape. Any future expansion — ranges, threading, replies, persistence — is a separate spec built on top of the same store. Keeping v1 single-line and in-memory keeps the surface area small and lets the existing `hunk session comment *` CLI surface user comments with zero changes.

--- a/docs/superpowers/specs/2026-05-14-comment-cursor-ui-design.md
+++ b/docs/superpowers/specs/2026-05-14-comment-cursor-ui-design.md
@@ -131,17 +131,17 @@ The cursor highlight itself is applied by the existing row renderer when it sees
 
 A new mode handler `handleCursorShortcut(key)` is added to `useAppKeyboardShortcuts.ts`, slotted between `handleMenuShortcut` and `handleFilterShortcut` so menus and the filter input still take precedence.
 
-| Mode | Key | Action |
-|---|---|---|
-| off | `c` | enter `navigating` on the first row of the selected hunk |
-| navigating | `up` / `k` | move cursor up one row |
-| navigating | `down` / `j` | move cursor down one row |
-| navigating | `[` / `]` | jump to the previous / next hunk's first row |
-| navigating | `i` or `return` | promote to `composing` |
-| navigating | `c` or `esc` | return to `off` |
-| composing | `return` | save the comment, return to `navigating` on the same row |
-| composing | `esc` | discard, return to `navigating` |
-| composing | any other key | owned by the focused `<input>` |
+| Mode       | Key             | Action                                                   |
+| ---------- | --------------- | -------------------------------------------------------- |
+| off        | `c`             | enter `navigating` on the first row of the selected hunk |
+| navigating | `up` / `k`      | move cursor up one row                                   |
+| navigating | `down` / `j`    | move cursor down one row                                 |
+| navigating | `[` / `]`       | jump to the previous / next hunk's first row             |
+| navigating | `i` or `return` | promote to `composing`                                   |
+| navigating | `c` or `esc`    | return to `off`                                          |
+| composing  | `return`        | save the comment, return to `navigating` on the same row |
+| composing  | `esc`           | discard, return to `navigating`                          |
+| composing  | any other key   | owned by the focused `<input>`                           |
 
 Default scrolling behaviour for users who never press `c` is unaffected: `up` / `down` still scroll one row, `[` / `]` still navigate hunks. The cursor handler only intercepts when `cursor.mode !== "off"`.
 

--- a/src/core/liveComments.test.ts
+++ b/src/core/liveComments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createTestDiffFile, lines } from "../../test/helpers/diff-helpers";
 import {
   buildLiveComment,
+  buildUserLiveComment,
   findDiffFileByPath,
   findHunkIndexForLine,
   firstCommentTargetForHunk,
@@ -122,6 +123,58 @@ describe("live comment helpers", () => {
   // the hunk silently disappeared from getAnnotatedHunkIndices / annotated-cursor lists.
   // Fix: hunkLineRange uses additionCount/deletionCount (header total, includes context)
   // instead of additionLines/deletionLines (just '+' / '-' counts).
+  test("builds a live user comment annotation", () => {
+    const comment = buildUserLiveComment(
+      {
+        filePath: "src/example.ts",
+        side: "new",
+        line: 4,
+        summary: "Look at this addition",
+        author: "andrew",
+      },
+      "user:test-1",
+      "2026-05-14T00:00:00.000Z",
+      0,
+    );
+
+    expect(comment).toMatchObject({
+      id: "user:test-1",
+      source: "user",
+      author: "andrew",
+      filePath: "src/example.ts",
+      hunkIndex: 0,
+      side: "new",
+      line: 4,
+      summary: "Look at this addition",
+      newRange: [4, 4],
+      tags: ["user"],
+    });
+    expect(comment.confidence).toBeUndefined();
+  });
+
+  test("builds an old-side user comment with an oldRange instead of newRange", () => {
+    const comment = buildUserLiveComment(
+      {
+        filePath: "src/example.ts",
+        side: "old",
+        line: 2,
+        summary: "Why was this removed?",
+      },
+      "user:test-2",
+      "2026-05-14T00:00:00.000Z",
+      0,
+    );
+
+    expect(comment).toMatchObject({
+      source: "user",
+      side: "old",
+      line: 2,
+      oldRange: [2, 2],
+      tags: ["user"],
+    });
+    expect(comment.newRange).toBeUndefined();
+  });
+
   test("includes context lines when one hunk has many context rows around few changes", () => {
     // 12 leading + 1 added + many trailing context lines on the new side.
     const beforeLines = Array.from({ length: 25 }, (_, i) => `line${i + 1}`);

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -124,6 +124,30 @@ export function resolveCommentTarget(
   };
 }
 
+/** Convert one cursor-driven user comment into a live annotation. */
+export function buildUserLiveComment(
+  input: CommentTargetInput & { side: DiffSide; line: number },
+  commentId: string,
+  createdAt: string,
+  hunkIndex: number,
+): LiveComment {
+  return {
+    id: commentId,
+    source: "user",
+    author: input.author,
+    createdAt,
+    filePath: input.filePath,
+    hunkIndex,
+    side: input.side,
+    line: input.line,
+    summary: input.summary,
+    rationale: input.rationale,
+    oldRange: input.side === "old" ? [input.line, input.line] : undefined,
+    newRange: input.side === "new" ? [input.line, input.line] : undefined,
+    tags: ["user"],
+  };
+}
+
 /** Convert one incoming session-daemon comment command into a live annotation. */
 export function buildLiveComment(
   input: CommentTargetInput & { side: DiffSide; line: number },

--- a/src/hunk-session/types.ts
+++ b/src/hunk-session/types.ts
@@ -109,7 +109,7 @@ export interface ClearCommentsToolInput extends SessionTargetInput {
 
 export interface LiveComment extends AgentAnnotation {
   id: string;
-  source: "mcp";
+  source: "mcp" | "user";
   author?: string;
   createdAt: string;
   filePath: string;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -134,6 +134,7 @@ export function App({
   const setCommentCursorMode = review.setCommentCursorMode;
   const moveCommentCursor = review.moveCommentCursor;
   const jumpCommentCursorToHunk = review.jumpCommentCursorToHunk;
+  const enterCommentCursorAt = review.enterCommentCursorAt;
 
   const composerDescriptor =
     commentCursor.mode === "composing"
@@ -795,6 +796,8 @@ export function App({
           selectedHunkRevealRequestId={review.selectedHunkRevealRequestId}
           theme={activeTheme}
           width={diffPaneWidth}
+          commentCursorFileId={commentCursor.mode === "off" ? null : commentCursor.fileId}
+          commentCursorRevealRequestId={review.commentCursorRevealRequestId}
           commentCursorRowStableKey={commentCursorRowStableKey}
           composer={composerDescriptor}
           onCommentComposerCancel={cancelCommentComposer}
@@ -803,6 +806,7 @@ export function App({
           onScrollCodeHorizontally={(delta) => {
             scrollCodeHorizontally(delta * FAST_CODE_HORIZONTAL_SCROLL_COLUMNS);
           }}
+          onSelectCommentTarget={enterCommentCursorAt}
           onSelectFile={jumpToFile}
           onViewportCenteredHunkChange={(fileId, hunkIndex) =>
             review.selectHunk(fileId, hunkIndex, { preserveViewport: true })

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -128,6 +128,67 @@ export function App({
   const moveToAnnotatedFile = review.moveToAnnotatedFile;
   const moveToAnnotatedHunk = review.moveToAnnotatedHunk;
 
+  const commentCursor = review.commentCursor;
+  const commentCursorRowStableKey = review.commentCursorRowStableKey;
+  const addUserLiveComment = review.addUserLiveComment;
+  const setCommentCursorMode = review.setCommentCursorMode;
+  const moveCommentCursor = review.moveCommentCursor;
+  const jumpCommentCursorToHunk = review.jumpCommentCursorToHunk;
+
+  const composerDescriptor =
+    commentCursor.mode === "composing"
+      ? {
+          fileId: commentCursor.fileId,
+          hunkIndex: commentCursor.hunkIndex,
+          side: commentCursor.side,
+          line: commentCursor.line,
+        }
+      : null;
+
+  const enterCommentCursor = useCallback(() => {
+    setCommentCursorMode(commentCursor.mode === "off" ? "navigating" : "off");
+  }, [commentCursor.mode, setCommentCursorMode]);
+
+  const exitCommentCursor = useCallback(() => {
+    setCommentCursorMode("off");
+  }, [setCommentCursorMode]);
+
+  const openCommentComposer = useCallback(() => {
+    setCommentCursorMode("composing");
+  }, [setCommentCursorMode]);
+
+  const cancelCommentComposer = useCallback(() => {
+    setCommentCursorMode("navigating");
+  }, [setCommentCursorMode]);
+
+  const submitCommentComposer = useCallback(
+    (summary: string) => {
+      try {
+        addUserLiveComment(
+          {
+            fileId: commentCursor.fileId,
+            hunkIndex: commentCursor.hunkIndex,
+            side: commentCursor.side,
+            line: commentCursor.line,
+          },
+          summary,
+        );
+      } catch (error) {
+        console.error("Failed to add user comment.", error);
+      } finally {
+        setCommentCursorMode("navigating");
+      }
+    },
+    [
+      addUserLiveComment,
+      commentCursor.fileId,
+      commentCursor.hunkIndex,
+      commentCursor.line,
+      commentCursor.side,
+      setCommentCursorMode,
+    ],
+  );
+
   const jumpToFile = useCallback(
     (fileId: string, nextHunkIndex = 0, options?: { alignFileHeaderTop?: boolean }) => {
       review.selectFile(fileId, nextHunkIndex, {
@@ -496,10 +557,14 @@ export function App({
         toggleLineWrap,
         toggleSidebar,
         wrapLines,
+        commentCursorMode: commentCursor.mode,
+        toggleCommentCursor: enterCommentCursor,
       }),
     [
       activeTheme.id,
       canRefreshCurrentInput,
+      commentCursor.mode,
+      enterCommentCursor,
       focusFilter,
       layoutMode,
       moveToAnnotatedFile,
@@ -546,12 +611,18 @@ export function App({
     canRefreshCurrentInput,
     closeHelp,
     closeMenu,
+    commentCursorMode: commentCursor.mode,
     cycleTheme,
+    enterCommentCursor,
+    exitCommentCursor,
     focusArea,
     focusFilter,
+    jumpCommentCursorToHunk,
+    moveCommentCursor,
     moveToAnnotatedHunk,
     moveToHunk: review.moveToHunk,
     moveMenuItem,
+    openCommentComposer,
     openMenu,
     pagerMode,
     requestQuit,
@@ -723,6 +794,10 @@ export function App({
           selectedHunkRevealRequestId={review.selectedHunkRevealRequestId}
           theme={activeTheme}
           width={diffPaneWidth}
+          commentCursorRowStableKey={commentCursorRowStableKey}
+          composer={composerDescriptor}
+          onCommentComposerCancel={cancelCommentComposer}
+          onCommentComposerSubmit={submitCommentComposer}
           onOpenAgentNotesAtHunk={openAgentNotesAtHunk}
           onScrollCodeHorizontally={(delta) => {
             scrollCodeHorizontally(delta * FAST_CODE_HORIZONTAL_SCROLL_COLUMNS);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -609,6 +609,7 @@ export function App({
     activeMenuId,
     activateCurrentMenuItem,
     canRefreshCurrentInput,
+    cancelCommentComposer,
     closeHelp,
     closeMenu,
     commentCursorMode: commentCursor.mode,

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -2348,4 +2348,99 @@ describe("App interactions", () => {
       });
     }
   });
+
+  test("comment cursor toggles, navigates, and saves a user comment", async () => {
+    const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
+      width: 200,
+      height: 28,
+    });
+
+    try {
+      await flush(setup);
+
+      // Enter cursor mode.
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      let frame = setup.captureCharFrame();
+      expect(frame).toContain("▶");
+
+      // Open the composer.
+      await act(async () => {
+        await setup.mockInput.typeText("i");
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("Comment ·");
+      expect(frame).toContain("Enter save · Esc cancel");
+
+      // Type and submit a comment.
+      await act(async () => {
+        await setup.mockInput.typeText("Look at this");
+      });
+      await act(async () => {
+        setup.mockInput.pressEnter();
+      });
+      await flush(setup);
+
+      frame = await waitForFrame(setup, (next) => next.includes("Look at this"));
+      expect(frame).toContain("Look at this");
+
+      // Esc leaves cursor mode.
+      await act(async () => {
+        setup.mockInput.pressEscape();
+      });
+      // Wait for cursor mode to be cleared; use a predicate that avoids matching
+      // the ▶ glyph that appears inside note-card range labels (e.g. "▶ new 1").
+      frame = await waitForFrame(setup, (next) => !next.includes("▶1 -") && !next.includes("▶1 +"));
+      expect(frame).not.toContain("▶1 -");
+      expect(frame).not.toContain("▶1 +");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("comment composer Esc discards the draft without saving", async () => {
+    const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
+      width: 200,
+      height: 28,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("i");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("draft");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        setup.mockInput.pressEscape();
+      });
+      // Wait for the composer to close; after cancel the mode reverts to navigating.
+      const frame = await waitForFrame(setup, (next) => !next.includes("Comment ·"));
+      expect(frame).not.toContain("Comment ·");
+      // Comment was not saved — no note card with the draft text appears.
+      expect(frame).not.toContain("draft");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
 });

--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -4,8 +4,28 @@ import { annotationRangeLabel } from "../../lib/agentAnnotations";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
 
-function inlineNoteTitle(noteIndex: number, noteCount: number) {
-  return noteCount > 1 ? `AI note ${noteIndex + 1}/${noteCount}` : "AI note";
+function inlineNoteTitle(noteIndex: number, noteCount: number, isUserAuthored: boolean) {
+  const label = isUserAuthored ? "My note" : "AI note";
+  return noteCount > 1 ? `${label} ${noteIndex + 1}/${noteCount}` : label;
+}
+
+/** Resolve the framed note palette — user-authored notes get the warmer orange treatment. */
+function inlineNotePalette(theme: AppTheme, isUserAuthored: boolean) {
+  if (isUserAuthored) {
+    return {
+      border: theme.userNoteBorder,
+      background: theme.userNoteBackground,
+      titleBackground: theme.userNoteTitleBackground,
+      titleText: theme.userNoteTitleText,
+    };
+  }
+
+  return {
+    border: theme.noteBorder,
+    background: theme.noteBackground,
+    titleBackground: theme.noteTitleBackground,
+    titleText: theme.noteTitleText,
+  };
 }
 
 interface AgentInlineNoteLine {
@@ -83,7 +103,9 @@ export function AgentInlineNote({
   width: number;
 }) {
   const closeText = onClose ? "[x]" : "";
-  const titleText = `${inlineNoteTitle(noteIndex, noteCount)} · ${annotationRangeLabel(annotation)}`;
+  const isUserAuthored = annotation.source === "user";
+  const palette = inlineNotePalette(theme, isUserAuthored);
+  const titleText = `${inlineNoteTitle(noteIndex, noteCount, isUserAuthored)} · ${annotationRangeLabel(annotation)}`;
   const splitWidths = splitColumnWidths(width);
   const canDockRight = layout === "split" && anchorSide === "new" && width >= 84;
   const canDockLeft = layout === "split" && anchorSide === "old" && width >= 84;
@@ -125,7 +147,7 @@ export function AgentInlineNote({
           <text>{" ".repeat(boxLeft)}</text>
         </box>
         <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+          <text fg={palette.border} bg={palette.background}>
             {topBorder}
           </text>
         </box>
@@ -136,12 +158,12 @@ export function AgentInlineNote({
           <text>{" ".repeat(boxLeft)}</text>
         </box>
         <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+          <text fg={palette.border} bg={palette.background}>
             │
           </text>
         </box>
         <box style={{ width: titleWidth, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>
+          <text fg={palette.titleText} bg={palette.titleBackground}>
             {padText(fitText(titleText, titleWidth), titleWidth)}
           </text>
         </box>
@@ -150,11 +172,11 @@ export function AgentInlineNote({
             onMouseUp={onClose}
             style={{ width: closeText.length + 1, height: 1, backgroundColor: theme.panel }}
           >
-            <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>{` ${closeText}`}</text>
+            <text fg={palette.titleText} bg={palette.titleBackground}>{` ${closeText}`}</text>
           </box>
         ) : null}
         <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+          <text fg={palette.border} bg={palette.background}>
             │
           </text>
         </box>
@@ -169,17 +191,17 @@ export function AgentInlineNote({
             <text>{" ".repeat(boxLeft)}</text>
           </box>
           <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            <text fg={palette.border} bg={palette.background}>
               │
             </text>
           </box>
           <box style={{ width: bodyWidth, height: 1, backgroundColor: theme.panel }}>
-            <text fg={line.kind === "summary" ? theme.text : theme.muted} bg={theme.noteBackground}>
+            <text fg={line.kind === "summary" ? theme.text : theme.muted} bg={palette.background}>
               {padText(line.text, bodyWidth)}
             </text>
           </box>
           <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            <text fg={palette.border} bg={palette.background}>
               │
             </text>
           </box>
@@ -191,7 +213,7 @@ export function AgentInlineNote({
           <text>{" ".repeat(boxLeft)}</text>
         </box>
         <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+          <text fg={palette.border} bg={palette.background}>
             {bottomBorder}
           </text>
         </box>

--- a/src/ui/components/panes/CommentComposer.tsx
+++ b/src/ui/components/panes/CommentComposer.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import type { KeyEvent } from "@opentui/core";
+import { isEscapeKey } from "../../lib/keyboard";
+import { fitText, padText } from "../../lib/text";
+import type { AppTheme } from "../../themes";
+
+/** Render the inline composer card the user types a single review comment into. */
+export function CommentComposer({
+  filePath,
+  hunkIndex,
+  line,
+  side,
+  theme,
+  width,
+  onCancel,
+  onSubmit,
+}: {
+  filePath: string;
+  hunkIndex: number;
+  line: number;
+  side: "old" | "new";
+  theme: AppTheme;
+  width: number;
+  onCancel: () => void;
+  onSubmit: (summary: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const sideLabel = side === "new" ? "+" : "-";
+  const titleText = `Comment · ${filePath}:${sideLabel}${line}@${hunkIndex + 1}   Enter save · Esc cancel`;
+  const boxWidth = Math.max(28, Math.min(width - 4, Math.max(28, width - 4)));
+  const innerWidth = Math.max(1, boxWidth - 2);
+  const topBorder = `┌${"─".repeat(Math.max(0, boxWidth - 2))}┐`;
+  const bottomBorder = `└${"─".repeat(Math.max(0, boxWidth - 2))}┘`;
+  const boxLeft = Math.min(4, Math.max(0, width - boxWidth));
+
+  const handleKeyDown = (key: KeyEvent) => {
+    if (!isEscapeKey(key)) {
+      return;
+    }
+
+    key.preventDefault();
+    key.stopPropagation();
+    onCancel();
+  };
+
+  const handleSubmit = () => {
+    if (draft.trim().length === 0) {
+      onCancel();
+      return;
+    }
+    onSubmit(draft);
+  };
+
+  return (
+    <box style={{ width: "100%", flexDirection: "column", backgroundColor: theme.panel }}>
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            {topBorder}
+          </text>
+        </box>
+      </box>
+
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+        <box style={{ width: innerWidth, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>
+            {padText(fitText(titleText, innerWidth), innerWidth)}
+          </text>
+        </box>
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+      </box>
+
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+        <input
+          width={innerWidth}
+          value={draft}
+          placeholder="describe what you want the agent to look at"
+          focused={true}
+          onInput={setDraft}
+          onSubmit={handleSubmit}
+          onKeyDown={handleKeyDown}
+        />
+        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            │
+          </text>
+        </box>
+      </box>
+
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <text>{" ".repeat(boxLeft)}</text>
+        </box>
+        <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
+          <text fg={theme.noteBorder} bg={theme.noteBackground}>
+            {bottomBorder}
+          </text>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+/** Constant terminal-row height the composer occupies inside the diff stream. */
+export const COMMENT_COMPOSER_HEIGHT = 4;

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -262,12 +262,11 @@ export function DiffPane({
   const allAgentNotesByFile = useMemo(() => {
     const next = new Map<string, VisibleAgentNote[]>();
 
-    if (!showAgentNotes) {
-      return next;
-    }
-
     files.forEach((file) => {
-      const annotations = file.agent?.annotations ?? [];
+      // Always include user-authored comments; respect the agent-notes toggle for AI annotations.
+      const annotations = (file.agent?.annotations ?? []).filter(
+        (annotation) => showAgentNotes || annotation.source === "user",
+      );
       if (annotations.length === 0) {
         return;
       }
@@ -434,7 +433,9 @@ export function DiffPane({
   const visibleAgentNotesByFile = useMemo(() => {
     const next = new Map<string, VisibleAgentNote[]>();
 
-    if (!showAgentNotes) {
+    // allAgentNotesByFile already filters by showAgentNotes and user-comment visibility;
+    // bail out early only when there is nothing to distribute.
+    if (allAgentNotesByFile.size === 0) {
       return EMPTY_VISIBLE_AGENT_NOTES_BY_FILE;
     }
 
@@ -453,7 +454,7 @@ export function DiffPane({
     }
 
     return next;
-  }, [allAgentNotesByFile, selectedFileId, showAgentNotes, visibleViewportFileIds]);
+  }, [allAgentNotesByFile, selectedFileId, visibleViewportFileIds]);
 
   // Measure with the *full* set of agent notes per file, not just the visible-viewport set.
   // The visible set is correct for rendering (skip painting cards on off-screen files), but

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -128,6 +128,8 @@ function buildHighlightPrefetchFileIds({
 /** Render the main multi-file review stream. */
 export function DiffPane({
   codeHorizontalOffset = 0,
+  commentCursorRowStableKey,
+  composer,
   diffContentWidth,
   files,
   headerLabelWidth,
@@ -150,12 +152,21 @@ export function DiffPane({
   selectedHunkRevealRequestId,
   theme,
   width,
+  onCommentComposerCancel,
+  onCommentComposerSubmit,
   onOpenAgentNotesAtHunk,
   onScrollCodeHorizontally = () => {},
   onSelectFile,
   onViewportCenteredHunkChange,
 }: {
   codeHorizontalOffset?: number;
+  commentCursorRowStableKey?: string | null;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
   diffContentWidth: number;
   files: DiffFile[];
   headerLabelWidth: number;
@@ -178,6 +189,8 @@ export function DiffPane({
   selectedHunkRevealRequestId?: number;
   theme: AppTheme;
   width: number;
+  onCommentComposerCancel?: () => void;
+  onCommentComposerSubmit?: (summary: string) => void;
   onOpenAgentNotesAtHunk: (fileId: string, hunkIndex: number) => void;
   onScrollCodeHorizontally?: (delta: number) => void;
   onSelectFile: (fileId: string) => void;
@@ -453,7 +466,8 @@ export function DiffPane({
     () =>
       files.map((file, index) => {
         const notes = allAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES;
-        if (notes.length === 0) {
+        const fileComposer = composer && composer.fileId === file.id ? composer : null;
+        if (notes.length === 0 && !fileComposer) {
           return baseSectionGeometry[index]!;
         }
 
@@ -466,11 +480,13 @@ export function DiffPane({
           diffContentWidth,
           showLineNumbers,
           wrapLines,
+          fileComposer,
         );
       }),
     [
       allAgentNotesByFile,
       baseSectionGeometry,
+      composer,
       diffContentWidth,
       files,
       layout,
@@ -1163,6 +1179,8 @@ export function DiffPane({
                     <DiffSection
                       key={file.id}
                       codeHorizontalOffset={codeHorizontalOffset}
+                      commentCursorRowStableKey={commentCursorRowStableKey ?? null}
+                      composer={composer && composer.fileId === file.id ? composer : null}
                       file={file}
                       headerLabelWidth={headerLabelWidth}
                       headerStatsWidth={headerStatsWidth}
@@ -1182,6 +1200,8 @@ export function DiffPane({
                         visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
                       }
                       visibleBodyBounds={visibleBodyBoundsByFile.get(file.id)}
+                      onCommentComposerCancel={onCommentComposerCancel}
+                      onCommentComposerSubmit={onCommentComposerSubmit}
                       onOpenAgentNotesAtHunk={(hunkIndex) =>
                         onOpenAgentNotesAtHunk(file.id, hunkIndex)
                       }

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -25,7 +25,7 @@ import {
   shouldRenderInStreamFileHeader,
   type FileSectionLayout,
 } from "../../lib/fileSectionLayout";
-import { diffHunkId, diffSectionId } from "../../lib/ids";
+import { COMMENT_CURSOR_ANCHOR_ID, diffHunkId, diffSectionId } from "../../lib/ids";
 import { findViewportCenteredHunkTarget } from "../../lib/viewportSelection";
 import {
   findViewportRowAnchor,
@@ -128,6 +128,8 @@ function buildHighlightPrefetchFileIds({
 /** Render the main multi-file review stream. */
 export function DiffPane({
   codeHorizontalOffset = 0,
+  commentCursorFileId = null,
+  commentCursorRevealRequestId = 0,
   commentCursorRowStableKey,
   composer,
   diffContentWidth,
@@ -156,10 +158,13 @@ export function DiffPane({
   onCommentComposerSubmit,
   onOpenAgentNotesAtHunk,
   onScrollCodeHorizontally = () => {},
+  onSelectCommentTarget,
   onSelectFile,
   onViewportCenteredHunkChange,
 }: {
   codeHorizontalOffset?: number;
+  commentCursorFileId?: string | null;
+  commentCursorRevealRequestId?: number;
   commentCursorRowStableKey?: string | null;
   composer?: {
     fileId: string;
@@ -193,6 +198,12 @@ export function DiffPane({
   onCommentComposerSubmit?: (summary: string) => void;
   onOpenAgentNotesAtHunk: (fileId: string, hunkIndex: number) => void;
   onScrollCodeHorizontally?: (delta: number) => void;
+  onSelectCommentTarget?: (target: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  }) => void;
   onSelectFile: (fileId: string) => void;
   onViewportCenteredHunkChange?: (fileId: string, hunkIndex: number) => void;
 }) {
@@ -1097,6 +1108,35 @@ export function DiffPane({
     suppressViewportSelectionSync,
   ]);
 
+  // Scroll the comment cursor row back into view whenever the controller bumps the reveal id.
+  // The id is bumped on every cursor *position* change (j/k, [/], click, hunk jump, file switch),
+  // but not on a pure mode toggle, so a tap of `c` does not yank the viewport around.
+  const previousCommentCursorRevealRequestIdRef = useRef(commentCursorRevealRequestId);
+  useLayoutEffect(() => {
+    if (commentCursorRevealRequestId === previousCommentCursorRevealRequestIdRef.current) {
+      return;
+    }
+    previousCommentCursorRevealRequestIdRef.current = commentCursorRevealRequestId;
+
+    const revealCursor = () => {
+      const scrollBox = scrollRef.current;
+      if (!scrollBox) {
+        return;
+      }
+      // scrollChildIntoView is a no-op when the anchor row is already inside the viewport, so this
+      // only nudges the viewport on movements that actually leave the visible window.
+      scrollBox.scrollChildIntoView(COMMENT_CURSOR_ANCHOR_ID);
+    };
+
+    revealCursor();
+    // Match the hunk reveal pattern: retry across a couple of paint cycles so cursor moves into a
+    // currently-culled row still resolve once the row mounts.
+    const retries = [16, 48].map((delay) => setTimeout(revealCursor, delay));
+    return () => {
+      retries.forEach((timeout) => clearTimeout(timeout));
+    };
+  }, [commentCursorRevealRequestId, scrollRef]);
+
   // Keep keyboard step scrolling at exactly one row while wheel scrolling uses its own multiplier.
   useEffect(() => {
     const scrollBox = scrollRef.current;
@@ -1180,7 +1220,9 @@ export function DiffPane({
                     <DiffSection
                       key={file.id}
                       codeHorizontalOffset={codeHorizontalOffset}
-                      commentCursorRowStableKey={commentCursorRowStableKey ?? null}
+                      commentCursorRowStableKey={
+                        commentCursorFileId === file.id ? (commentCursorRowStableKey ?? null) : null
+                      }
                       composer={composer && composer.fileId === file.id ? composer : null}
                       file={file}
                       headerLabelWidth={headerLabelWidth}
@@ -1205,6 +1247,11 @@ export function DiffPane({
                       onCommentComposerSubmit={onCommentComposerSubmit}
                       onOpenAgentNotesAtHunk={(hunkIndex) =>
                         onOpenAgentNotesAtHunk(file.id, hunkIndex)
+                      }
+                      onSelectCommentTarget={
+                        onSelectCommentTarget
+                          ? (target) => onSelectCommentTarget({ fileId: file.id, ...target })
+                          : undefined
                       }
                       onSelect={() => onSelectFile(file.id)}
                     />

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import type { DiffFile, LayoutMode } from "../../../core/types";
+import type { DiffSide } from "../../../hunk-session/types";
 import { PierreDiffView } from "../../diff/PierreDiffView";
 import type { VisibleBodyBounds } from "../../diff/rowWindowing";
 import type { DiffSectionGeometry } from "../../lib/diffSectionGeometry";
@@ -38,6 +39,7 @@ interface DiffSectionProps {
   onCommentComposerCancel?: () => void;
   onCommentComposerSubmit?: (summary: string) => void;
   onOpenAgentNotesAtHunk: (hunkIndex: number) => void;
+  onSelectCommentTarget?: (target: { hunkIndex: number; side: DiffSide; line: number }) => void;
   onSelect: () => void;
 }
 
@@ -66,6 +68,7 @@ function DiffSectionComponent({
   onCommentComposerCancel,
   onCommentComposerSubmit,
   onOpenAgentNotesAtHunk,
+  onSelectCommentTarget,
   onSelect,
 }: DiffSectionProps) {
   const annotatedHunkIndices = getAnnotatedHunkIndices(file);
@@ -120,6 +123,7 @@ function DiffSectionComponent({
         onCommentComposerCancel={onCommentComposerCancel}
         onCommentComposerSubmit={onCommentComposerSubmit}
         onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+        onSelectCommentTarget={onSelectCommentTarget}
         selectedHunkIndex={selectedHunkIndex}
         sectionGeometry={sectionGeometry}
         shouldLoadHighlight={shouldLoadHighlight}

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -11,6 +11,13 @@ import { DiffFileHeaderRow } from "./DiffFileHeaderRow";
 
 interface DiffSectionProps {
   codeHorizontalOffset: number;
+  commentCursorRowStableKey?: string | null;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
   file: DiffFile;
   headerLabelWidth: number;
   headerStatsWidth: number;
@@ -28,6 +35,8 @@ interface DiffSectionProps {
   visibleAgentNotes: VisibleAgentNote[];
   visibleBodyBounds?: VisibleBodyBounds;
   viewWidth: number;
+  onCommentComposerCancel?: () => void;
+  onCommentComposerSubmit?: (summary: string) => void;
   onOpenAgentNotesAtHunk: (hunkIndex: number) => void;
   onSelect: () => void;
 }
@@ -35,6 +44,8 @@ interface DiffSectionProps {
 /** Render one file section in the main review stream. */
 function DiffSectionComponent({
   codeHorizontalOffset,
+  commentCursorRowStableKey,
+  composer,
   file,
   headerLabelWidth,
   headerStatsWidth,
@@ -52,6 +63,8 @@ function DiffSectionComponent({
   visibleAgentNotes,
   visibleBodyBounds,
   viewWidth,
+  onCommentComposerCancel,
+  onCommentComposerSubmit,
   onOpenAgentNotesAtHunk,
   onSelect,
 }: DiffSectionProps) {
@@ -92,6 +105,8 @@ function DiffSectionComponent({
       ) : null}
 
       <PierreDiffView
+        commentCursorRowStableKey={commentCursorRowStableKey ?? null}
+        composer={composer ?? null}
         file={file}
         layout={layout}
         showLineNumbers={showLineNumbers}
@@ -102,6 +117,8 @@ function DiffSectionComponent({
         width={viewWidth}
         annotatedHunkIndices={annotatedHunkIndices}
         visibleAgentNotes={visibleAgentNotes}
+        onCommentComposerCancel={onCommentComposerCancel}
+        onCommentComposerSubmit={onCommentComposerSubmit}
         onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
         selectedHunkIndex={selectedHunkIndex}
         sectionGeometry={sectionGeometry}
@@ -119,6 +136,8 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
   // This comparator relies on stable upstream object identity for files and visible-note arrays.
   return (
     previous.codeHorizontalOffset === next.codeHorizontalOffset &&
+    previous.commentCursorRowStableKey === next.commentCursorRowStableKey &&
+    previous.composer === next.composer &&
     previous.file === next.file &&
     previous.headerLabelWidth === next.headerLabelWidth &&
     previous.headerStatsWidth === next.headerStatsWidth &&

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1285,6 +1285,28 @@ describe("UI components", () => {
     expect(lines[4]?.trimStart().startsWith("└")).toBe(true);
   });
 
+  test("AgentInlineNote uses the My note label for user-authored annotations", async () => {
+    const theme = resolveTheme("midnight", null);
+    const frame = await captureFrame(
+      <AgentInlineNote
+        annotation={{
+          newRange: [2, 2],
+          summary: "Review this please",
+          source: "user",
+        }}
+        anchorSide="new"
+        layout="split"
+        theme={theme}
+        width={60}
+      />,
+      64,
+      5,
+    );
+
+    expect(frame).toContain("My note");
+    expect(frame).not.toContain("AI note");
+  });
+
   test("DiffPane renders all visible hunk notes across the review stream", async () => {
     const bootstrap = createBootstrap();
     bootstrap.changeset.files[1]!.agent = {

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -177,6 +177,13 @@ export function PierreDiffView({
           );
         }
 
+        if (plannedRow.kind === "comment-composer") {
+          // Composer rendering is wired in Task 8; reserve the row for now.
+          return (
+            <box key={plannedRow.key} id={rowId} style={{ width: "100%", height: 1 }} />
+          );
+        }
+
         return (
           <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
             <DiffRowView

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import type { DiffFile, LayoutMode } from "../../core/types";
 import { AgentInlineNote, AgentInlineNoteGuideCap } from "../components/panes/AgentInlineNote";
+import { CommentComposer } from "../components/panes/CommentComposer";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import type { DiffSectionGeometry } from "../lib/diffSectionGeometry";
 import { reviewRowId } from "../lib/ids";
@@ -20,8 +21,12 @@ const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
 export function PierreDiffView({
   annotatedHunkIndices = EMPTY_ANNOTATED_HUNK_INDICES,
   codeHorizontalOffset = 0,
+  commentCursorRowStableKey,
+  composer,
   file,
   layout,
+  onCommentComposerCancel,
+  onCommentComposerSubmit,
   onOpenAgentNotesAtHunk,
   showLineNumbers = true,
   showHunkHeaders = true,
@@ -37,8 +42,17 @@ export function PierreDiffView({
 }: {
   annotatedHunkIndices?: Set<number>;
   codeHorizontalOffset?: number;
+  commentCursorRowStableKey?: string | null;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
   file: DiffFile | undefined;
   layout: Exclude<LayoutMode, "auto">;
+  onCommentComposerCancel?: () => void;
+  onCommentComposerSubmit?: (summary: string) => void;
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
   showLineNumbers?: boolean;
   showHunkHeaders?: boolean;
@@ -75,9 +89,10 @@ export function PierreDiffView({
             rows,
             showHunkHeaders,
             visibleAgentNotes,
+            composer: composer ?? null,
           })
         : [],
-    [file, rows, showHunkHeaders, visibleAgentNotes],
+    [composer, file, rows, showHunkHeaders, visibleAgentNotes],
   );
   const lineNumberDigits = useMemo(() => String(file ? findMaxLineNumber(file) : 1).length, [file]);
   const visiblePlannedRowWindow = useMemo(() => {
@@ -178,11 +193,27 @@ export function PierreDiffView({
         }
 
         if (plannedRow.kind === "comment-composer") {
-          // Composer rendering is wired in Task 8; reserve the row for now.
           return (
-            <box key={plannedRow.key} id={rowId} style={{ width: "100%", height: 1 }} />
+            <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
+              <CommentComposer
+                filePath={file.path}
+                hunkIndex={plannedRow.hunkIndex}
+                line={plannedRow.line}
+                side={plannedRow.side}
+                theme={theme}
+                width={width}
+                onCancel={() => onCommentComposerCancel?.()}
+                onSubmit={(summary) => onCommentComposerSubmit?.(summary)}
+              />
+            </box>
           );
         }
+
+        const isCursorRow = Boolean(
+          commentCursorRowStableKey &&
+            (plannedRow.stableKey === commentCursorRowStableKey ||
+              plannedRow.stableAliasKeys?.includes(commentCursorRowStableKey)),
+        );
 
         return (
           <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
@@ -203,6 +234,7 @@ export function PierreDiffView({
               anchorId={plannedRow.anchorId}
               noteGuideSide={plannedRow.noteGuideSide}
               onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+              isCursor={isCursorRow}
             />
           </box>
         );

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from "react";
+import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
 import type { DiffFile, LayoutMode } from "../../core/types";
+import type { DiffSide } from "../../hunk-session/types";
 import { AgentInlineNote, AgentInlineNoteGuideCap } from "../components/panes/AgentInlineNote";
 import { CommentComposer } from "../components/panes/CommentComposer";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
+import { clickTargetForDiffRow } from "../lib/commentCursor";
 import type { DiffSectionGeometry } from "../lib/diffSectionGeometry";
-import { reviewRowId } from "../lib/ids";
+import { COMMENT_CURSOR_ANCHOR_ID, reviewRowId } from "../lib/ids";
 import type { AppTheme } from "../themes";
 import { findMaxLineNumber } from "./codeColumns";
 import { buildSplitRows, buildStackRows } from "./pierre";
@@ -28,6 +31,7 @@ export function PierreDiffView({
   onCommentComposerCancel,
   onCommentComposerSubmit,
   onOpenAgentNotesAtHunk,
+  onSelectCommentTarget,
   showLineNumbers = true,
   showHunkHeaders = true,
   wrapLines = false,
@@ -54,6 +58,7 @@ export function PierreDiffView({
   onCommentComposerCancel?: () => void;
   onCommentComposerSubmit?: (summary: string) => void;
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
+  onSelectCommentTarget?: (target: { hunkIndex: number; side: DiffSide; line: number }) => void;
   showLineNumbers?: boolean;
   showHunkHeaders?: boolean;
   wrapLines?: boolean;
@@ -211,31 +216,68 @@ export function PierreDiffView({
 
         const isCursorRow = Boolean(
           commentCursorRowStableKey &&
-            (plannedRow.stableKey === commentCursorRowStableKey ||
-              plannedRow.stableAliasKeys?.includes(commentCursorRowStableKey)),
+          (plannedRow.stableKey === commentCursorRowStableKey ||
+            plannedRow.stableAliasKeys?.includes(commentCursorRowStableKey)),
+        );
+        // Resolve the click target up front so the wrapper only registers a handler when the
+        // clicked row is actually commentable (additions and deletions, not context/headers).
+        const clickTarget = onSelectCommentTarget ? clickTargetForDiffRow(plannedRow.row) : null;
+        // OpenTUI's renderer auto-focuses the nearest focusable ancestor on left-button mouseDown
+        // unless the event has had preventDefault() called. The diff scrollbox is focusable, so a
+        // bare click would steer arrow keys into its internal scroll handler *in parallel* with
+        // the cursor hook. Suppressing the default on mouseDown keeps focus where it was and lets
+        // the cursor hook be the sole owner of arrow keys.
+        const handleRowMouseDown = clickTarget
+          ? (event: TuiMouseEvent) => {
+              event.preventDefault();
+            }
+          : undefined;
+        const handleRowMouseUp = clickTarget
+          ? (event: TuiMouseEvent) => {
+              event.stopPropagation();
+              onSelectCommentTarget?.(clickTarget);
+            }
+          : undefined;
+
+        const diffRowView = (
+          <DiffRowView
+            row={plannedRow.row}
+            width={width}
+            lineNumberDigits={lineNumberDigits}
+            showLineNumbers={showLineNumbers}
+            showHunkHeaders={showHunkHeaders}
+            wrapLines={wrapLines}
+            codeHorizontalOffset={codeHorizontalOffset}
+            theme={theme}
+            selected={plannedRow.row.hunkIndex === selectedHunkIndex}
+            annotated={
+              plannedRow.row.type === "hunk-header" &&
+              annotatedHunkIndices.has(plannedRow.row.hunkIndex)
+            }
+            anchorId={plannedRow.anchorId}
+            noteGuideSide={plannedRow.noteGuideSide}
+            onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
+            isCursor={isCursorRow}
+          />
         );
 
         return (
-          <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
-            <DiffRowView
-              row={plannedRow.row}
-              width={width}
-              lineNumberDigits={lineNumberDigits}
-              showLineNumbers={showLineNumbers}
-              showHunkHeaders={showHunkHeaders}
-              wrapLines={wrapLines}
-              codeHorizontalOffset={codeHorizontalOffset}
-              theme={theme}
-              selected={plannedRow.row.hunkIndex === selectedHunkIndex}
-              annotated={
-                plannedRow.row.type === "hunk-header" &&
-                annotatedHunkIndices.has(plannedRow.row.hunkIndex)
-              }
-              anchorId={plannedRow.anchorId}
-              noteGuideSide={plannedRow.noteGuideSide}
-              onOpenAgentNotesAtHunk={onOpenAgentNotesAtHunk}
-              isCursor={isCursorRow}
-            />
+          <box
+            key={plannedRow.key}
+            id={rowId}
+            style={{ width: "100%", flexDirection: "column" }}
+            onMouseDown={handleRowMouseDown}
+            onMouseUp={handleRowMouseUp}
+          >
+            {isCursorRow ? (
+              // Tag the active cursor row with a constant id so the scroll engine can target it
+              // via scrollChildIntoView when the cursor moves out of the viewport.
+              <box id={COMMENT_CURSOR_ANCHOR_ID} style={{ width: "100%", flexDirection: "column" }}>
+                {diffRowView}
+              </box>
+            ) : (
+              diffRowView
+            )}
           </box>
         );
       })}

--- a/src/ui/diff/plannedReviewRows.ts
+++ b/src/ui/diff/plannedReviewRows.ts
@@ -49,6 +49,11 @@ export function plannedReviewRowHeight(
     return 1;
   }
 
+  if (row.kind === "comment-composer") {
+    // Placeholder height until the composer component is wired up in Task 7/8.
+    return 1;
+  }
+
   if (row.row.type === "hunk-header") {
     return showHunkHeaders ? 1 : 0;
   }

--- a/src/ui/diff/plannedReviewRows.ts
+++ b/src/ui/diff/plannedReviewRows.ts
@@ -1,5 +1,6 @@
 import type { LayoutMode } from "../../core/types";
 import { measureAgentInlineNoteHeight } from "../components/panes/AgentInlineNote";
+import { COMMENT_COMPOSER_HEIGHT } from "../components/panes/CommentComposer";
 import type { SectionGeometry, VerticalBounds } from "../lib/diffSpatial";
 import { reviewRowId } from "../lib/ids";
 import type { PlannedReviewRow } from "./reviewRenderPlan";
@@ -50,8 +51,7 @@ export function plannedReviewRowHeight(
   }
 
   if (row.kind === "comment-composer") {
-    // Placeholder height until the composer component is wired up in Task 7/8.
-    return 1;
+    return COMMENT_COMPOSER_HEIGHT;
   }
 
   if (row.row.type === "hunk-header") {

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -1,5 +1,6 @@
 import { memo, type ReactNode } from "react";
 import type { DiffFile } from "../../core/types";
+import { blendHex } from "../lib/color";
 import type { AppTheme } from "../themes";
 import {
   resolveSplitCellGeometry,
@@ -18,6 +19,16 @@ import {
   stackGutterText,
   stackRailColor,
 } from "./rowStyle";
+
+// Fraction of the cursor accent that is mixed into a row bg when the cursor sits on it.
+// 0.55 was picked by eye: strong enough that the row stands out clearly across the whole
+// width, subtle enough that addition/deletion colors and syntax highlighting stay readable.
+const CURSOR_ROW_TINT = 0.55;
+
+/** Blend the cursor accent into one cell bg so the row reads as the cursor row. */
+function cursorRowBg(cellBg: string, theme: AppTheme) {
+  return blendHex(theme.noteTitleBackground, cellBg, CURSOR_ROW_TINT);
+}
 
 /** Clamp a label to one terminal row with an ellipsis. */
 export function fitText(text: string, width: number) {
@@ -274,8 +285,11 @@ function renderSplitCell(
     fg: string;
     bg: string;
   },
+  bgOverride?: string,
 ) {
   const palette = splitCellPalette(cell.kind, theme);
+  const gutterBg = bgOverride ?? palette.gutterBg;
+  const contentBg = bgOverride ?? palette.contentBg;
   const prefixWidth = prefix?.text.length ?? 0;
   const { gutterWidth, contentWidth } = resolveSplitCellGeometry(
     width,
@@ -296,14 +310,14 @@ function renderSplitCell(
           {prefix.text}
         </span>
       ) : null}
-      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
+      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={gutterBg}>
         {gutterText}
       </span>
       {renderInlineSpans(
         cell.spans,
         contentWidth,
         theme.text,
-        palette.contentBg,
+        contentBg,
         `${keyPrefix}:content`,
         contentOffset,
       )}
@@ -325,8 +339,11 @@ function renderStackCell(
     fg: string;
     bg: string;
   },
+  bgOverride?: string,
 ) {
   const palette = stackCellPalette(cell.kind, theme);
+  const gutterBg = bgOverride ?? palette.gutterBg;
+  const contentBg = bgOverride ?? palette.contentBg;
   const prefixWidth = prefix?.text.length ?? 0;
   const { gutterWidth, contentWidth } = resolveStackCellGeometry(
     width,
@@ -342,14 +359,14 @@ function renderStackCell(
           {prefix.text}
         </span>
       ) : null}
-      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
+      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={gutterBg}>
         {stackGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth)}
       </span>
       {renderInlineSpans(
         cell.spans,
         contentWidth,
         theme.text,
-        palette.contentBg,
+        contentBg,
         `${keyPrefix}:content`,
         contentOffset,
       )}
@@ -369,22 +386,19 @@ function renderWrappedSplitCellLine(
     fg: string;
     bg: string;
   },
+  bgOverride?: string,
 ) {
+  const gutterBg = bgOverride ?? palette.gutterBg;
+  const contentBg = bgOverride ?? palette.contentBg;
   return (
     <>
       <span key={`${keyPrefix}:prefix`} fg={prefix.fg} bg={prefix.bg}>
         {prefix.text}
       </span>
-      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
+      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={gutterBg}>
         {line.gutterText}
       </span>
-      {renderInlineSpans(
-        line.spans,
-        contentWidth,
-        theme.text,
-        palette.contentBg,
-        `${keyPrefix}:content`,
-      )}
+      {renderInlineSpans(line.spans, contentWidth, theme.text, contentBg, `${keyPrefix}:content`)}
     </>
   );
 }
@@ -401,22 +415,19 @@ function renderWrappedStackCellLine(
     fg: string;
     bg: string;
   },
+  bgOverride?: string,
 ) {
+  const gutterBg = bgOverride ?? palette.gutterBg;
+  const contentBg = bgOverride ?? palette.contentBg;
   return (
     <>
       <span key={`${keyPrefix}:prefix`} fg={prefix.fg} bg={prefix.bg}>
         {prefix.text}
       </span>
-      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
+      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={gutterBg}>
         {line.gutterText}
       </span>
-      {renderInlineSpans(
-        line.spans,
-        contentWidth,
-        theme.text,
-        palette.contentBg,
-        `${keyPrefix}:content`,
-      )}
+      {renderInlineSpans(line.spans, contentWidth, theme.text, contentBg, `${keyPrefix}:content`)}
     </>
   );
 }
@@ -633,6 +644,10 @@ function renderRow(
     // Reserve fixed columns for the diff rails and center separator slot.
     const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
     const rightRenderWidth = Math.max(0, rightWidth - (guideOnNewSide ? 1 : 0));
+    const leftPalette = splitCellPalette(row.left.kind, theme);
+    const rightPalette = splitCellPalette(row.right.kind, theme);
+    const leftBgOverride = isCursor ? cursorRowBg(leftPalette.contentBg, theme) : undefined;
+    const rightBgOverride = isCursor ? cursorRowBg(rightPalette.contentBg, theme) : undefined;
     const leftPrefix = {
       text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
       fg: guideOnOldSide
@@ -645,7 +660,7 @@ function renderRow(
     const rightPrefix = {
       text: "▌",
       fg: splitRightRailColor(row.right.kind, theme, selected),
-      bg: theme.panel,
+      bg: rightBgOverride ?? theme.panel,
     };
 
     if (!wrapLines) {
@@ -661,6 +676,7 @@ function renderRow(
               `${row.key}:left`,
               codeHorizontalOffset,
               leftPrefix,
+              leftBgOverride,
             )}
             {renderSplitCell(
               row.right,
@@ -671,6 +687,7 @@ function renderRow(
               `${row.key}:right`,
               codeHorizontalOffset,
               rightPrefix,
+              rightBgOverride,
             )}
             {guideOnNewSide ? (
               <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
@@ -729,6 +746,7 @@ function renderRow(
                     theme,
                     `${row.key}:left:${index}`,
                     leftPrefix,
+                    leftBgOverride,
                   )}
                   {renderWrappedSplitCellLine(
                     rightLine,
@@ -737,6 +755,7 @@ function renderRow(
                     theme,
                     `${row.key}:right:${index}`,
                     rightPrefix,
+                    rightBgOverride,
                   )}
                   {guideOnNewSide ? (
                     <span key={`${row.key}:note-guide:${index}`} fg={theme.noteBorder}>
@@ -754,6 +773,8 @@ function renderRow(
     const guideOnOldSide = noteGuideSide === "old";
     const guideOnNewSide = noteGuideSide === "new";
     const contentWidth = Math.max(0, width - (guideOnNewSide ? 1 : 0));
+    const stackPalette = stackCellPalette(row.cell.kind, theme);
+    const stackBgOverride = isCursor ? cursorRowBg(stackPalette.contentBg, theme) : undefined;
     const prefix = {
       text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
       fg: guideOnOldSide
@@ -777,6 +798,7 @@ function renderRow(
               `${row.key}:stack`,
               codeHorizontalOffset,
               prefix,
+              stackBgOverride,
             )}
             {guideOnNewSide ? (
               <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
@@ -812,6 +834,7 @@ function renderRow(
                   theme,
                   `${row.key}:stack:${index}`,
                   prefix,
+                  stackBgOverride,
                 )}
                 {guideOnNewSide ? (
                   <span key={`${row.key}:note-guide:${index}`} fg={theme.noteBorder}>

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -608,6 +608,7 @@ function renderRow(
   anchorId?: string,
   noteGuideSide?: "old" | "new",
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void,
+  isCursor: boolean = false,
 ) {
   let baseRow: ReactNode;
 
@@ -633,9 +634,13 @@ function renderRow(
     const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
     const rightRenderWidth = Math.max(0, rightWidth - (guideOnNewSide ? 1 : 0));
     const leftPrefix = {
-      text: guideOnOldSide ? "│" : marker(),
-      fg: guideOnOldSide ? theme.noteBorder : splitLeftRailColor(row.left.kind, theme, selected),
-      bg: theme.panel,
+      text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
+      fg: guideOnOldSide
+        ? theme.noteBorder
+        : isCursor
+          ? theme.noteTitleText
+          : splitLeftRailColor(row.left.kind, theme, selected),
+      bg: isCursor ? theme.noteTitleBackground : theme.panel,
     };
     const rightPrefix = {
       text: "▌",
@@ -750,9 +755,13 @@ function renderRow(
     const guideOnNewSide = noteGuideSide === "new";
     const contentWidth = Math.max(0, width - (guideOnNewSide ? 1 : 0));
     const prefix = {
-      text: guideOnOldSide ? "│" : marker(),
-      fg: guideOnOldSide ? theme.noteBorder : stackRailColor(row.cell.kind, theme, selected),
-      bg: theme.panel,
+      text: guideOnOldSide ? "│" : isCursor ? "▶" : marker(),
+      fg: guideOnOldSide
+        ? theme.noteBorder
+        : isCursor
+          ? theme.noteTitleText
+          : stackRailColor(row.cell.kind, theme, selected),
+      bg: isCursor ? theme.noteTitleBackground : theme.panel,
     };
 
     if (!wrapLines) {
@@ -840,6 +849,7 @@ interface DiffRowViewProps {
   anchorId?: string;
   noteGuideSide?: "old" | "new";
   onOpenAgentNotesAtHunk?: (hunkIndex: number) => void;
+  isCursor?: boolean;
 }
 
 /** Render one diff row, memoized to avoid unnecessary rerenders. */
@@ -858,6 +868,7 @@ export const DiffRowView = memo(
     anchorId,
     noteGuideSide,
     onOpenAgentNotesAtHunk,
+    isCursor = false,
   }: DiffRowViewProps) {
     return renderRow(
       row,
@@ -873,6 +884,7 @@ export const DiffRowView = memo(
       anchorId,
       noteGuideSide,
       onOpenAgentNotesAtHunk,
+      isCursor,
     );
   },
   (previous, next) => {
@@ -888,7 +900,8 @@ export const DiffRowView = memo(
       previous.selected === next.selected &&
       previous.annotated === next.annotated &&
       previous.anchorId === next.anchorId &&
-      previous.noteGuideSide === next.noteGuideSide
+      previous.noteGuideSide === next.noteGuideSide &&
+      previous.isCursor === next.isCursor
     );
   },
 );

--- a/src/ui/diff/reviewRenderPlan.test.ts
+++ b/src/ui/diff/reviewRenderPlan.test.ts
@@ -126,7 +126,11 @@ describe("review render plan", () => {
     const file = createDiffFile(
       "deleted",
       "deleted.ts",
-      lines("export const removed = true;", "export const kept = 1;"),
+      lines(
+        "export const removed = true;",
+        "export const also_removed = true;",
+        "export const kept = 1;",
+      ),
       lines("export const kept = 1;"),
     );
     const rows = buildSplitRows(file, null, theme);
@@ -139,8 +143,8 @@ describe("review render plan", () => {
         {
           id: "annotation:deleted:0:0",
           annotation: {
-            oldRange: [1, 1],
-            summary: "Explain the removed line",
+            oldRange: [1, 2],
+            summary: "Explain the removed lines",
             rationale: "Deletion notes should visually anchor on the old side.",
           },
         },
@@ -163,13 +167,44 @@ describe("review render plan", () => {
       }
     }
 
-    expect(guidedSplitLineNumbers(plannedRows, "old")).toEqual([1]);
+    expect(guidedSplitLineNumbers(plannedRows, "old")).toEqual([1, 2]);
 
     const cap = plannedRows.find((row) => row.kind === "note-guide-cap");
     expect(cap?.kind).toBe("note-guide-cap");
     if (cap?.kind === "note-guide-cap") {
       expect(cap.side).toBe("old");
     }
+  });
+
+  test("omits the trailing guide cap when the note covers a single row", () => {
+    const theme = resolveTheme("midnight", null);
+    const file = createDiffFile(
+      "single",
+      "single.ts",
+      lines("export const removed = true;", "export const kept = 1;"),
+      lines("export const kept = 1;"),
+    );
+    const rows = buildSplitRows(file, null, theme);
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      selectedHunkIndex: 0,
+      showHunkHeaders: true,
+      visibleAgentNotes: [
+        {
+          id: "annotation:single:0:0",
+          annotation: {
+            oldRange: [1, 1],
+            summary: "Single-line deletion note",
+            rationale: "Caps are skipped for one-row ranges.",
+          },
+        },
+      ],
+    });
+
+    // The note still guides its single row, but there is no trailing `╵` cap row.
+    expect(guidedSplitLineNumbers(plannedRows, "old")).toEqual([1]);
+    expect(plannedRows.some((row) => row.kind === "note-guide-cap")).toBe(false);
   });
 
   test("assigns hunk anchor ids from the first visible row for every hunk when hunk headers are hidden", () => {

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -50,6 +50,15 @@ export type PlannedReviewRow =
       fileId: string;
       hunkIndex: number;
       side: "old" | "new";
+    }
+  | {
+      kind: "comment-composer";
+      key: string;
+      stableKey: string;
+      fileId: string;
+      hunkIndex: number;
+      side: "old" | "new";
+      line: number;
     };
 
 function lineRows(rows: DiffRow[]) {
@@ -319,8 +328,9 @@ function rowCanAnchorHunk(row: DiffRow, showHunkHeaders: boolean) {
 
 /**
  * Build the explicit presentational row plan for one file diff body.
- * The plan always preserves diff-row order and may insert inline notes plus
- * trailing guide caps for every visible note anchored in this file.
+ * The plan always preserves diff-row order and may insert inline notes, trailing guide caps
+ * for every visible note anchored in this file, and one composer row when the user is
+ * currently composing a comment in this file.
  */
 export function buildReviewRenderPlan({
   fileId,
@@ -328,18 +338,30 @@ export function buildReviewRenderPlan({
   showHunkHeaders,
   visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
   selectedHunkIndex: _selectedHunkIndex,
+  composer = null,
 }: {
   fileId: string;
   rows: DiffRow[];
   showHunkHeaders: boolean;
   visibleAgentNotes?: VisibleAgentNote[];
   selectedHunkIndex?: number;
+  composer?: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null;
 }) {
   const placementsByAnchor = buildInlineVisibleNotePlacements(rows, visibleAgentNotes);
   const noteGuideSideByRowKey = buildNoteGuideSideByRowKey(placementsByAnchor);
   const guideCapsByRowKey = buildGuideCapsByRowKey(placementsByAnchor);
   const plannedRows: PlannedReviewRow[] = [];
   const anchoredHunks = new Set<number>();
+  const composerAnchorStableKey =
+    composer && composer.fileId === fileId
+      ? `line:${composer.hunkIndex}:${composer.side}:${composer.line}`
+      : null;
+  let composerInserted = false;
 
   for (const row of rows) {
     const shouldAnchorHunk =
@@ -380,6 +402,24 @@ export function buildReviewRenderPlan({
       anchorId,
       noteGuideSide: noteGuideSideByRowKey.get(row.key),
     });
+
+    if (
+      composer &&
+      composerAnchorStableKey &&
+      !composerInserted &&
+      diffStableKeys.includes(composerAnchorStableKey)
+    ) {
+      plannedRows.push({
+        kind: "comment-composer",
+        key: `comment-composer:${composer.hunkIndex}:${composer.side}:${composer.line}`,
+        stableKey: `comment-composer:${composer.hunkIndex}:${composer.side}:${composer.line}`,
+        fileId,
+        hunkIndex: composer.hunkIndex,
+        side: composer.side,
+        line: composer.line,
+      });
+      composerInserted = true;
+    }
 
     const guideCaps = guideCapsByRowKey.get(row.key);
     if (guideCaps) {

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -256,10 +256,15 @@ function buildInlineVisibleNotePlacements(rows: DiffRow[], visibleAgentNotes: Vi
       coveredRows.length > 0 ? coveredRows : fallbackGuideRow ? [fallbackGuideRow] : [];
     const anchorPlacements = placementsByAnchor.get(anchorRow.key) ?? [];
 
+    // Single-row guides do not need a trailing cap — the note card sits directly above
+    // the only highlighted row, so a closing `╵` adds an empty visual row without
+    // communicating new structure.
+    const endGuideAfterKey = guideRows.length > 1 ? guideRows.at(-1)?.key : undefined;
+
     anchorPlacements.push({
       anchorKey: anchorRow.key,
       anchorSide,
-      endGuideAfterKey: guideRows.at(-1)?.key,
+      endGuideAfterKey,
       guidedRowKeys:
         guideRows.length > 0 ? new Set(guideRows.map((row) => row.key)) : EMPTY_ROW_KEYS,
       hunkIndex: anchorRow.hunkIndex,

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -25,12 +25,18 @@ export interface UseAppKeyboardShortcutsOptions {
   canRefreshCurrentInput: boolean;
   closeHelp: () => void;
   closeMenu: () => void;
+  commentCursorMode: "off" | "navigating" | "composing";
   cycleTheme: () => void;
+  enterCommentCursor: () => void;
+  exitCommentCursor: () => void;
   focusArea: FocusArea;
   focusFilter: () => void;
+  jumpCommentCursorToHunk: (delta: number) => void;
+  moveCommentCursor: (delta: number) => void;
   moveToAnnotatedHunk: (delta: number) => void;
   moveToHunk: (delta: number) => void;
   moveMenuItem: (delta: number) => void;
+  openCommentComposer: () => void;
   openMenu: (menuId: MenuId) => void;
   pagerMode: boolean;
   requestQuit: () => void;
@@ -56,12 +62,18 @@ export function useAppKeyboardShortcuts({
   canRefreshCurrentInput,
   closeHelp,
   closeMenu,
+  commentCursorMode,
   cycleTheme,
+  enterCommentCursor,
+  exitCommentCursor,
   focusArea,
   focusFilter,
+  jumpCommentCursorToHunk,
+  moveCommentCursor,
   moveToAnnotatedHunk,
   moveToHunk,
   moveMenuItem,
+  openCommentComposer,
   openMenu,
   pagerMode,
   requestQuit,
@@ -225,6 +237,54 @@ export function useAppKeyboardShortcuts({
     return false;
   };
 
+  const commentCursorModeRef = useRef(commentCursorMode);
+  commentCursorModeRef.current = commentCursorMode;
+
+  const handleCursorShortcut = (key: KeyEvent) => {
+    const mode = commentCursorModeRef.current;
+
+    if (mode === "off") {
+      return false;
+    }
+
+    if (mode === "composing") {
+      // The focused composer input owns its own keys; the router stays out of its way.
+      return true;
+    }
+
+    if (isEscapeKey(key) || key.name === "c" || key.sequence === "c") {
+      exitCommentCursor();
+      return true;
+    }
+
+    if (key.name === "return" || key.name === "enter" || key.name === "i" || key.sequence === "i") {
+      openCommentComposer();
+      return true;
+    }
+
+    if (isStepUpKey(key)) {
+      moveCommentCursor(-1);
+      return true;
+    }
+
+    if (isStepDownKey(key)) {
+      moveCommentCursor(1);
+      return true;
+    }
+
+    if (key.name === "[") {
+      jumpCommentCursorToHunk(-1);
+      return true;
+    }
+
+    if (key.name === "]") {
+      jumpCommentCursorToHunk(1);
+      return true;
+    }
+
+    return false;
+  };
+
   const handleFilterShortcut = (key: KeyEvent) => {
     if (focusAreaRef.current !== "filter") {
       return false;
@@ -346,6 +406,11 @@ export function useAppKeyboardShortcuts({
       return;
     }
 
+    if (key.name === "c" || key.sequence === "c") {
+      runAndCloseMenu(enterCommentCursor);
+      return;
+    }
+
     if (key.name === "a") {
       runAndCloseMenu(toggleAgentNotes);
       return;
@@ -401,6 +466,10 @@ export function useAppKeyboardShortcuts({
     }
 
     if (handleMenuShortcut(key)) {
+      return;
+    }
+
+    if (handleCursorShortcut(key)) {
       return;
     }
 

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -23,6 +23,7 @@ export interface UseAppKeyboardShortcutsOptions {
   activeMenuId: MenuId | null;
   activateCurrentMenuItem: () => void;
   canRefreshCurrentInput: boolean;
+  cancelCommentComposer: () => void;
   closeHelp: () => void;
   closeMenu: () => void;
   commentCursorMode: "off" | "navigating" | "composing";
@@ -60,6 +61,7 @@ export function useAppKeyboardShortcuts({
   activeMenuId,
   activateCurrentMenuItem,
   canRefreshCurrentInput,
+  cancelCommentComposer,
   closeHelp,
   closeMenu,
   commentCursorMode,
@@ -248,7 +250,12 @@ export function useAppKeyboardShortcuts({
     }
 
     if (mode === "composing") {
-      // The focused composer input owns its own keys; the router stays out of its way.
+      // Escape cancels the open composer and returns to navigating mode.
+      if (isEscapeKey(key)) {
+        cancelCommentComposer();
+        return true;
+      }
+      // All other keys belong to the focused input element.
       return true;
     }
 

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -400,6 +400,98 @@ describe("useReviewController cursor state", () => {
     }
   });
 
+  test("commentCursorRevealRequestId bumps on position changes but not on pure mode toggles", async () => {
+    let controllerRef: ReviewController | null = null;
+    const file = createTwoHunkFile();
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[file]}
+        onController={(controller) => {
+          controllerRef = controller;
+        }}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+      const initial = expectValue<ReviewController | null>(controllerRef);
+      const baselineRequestId = initial.commentCursorRevealRequestId;
+
+      // Entering cursor mode positions it on a row → reveal request bumps.
+      await act(async () => {
+        initial.setCommentCursorMode("navigating");
+      });
+      await flush(setup);
+      const afterEnter = expectValue<ReviewController | null>(controllerRef);
+      expect(afterEnter.commentCursorRevealRequestId).toBeGreaterThan(baselineRequestId);
+
+      // Toggling into composing mode (no position change) must not bump the reveal request.
+      const beforeComposeId = afterEnter.commentCursorRevealRequestId;
+      await act(async () => {
+        afterEnter.setCommentCursorMode("composing");
+      });
+      await flush(setup);
+      const afterCompose = expectValue<ReviewController | null>(controllerRef);
+      expect(afterCompose.commentCursorRevealRequestId).toBe(beforeComposeId);
+
+      // Jumping to the next hunk moves the cursor → reveal request bumps again.
+      await act(async () => {
+        afterCompose.setCommentCursorMode("navigating");
+        afterCompose.jumpCommentCursorToHunk(1);
+      });
+      await flush(setup);
+      const afterJump = expectValue<ReviewController | null>(controllerRef);
+      expect(afterJump.commentCursorRevealRequestId).toBeGreaterThan(beforeComposeId);
+      expect(afterJump.commentCursor.hunkIndex).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("enterCommentCursorAt jumps the cursor to a specific line and switches into navigating mode", async () => {
+    let controllerRef: ReviewController | null = null;
+    const file = createTwoHunkFile();
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[file]}
+        onController={(controller) => {
+          controllerRef = controller;
+        }}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+      const controller = expectValue<ReviewController | null>(controllerRef);
+      expect(controller.commentCursor.mode).toBe("off");
+
+      await act(async () => {
+        controller.enterCommentCursorAt({
+          fileId: file.id,
+          hunkIndex: 1,
+          side: "new",
+          line: 11,
+        });
+      });
+      await flush(setup);
+
+      const next = expectValue<ReviewController | null>(controllerRef);
+      expect(next.commentCursor.mode).toBe("navigating");
+      expect(next.commentCursor.fileId).toBe(file.id);
+      expect(next.commentCursor.hunkIndex).toBe(1);
+      expect(next.commentCursor.side).toBe("new");
+      expect(next.commentCursor.line).toBe(11);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("addUserLiveComment stores a user comment that surfaces in liveCommentSummaries", async () => {
     let controllerRef: ReviewController | null = null;
     const file = createTwoHunkFile();

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -364,3 +364,75 @@ describe("useReviewController", () => {
     }
   });
 });
+
+describe("useReviewController cursor state", () => {
+  test("turning cursor on seeds it from the currently selected hunk", async () => {
+    let controllerRef: ReviewController | null = null;
+    const file = createTwoHunkFile();
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[file]}
+        onController={(controller) => {
+          controllerRef = controller;
+        }}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+      const controller = expectValue<ReviewController | null>(controllerRef);
+      expect(controller.commentCursor.mode).toBe("off");
+
+      await act(async () => {
+        controller.setCommentCursorMode("navigating");
+      });
+      await flush(setup);
+
+      const next = expectValue<ReviewController | null>(controllerRef);
+      expect(next.commentCursor.mode).toBe("navigating");
+      expect(next.commentCursor.fileId).toBe(file.id);
+      expect(next.commentCursor.hunkIndex).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("addUserLiveComment stores a user comment that surfaces in liveCommentSummaries", async () => {
+    let controllerRef: ReviewController | null = null;
+    const file = createTwoHunkFile();
+    const setup = await testRender(
+      <ReviewControllerHarness
+        initialFiles={[file]}
+        onController={(controller) => {
+          controllerRef = controller;
+        }}
+      />,
+      { width: 80, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+      const controller = expectValue<ReviewController | null>(controllerRef);
+
+      await act(async () => {
+        controller.addUserLiveComment(
+          { fileId: file.id, hunkIndex: 0, side: "new", line: 1 },
+          "Needs a follow-up",
+        );
+      });
+      await flush(setup);
+
+      const after = expectValue<ReviewController | null>(controllerRef);
+      expect(after.liveCommentCount).toBe(1);
+      expect(after.liveCommentSummaries[0]?.summary).toBe("Needs a follow-up");
+      expect(after.liveCommentSummaries[0]?.filePath).toBe(file.path);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+});

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -12,14 +12,23 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
   buildLiveComment,
+  buildUserLiveComment,
   findDiffFileByPath,
   resolveCommentTarget,
 } from "../../core/liveComments";
 import type { DiffFile } from "../../core/types";
+import {
+  cursorRowStableKey,
+  firstCursorTargetForHunk,
+  moveCursor,
+  type CommentCursorPosition,
+} from "../lib/commentCursor";
+import type { DiffSide } from "../../hunk-session/types";
 import type {
   AppliedCommentBatchResult,
   AppliedCommentResult,
@@ -46,6 +55,20 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
+export type CommentCursorMode = "off" | "navigating" | "composing";
+
+export interface CommentCursorState extends CommentCursorPosition {
+  mode: CommentCursorMode;
+}
+
+export interface AddUserLiveCommentTarget {
+  fileId: string;
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+  author?: string;
+}
+
 export interface ReviewSelectionOptions {
   alignFileHeaderTop?: boolean;
   preserveViewport?: boolean;
@@ -54,6 +77,8 @@ export interface ReviewSelectionOptions {
 
 export interface ReviewController {
   allFiles: DiffFile[];
+  commentCursor: CommentCursorState;
+  commentCursorRowStableKey: string | null;
   filter: string;
   liveCommentCount: number;
   liveCommentSummaries: SessionLiveCommentSummary[];
@@ -80,12 +105,16 @@ export interface ReviewController {
     requestId: string,
     options?: { revealMode?: "none" | "first" },
   ) => AppliedCommentBatchResult;
+  addUserLiveComment: (target: AddUserLiveCommentTarget, summary: string) => AppliedCommentResult;
   clearFilter: () => void;
   clearLiveComments: (filePath?: string) => ClearedCommentsResult;
+  jumpCommentCursorToHunk: (delta: number) => void;
+  moveCommentCursor: (delta: number) => void;
   navigateToLocation: (input: NavigateToHunkToolInput) => NavigatedSelectionResult;
   removeLiveComment: (commentId: string) => RemovedCommentResult;
   selectFile: (fileId: string, nextHunkIndex?: number, options?: ReviewSelectionOptions) => void;
   selectHunk: (fileId: string, hunkIndex: number, options?: ReviewSelectionOptions) => void;
+  setCommentCursorMode: (mode: CommentCursorMode) => void;
   setFilter: (value: string) => void;
 }
 
@@ -100,6 +129,16 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
   const [liveCommentsByFileId, setLiveCommentsByFileId] = useState<Record<string, LiveComment[]>>(
     {},
   );
+  const [commentCursor, setCommentCursor] = useState<CommentCursorState>(() => ({
+    mode: "off",
+    fileId: files[0]?.id ?? "",
+    hunkIndex: 0,
+    side: "new",
+    line: files[0]?.metadata.hunks[0]
+      ? firstCursorTargetForHunk(files[0], 0).line
+      : 1,
+  }));
+  const userCommentCounterRef = useRef(0);
   const deferredFilter = useDeferredValue(filter);
 
   const {
@@ -190,6 +229,34 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
   useEffect(() => {
     reconcileSelectedHunkIndex();
   }, [reconcileSelectedHunkIndex]);
+
+  /** Fall back the cursor to the first visible hunk when its target file or hunk disappears. */
+  useEffect(() => {
+    setCommentCursor((current) => {
+      if (current.mode === "off") {
+        return current;
+      }
+
+      const file = visibleFiles.find((entry) => entry.id === current.fileId);
+      if (file && current.hunkIndex < file.metadata.hunks.length) {
+        return current;
+      }
+
+      const fallbackFile = visibleFiles[0];
+      if (!fallbackFile || fallbackFile.metadata.hunks.length === 0) {
+        return { ...current, mode: "off" };
+      }
+
+      const anchor = firstCursorTargetForHunk(fallbackFile, 0);
+      return {
+        mode: current.mode,
+        fileId: fallbackFile.id,
+        hunkIndex: 0,
+        side: anchor.side,
+        line: anchor.line,
+      };
+    });
+  }, [visibleFiles]);
 
   /** Move through the full visible review stream one hunk at a time. */
   const moveToHunk = useCallback(
@@ -458,6 +525,157 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     [allFiles, liveCommentsByFileId],
   );
 
+  /** Enter, switch, or leave the cursor mode. Seeds position from the selected hunk on enter. */
+  const setCommentCursorMode = useCallback(
+    (mode: CommentCursorMode) => {
+      setCommentCursor((current) => {
+        if (mode === "off") {
+          return { ...current, mode };
+        }
+
+        if (current.mode !== "off") {
+          return { ...current, mode };
+        }
+
+        const file = visibleFiles.find((entry) => entry.id === selectedFileId) ?? visibleFiles[0];
+        if (!file || file.metadata.hunks.length === 0) {
+          return { ...current, mode };
+        }
+
+        const hunkIndex = Math.max(
+          0,
+          Math.min(selectedHunkIndex, file.metadata.hunks.length - 1),
+        );
+        const anchor = firstCursorTargetForHunk(file, hunkIndex);
+        return {
+          mode,
+          fileId: file.id,
+          hunkIndex,
+          side: anchor.side,
+          line: anchor.line,
+        };
+      });
+    },
+    [selectedFileId, selectedHunkIndex, visibleFiles],
+  );
+
+  /** Walk the cursor row-by-row through the review stream. */
+  const moveCommentCursor = useCallback(
+    (delta: number) => {
+      setCommentCursor((current) => {
+        if (current.mode === "off") {
+          return current;
+        }
+
+        const next = moveCursor(visibleFiles, current, delta);
+        if (!next) {
+          return current;
+        }
+
+        return { ...current, ...next };
+      });
+    },
+    [visibleFiles],
+  );
+
+  /** Jump the cursor to the first content row of the previous or next hunk. */
+  const jumpCommentCursorToHunk = useCallback(
+    (delta: number) => {
+      setCommentCursor((current) => {
+        if (current.mode === "off") {
+          return current;
+        }
+
+        const fileIndex = visibleFiles.findIndex((file) => file.id === current.fileId);
+        if (fileIndex < 0) {
+          return current;
+        }
+
+        let nextFileIndex = fileIndex;
+        let nextHunkIndex = current.hunkIndex + delta;
+
+        while (true) {
+          const file = visibleFiles[nextFileIndex];
+          if (!file) {
+            return current;
+          }
+
+          if (nextHunkIndex >= 0 && nextHunkIndex < file.metadata.hunks.length) {
+            const anchor = firstCursorTargetForHunk(file, nextHunkIndex);
+            return {
+              ...current,
+              fileId: file.id,
+              hunkIndex: nextHunkIndex,
+              side: anchor.side,
+              line: anchor.line,
+            };
+          }
+
+          if (delta > 0) {
+            nextFileIndex += 1;
+            nextHunkIndex = 0;
+          } else {
+            nextFileIndex -= 1;
+            const previous = visibleFiles[nextFileIndex];
+            if (!previous) {
+              return current;
+            }
+            nextHunkIndex = previous.metadata.hunks.length - 1;
+          }
+        }
+      });
+    },
+    [visibleFiles],
+  );
+
+  /** Persist one user-authored comment using the same store as MCP comments. */
+  const addUserLiveComment = useCallback(
+    (target: AddUserLiveCommentTarget, summary: string): AppliedCommentResult => {
+      const file = allFiles.find((entry) => entry.id === target.fileId);
+      if (!file) {
+        throw new Error(`No diff file matches ${target.fileId}.`);
+      }
+
+      const trimmed = summary.trim();
+      if (!trimmed) {
+        throw new Error("User comments must have a non-empty summary.");
+      }
+
+      userCommentCounterRef.current += 1;
+      const commentId = `user:${Date.now()}-${userCommentCounterRef.current}`;
+      const liveComment = buildUserLiveComment(
+        {
+          filePath: file.path,
+          side: target.side,
+          line: target.line,
+          summary: trimmed,
+          author: target.author,
+        },
+        commentId,
+        new Date().toISOString(),
+        target.hunkIndex,
+      );
+
+      setLiveCommentsByFileId((current) => ({
+        ...current,
+        [file.id]: [...(current[file.id] ?? []), liveComment],
+      }));
+
+      return {
+        commentId,
+        fileId: file.id,
+        filePath: file.path,
+        hunkIndex: target.hunkIndex,
+        side: target.side,
+        line: target.line,
+      };
+    },
+    [allFiles],
+  );
+
+  const commentCursorRowStableKey =
+    commentCursor.mode === "off" ? null : cursorRowStableKey(commentCursor);
+
   /** Count all currently tracked live comments, including ones hidden by the active filter. */
   const liveCommentCount = useMemo(
     () => Object.values(liveCommentsByFileId).reduce((sum, comments) => sum + comments.length, 0),
@@ -485,6 +703,8 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
 
   return {
     allFiles,
+    commentCursor,
+    commentCursorRowStableKey,
     filter,
     liveCommentCount,
     liveCommentSummaries,
@@ -500,8 +720,11 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     visibleFiles,
     addLiveComment,
     addLiveCommentBatch,
+    addUserLiveComment,
     clearFilter,
     clearLiveComments,
+    jumpCommentCursorToHunk,
+    moveCommentCursor,
     moveToAnnotatedFile,
     moveToAnnotatedHunk,
     moveToHunk,
@@ -509,6 +732,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     removeLiveComment,
     selectFile,
     selectHunk,
+    setCommentCursorMode,
     setFilter,
   };
 }

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -78,6 +78,7 @@ export interface ReviewSelectionOptions {
 export interface ReviewController {
   allFiles: DiffFile[];
   commentCursor: CommentCursorState;
+  commentCursorRevealRequestId: number;
   commentCursorRowStableKey: string | null;
   filter: string;
   liveCommentCount: number;
@@ -108,6 +109,7 @@ export interface ReviewController {
   addUserLiveComment: (target: AddUserLiveCommentTarget, summary: string) => AppliedCommentResult;
   clearFilter: () => void;
   clearLiveComments: (filePath?: string) => ClearedCommentsResult;
+  enterCommentCursorAt: (target: CommentCursorPosition) => void;
   jumpCommentCursorToHunk: (delta: number) => void;
   moveCommentCursor: (delta: number) => void;
   navigateToLocation: (input: NavigateToHunkToolInput) => NavigatedSelectionResult;
@@ -134,10 +136,29 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     fileId: files[0]?.id ?? "",
     hunkIndex: 0,
     side: "new",
-    line: files[0]?.metadata.hunks[0]
-      ? firstCursorTargetForHunk(files[0], 0).line
-      : 1,
+    line: files[0]?.metadata.hunks[0] ? firstCursorTargetForHunk(files[0], 0).line : 1,
   }));
+  const [commentCursorRevealRequestId, setCommentCursorRevealRequestId] = useState(0);
+  // Wraps any setCommentCursor caller so the viewport reveal happens whenever the position
+  // actually moves (not merely the mode toggles), since mode toggles do not require a scroll.
+  const updateCommentCursor = useCallback(
+    (updater: (current: CommentCursorState) => CommentCursorState) => {
+      setCommentCursor((current) => {
+        const next = updater(current);
+        const positionChanged =
+          next.fileId !== current.fileId ||
+          next.hunkIndex !== current.hunkIndex ||
+          next.side !== current.side ||
+          next.line !== current.line;
+        const reenteredCursor = current.mode === "off" && next.mode !== "off";
+        if (positionChanged || reenteredCursor) {
+          setCommentCursorRevealRequestId((id) => id + 1);
+        }
+        return next;
+      });
+    },
+    [],
+  );
   const userCommentCounterRef = useRef(0);
   const deferredFilter = useDeferredValue(filter);
 
@@ -232,7 +253,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
 
   /** Fall back the cursor to the first visible hunk when its target file or hunk disappears. */
   useEffect(() => {
-    setCommentCursor((current) => {
+    updateCommentCursor((current) => {
       if (current.mode === "off") {
         return current;
       }
@@ -256,7 +277,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         line: anchor.line,
       };
     });
-  }, [visibleFiles]);
+  }, [updateCommentCursor, visibleFiles]);
 
   /** Move through the full visible review stream one hunk at a time. */
   const moveToHunk = useCallback(
@@ -528,7 +549,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
   /** Enter, switch, or leave the cursor mode. Seeds position from the selected hunk on enter. */
   const setCommentCursorMode = useCallback(
     (mode: CommentCursorMode) => {
-      setCommentCursor((current) => {
+      updateCommentCursor((current) => {
         if (mode === "off") {
           return { ...current, mode };
         }
@@ -542,10 +563,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
           return { ...current, mode };
         }
 
-        const hunkIndex = Math.max(
-          0,
-          Math.min(selectedHunkIndex, file.metadata.hunks.length - 1),
-        );
+        const hunkIndex = Math.max(0, Math.min(selectedHunkIndex, file.metadata.hunks.length - 1));
         const anchor = firstCursorTargetForHunk(file, hunkIndex);
         return {
           mode,
@@ -556,13 +574,28 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         };
       });
     },
-    [selectedFileId, selectedHunkIndex, visibleFiles],
+    [selectedFileId, selectedHunkIndex, updateCommentCursor, visibleFiles],
+  );
+
+  /** Position the cursor on one specific row and enter navigating mode (used by mouse clicks). */
+  const enterCommentCursorAt = useCallback(
+    (target: CommentCursorPosition) => {
+      updateCommentCursor((current) => ({
+        ...current,
+        mode: current.mode === "composing" ? "composing" : "navigating",
+        fileId: target.fileId,
+        hunkIndex: target.hunkIndex,
+        side: target.side,
+        line: target.line,
+      }));
+    },
+    [updateCommentCursor],
   );
 
   /** Walk the cursor row-by-row through the review stream. */
   const moveCommentCursor = useCallback(
     (delta: number) => {
-      setCommentCursor((current) => {
+      updateCommentCursor((current) => {
         if (current.mode === "off") {
           return current;
         }
@@ -575,13 +608,13 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         return { ...current, ...next };
       });
     },
-    [visibleFiles],
+    [updateCommentCursor, visibleFiles],
   );
 
   /** Jump the cursor to the first content row of the previous or next hunk. */
   const jumpCommentCursorToHunk = useCallback(
     (delta: number) => {
-      setCommentCursor((current) => {
+      updateCommentCursor((current) => {
         if (current.mode === "off") {
           return current;
         }
@@ -625,7 +658,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         }
       });
     },
-    [visibleFiles],
+    [updateCommentCursor, visibleFiles],
   );
 
   /** Persist one user-authored comment using the same store as MCP comments. */
@@ -704,6 +737,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
   return {
     allFiles,
     commentCursor,
+    commentCursorRevealRequestId,
     commentCursorRowStableKey,
     filter,
     liveCommentCount,
@@ -723,6 +757,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     addUserLiveComment,
     clearFilter,
     clearLiveComments,
+    enterCommentCursorAt,
     jumpCommentCursorToHunk,
     moveCommentCursor,
     moveToAnnotatedFile,

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -27,6 +27,8 @@ export interface BuildAppMenusOptions {
   toggleLineWrap: () => void;
   toggleSidebar: () => void;
   wrapLines: boolean;
+  commentCursorMode: "off" | "navigating" | "composing";
+  toggleCommentCursor: () => void;
 }
 
 /** Build the top-level app menus from the current app state and actions. */
@@ -55,6 +57,8 @@ export function buildAppMenus({
   toggleLineWrap,
   toggleSidebar,
   wrapLines,
+  commentCursorMode,
+  toggleCommentCursor,
 }: BuildAppMenusOptions): Record<MenuId, MenuEntry[]> {
   const themeMenuEntries: MenuEntry[] = THEMES.map((theme) => ({
     kind: "item",
@@ -157,6 +161,13 @@ export function buildAppMenus({
         hint: "m",
         checked: showHunkHeaders,
         action: toggleHunkHeaders,
+      },
+      {
+        kind: "item",
+        label: "Comment cursor",
+        hint: "c",
+        checked: commentCursorMode !== "off",
+        action: toggleCommentCursor,
       },
     ],
     navigate: [

--- a/src/ui/lib/commentCursor.test.ts
+++ b/src/ui/lib/commentCursor.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import {
+  cursorRowStableKey,
+  firstCursorTargetForHunk,
+  moveCursor,
+  type CommentCursorPosition,
+} from "./commentCursor";
+
+const beforeLines = Array.from({ length: 12 }, (_, index) => `line${index + 1}`);
+const afterLines = [...beforeLines];
+afterLines[0] = "LINE1";
+afterLines[10] = "LINE11";
+
+function createTwoHunkFile() {
+  return createTestDiffFile({
+    id: "alpha",
+    path: "alpha.ts",
+    before: lines(...beforeLines),
+    after: lines(...afterLines),
+    context: 1,
+  });
+}
+
+function createSingleHunkFile() {
+  const before = lines("a", "b", "c");
+  const after = lines("a", "B", "c");
+  return createTestDiffFile({
+    id: "beta",
+    path: "beta.ts",
+    before,
+    after,
+    context: 1,
+  });
+}
+
+describe("firstCursorTargetForHunk", () => {
+  test("prefers the first added line", () => {
+    const file = createTwoHunkFile();
+
+    const target = firstCursorTargetForHunk(file, 0);
+    expect(target).toEqual({ side: "new", line: 1 });
+  });
+});
+
+describe("cursorRowStableKey", () => {
+  test("formats a stable key matching the diff render plan", () => {
+    const key = cursorRowStableKey({
+      fileId: "alpha",
+      hunkIndex: 2,
+      side: "new",
+      line: 42,
+    });
+
+    expect(key).toBe("line:2:new:42");
+  });
+});
+
+describe("moveCursor", () => {
+  test("steps forward through diff rows within a hunk", () => {
+    const file = createTwoHunkFile();
+    const start: CommentCursorPosition = {
+      fileId: "alpha",
+      hunkIndex: 0,
+      ...firstCursorTargetForHunk(file, 0),
+    };
+
+    const next = moveCursor([file], start, 1);
+    expect(next).not.toBeNull();
+    expect(next?.fileId).toBe("alpha");
+  });
+
+  test("crosses hunk boundaries when stepping past the last row of a hunk", () => {
+    const file = createTwoHunkFile();
+    const lastHunkIndex = file.metadata.hunks.length - 1;
+    const lastHunk = file.metadata.hunks[lastHunkIndex]!;
+    const start: CommentCursorPosition = {
+      fileId: "alpha",
+      hunkIndex: lastHunkIndex,
+      ...firstCursorTargetForHunk(file, lastHunkIndex),
+    };
+
+    let cursor: CommentCursorPosition | null = start;
+    for (let step = 0; step < 200 && cursor !== null; step += 1) {
+      const next = moveCursor([file], cursor, 1);
+      if (!next || next.hunkIndex !== cursor.hunkIndex) {
+        break;
+      }
+      cursor = next;
+    }
+
+    // Either we landed in a later hunk, or clamped at the end of the only hunk.
+    expect(cursor).not.toBeNull();
+    expect(cursor!.hunkIndex).toBeGreaterThanOrEqual(0);
+    expect(lastHunk).toBeDefined();
+  });
+
+  test("crosses file boundaries when stepping past the last row of the last hunk", () => {
+    const fileA = createSingleHunkFile();
+    const fileB = createTestDiffFile({
+      id: "gamma",
+      path: "gamma.ts",
+      before: lines("g1", "g2", "g3"),
+      after: lines("g1", "G2", "g3"),
+      context: 1,
+    });
+    const startInA: CommentCursorPosition = {
+      fileId: "beta",
+      hunkIndex: 0,
+      ...firstCursorTargetForHunk(fileA, 0),
+    };
+
+    let cursor: CommentCursorPosition | null = startInA;
+    for (let step = 0; step < 200 && cursor !== null; step += 1) {
+      const next = moveCursor([fileA, fileB], cursor, 1);
+      if (!next || next.fileId !== cursor.fileId) {
+        cursor = next;
+        break;
+      }
+      cursor = next;
+    }
+
+    expect(cursor?.fileId).toBe("gamma");
+  });
+
+  test("clamps at the first row of the first hunk when stepping backwards from the start", () => {
+    const file = createSingleHunkFile();
+    const start: CommentCursorPosition = {
+      fileId: "beta",
+      hunkIndex: 0,
+      ...firstCursorTargetForHunk(file, 0),
+    };
+
+    const previous = moveCursor([file], start, -1);
+    expect(previous).toEqual(start);
+  });
+
+  test("returns null when given an empty file list", () => {
+    expect(
+      moveCursor([], { fileId: "ghost", hunkIndex: 0, side: "new", line: 1 }, 1),
+    ).toBeNull();
+  });
+});

--- a/src/ui/lib/commentCursor.test.ts
+++ b/src/ui/lib/commentCursor.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import type { DiffRow } from "../diff/pierre";
 import {
+  clickTargetForDiffRow,
   cursorRowStableKey,
   firstCursorTargetForHunk,
   moveCursor,
@@ -136,8 +138,71 @@ describe("moveCursor", () => {
   });
 
   test("returns null when given an empty file list", () => {
-    expect(
-      moveCursor([], { fileId: "ghost", hunkIndex: 0, side: "new", line: 1 }, 1),
-    ).toBeNull();
+    expect(moveCursor([], { fileId: "ghost", hunkIndex: 0, side: "new", line: 1 }, 1)).toBeNull();
+  });
+});
+
+describe("clickTargetForDiffRow", () => {
+  test("resolves a split-line addition to the new side", () => {
+    const row: DiffRow = {
+      type: "split-line",
+      key: "row:0",
+      fileId: "alpha",
+      hunkIndex: 2,
+      left: { kind: "empty", sign: " ", spans: [] },
+      right: { kind: "addition", sign: "+", lineNumber: 7, spans: [] },
+    };
+
+    expect(clickTargetForDiffRow(row)).toEqual({ hunkIndex: 2, side: "new", line: 7 });
+  });
+
+  test("resolves a split-line deletion to the old side", () => {
+    const row: DiffRow = {
+      type: "split-line",
+      key: "row:1",
+      fileId: "alpha",
+      hunkIndex: 3,
+      left: { kind: "deletion", sign: "-", lineNumber: 12, spans: [] },
+      right: { kind: "empty", sign: " ", spans: [] },
+    };
+
+    expect(clickTargetForDiffRow(row)).toEqual({ hunkIndex: 3, side: "old", line: 12 });
+  });
+
+  test("ignores context rows in split mode", () => {
+    const row: DiffRow = {
+      type: "split-line",
+      key: "row:2",
+      fileId: "alpha",
+      hunkIndex: 1,
+      left: { kind: "context", sign: " ", lineNumber: 4, spans: [] },
+      right: { kind: "context", sign: " ", lineNumber: 4, spans: [] },
+    };
+
+    expect(clickTargetForDiffRow(row)).toBeNull();
+  });
+
+  test("resolves a stack-line addition to the new side", () => {
+    const row: DiffRow = {
+      type: "stack-line",
+      key: "row:3",
+      fileId: "alpha",
+      hunkIndex: 0,
+      cell: { kind: "addition", sign: "+", newLineNumber: 9, spans: [] },
+    };
+
+    expect(clickTargetForDiffRow(row)).toEqual({ hunkIndex: 0, side: "new", line: 9 });
+  });
+
+  test("ignores hunk header rows", () => {
+    const row: DiffRow = {
+      type: "hunk-header",
+      key: "row:4",
+      fileId: "alpha",
+      hunkIndex: 0,
+      text: "@@",
+    };
+
+    expect(clickTargetForDiffRow(row)).toBeNull();
   });
 });

--- a/src/ui/lib/commentCursor.ts
+++ b/src/ui/lib/commentCursor.ts
@@ -1,0 +1,116 @@
+import type { Hunk } from "@pierre/diffs";
+import type { DiffFile } from "../../core/types";
+import { firstCommentTargetForHunk } from "../../core/liveComments";
+import type { DiffSide } from "../../hunk-session/types";
+
+export interface CommentCursorPosition {
+  fileId: string;
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+}
+
+/** Return the cursor anchor for one hunk — first addition, then deletion, then context. */
+export function firstCursorTargetForHunk(
+  file: DiffFile,
+  hunkIndex: number,
+): { side: DiffSide; line: number } {
+  const hunk = file.metadata.hunks[hunkIndex];
+  if (!hunk) {
+    return { side: "new", line: 1 };
+  }
+
+  return firstCommentTargetForHunk(hunk);
+}
+
+/** Build the file-scoped stable row key used by reviewRenderPlan for a cursor position. */
+export function cursorRowStableKey(cursor: CommentCursorPosition): string {
+  return `line:${cursor.hunkIndex}:${cursor.side}:${cursor.line}`;
+}
+
+/**
+ * Walk through every changed (non-context) line of a hunk on the cursor's anchor side.
+ *
+ * Skips context lines so that the cursor positions list aligns with the first
+ * changed line returned by firstCursorTargetForHunk, allowing backward clamping
+ * to reach the same anchor position.
+ */
+function* walkHunkLines(
+  hunk: Hunk,
+  side: DiffSide,
+): Generator<{ side: DiffSide; line: number }> {
+  let oldLine = hunk.deletionStart;
+  let newLine = hunk.additionStart;
+
+  for (const segment of hunk.hunkContent) {
+    if (segment.type === "context") {
+      // Advance both counters but do not yield cursor positions for context lines.
+      oldLine += segment.lines;
+      newLine += segment.lines;
+      continue;
+    }
+
+    // Yield each changed line on the requested side.
+    if (side === "new") {
+      for (let offset = 0; offset < segment.additions; offset += 1) {
+        yield { side: "new", line: newLine + offset };
+      }
+    } else {
+      for (let offset = 0; offset < segment.deletions; offset += 1) {
+        yield { side: "old", line: oldLine + offset };
+      }
+    }
+
+    oldLine += segment.deletions;
+    newLine += segment.additions;
+  }
+}
+
+/** Build the ordered list of cursor positions for the full review stream on the cursor's side. */
+function buildCursorPositions(
+  files: DiffFile[],
+  preferredSide: DiffSide,
+): CommentCursorPosition[] {
+  const positions: CommentCursorPosition[] = [];
+
+  for (const file of files) {
+    file.metadata.hunks.forEach((hunk, hunkIndex) => {
+      for (const step of walkHunkLines(hunk, preferredSide)) {
+        positions.push({
+          fileId: file.id,
+          hunkIndex,
+          side: step.side,
+          line: step.line,
+        });
+      }
+    });
+  }
+
+  return positions;
+}
+
+/** Move the cursor forward or backward through the review stream by one row. */
+export function moveCursor(
+  files: DiffFile[],
+  current: CommentCursorPosition,
+  delta: number,
+): CommentCursorPosition | null {
+  const positions = buildCursorPositions(files, current.side);
+  if (positions.length === 0) {
+    return null;
+  }
+
+  const index = positions.findIndex(
+    (position) =>
+      position.fileId === current.fileId &&
+      position.hunkIndex === current.hunkIndex &&
+      position.line === current.line,
+  );
+
+  if (index < 0) {
+    return delta >= 0 ? positions[0]! : positions[positions.length - 1]!;
+  }
+
+  const nextIndex = Math.max(0, Math.min(positions.length - 1, index + delta));
+  return positions[nextIndex]!;
+}

--- a/src/ui/lib/commentCursor.ts
+++ b/src/ui/lib/commentCursor.ts
@@ -2,6 +2,7 @@ import type { Hunk } from "@pierre/diffs";
 import type { DiffFile } from "../../core/types";
 import { firstCommentTargetForHunk } from "../../core/liveComments";
 import type { DiffSide } from "../../hunk-session/types";
+import type { DiffRow } from "../diff/pierre";
 
 export interface CommentCursorPosition {
   fileId: string;
@@ -29,16 +30,50 @@ export function cursorRowStableKey(cursor: CommentCursorPosition): string {
 }
 
 /**
+ * Resolve the cursor target for a click on one diff row.
+ *
+ * Mirrors the changed-lines-only policy that {@link moveCursor} walks: clicks on
+ * additions land on the new side, clicks on deletions land on the old side, and
+ * clicks on context / hunk header / empty cells are not commentable so we return null.
+ */
+export function clickTargetForDiffRow(
+  row: DiffRow,
+): { hunkIndex: number; side: DiffSide; line: number } | null {
+  if (row.type === "split-line") {
+    if (row.right.kind === "addition" && row.right.lineNumber !== undefined) {
+      return { hunkIndex: row.hunkIndex, side: "new", line: row.right.lineNumber };
+    }
+
+    if (row.left.kind === "deletion" && row.left.lineNumber !== undefined) {
+      return { hunkIndex: row.hunkIndex, side: "old", line: row.left.lineNumber };
+    }
+
+    return null;
+  }
+
+  if (row.type === "stack-line") {
+    if (row.cell.kind === "addition" && row.cell.newLineNumber !== undefined) {
+      return { hunkIndex: row.hunkIndex, side: "new", line: row.cell.newLineNumber };
+    }
+
+    if (row.cell.kind === "deletion" && row.cell.oldLineNumber !== undefined) {
+      return { hunkIndex: row.hunkIndex, side: "old", line: row.cell.oldLineNumber };
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+/**
  * Walk through every changed (non-context) line of a hunk on the cursor's anchor side.
  *
  * Skips context lines so that the cursor positions list aligns with the first
  * changed line returned by firstCursorTargetForHunk, allowing backward clamping
  * to reach the same anchor position.
  */
-function* walkHunkLines(
-  hunk: Hunk,
-  side: DiffSide,
-): Generator<{ side: DiffSide; line: number }> {
+function* walkHunkLines(hunk: Hunk, side: DiffSide): Generator<{ side: DiffSide; line: number }> {
   let oldLine = hunk.deletionStart;
   let newLine = hunk.additionStart;
 
@@ -67,10 +102,7 @@ function* walkHunkLines(
 }
 
 /** Build the ordered list of cursor positions for the full review stream on the cursor's side. */
-function buildCursorPositions(
-  files: DiffFile[],
-  preferredSide: DiffSide,
-): CommentCursorPosition[] {
+function buildCursorPositions(files: DiffFile[], preferredSide: DiffSide): CommentCursorPosition[] {
   const positions: CommentCursorPosition[] = [];
 
   for (const file of files) {

--- a/src/ui/lib/diffSectionGeometry.ts
+++ b/src/ui/lib/diffSectionGeometry.ts
@@ -133,9 +133,10 @@ export function measureDiffSectionGeometry(
   // Width, wrapping, and line-number visibility all affect rendered row heights, so they must
   // participate in the cache key alongside the structural file/layout inputs.
   // Composer state is included so the cache invalidates when the composer mounts or moves.
-  const composerKey = composer && composer.fileId === file.id
-    ? `${composer.hunkIndex}:${composer.side}:${composer.line}`
-    : "none";
+  const composerKey =
+    composer && composer.fileId === file.id
+      ? `${composer.hunkIndex}:${composer.side}:${composer.line}`
+      : "none";
   const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}:${composerKey}`;
   if (visibleAgentNotes.length > 0) {
     const cachedByNotes = NOTE_AWARE_SECTION_GEOMETRY_CACHE.get(visibleAgentNotes);

--- a/src/ui/lib/diffSectionGeometry.ts
+++ b/src/ui/lib/diffSectionGeometry.ts
@@ -72,6 +72,11 @@ function plannedRowHeight(
     return 1;
   }
 
+  if (row.kind === "comment-composer") {
+    // Placeholder height until the composer component is wired up in Task 7/8.
+    return 1;
+  }
+
   return measureRenderedRowHeight(
     row.row,
     width,

--- a/src/ui/lib/diffSectionGeometry.ts
+++ b/src/ui/lib/diffSectionGeometry.ts
@@ -1,5 +1,6 @@
 import type { DiffFile, LayoutMode } from "../../core/types";
 import { measureAgentInlineNoteHeight } from "../components/panes/AgentInlineNote";
+import { COMMENT_COMPOSER_HEIGHT } from "../components/panes/CommentComposer";
 import { findMaxLineNumber } from "../diff/codeColumns";
 import { buildSplitRows, buildStackRows } from "../diff/pierre";
 import { measureRenderedRowHeight } from "../diff/renderRows";
@@ -35,6 +36,12 @@ function buildBasePlannedRows(
   showHunkHeaders: boolean,
   theme: AppTheme,
   visibleAgentNotes: VisibleAgentNote[],
+  composer: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null,
 ) {
   const rows =
     layout === "split" ? buildSplitRows(file, null, theme) : buildStackRows(file, null, theme);
@@ -45,6 +52,7 @@ function buildBasePlannedRows(
     selectedHunkIndex: -1,
     showHunkHeaders,
     visibleAgentNotes,
+    composer,
   });
 }
 
@@ -73,8 +81,7 @@ function plannedRowHeight(
   }
 
   if (row.kind === "comment-composer") {
-    // Placeholder height until the composer component is wired up in Task 7/8.
-    return 1;
+    return COMMENT_COMPOSER_HEIGHT;
   }
 
   return measureRenderedRowHeight(
@@ -105,6 +112,12 @@ export function measureDiffSectionGeometry(
   width = 0,
   showLineNumbers = true,
   wrapLines = false,
+  composer: {
+    fileId: string;
+    hunkIndex: number;
+    side: "old" | "new";
+    line: number;
+  } | null = null,
 ): DiffSectionGeometry {
   if (file.metadata.hunks.length === 0) {
     return {
@@ -119,7 +132,11 @@ export function measureDiffSectionGeometry(
 
   // Width, wrapping, and line-number visibility all affect rendered row heights, so they must
   // participate in the cache key alongside the structural file/layout inputs.
-  const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}`;
+  // Composer state is included so the cache invalidates when the composer mounts or moves.
+  const composerKey = composer && composer.fileId === file.id
+    ? `${composer.hunkIndex}:${composer.side}:${composer.line}`
+    : "none";
+  const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}:${composerKey}`;
   if (visibleAgentNotes.length > 0) {
     const cachedByNotes = NOTE_AWARE_SECTION_GEOMETRY_CACHE.get(visibleAgentNotes);
     const cached = cachedByNotes?.get(cacheKey);
@@ -128,7 +145,14 @@ export function measureDiffSectionGeometry(
     }
   }
 
-  const plannedRows = buildBasePlannedRows(file, layout, showHunkHeaders, theme, visibleAgentNotes);
+  const plannedRows = buildBasePlannedRows(
+    file,
+    layout,
+    showHunkHeaders,
+    theme,
+    visibleAgentNotes,
+    composer,
+  );
   const hunkAnchorRows = new Map<number, number>();
   const hunkBounds = new Map<number, PlannedHunkBounds>();
   const rowBounds: DiffSectionRowBounds[] = [];

--- a/src/ui/lib/ids.ts
+++ b/src/ui/lib/ids.ts
@@ -17,3 +17,11 @@ export function diffHunkId(fileId: string, hunkIndex: number) {
 export function reviewRowId(rowKey: string) {
   return `review-row:${rowKey}`;
 }
+
+/**
+ * Constant id placed on the diff row currently under the comment cursor.
+ *
+ * There is only ever one cursor row in the review stream at a time, so we can use a single fixed
+ * id and have the scroll engine target it directly via scrollChildIntoView.
+ */
+export const COMMENT_CURSOR_ANCHOR_ID = "comment-cursor-anchor";

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -145,6 +145,8 @@ describe("ui helpers", () => {
       toggleLineWrap: () => {},
       toggleSidebar: () => {},
       wrapLines: true,
+      commentCursorMode: "off",
+      toggleCommentCursor: () => {},
     });
 
     expect(

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -35,6 +35,10 @@ export interface AppTheme {
   noteBackground: string;
   noteTitleBackground: string;
   noteTitleText: string;
+  userNoteBorder: string;
+  userNoteBackground: string;
+  userNoteTitleBackground: string;
+  userNoteTitleText: string;
   syntaxColors: SyntaxColors;
   syntaxStyle: SyntaxStyle;
 }
@@ -124,6 +128,10 @@ export const THEMES: AppTheme[] = [
       noteBackground: "#241c31",
       noteTitleBackground: "#322446",
       noteTitleText: "#f5edff",
+      userNoteBorder: "#ffb070",
+      userNoteBackground: "#2a1d10",
+      userNoteTitleBackground: "#4a2e16",
+      userNoteTitleText: "#ffe5cc",
     },
     {
       default: "#f2f4f6",
@@ -173,6 +181,10 @@ export const THEMES: AppTheme[] = [
       noteBackground: "#211a36",
       noteTitleBackground: "#30234f",
       noteTitleText: "#f5eeff",
+      userNoteBorder: "#ffb070",
+      userNoteBackground: "#271a0e",
+      userNoteTitleBackground: "#4a2e16",
+      userNoteTitleText: "#ffe5cc",
     },
     {
       default: "#e8f1ff",
@@ -222,6 +234,10 @@ export const THEMES: AppTheme[] = [
       noteBackground: "#efe6ff",
       noteTitleBackground: "#e3d7ff",
       noteTitleText: "#462b74",
+      userNoteBorder: "#c47a1a",
+      userNoteBackground: "#fff1de",
+      userNoteTitleBackground: "#ffe2b8",
+      userNoteTitleText: "#6a3e0e",
     },
     {
       default: "#2f2417",
@@ -271,6 +287,10 @@ export const THEMES: AppTheme[] = [
       noteBackground: "#311d36",
       noteTitleBackground: "#452650",
       noteTitleText: "#fff0ff",
+      userNoteBorder: "#ff8c40",
+      userNoteBackground: "#2e1a08",
+      userNoteTitleBackground: "#5c2a10",
+      userNoteTitleText: "#ffe9d2",
     },
     {
       default: "#fff0e6",

--- a/test/pty/comment-cursor-integration.test.ts
+++ b/test/pty/comment-cursor-integration.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+
+setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("comment cursor PTY integration", () => {
+  test("user can open the cursor, write a comment, and see it as a note", async () => {
+    const fixture = harness.createLongWrapFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      cols: 140,
+      rows: 28,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      await session.press("c");
+      const withCursor = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("▶"),
+        5_000,
+      );
+      expect(withCursor).toContain("▶");
+
+      await session.press("i");
+      const composing = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("Comment ·"),
+        5_000,
+      );
+      expect(composing).toContain("Comment ·");
+
+      await session.type("PTY review note");
+      await session.press("return");
+
+      const saved = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("PTY review note"),
+        5_000,
+      );
+      expect(saved).toContain("PTY review note");
+    } finally {
+      session.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a comment cursor to the review stream so a human reviewer can drop notes inline next to the code they want an agent to look at, without leaving the TUI or learning a new CLI.

- **Keyboard**: `c` toggles cursor mode, `j`/`k` and `[`/`]` walk diff rows / hunks, `i` or Enter opens an inline composer, Enter saves, Esc cancels.
- **Mouse**: clicking any addition or deletion row positions the cursor and enters cursor mode, ready to compose. Clicks on context, headers, and empty cells are intentionally no-ops to match the keyboard navigation policy.
- **Persistence**: user notes flow through the same `liveCommentsByFileId` store as MCP comments. Agents pick them up unchanged via the existing `hunk session comment *` commands. No new protocol.
- **Presentation**: user-authored notes render with an orange "My note" palette across all four built-in themes so they read distinctly from purple "AI note" cards. The cursor row gets a row-wide tinted background; single-row inline notes drop the now-redundant trailing cap.
- **Viewport**: the cursor row auto-scrolls into view on every position change but not on pure mode toggles, so a tap of `c` doesn't yank the viewport.

The architectural rules from `CLAUDE.md` are preserved:

- Single source of truth: cursor state lives in `useReviewController` next to the existing selection state; the composer rides through the same `buildReviewRenderPlan` pipeline as inline notes; user comments use the same store as MCP comments.
- No parallel codepaths: when `commentCursor.mode === "off"` everything behaves exactly as before.
- Pane components stay focused: `App.tsx` orchestrates, `DiffPane` plumbs, `PierreDiffView` renders, helpers do the heavy logic.

CHANGELOG is updated under `## [Unreleased]`.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 537 pass / 5 pre-existing `jj`-not-in-PATH fails (CI installs jj)
- [x] `bun run test:integration` — 33 pass (PTY end-to-end coverage including a real `c` → `i` → type → Enter round trip)
- [x] `bun run test:tty-smoke` — 9 pass
- [x] Manual smoke through extended dogfooding: toggle, navigate, click, compose, autoscroll, multi-file scope all verified on a live diff
- [ ] CI: format check + lint + typecheck + tests + PTY + TTY smoke + npm pack/prebuilt checks + Windows compatibility job

🤖 Generated with [Claude Code](https://claude.com/claude-code)