### PR TITLE
fix: resolve editor paths from repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed the `e` editor shortcut when Hunk is launched from a repo subdirectory.
 - Fixed VCS auto-detection so a Git repository nested under a parent Jujutsu workspace still uses Git mode by default.
 
 ## [0.13.1] - 2026-05-19

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -437,7 +437,14 @@ export function App({
   }, [refreshCurrentInput]);
 
   const triggerEditSelectedFile = useCallback(() => {
+    const basePath =
+      bootstrap.input.kind === "vcs" ||
+      bootstrap.input.kind === "show" ||
+      bootstrap.input.kind === "stash-show"
+        ? bootstrap.changeset.sourceLabel
+        : undefined;
     const message = openSelectedFileInEditor({
+      basePath,
       file: selectedFile,
       renderer,
       selectedHunk: review.selectedHunk,
@@ -452,6 +459,8 @@ export function App({
       triggerRefreshCurrentInput();
     }
   }, [
+    bootstrap.changeset.sourceLabel,
+    bootstrap.input.kind,
     canRefreshCurrentInput,
     renderer,
     review.selectedHunk,

--- a/src/ui/lib/openInEditor.test.ts
+++ b/src/ui/lib/openInEditor.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildEditorCommand, shouldSuspendForEditor } from "./openInEditor";
+import { resolve } from "node:path";
+import {
+  buildEditorCommand,
+  resolveEditableFilePath,
+  shouldSuspendForEditor,
+} from "./openInEditor";
 
 describe("open in editor helpers", () => {
   test("builds vi-style editor args without shell quoting", () => {
@@ -58,5 +63,11 @@ describe("open in editor helpers", () => {
     expect(shouldSuspendForEditor("code --reuse-window")).toBe(false);
     expect(shouldSuspendForEditor('"C:\\Program Files\\Cursor\\cursor.exe"')).toBe(false);
     expect(shouldSuspendForEditor("nvim")).toBe(true);
+  });
+
+  test("resolves repo-relative diff paths from the diff source path", () => {
+    expect(resolveEditableFilePath("src/main.tsx", "/tmp/project")).toBe(
+      resolve("/tmp/project", "src/main.tsx"),
+    );
   });
 });

--- a/src/ui/lib/openInEditor.ts
+++ b/src/ui/lib/openInEditor.ts
@@ -71,12 +71,19 @@ export function buildEditorCommand({
   return { command, args: [...editorArgs, filePath] };
 }
 
+/** Resolve diff paths relative to their source repo instead of the launch cwd. */
+export function resolveEditableFilePath(filePath: string, basePath = process.cwd()) {
+  return resolve(basePath, filePath);
+}
+
 /** Open the selected file in $EDITOR, suspending TUI for terminal editors. */
 export function openSelectedFileInEditor({
+  basePath,
   file,
   renderer,
   selectedHunk,
 }: {
+  basePath?: string;
   file: DiffFile | undefined;
   renderer: Pick<CliRenderer, "suspend" | "resume" | "isDestroyed">;
   selectedHunk: DiffFile["metadata"]["hunks"][number] | undefined;
@@ -90,7 +97,7 @@ export function openSelectedFileInEditor({
     return "$EDITOR is not set.";
   }
 
-  const absolutePath = resolve(process.cwd(), file.path);
+  const absolutePath = resolveEditableFilePath(file.path, basePath);
   if (!existsSync(absolutePath)) {
     return `Cannot edit ${file.path}: file does not exist on disk.`;
   }


### PR DESCRIPTION
@benvinegar - there is a bug when launching the editor from a place that is not the repo root. 
This PR should fix it. 