### PR TITLE
fix(core): harden plain text pager spawning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Hardened plain-text pager startup so `PAGER` and `HUNK_TEXT_PAGER` shell metacharacters are passed as arguments instead of being evaluated implicitly.
 - Fixed split diff alignment for wide CJK and emoji characters by measuring rendered text in terminal cells.
 - Fixed Ctrl-S saving for inline notes when tmux sends CSI-u keyboard input.
 - Restricted session reloads so daemon commands cannot read files outside the initial Hunk session root.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "bun": "^1.3.10",
         "commander": "^14.0.3",
         "diff": "^8.0.3",
+        "shell-quote": "1.8.3",
         "string-width": "^8.2.1",
         "zod": "^4.3.6",
       },
@@ -21,6 +22,7 @@
         "@opentui/react": "^0.1.88",
         "@types/bun": "1.3.13",
         "@types/react": "^19.2.14",
+        "@types/shell-quote": "1.7.5",
         "@types/ws": "^8.18.1",
         "lint-staged": "^16.4.0",
         "oxfmt": "^0.41.0",
@@ -299,6 +301,8 @@
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/shell-quote": ["@types/shell-quote@1.7.5", "", {}, "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 

--- a/nix/bun.lock.nix
+++ b/nix/bun.lock.nix
@@ -477,6 +477,10 @@
     url = "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz";
     hash = "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==";
   };
+  "@types/shell-quote@1.7.5" = fetchurl {
+    url = "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.7.5.tgz";
+    hash = "sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==";
+  };
   "@types/unist@3.0.3" = fetchurl {
     url = "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz";
     hash = "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==";

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "bun": "^1.3.10",
     "commander": "^14.0.3",
     "diff": "^8.0.3",
+    "shell-quote": "1.8.3",
     "string-width": "^8.2.1",
     "zod": "^4.3.6"
   },
@@ -91,6 +92,7 @@
     "@opentui/react": "^0.1.88",
     "@types/bun": "1.3.13",
     "@types/react": "^19.2.14",
+    "@types/shell-quote": "1.7.5",
     "@types/ws": "^8.18.1",
     "lint-staged": "^16.4.0",
     "oxfmt": "^0.41.0",

--- a/src/core/pager.test.ts
+++ b/src/core/pager.test.ts
@@ -8,6 +8,15 @@ import {
   type PlainTextPagerDeps,
 } from "./pager";
 
+function createClosingPager(code = 0) {
+  const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
+  pager.stdin = new PassThrough();
+  queueMicrotask(() => {
+    pager.emit("close", code);
+  });
+  return pager;
+}
+
 function createPagerDeps(overrides: Partial<PlainTextPagerDeps> = {}): PlainTextPagerDeps {
   return {
     stdout: {
@@ -17,12 +26,7 @@ function createPagerDeps(overrides: Partial<PlainTextPagerDeps> = {}): PlainText
       },
     },
     spawnImpl() {
-      const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
-      pager.stdin = new PassThrough();
-      queueMicrotask(() => {
-        pager.emit("close", 0);
-      });
-      return pager as never;
+      return createClosingPager() as never;
     },
     ...overrides,
   };
