### PR TITLE
fix(ui): save notes from tmux Ctrl-S input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed Ctrl-S saving for inline notes when tmux sends CSI-u keyboard input.
 - Fixed the `e` editor shortcut when Hunk is launched from a repo subdirectory.
 - Fixed VCS auto-detection so a Git repository nested under a parent Jujutsu workspace still uses Git mode by default.
 

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -2214,6 +2214,42 @@ describe("App interactions", () => {
     }
   });
 
+  test("draft note saves Ctrl-S when tmux sends CSI-u input", async () => {
+    const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
+      width: 240,
+      height: 24,
+      useKittyKeyboard: null,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("Save from tmux CSI-u.");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.pressKeys(["\u001b[115;5u"]);
+      });
+      await flush(setup);
+
+      const frame = setup.captureCharFrame();
+      expect(frame).toContain("Your note");
+      expect(frame).toContain("Save from tmux CSI-u.");
+      expect(frame).not.toContain("Draft note");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("draft note blur restores app shortcuts without discarding the draft", async () => {
     const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
       width: 240,

--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -2,7 +2,7 @@ import type { TextareaRenderable } from "@opentui/core";
 import { flushSync } from "@opentui/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types";
-import { isEscapeKey } from "../../lib/keyboard";
+import { isEscapeKey, isSaveDraftNoteKey } from "../../lib/keyboard";
 import { wrapText } from "../../lib/agentPopover";
 import { annotationRangeLabel, reviewNoteSource } from "../../lib/agentAnnotations";
 import { fitText, padText } from "../../lib/text";
@@ -393,6 +393,13 @@ export function AgentInlineNote({
                     draftContentWidth,
                   ) + 1,
                 );
+              }
+
+              if (isSaveDraftNoteKey(key)) {
+                key.preventDefault();
+                key.stopPropagation();
+                draft.onSave();
+                return;
               }
 
               if (isEscapeKey(key)) {

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ import {
   isHalfPageUpKey,
   isPageDownKey,
   isPageUpKey,
+  isSaveDraftNoteKey,
   isShiftSpacePageUpKey,
   isStepDownKey,
   isStepUpKey,
@@ -136,6 +137,11 @@ export function useAppKeyboardShortcuts({
   const runAndCloseMenu = (action: () => void) => {
     action();
     closeMenu();
+  };
+
+  const consumeKey = (key: KeyEvent) => {
+    key.preventDefault();
+    key.stopPropagation();
   };
 
   const handleMenuToggleShortcut = (key: KeyEvent) => {
@@ -296,11 +302,13 @@ export function useAppKeyboardShortcuts({
     }
 
     if (isEscapeKey(key)) {
+      consumeKey(key);
       cancelDraftNote();
       return true;
     }
 
-    if (key.ctrl && (key.name === "s" || key.sequence === "\u0013")) {
+    if (isSaveDraftNoteKey(key)) {
+      consumeKey(key);
       saveDraftNote();
       return true;
     }

--- a/src/ui/lib/keyboard.ts
+++ b/src/ui/lib/keyboard.ts
@@ -1,7 +1,6 @@
 import type { KeyEvent } from "@opentui/core";
 
 const CTRL_S = "\u0013";
-const CTRL_S_HEX_LABEL = "0x13";
 const CTRL_S_CSI_U = "\u001b[115;5u";
 
 function isSpaceKey(key: KeyEvent) {
@@ -24,9 +23,7 @@ export function isSaveDraftNoteKey(key: KeyEvent) {
     sequence === CTRL_S ||
     raw === CTRL_S ||
     sequence === CTRL_S_CSI_U ||
-    raw === CTRL_S_CSI_U ||
-    sequence === CTRL_S_HEX_LABEL ||
-    raw === CTRL_S_HEX_LABEL
+    raw === CTRL_S_CSI_U
   );
 }
 

--- a/src/ui/lib/keyboard.ts
+++ b/src/ui/lib/keyboard.ts
@@ -1,5 +1,9 @@
 import type { KeyEvent } from "@opentui/core";
 
+const CTRL_S = "\u0013";
+const CTRL_S_HEX_LABEL = "0x13";
+const CTRL_S_CSI_U = "\u001b[115;5u";
+
 function isSpaceKey(key: KeyEvent) {
   return key.name === "space" || key.name === " " || key.sequence === " ";
 }
@@ -7,6 +11,23 @@ function isSpaceKey(key: KeyEvent) {
 /** Normalize the escape key aliases emitted by different terminal input paths. */
 export function isEscapeKey(key: KeyEvent) {
   return key.name === "escape" || key.name === "esc";
+}
+
+/** Match Ctrl-S across raw, Kitty/CSI-u, and tmux control-mode encodings. */
+export function isSaveDraftNoteKey(key: KeyEvent) {
+  const name = key.name?.toLowerCase();
+  const sequence = key.sequence;
+  const raw = key.raw;
+
+  return (
+    (key.ctrl && (name === "s" || sequence === "s" || sequence === CTRL_S)) ||
+    sequence === CTRL_S ||
+    raw === CTRL_S ||
+    sequence === CTRL_S_CSI_U ||
+    raw === CTRL_S_CSI_U ||
+    sequence === CTRL_S_HEX_LABEL ||
+    raw === CTRL_S_HEX_LABEL
+  );
 }
 
 /** Match any key alias that should scroll forward by a full viewport. */


### PR DESCRIPTION
## Summary

- Normalize Ctrl-S note-saving input across raw control, CSI-u, and tmux control-mode encodings
- Prevent handled save/cancel shortcut keys from reaching the focused textarea
- Add regression coverage for CSI-u Ctrl-S input

Fixes #345

## Testing

- bun run typecheck
- bun test
- tmux smoke: raw `C-s` saved a draft note without inserting `0x13`
- tmux smoke: literal CSI-u `ESC [ 115 ; 5 u` saved a draft note without inserting `0x13` or `115;5u`

*This PR description was generated by Pi using OpenAI GPT-5 Codex*