### PR TITLE
fix(ui): align split diffs with wide characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed split diff alignment for wide CJK and emoji characters by measuring rendered text in terminal cells.
 - Fixed Ctrl-S saving for inline notes when tmux sends CSI-u keyboard input.
 - Fixed the `e` editor shortcut when Hunk is launched from a repo subdirectory.
 - Fixed VCS auto-detection so a Git repository nested under a parent Jujutsu workspace still uses Git mode by default.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "bun": "^1.3.10",
         "commander": "^14.0.3",
         "diff": "^8.0.3",
+        "string-width": "^8.2.1",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -555,7 +556,7 @@
 
     "string-dedent": ["string-dedent@3.0.2", "", {}, "sha512-M4q+HpHCtGXlbyzYDOcOo7V185dlq6YXvGUPcWZqL4vttCX9gFYoWIOxcPd7v5CAYcTJsGLs3ZJCAH2TXONF/g=="],
 
-    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
+    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -660,6 +661,8 @@
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@opentui/core/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
     "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
 

--- a/nix/bun.lock.nix
+++ b/nix/bun.lock.nix
@@ -1017,6 +1017,10 @@
     url = "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz";
     hash = "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==";
   };
+  "string-width@8.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz";
+    hash = "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==";
+  };
   "string_decoder@1.3.0" = fetchurl {
     url = "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz";
     hash = "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==";

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "bun": "^1.3.10",
     "commander": "^14.0.3",
     "diff": "^8.0.3",
+    "string-width": "^8.2.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -575,6 +575,50 @@ describe("UI components", () => {
     }
   });
 