@@ -107,6 +111,9 @@ describe("plain text pager fallback", () => {
     );
     expect(resolveTextPagerCommand({ HUNK_TEXT_PAGER: "hunk pager" })).toBe("less -R");
     expect(resolveTextPagerCommand({ PAGER: "env FOO=1 hunk pager" })).toBe("less -R");
+    expect(resolveTextPagerCommand({ PAGER: String.raw`"C:\tools\hunk.exe" pager` })).toBe(
+      "less -R",
+    );
   });
 
   test("writes directly to stdout when not attached to a terminal", async () => {
@@ -135,6 +142,95 @@ describe("plain text pager fallback", () => {
     expect(spawnCalled).toBe(false);
   });
 
+  test("spawns pager commands without a shell", async () => {
+    const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
+    pager.stdin = new PassThrough();
+    let written = "";
+    pager.stdin.on("data", (chunk) => {
+      written += String(chunk);
+    });
+
+    await pagePlainText(
+      "needs pager",
+      { PAGER: "less -R" },
+      createPagerDeps({
+        spawnImpl(command, args, options) {
+          expect(command).toBe("less");
+          expect(args).toEqual(["-R"]);
+          expect(options.shell).toBe(false);
+          queueMicrotask(() => {
+            pager.emit("close", 0);
+          });
+          return pager as never;
+        },
+      }),
+    );
+
+    expect(written).toBe("needs pager");
+  });
+
+  test("passes shell metacharacters as pager arguments instead of evaluating them", async () => {
+    await pagePlainText(
+      "plain text",
+      { HUNK_TEXT_PAGER: "cat >/tmp/hunk-owned; touch /tmp/hunk-owned" },
+      createPagerDeps({
+        spawnImpl(command, args, options) {
+          expect(command).toBe("cat");
+          expect(args).toEqual([">", "/tmp/hunk-owned", ";", "touch", "/tmp/hunk-owned"]);
+          expect(options.shell).toBe(false);
+          return createClosingPager() as never;
+        },
+      }),
+    );
+  });
+
+  test("preserves quoted pager arguments, variable references, and inline env assignments", async () => {
+    await pagePlainText(
+      "plain text",
+      { PAGER: "LESS='-R -F' \"less\" --pattern='hello world' --prompt=$LESS" },
+      createPagerDeps({
+        spawnImpl(command, args, options) {
+          expect(command).toBe("less");
+          expect(args).toEqual(["--pattern=hello world", "--prompt=$LESS"]);
+          expect(options.env?.LESS).toBe("-R -F");
+          expect(options.shell).toBe(false);
+          return createClosingPager() as never;
+        },
+      }),
+    );
+  });
+
+  test("preserves backslashes in quoted Windows-style pager commands", async () => {
+    await pagePlainText(
+      "plain text",
+      { PAGER: String.raw`"C:\Program Files\less\less.exe" -R` },
+      createPagerDeps({
+        spawnImpl(command, args) {
+          expect(command).toBe(String.raw`C:\Program Files\less\less.exe`);
+          expect(args).toEqual(["-R"]);
+          return createClosingPager() as never;
+        },
+      }),
+    );
+  });
+
+  test("supports simple env wrappers while still blocking recursive hunk pagers", async () => {
+    expect(resolveTextPagerCommand({ PAGER: "env LESS=FRX hunk pager" })).toBe("less -R");
+
+    await pagePlainText(
+      "plain text",
+      { PAGER: "env LESS=FRX less -R" },
+      createPagerDeps({
+        spawnImpl(command, args, options) {
+          expect(command).toBe("less");
+          expect(args).toEqual(["-R"]);
+          expect(options.env?.LESS).toBe("FRX");
+          return createClosingPager() as never;
+        },
+      }),
+    );
+  });
+
   test("throws when the pager exits with a non-zero status", async () => {
     const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
     pager.stdin = new PassThrough();
@@ -147,9 +243,10 @@ describe("plain text pager fallback", () => {
       "needs pager",
       { PAGER: "less -R" },
       createPagerDeps({
-        spawnImpl(command, options) {
-          expect(command).toBe("less -R");
-          expect(options.shell).toBe(true);
+        spawnImpl(command, args, options) {
+          expect(command).toBe("less");
+          expect(args).toEqual(["-R"]);
+          expect(options.shell).toBe(false);
           queueMicrotask(() => {
             pager.emit("close", 1);
           });

--- a/src/core/pager.test.ts
+++ b/src/core/pager.test.ts
@@ -258,4 +258,32 @@ describe("plain text pager fallback", () => {
     await expect(promise).rejects.toThrow("Pager command failed: less -R");
     expect(written).toBe("needs pager");
   });
+
+  test("throws when the pager emits an async spawn error", async () => {
+    const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
+    pager.stdin = new PassThrough();
+    const spawnError = new Error("spawn ENOENT");
+
+    const promise = pagePlainText(
+      "needs pager",
+      { PAGER: "missing-pager" },
+      createPagerDeps({
+        spawnImpl(command, args, options) {
+          expect(command).toBe("missing-pager");
+          expect(args).toEqual([]);
+          expect(options.shell).toBe(false);
+          queueMicrotask(() => {
+            pager.emit("error", spawnError);
+            pager.emit("close", null);
+          });
+          return pager as never;
+        },
+      }),
+    );
+
+    await expect(promise).rejects.toThrow("Pager command failed: missing-pager");
+    await promise.catch((error) => {
+      expect(error.cause).toBe(spawnError);
+    });
+  });
 });

--- a/src/core/pager.ts
+++ b/src/core/pager.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { once } from "node:events";
+import { parse as parseShellCommand, type ParseEntry } from "shell-quote";
 import { stripTerminalControl } from "./patch/normalize";
 
 /** Detect whether generic pager stdin looks like a diff/patch that Hunk should review. */
@@ -13,21 +14,120 @@ export function looksLikePatchInput(text: string) {
   );
 }
 
-/** Choose a plain-text pager command while avoiding recursive `hunk pager` launches. */
-export function resolveTextPagerCommand(env: NodeJS.ProcessEnv = process.env) {
-  const candidate = env.HUNK_TEXT_PAGER ?? env.PAGER;
+interface ResolvedPagerCommand {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  displayCommand: string;
+}
 
-  if (!candidate || /(^|\s)hunk(\s|$)/.test(candidate)) {
+/** Convert shell-quote parse entries to literal argv tokens without evaluating shell operators. */
+function pagerWordFromParseEntry(entry: ParseEntry) {
+  if (typeof entry === "string") {
+    return entry;
+  }
+
+  if ("op" in entry) {
+    return entry.op === "glob" ? entry.pattern : entry.op;
+  }
+
+  return null;
+}
+
+/** Split a pager command into argv words without shell execution or variable expansion. */
+function splitPagerCommand(command: string) {
+  const preserveVariableReference = (name: string) => `$${name}`;
+  return parseShellCommand(command, preserveVariableReference).flatMap((entry) => {
+    const word = pagerWordFromParseEntry(entry);
+    return word === null ? [] : [word];
+  });
+}
+
+/** Return a normalized executable name for policy checks across Unix and Windows paths. */
+function executableName(command: string) {
+  return (
+    command
+      .split(/[\\/]/)
+      .at(-1)
+      ?.replace(/\.(?:cmd|exe)$/i, "")
+      .toLowerCase() ?? ""
+  );
+}
+
+/** Detect simple shell-style `NAME=value` environment assignments before a command. */
+function parseEnvAssignment(word: string): [string, string] | null {
+  const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(word);
+  return match ? [match[1] ?? "", match[2] ?? ""] : null;
+}
+
+/** Return the executable token after supported env-assignment prefixes. */
+function resolvePagerSpec(command: string): ResolvedPagerCommand | null {
+  const words = splitPagerCommand(command);
+  const envOverrides: NodeJS.ProcessEnv = {};
+  let commandIndex = 0;
+
+  while (commandIndex < words.length) {
+    const word = words[commandIndex];
+    const assignment = word ? parseEnvAssignment(word) : null;
+    if (!assignment) {
+      break;
+    }
+    const [key, value] = assignment;
+    envOverrides[key] = value;
+    commandIndex += 1;
+  }
+
+  // Support the common `env NAME=value pager ...` wrapper without invoking a shell.
+  if (executableName(words[commandIndex] ?? "") === "env") {
+    let envIndex = commandIndex + 1;
+    const wrappedEnv: NodeJS.ProcessEnv = {};
+
+    while (envIndex < words.length) {
+      const word = words[envIndex];
+      const assignment = word ? parseEnvAssignment(word) : null;
+      if (!assignment) {
+        break;
+      }
+      const [key, value] = assignment;
+      wrappedEnv[key] = value;
+      envIndex += 1;
+    }
+
+    if (envIndex < words.length) {
+      commandIndex = envIndex;
+      Object.assign(envOverrides, wrappedEnv);
+    }
+  }
+
+  const executable = words[commandIndex];
+  if (!executable) {
+    return null;
+  }
+
+  return {
+    command: executable,
+    args: words.slice(commandIndex + 1),
+    env: envOverrides,
+    displayCommand: command,
+  };
+}
+
+/** Choose a plain-text pager command while avoiding recursive `hunk pager` launches. */
+export function resolveTextPagerCommand(env: NodeJS.ProcessEnv = process.env): string {
+  const candidate = env.HUNK_TEXT_PAGER ?? env.PAGER;
+  const pagerSpec = candidate ? resolvePagerSpec(candidate) : null;
+
+  if (!pagerSpec || executableName(pagerSpec.command) === "hunk") {
     return "less -R";
   }
 
-  return candidate;
+  return pagerSpec.displayCommand;
 }
 
 /** Minimal dependencies for testing pager behavior without spawning a real subprocess. */
 export interface PlainTextPagerDeps {
   stdout: Pick<NodeJS.WriteStream, "isTTY" | "write">;
-  spawnImpl: (command: string, options: SpawnOptions) => ChildProcess;
+  spawnImpl: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
 }
 
 /** Stream plain text through a normal pager, or write directly when not attached to a terminal. */
@@ -45,16 +145,36 @@ export async function pagePlainText(
   }
 
   const pagerCommand = resolveTextPagerCommand(env);
-  const pager = deps.spawnImpl(pagerCommand, {
-    shell: true,
-    stdio: ["pipe", "inherit", "inherit"],
-    env,
+  const pagerSpec = resolvePagerSpec(pagerCommand) ?? resolvePagerSpec("less -R");
+
+  if (!pagerSpec) {
+    deps.stdout.write(text);
+    return;
+  }
+
+  let pager: ChildProcess;
+  try {
+    pager = deps.spawnImpl(pagerSpec.command, pagerSpec.args, {
+      shell: false,
+      stdio: ["pipe", "inherit", "inherit"],
+      env: {
+        ...env,
+        ...pagerSpec.env,
+      },
+    });
+  } catch (error) {
+    throw new Error(`Pager command failed: ${pagerCommand}`, { cause: error });
+  }
+
+  let spawnError: unknown;
+  pager.once("error", (error) => {
+    spawnError = error;
   });
 
   pager.stdin?.end(text);
   const [code] = await once(pager, "close");
 
-  if (typeof code === "number" && code !== 0) {
-    throw new Error(`Pager command failed: ${pagerCommand}`);
+  if (spawnError || (typeof code === "number" && code !== 0)) {
+    throw new Error(`Pager command failed: ${pagerCommand}`, { cause: spawnError });
   }
 }

--- a/src/core/pager.ts
+++ b/src/core/pager.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
-import { once } from "node:events";
 import { parse as parseShellCommand, type ParseEntry } from "shell-quote";
 import { stripTerminalControl } from "./patch/normalize";
 
@@ -13,6 +12,8 @@ export function looksLikePatchInput(text: string) {
     /^@@ /m.test(normalized)
   );
 }
+
+const DEFAULT_TEXT_PAGER_COMMAND = "less -R";
 
 interface ResolvedPagerCommand {
   command: string;
@@ -112,16 +113,25 @@ function resolvePagerSpec(command: string): ResolvedPagerCommand | null {
   };
 }
 
-/** Choose a plain-text pager command while avoiding recursive `hunk pager` launches. */
-export function resolveTextPagerCommand(env: NodeJS.ProcessEnv = process.env): string {
+/** Choose a plain-text pager process while avoiding recursive `hunk pager` launches. */
+function resolveTextPagerSpec(env: NodeJS.ProcessEnv = process.env): ResolvedPagerCommand {
   const candidate = env.HUNK_TEXT_PAGER ?? env.PAGER;
   const pagerSpec = candidate ? resolvePagerSpec(candidate) : null;
 
   if (!pagerSpec || executableName(pagerSpec.command) === "hunk") {
-    return "less -R";
+    const fallbackSpec = resolvePagerSpec(DEFAULT_TEXT_PAGER_COMMAND);
+    if (!fallbackSpec) {
+      throw new Error(`Default pager command is invalid: ${DEFAULT_TEXT_PAGER_COMMAND}`);
+    }
+    return fallbackSpec;
   }
 
-  return pagerSpec.displayCommand;
+  return pagerSpec;
+}
+
+/** Choose a plain-text pager command while avoiding recursive `hunk pager` launches. */
+export function resolveTextPagerCommand(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveTextPagerSpec(env).displayCommand;
 }
 
 /** Minimal dependencies for testing pager behavior without spawning a real subprocess. */
@@ -144,13 +154,8 @@ export async function pagePlainText(
     return;
   }
 
-  const pagerCommand = resolveTextPagerCommand(env);
-  const pagerSpec = resolvePagerSpec(pagerCommand) ?? resolvePagerSpec("less -R");
-
-  if (!pagerSpec) {
-    deps.stdout.write(text);
-    return;
-  }
+  const pagerSpec = resolveTextPagerSpec(env);
+  const pagerCommand = pagerSpec.displayCommand;
 
   let pager: ChildProcess;
   try {
@@ -167,12 +172,17 @@ export async function pagePlainText(
   }
 
   let spawnError: unknown;
-  pager.once("error", (error) => {
-    spawnError = error;
+  const closeCode = new Promise<number | null>((resolve) => {
+    pager.once("error", (error) => {
+      spawnError = error;
+    });
+    pager.once("close", (code) => {
+      resolve(typeof code === "number" ? code : null);
+    });
   });
 
   pager.stdin?.end(text);
-  const [code] = await once(pager, "close");
+  const code = await closeCode;
 
   if (spawnError || (typeof code === "number" && code !== 0)) {
     throw new Error(`Pager command failed: ${pagerCommand}`, { cause: spawnError });


### PR DESCRIPTION
## Summary

- Harden plain-text pager startup by parsing `PAGER` / `HUNK_TEXT_PAGER` into argv and spawning without an implicit shell.
- Preserve common pager configuration forms like quoted arguments, simple `NAME=value` prefixes, and `env NAME=value pager ...` wrappers.
- Add focused pager tests for literal shell metacharacters, recursive `hunk` fallback, quoted Windows paths, and inline env assignments.

Refs #355.

## Verification

- `bun run typecheck`
- `bun test`
- `bun run format:check`
- `bun run lint`
- Manual PTY marker check: implicit `; touch marker` no longer executes; explicit `sh -c ...` still works as intentional pager config.

*This PR description was generated by Pi using OpenAI GPT-5*
