### PR TITLE
Security: Unsafe shell execution with user-controlled pager command

### DIFF
--- a/src/core/pager.ts
+++ b/src/core/pager.ts
@@ -24,10 +24,47 @@ export function resolveTextPagerCommand(env: NodeJS.ProcessEnv = process.env) {
   return candidate;
 }
 
+function parsePagerCommand(command: string): [string, string[]] {
+  const args: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  let quoteChar = "";
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+
+    if (inQuotes) {
+      if (char === quoteChar) {
+        inQuotes = false;
+        quoteChar = "";
+      } else {
+        current += char;
+      }
+    } else if (char === '"' || char === "'") {
+      inQuotes = true;
+      quoteChar = char;
+    } else if (char === " " || char === "\t") {
+      if (current.length > 0) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.length > 0) {
+    args.push(current);
+  }
+
+  const [executable, ...rest] = args;
+  return [executable ?? "", rest];
+}
+
 /** Minimal dependencies for testing pager behavior without spawning a real subprocess. */
 export interface PlainTextPagerDeps {
   stdout: Pick<NodeJS.WriteStream, "isTTY" | "write">;
-  spawnImpl: (command: string, options: SpawnOptions) => ChildProcess;
+  spawnImpl: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
 }
 
 /** Stream plain text through a normal pager, or write directly when not attached to a terminal. */
@@ -45,8 +82,9 @@ export async function pagePlainText(
   }
 
   const pagerCommand = resolveTextPagerCommand(env);
-  const pager = deps.spawnImpl(pagerCommand, {
-    shell: true,
+  const [executable, args] = parsePagerCommand(pagerCommand);
+  const pager = deps.spawnImpl(executable, args, {
+    shell: false,
     stdio: ["pipe", "inherit", "inherit"],
     env,
   });


### PR DESCRIPTION
## Summary

Security: Unsafe shell execution with user-controlled pager command

## Problem

**Severity**: `High` | **File**: `src/core/pager.ts:L45`

The `pagePlainText` function in `src/core/pager.ts` spawns a pager command with `shell: true` using the `resolveTextPagerCommand` result. While the function attempts to prevent recursive `hunk` launches via regex, the `PAGER` or `HUNK_TEXT_PAGER` environment variable is passed directly to the shell without proper sanitization. An attacker who can control these environment variables could inject arbitrary shell commands (e.g., `PAGER='$(malicious)'` or backtick injection). The regex check `/(^|\s)hunk(\s|$)/` is insufficient to prevent command injection.

## Solution

Avoid `shell: true` and instead parse the pager command into arguments using a safe argument parser, or use `execFile` with an explicit array of arguments. If shell is required, strictly validate the pager command against an allowlist of known safe pagers, or use `shell: false` with `spawn` and pass the command as an first argument with any flags as subsequent array elements.

## Changes

- `src/core/pager.ts` (modified)