### PR TITLE
fix(ui): honor custom themes in static pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Fixed Ctrl-S saving for inline notes when tmux sends CSI-u keyboard input.
 - Restricted session reloads so daemon commands cannot read files outside the initial Hunk session root.
+- Fixed static pager output so captured pager hosts honor configured custom themes.
 - Fixed the `e` editor shortcut when Hunk is launched from a repo subdirectory.
 - Fixed VCS auto-detection so a Git repository nested under a parent Jujutsu workspace still uses Git mode by default.
 

--- a/src/core/startup.test.ts
+++ b/src/core/startup.test.ts
@@ -182,11 +182,12 @@ describe("startup planning", () => {
   test("routes diff-like pager stdin to static output when the host advertises a captured pager", async () => {
     let loaded = false;
     const patchText = "diff --git a/a.ts b/a.ts\n@@ -1 +1 @@\n-old\n+new\n";
+    const customTheme = { base: "paper", text: "#123456" };
 
     const plan = await prepareStartupPlan(["bun", "hunk", "pager"], {
       parseCliImpl: async () => ({
         kind: "pager",
-        options: { theme: "paper" },
+        options: { theme: "custom" },
       }),
       readStdinText: async () => patchText,
       looksLikePatchInputImpl: () => true,
@@ -197,8 +198,9 @@ describe("startup planning", () => {
         ({
           input: {
             ...input,
-            options: { ...input.options, lineNumbers: false, theme: "paper" },
+            options: { ...input.options, lineNumbers: false, theme: "custom" },
           },
+          customTheme,
         }) as never,
       loadAppBootstrapImpl: async () => {
         loaded = true;
@@ -209,7 +211,8 @@ describe("startup planning", () => {
     expect(plan).toEqual({
       kind: "static-diff-pager",
       text: patchText,
-      options: { theme: "paper", pager: true, lineNumbers: false },
+      options: { theme: "custom", pager: true, lineNumbers: false },
+      customTheme,
     });
     expect(loaded).toBe(false);
   });

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -37,6 +37,7 @@ export type StartupPlan =
       kind: "static-diff-pager";
       text: string;
       options: CliInput["options"];
+      customTheme?: AppBootstrap["customTheme"];
     }
   | {
       kind: "app";
@@ -127,15 +128,18 @@ export async function prepareStartupPlan(
           pager: true,
         },
       };
-      const configuredStaticInput = resolveConfiguredCliInputImpl(
+      const configuredStatic = resolveConfiguredCliInputImpl(
         resolveRuntimeCliInputImpl(staticPatchInput),
-      ).input;
-
-      return {
+      );
+      const staticPlan = {
         kind: "static-diff-pager" as const,
         text: stdinText,
-        options: configuredStaticInput.options,
+        options: configuredStatic.input.options,
       };
+
+      return configuredStatic.customTheme
+        ? { ...staticPlan, customTheme: configuredStatic.customTheme }
+        : staticPlan;
     };
 
     if (!looksLikePatchInputImpl(stdinText)) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -60,7 +60,12 @@ async function main() {
   }
 
   if (startupPlan.kind === "static-diff-pager") {
-    process.stdout.write(await renderStaticDiffPager(startupPlan.text, startupPlan.options));
+    process.stdout.write(
+      await renderStaticDiffPager(startupPlan.text, startupPlan.options, {
+        customTheme: startupPlan.customTheme,
+        stderr: process.stderr,
+      }),
+    );
     process.exit(0);
   }
 

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -35,6 +35,20 @@ describe("static diff pager", () => {
     expect(plain).toContain("▌+ const value = 2;");
   });
 
+  test("uses configured custom themes in static pager output", async () => {
+    const patchText =
+      "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-const value = 1;\n+const value = 2;\n";
+
+    const output = await renderStaticDiffPager(
+      patchText,
+      { theme: "custom" },
+      { customTheme: { base: "graphite", text: "#123456" } },
+    );
+
+    expect(stripAnsi(output)).toContain("a.ts modified +1 -1");
+    expect(output).toContain("\x1b[38;2;18;52;86m");
+  });
+
   test("shows semantic file metadata without raw patch headers", async () => {
     const patchText = [
       "diff --git a/new.txt b/new.txt",

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -15,7 +15,7 @@
  * text so pager pipelines keep working.
  */
 import { loadAppBootstrap } from "../core/loaders";
-import type { CommonOptions, DiffFile } from "../core/types";
+import type { CommonOptions, CustomThemeConfig, DiffFile } from "../core/types";
 import { buildStackRows, loadHighlightedDiff, type DiffRow, type RenderSpan } from "./diff/pierre";
 import {
   diffRailMarker,
@@ -202,6 +202,7 @@ function fallbackMessage(error: unknown) {
 }
 
 export interface StaticDiffPagerDeps {
+  customTheme?: CustomThemeConfig;
   stderr?: Pick<NodeJS.WriteStream, "write">;
 }
 
@@ -225,7 +226,7 @@ export async function renderStaticDiffPager(
         pager: true,
       },
     });
-    const theme = resolveTheme(options.theme, null);
+    const theme = resolveTheme(options.theme, null, deps.customTheme);
     const rendered = await Promise.all(
       bootstrap.changeset.files.map((file) => renderStaticFile(file, theme, options)),
     );


### PR DESCRIPTION
## Summary

- Carry configured custom theme data through the static diff pager startup plan.
- Pass custom themes into static pager theme resolution so captured pager hosts render the selected palette.
- Add regression coverage and a changelog entry.

## Testing

- `bun test src/core/startup.test.ts src/ui/staticDiffPager.test.ts`
- `bun run typecheck`

*This PR description was generated by Pi using OpenAI GPT-5*