+  test("DiffRowView preserves zero-width combining spans in nowrap and wrapped rows", async () => {
+    const theme = resolveTheme("midnight", null);
+    const row = {
+      type: "stack-line" as const,
+      key: "alpha:line:combining",
+      fileId: "alpha",
+      hunkIndex: 0,
+      cell: {
+        kind: "addition" as const,
+        sign: "+" as const,
+        newLineNumber: 2,
+        spans: [{ text: "e" }, { text: "\u0301" }, { text: "x" }],
+      },
+    };
+
+    for (const wrapLines of [false, true]) {
+      const setup = await testRender(
+        <DiffRowView
+          row={row}
+          width={40}
+          lineNumberDigits={1}
+          showLineNumbers={true}
+          showHunkHeaders={true}
+          wrapLines={wrapLines}
+          codeHorizontalOffset={0}
+          theme={theme}
+          selected={false}
+        />,
+        { width: 48, height: 3 },
+      );
+
+      try {
+        await act(async () => {
+          await setup.renderOnce();
+        });
+        expect(setup.captureCharFrame()).toContain("e\u0301x");
+      } finally {
+        await act(async () => {
+          setup.renderer.destroy();
+        });
+      }
+    }
+  });
+
   test("DiffPane only shows the add-note affordance after pointer movement", async () => {
     const files = createWindowingFiles(6);
     const theme = resolveTheme("midnight", null);

--- a/src/ui/diff/codeColumns.test.ts
+++ b/src/ui/diff/codeColumns.test.ts
@@ -29,6 +29,12 @@ describe("code column measurement", () => {
 
     expect(maxFileCodeLineWidth(file)).toBe("the widest generated line".length);
   });
+
+  test("counts wide CJK characters by terminal cells", () => {
+    const file = createLargeLineFixture(2, "日本語");
+
+    expect(maxFileCodeLineWidth(file)).toBe(6);
+  });
 });
 
 describe("findMaxLineNumberInRows", () => {

--- a/src/ui/diff/codeColumns.ts
+++ b/src/ui/diff/codeColumns.ts
@@ -1,9 +1,12 @@
 import type { DiffFile, LayoutMode } from "../../core/types";
+import { measureTextWidth } from "../lib/text";
 import type { DiffRow } from "./pierre";
 
 export const DIFF_CODE_TAB_WIDTH = 2;
 export const DIFF_RAIL_PREFIX_WIDTH = 1;
 export const DIFF_SPLIT_SEPARATOR_WIDTH = 1;
+
+const maxFileCodeLineWidthCache = new WeakMap<DiffFile["metadata"], number>();
 
 /** Expand tabs the same way the diff renderer does before measuring visible columns. */
 export function expandDiffTabs(text: string) {
@@ -12,11 +15,16 @@ export function expandDiffTabs(text: string) {
 
 /** Measure one rendered code line after tab expansion and newline trimming. */
 export function measureRenderedCodeLineWidth(line: string | undefined) {
-  return expandDiffTabs((line ?? "").replace(/\n$/, "")).length;
+  return measureTextWidth(expandDiffTabs((line ?? "").replace(/\n$/, "")));
 }
 
 /** Track the widest rendered code line for one file. */
 export function maxFileCodeLineWidth(file: DiffFile) {
+  const cachedWidth = maxFileCodeLineWidthCache.get(file.metadata);
+  if (cachedWidth !== undefined) {
+    return cachedWidth;
+  }
+
   const deletionLines = file.metadata.deletionLines ?? [];
   const additionLines = file.metadata.additionLines ?? [];
 
@@ -30,6 +38,7 @@ export function maxFileCodeLineWidth(file: DiffFile) {
     maxWidth = Math.max(maxWidth, measureRenderedCodeLineWidth(line));
   }
 
+  maxFileCodeLineWidthCache.set(file.metadata, maxWidth);
   return maxWidth;
 }
 

--- a/src/ui/diff/pierre.test.ts
+++ b/src/ui/diff/pierre.test.ts
@@ -9,8 +9,10 @@ import {
   spansForHighlightedSourceLine,
   type DiffRow,
 } from "./pierre";
+import { resolveSplitPaneWidths } from "./codeColumns";
 import { renderCodeOnlyPlannedRowText, renderDecoratedPlannedRowText } from "./renderRows";
 import { buildReviewRenderPlan } from "./reviewRenderPlan";
+import { measureTextWidth } from "../lib/text";
 import { resolveTheme } from "../themes";
 
 function createDiffFile(): DiffFile {
@@ -203,6 +205,66 @@ describe("Pierre diff rows", () => {
 
     expect(line).toContain("- export const answer = 41;");
     expect(line).toContain("+ export const answer = 42;");
+  });
+
+  test("keeps the split separator aligned after wide characters", () => {
+    const metadata = parseDiffFromFile(
+      {
+        name: "i18n.ts",
+        contents: "export const message = '日本語';\n",
+        cacheKey: "before-wide",
+      },
+      {
+        name: "i18n.ts",
+        contents: "export const message = 'abc';\n",
+        cacheKey: "after-wide",
+      },
+      { context: 3 },
+      true,
+    );
+    const file: DiffFile = {
+      id: "i18n",
+      path: "i18n.ts",
+      patch: "",
+      language: "typescript",
+      stats: { additions: 1, deletions: 1 },
+      metadata,
+      agent: null,
+    };
+    const theme = resolveTheme("midnight", null);
+    const rows = buildSplitRows(file, null, theme);
+    const plannedRows = buildReviewRenderPlan({ fileId: file.id, rows, showHunkHeaders: true });
+    const changedRow = plannedRows.find(
+      (row) =>
+        row.kind === "diff-row" &&
+        row.row.type === "split-line" &&
+        row.row.left.kind === "deletion",
+    );
+
+    expect(changedRow).toBeDefined();
+    if (!changedRow || changedRow.kind !== "diff-row") {
+      throw new Error("Expected a planned split diff row");
+    }
+
+    const width = 80;
+    const { leftWidth } = resolveSplitPaneWidths(width);
+    const line = renderDecoratedPlannedRowText(changedRow, {
+      codeHorizontalOffset: 0,
+      lineNumberDigits: 1,
+      showHunkHeaders: true,
+      showLineNumbers: true,
+      theme,
+      width,
+      wrapLines: false,
+    })[0];
+    expect(line).toBeDefined();
+    if (!line) {
+      throw new Error("Expected a rendered split row");
+    }
+    const centerSeparatorIndex = line.indexOf("▌", 1);
+
+    expect(line).toContain("日本語");
+    expect(measureTextWidth(line.slice(0, centerSeparatorIndex))).toBe(leftWidth);
   });
 
   test("renders planned stack rows with horizontal copy offset", () => {

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -24,6 +24,7 @@ import {
 import { type PlannedReviewRow } from "./reviewRenderPlan";
 import { inlineNoteTitle } from "../components/panes/AgentInlineNote";
 import { wrapText } from "../lib/agentPopover";
+import { measureTextWidth, padText as padTextByWidth, sliceTextByWidth } from "../lib/text";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
 
 /** Clamp a label to one terminal row with an ellipsis. */
@@ -32,7 +33,7 @@ export function fitText(text: string, width: number) {
     return "";
   }
 
-  if (text.length <= width) {
+  if (measureTextWidth(text) <= width) {
     return text;
   }
 
@@ -40,7 +41,17 @@ export function fitText(text: string, width: number) {
     return "…";
   }
 
-  return `${text.slice(0, width - 1)}…`;
+  return `${sliceTextByWidth(text, 0, width - 1).text}…`;
+}
+
+/** Append a styled span while preserving color-run coalescing. */
+function appendRenderSpan(target: RenderSpan[], span: RenderSpan) {
+  const previous = target.at(-1);
+  if (previous && previous.fg === span.fg && previous.bg === span.bg) {
+    previous.text += span.text;
+  } else {
+    target.push(span);
+  }
 }
 
 /** Slice styled spans to one visible window while preserving color runs. */
@@ -62,33 +73,33 @@ function sliceSpansWindow(spans: RenderSpan[], offset: number, width: number) {
       break;
     }
 
-    if (remainingOffset >= span.text.length) {
-      remainingOffset -= span.text.length;
+    const spanWidth = measureTextWidth(span.text);
+    if (spanWidth === 0) {
+      appendRenderSpan(sliced, span);
       continue;
     }
 
-    const start = remainingOffset;
-    const text = span.text.slice(start, start + remaining);
+    if (remainingOffset >= spanWidth) {
+      remainingOffset -= spanWidth;
+      continue;
+    }
+
+    const visible = sliceTextByWidth(span.text, remainingOffset, remaining);
     remainingOffset = 0;
 
-    if (text.length === 0) {
+    if (visible.text.length === 0) {
       continue;
     }
 
     const nextSpan = {
       ...span,
-      text,
+      text: visible.text,
     };
 
-    const previous = sliced.at(-1);
-    if (previous && previous.fg === nextSpan.fg && previous.bg === nextSpan.bg) {
-      previous.text += nextSpan.text;
-    } else {
-      sliced.push(nextSpan);
-    }
+    appendRenderSpan(sliced, nextSpan);
 
-    remaining -= text.length;
-    usedWidth += text.length;
+    remaining -= visible.width;
+    usedWidth += visible.width;
   }
 
   return {
@@ -121,8 +132,9 @@ function renderInlineSpans(
   let elementIndex = 0;
 
   for (const span of trimmed) {
+    const spanWidth = measureTextWidth(span.text);
     const spanStart = colPos;
-    const spanEnd = colPos + span.text.length;
+    const spanEnd = colPos + spanWidth;
     colPos = spanEnd;
 
     if (
@@ -145,7 +157,7 @@ function renderInlineSpans(
 
     // Compute the split offsets within this span's text.
     const localSelStart = Math.max(0, selectionColRange.start - spanStart);
-    const localSelEnd = Math.min(span.text.length, selectionColRange.end - spanStart);
+    const localSelEnd = Math.min(spanWidth, selectionColRange.end - spanStart);
 
     if (localSelStart >= localSelEnd) {
       // No overlap after clamping — render original.
@@ -162,9 +174,9 @@ function renderInlineSpans(
     }
 
     // Split the span at selection boundaries for character-level precision.
-    const prefix = span.text.slice(0, localSelStart);
-    const selected = span.text.slice(localSelStart, localSelEnd);
-    const suffix = span.text.slice(localSelEnd);
+    const prefix = sliceTextByWidth(span.text, 0, localSelStart).text;
+    const selected = sliceTextByWidth(span.text, localSelStart, localSelEnd - localSelStart).text;
+    const suffix = sliceTextByWidth(span.text, localSelEnd, spanWidth - localSelEnd).text;
 
     if (prefix) {
       elements.push(
@@ -204,8 +216,8 @@ function renderInlineSpans(
   // Trailing padding after all spans.
   if (needsBlending) {
     // Compute how much of the padding falls within the selection.
-    // The padding starts at colPos (which is now sum of all span text lengths =
-    // usedWidth after slicing) and extends to `width`.
+    // The padding starts at colPos (which is now the terminal-cell width consumed by
+    // the rendered spans) and extends to `width`.
     const padStart = colPos;
     const padEnd = colPos + Math.max(0, width - usedWidth);
     const paddingAmount = Math.max(0, width - usedWidth);
@@ -286,33 +298,49 @@ function wrapSpans(spans: RenderSpan[], width: number) {
   let remaining = width;
 
   for (const span of spans) {
+    const spanWidth = measureTextWidth(span.text);
+    if (spanWidth === 0) {
+      appendRenderSpan(current, span);
+      continue;
+    }
+
     let offset = 0;
 
-    while (offset < span.text.length) {
+    while (offset < spanWidth) {
       if (remaining <= 0) {
         current = [];
         lines.push(current);
         remaining = width;
       }
 
-      const text = span.text.slice(offset, offset + remaining);
-      if (text.length === 0) {
-        break;
+      const visible = sliceTextByWidth(span.text, offset, remaining);
+      if (visible.width === 0) {
+        // A single wide cluster cannot fit in the remaining cells; continue on the next row.
+        current = [];
+        lines.push(current);
+        remaining = width;
+        const forced = sliceTextByWidth(span.text, offset, width);
+        if (forced.width === 0) {
+          break;
+        }
+        const nextSpan = {
+          ...span,
+          text: forced.text,
+        };
+        current.push(nextSpan);
+        offset += forced.width;
+        remaining = Math.max(0, width - forced.width);
+        continue;
       }
 
       const nextSpan = {
         ...span,
-        text,
+        text: visible.text,
       };
-      const previous = current.at(-1);
-      if (previous && previous.fg === nextSpan.fg && previous.bg === nextSpan.bg) {
-        previous.text += nextSpan.text;
-      } else {
-        current.push(nextSpan);
-      }
+      appendRenderSpan(current, nextSpan);
 
-      offset += text.length;
-      remaining -= text.length;
+      offset += visible.width;
+      remaining -= visible.width;
     }
   }
 
@@ -389,12 +417,13 @@ function spansToPlainText(spans: RenderSpan[], width: number, horizontalOffset =
     return "";
   }
 
-  const visibleText = spans
-    .map((span) => span.text)
-    .join("")
-    .slice(Math.max(0, horizontalOffset), Math.max(0, horizontalOffset) + width);
+  const visible = sliceTextByWidth(
+    spans.map((span) => span.text).join(""),
+    Math.max(0, horizontalOffset),
+    width,
+  );
 
-  return visibleText.padEnd(Math.max(0, width), " ");
+  return padTextByWidth(visible.text, Math.max(0, width));
 }
 
 /** Flatten styled spans to their visible text content. */
@@ -404,7 +433,8 @@ function spansText(spans: RenderSpan[]) {
 
 /** Return one cell's code text without rail, gutter, sign, or line-number decorations. */
 function cellCodeText(spans: RenderSpan[], horizontalOffset = 0) {
-  return spansText(spans).slice(Math.max(0, horizontalOffset));
+  return sliceTextByWidth(spansText(spans), Math.max(0, horizontalOffset), Number.MAX_SAFE_INTEGER)
+    .text;
 }
 
 function buildPlainSplitCellLines(
@@ -501,7 +531,7 @@ function buildPlainStackCellLines(
 /** Render the marker + label that hunk-header and collapsed rows share in plain-text form. */
 function renderHeaderRowText(text: string, width: number) {
   const label = fitText(text, Math.max(0, width - 1));
-  return marker() + label.padEnd(Math.max(0, width - 1), " ");
+  return marker() + padTextByWidth(label, Math.max(0, width - 1));
 }
 
 interface PlannedRowTextOptions {
@@ -608,14 +638,11 @@ export function renderDecoratedPlannedRowText(
         contentWidth: rightContentWidth,
         spansText: " ".repeat(Math.max(0, rightRenderWidth - rightPrefixPad)),
       };
-      const normalizedLeft = (
-        `${leftPrefix}${leftLine.spansText}` +
-        " ".repeat(Math.max(0, leftWidth - leftLine.spansText.length))
-      ).slice(0, Math.max(0, leftWidth));
-      const normalizedRight = (
-        `${rightPrefix}${rightLine.spansText}` +
-        " ".repeat(Math.max(0, rightRenderWidth - rightLine.spansText.length))
-      ).slice(0, Math.max(0, rightRenderWidth));
+      const normalizedLeft = padTextByWidth(`${leftPrefix}${leftLine.spansText}`, leftWidth);
+      const normalizedRight = padTextByWidth(
+        `${rightPrefix}${rightLine.spansText}`,
+        rightRenderWidth,
+      );
 
       if (side === "left") {
         return normalizedLeft;
@@ -649,7 +676,7 @@ export function renderDecoratedPlannedRowText(
 
   return cellLines.map((line) => {
     const visibleLine = `${prefix}${line.spansText}`;
-    const normalized = visibleLine.padEnd(Math.max(1, contentWidth + prefix.length), " ");
+    const normalized = padTextByWidth(visibleLine, Math.max(1, contentWidth + prefix.length));
     return `${normalized}${guideOnNewSide ? "│" : ""}`;
   });
 }

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -1,10 +1,72 @@
+import stringWidth from "string-width";
+
+const printableAsciiRegex = /^[\u0020-\u007E]*$/;
+const graphemeSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+/** Iterate user-visible text clusters so wide and combining characters stay together. */
+function textClusters(text: string) {
+  if (!graphemeSegmenter) {
+    return Array.from(text);
+  }
+
+  return Array.from(graphemeSegmenter.segment(text), (segment) => segment.segment);
+}
+
+/** Measure text in terminal cells, treating CJK and emoji clusters as wide. */
+export function measureTextWidth(text: string) {
+  return printableAsciiRegex.test(text) ? text.length : stringWidth(text);
+}
+
+/** Slice text by terminal cells without splitting wide or combining clusters. */
+export function sliceTextByWidth(text: string, offset: number, width: number) {
+  const startOffset = Math.max(0, offset);
+  const maxWidth = Math.max(0, width);
+  if (maxWidth === 0) {
+    return { text: "", width: 0 };
+  }
+
+  if (printableAsciiRegex.test(text)) {
+    const sliced = text.slice(startOffset, startOffset + maxWidth);
+    return { text: sliced, width: sliced.length };
+  }
+
+  let cursor = 0;
+  let usedWidth = 0;
+  let visibleText = "";
+
+  for (const cluster of textClusters(text)) {
+    const clusterWidth = measureTextWidth(cluster);
+    const clusterStart = cursor;
+    const clusterEnd = cursor + clusterWidth;
+    cursor = clusterEnd;
+
+    if (clusterEnd <= startOffset) {
+      continue;
+    }
+    if (clusterStart < startOffset) {
+      continue;
+    }
+    if (usedWidth + clusterWidth > maxWidth) {
+      break;
+    }
+
+    visibleText += cluster;
+    usedWidth += clusterWidth;
+  }
+
+  return { text: visibleText, width: usedWidth };
+}
+
 /** Clamp text to a fixed width using a plain-dot terminal fallback marker. */
 export function fitText(text: string, width: number) {
   if (width <= 0) {
     return "";
   }
 
-  if (text.length <= width) {
+  if (measureTextWidth(text) <= width) {
     return text;
   }
 
@@ -12,11 +74,11 @@ export function fitText(text: string, width: number) {
     return ".";
   }
 
-  return `${text.slice(0, width - 1)}.`;
+  return `${sliceTextByWidth(text, 0, width - 1).text}.`;
 }
 
 /** Clamp and then right-pad text to an exact width. */
 export function padText(text: string, width: number) {
   const trimmed = fitText(text, width);
-  return trimmed.padEnd(width, " ");
+  return `${trimmed}${" ".repeat(Math.max(0, width - measureTextWidth(trimmed)))}`;
 }

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -21,7 +21,7 @@ import {
   isStepDownKey,
   isStepUpKey,
 } from "./keyboard";
-import { fitText, padText } from "./text";
+import { fitText, measureTextWidth, padText, sliceTextByWidth } from "./text";
 import { computeHunkRevealScrollTop } from "./hunkScroll";
 import { estimateDiffSectionBodyRows, measureDiffSectionGeometry } from "./diffSectionGeometry";
 import { resizeSidebarWidth } from "./sidebar";
@@ -275,6 +275,14 @@ describe("ui helpers", () => {
     expect(fitText("hello", 4)).toBe("hel.");
     expect(padText("hello", 4)).toBe("hel.");
     expect(padText("ok", 4)).toBe("ok  ");
+  });
+
+  test("text helpers measure and slice wide characters by terminal cells", () => {
+    expect(measureTextWidth("日本語")).toBe(6);
+    expect(sliceTextByWidth("a日本b", 1, 4)).toEqual({ text: "日本", width: 4 });
+    expect(sliceTextByWidth("a日本b", 2, 4)).toEqual({ text: "本b", width: 3 });
+    expect(fitText("日本語", 5)).toBe("日本.");
+    expect(measureTextWidth(padText("日本", 6))).toBe(6);
   });
 
   test("agent popover helpers wrap text and right-align the card within the viewport", () => {

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -125,6 +125,17 @@ export function createPtyHarness() {
     return { dir, before, after };
   }
 
+  function createWideCharacterFilePair() {
+    const dir = makeTempDir("hunk-tuistory-wide-");
+    const before = join(dir, "before.ts");
+    const after = join(dir, "after.ts");
+
+    writeText(before, "export const wide = '日本語';\nexport const plain = 'before';\n");
+    writeText(after, "export const wide = '한국어';\nexport const plain = 'after';\n");
+
+    return { dir, before, after };
+  }
+
   function createDeletionOnlyFilePair() {
     const dir = makeTempDir("hunk-tuistory-deletion-");
     const before = join(dir, "before.ts");
@@ -625,6 +636,7 @@ export function createPtyHarness() {
     createScrollableFilePair,
     createSidebarJumpRepoFixture,
     createTwoFileRepoFixture,
+    createWideCharacterFilePair,
     launchHunk,
     launchHunkWithFileBackedStdin,
     launchShellCommand,

--- a/test/pty/ui-integration.test.ts
+++ b/test/pty/ui-integration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import stringWidth from "string-width";
 import type { Session } from "tuistory";
 import { createPtyHarness } from "./harness";
 
@@ -109,6 +110,46 @@ async function revealAddNoteOnRow(session: Session, row: number) {
 }
 
 describe("live UI integration", () => {
+  test("split rows keep the center separator aligned after wide characters", async () => {
+    const fixture = harness.createWideCharacterFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      cols: 140,
+      rows: 16,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      const snapshot = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("日本語") && text.includes("plain"),
+        5_000,
+      );
+      const lines = snapshot.split("\n");
+      const wideLine = lines.find((line) => line.includes("日本語"));
+      const plainLine = lines.find((line) => line.includes("plain"));
+
+      expect(wideLine).toBeDefined();
+      expect(plainLine).toBeDefined();
+      if (!wideLine || !plainLine) {
+        throw new Error(`Expected wide and plain split rows in snapshot:\n${snapshot}`);
+      }
+
+      const wideSeparatorIndex = wideLine.indexOf("▌", 1);
+      const plainSeparatorIndex = plainLine.indexOf("▌", 1);
+
+      expect(wideSeparatorIndex).toBeGreaterThan(0);
+      expect(plainSeparatorIndex).toBeGreaterThan(0);
+      expect(stringWidth(wideLine.slice(0, wideSeparatorIndex))).toBe(
+        stringWidth(plainLine.slice(0, plainSeparatorIndex)),
+      );
+    } finally {
+      session.close();
+    }
+  });
+
   test("real PTY sessions can toggle wrapped lines on and off", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
@@ -365,16 +406,23 @@ describe("live UI integration", () => {
         timeout: 15_000,
       });
 
-      for (let index = 0; index < 19; index += 1) {
+      let reachedShortFileMidHunk = false;
+      for (let index = 0; index < 24; index += 1) {
         await session.press("]");
-        await session.waitIdle({ timeout: 40 });
+        const snapshot = await session.text({ immediate: true });
+        if (snapshot.includes("export const mid = 4;")) {
+          reachedShortFileMidHunk = true;
+          break;
+        }
       }
 
-      await harness.waitForSnapshot(
-        session,
-        (text) => text.includes("export const mid = 4;"),
-        5_000,
-      );
+      if (!reachedShortFileMidHunk) {
+        await harness.waitForSnapshot(
+          session,
+          (text) => text.includes("export const mid = 4;"),
+          5_000,
+        );
+      }
 
       await session.press("[");
       await session.waitIdle({ timeout: 80 });


### PR DESCRIPTION
## Summary

- Fix split diff alignment for CJK/emoji-width text by measuring and slicing rendered spans in terminal cells.
- Add ASCII fast paths and cache max code-line width per diff metadata object to keep common diffs cheap.
- Add unit/render regression coverage plus a Tuistory PTY test for wide-character separator alignment.

Closes #324

## Tests

- `bun run typecheck`
- `bun run lint`
- `bun test`
- `bun test test/pty/ui-integration.test.ts --test-name-pattern "wide characters"`

*This PR description was generated by Pi using OpenAI ChatGPT*
