### PR TITLE
refactor(ui): centralize diff section row planning

### DIFF
--- a/benchmarks/large-stream-profile.ts
+++ b/benchmarks/large-stream-profile.ts
@@ -3,7 +3,7 @@
 import { performance } from "perf_hooks";
 import { buildSplitRows } from "../src/ui/diff/pierre";
 import { buildReviewRenderPlan } from "../src/ui/diff/reviewRenderPlan";
-import { measureDiffSectionGeometry } from "../src/ui/lib/diffSectionGeometry";
+import { measureDiffSectionGeometry } from "../src/ui/diff/diffSectionGeometry";
 import { resolveTheme } from "../src/ui/themes";
 import {
   createLargeSplitStreamFiles,

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -31,7 +31,7 @@ import { computeHunkRevealScrollTop } from "../../lib/hunkScroll";
 import {
   measureDiffSectionGeometry,
   type DiffSectionGeometry,
-} from "../../lib/diffSectionGeometry";
+} from "../../diff/diffSectionGeometry";
 import { createReviewMouseWheelScrollAcceleration } from "../../lib/scrollAcceleration";
 import {
   buildFileSectionLayouts,

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -3,7 +3,7 @@ import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../../core/typ
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import { PierreDiffView, type ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
 import type { VisibleBodyBounds } from "../../diff/rowWindowing";
-import type { DiffSectionGeometry } from "../../lib/diffSectionGeometry";
+import type { DiffSectionGeometry } from "../../diff/diffSectionGeometry";
 import type { VisibleAgentNote } from "../../lib/agentAnnotations";
 import type { CopySelectedRowRange } from "./copySelection";
 import { diffSectionId } from "../../lib/ids";

--- a/src/ui/components/panes/copySelection.test.ts
+++ b/src/ui/components/panes/copySelection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { parseDiffFromFile } from "@pierre/diffs";
 import type { DiffFile } from "../../../core/types";
 import { resolveTheme } from "../../themes";
-import { measureDiffSectionGeometry } from "../../lib/diffSectionGeometry";
+import { measureDiffSectionGeometry } from "../../diff/diffSectionGeometry";
 import { buildFileSectionLayouts } from "../../lib/fileSectionLayout";
 import {
   buildCopySelectedRowKeys,

--- a/src/ui/components/panes/copySelection.ts
+++ b/src/ui/components/panes/copySelection.ts
@@ -6,7 +6,10 @@ import {
   resolveStackCellGeometry,
 } from "../../diff/codeColumns";
 import { renderCodeOnlyPlannedRowText, renderDecoratedPlannedRowText } from "../../diff/renderRows";
-import { type DiffSectionGeometry, type DiffSectionRowBounds } from "../../lib/diffSectionGeometry";
+import {
+  type DiffSectionGeometry,
+  type DiffSectionRowBounds,
+} from "../../diff/diffSectionGeometry";
 import type { FileSectionLayout } from "../../lib/fileSectionLayout";
 import { fileLabelParts } from "../../lib/files";
 import { fitText } from "../../lib/text";

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../../test/helpers/diff-helpers";
 import { hexColorDistance } from "../lib/color";
 import { resolveTheme } from "../themes";
-import { measureDiffSectionGeometry } from "../lib/diffSectionGeometry";
+import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts, buildInStreamFileHeaderHeights } from "../lib/fileSectionLayout";
 
 const { AppHost } = await import("../AppHost");

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -4,19 +4,13 @@ import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types"
 import { AgentInlineNote } from "../components/panes/AgentInlineNote";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
-import type { DiffSectionGeometry } from "../lib/diffSectionGeometry";
+import type { DiffSectionGeometry } from "./diffSectionGeometry";
 import { reviewRowId } from "../lib/ids";
 import type { AppTheme } from "../themes";
-import { findMaxLineNumber, findMaxLineNumberInRows } from "./codeColumns";
-import { expandCollapsedRows, type FileSourceStatus } from "./expandCollapsedRows";
-import {
-  buildSplitRows,
-  buildStackRows,
-  spansForHighlightedSourceLine,
-  type DiffRow,
-} from "./pierre";
+import { type FileSourceStatus } from "./expandCollapsedRows";
+import { spansForHighlightedSourceLine, type DiffRow } from "./pierre";
 import { plannedReviewRowVisible } from "./plannedReviewRows";
-import { buildReviewRenderPlan } from "./reviewRenderPlan";
+import { buildDiffSectionRowPlan } from "./diffSectionRowPlan";
 import { resolveVisiblePlannedRowWindow, type VisibleBodyBounds } from "./rowWindowing";
 import { diffMessage, DiffRowView, fitText } from "./renderRows";
 import { useHighlightedDiff } from "./useHighlightedDiff";
@@ -195,47 +189,37 @@ export function PierreDiffView({
     [resolvedHighlightedSource, theme],
   );
 
-  const rows = useMemo(
+  const sectionRowPlan = useMemo(
     () =>
-      file
-        ? layout === "split"
-          ? buildSplitRows(file, resolvedHighlighted, theme)
-          : buildStackRows(file, resolvedHighlighted, theme)
-        : [],
-    [file, layout, resolvedHighlighted, theme],
+      buildDiffSectionRowPlan({
+        expandedKeys: expandedGapKeys,
+        file,
+        highlightedDiff: resolvedHighlighted,
+        layout,
+        showHunkHeaders,
+        sourceLineSpans,
+        sourceStatus,
+        theme,
+        visibleAgentNotes,
+      }),
+    [
+      expandedGapKeys,
+      file,
+      layout,
+      resolvedHighlighted,
+      showHunkHeaders,
+      sourceLineSpans,
+      sourceStatus,
+      theme,
+      visibleAgentNotes,
+    ],
   );
-  const expansionSide = file?.metadata.type === "deleted" ? "old" : "new";
+  const plannedRows = sectionRowPlan.plannedRows;
+  const lineNumberDigits = sectionRowPlan.lineNumberDigits;
   const fileHasSourceFetcher = Boolean(file?.sourceFetcher);
   const gapToggleHandler = useMemo(
     () => (fileHasSourceFetcher ? onToggleGap : undefined),
     [fileHasSourceFetcher, onToggleGap],
-  );
-  const expandedRows = useMemo(
-    () =>
-      expandCollapsedRows(rows, {
-        layout,
-        expandedKeys: expandedGapKeys,
-        sourceLineSpans,
-        sourceStatus,
-        side: expansionSide,
-      }),
-    [rows, layout, expandedGapKeys, sourceLineSpans, sourceStatus, expansionSide],
-  );
-  const plannedRows = useMemo(
-    () =>
-      file
-        ? buildReviewRenderPlan({
-            fileId: file.id,
-            rows: expandedRows,
-            showHunkHeaders,
-            visibleAgentNotes,
-          })
-        : [],
-    [file, expandedRows, showHunkHeaders, visibleAgentNotes],
-  );
-  const lineNumberDigits = useMemo(
-    () => String(findMaxLineNumberInRows(expandedRows, file ? findMaxLineNumber(file) : 1)).length,
-    [expandedRows, file],
   );
   const visiblePlannedRowWindow = useMemo(() => {
     // Fall back to the full row list unless all three row-windowing inputs are ready:

--- a/src/ui/diff/diffSectionGeometry.test.ts
+++ b/src/ui/diff/diffSectionGeometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { VisibleAgentNote } from "./agentAnnotations";
+import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import { measureDiffSectionGeometry } from "./diffSectionGeometry";
 import { resolveTheme } from "../themes";
 import {

--- a/src/ui/diff/diffSectionGeometry.ts
+++ b/src/ui/diff/diffSectionGeometry.ts
@@ -1,18 +1,18 @@
 import type { DiffFile, LayoutMode } from "../../core/types";
 import { measureAgentInlineNoteHeight } from "../components/panes/AgentInlineNote";
-import { findMaxLineNumber, findMaxLineNumberInRows } from "../diff/codeColumns";
-import { expandCollapsedRows, type FileSourceStatus } from "../diff/expandCollapsedRows";
-import { buildSplitRows, buildStackRows } from "../diff/pierre";
-import { measureRenderedRowHeight } from "../diff/renderRows";
+import type { VisibleAgentNote } from "../lib/agentAnnotations";
+import type { SectionGeometry, VerticalBounds } from "../lib/diffSpatial";
+import { reviewRowId } from "../lib/ids";
+import type { AppTheme } from "../themes";
+import { findMaxLineNumber } from "./codeColumns";
+import { buildDiffSectionRowPlan, type DiffSectionRowPlan } from "./diffSectionRowPlan";
+import { type FileSourceStatus } from "./expandCollapsedRows";
 import {
   plannedReviewRowContributesToHunkBounds,
   type PlannedHunkBounds,
-} from "../diff/plannedReviewRows";
-import { buildReviewRenderPlan, type PlannedReviewRow } from "../diff/reviewRenderPlan";
-import type { SectionGeometry, VerticalBounds } from "./diffSpatial";
-import { reviewRowId } from "./ids";
-import type { VisibleAgentNote } from "./agentAnnotations";
-import type { AppTheme } from "../themes";
+} from "./plannedReviewRows";
+import type { PlannedReviewRow } from "./reviewRenderPlan";
+import { measureRenderedRowHeight } from "./renderRows";
 
 const EMPTY_EXPANDED_GAP_KEYS: ReadonlySet<string> = new Set();
 
@@ -36,38 +36,6 @@ export interface DiffSectionGeometry extends SectionGeometry<PlannedHunkBounds> 
   rowBounds: DiffSectionRowBounds[];
   rowBoundsByKey: Map<string, DiffSectionRowBounds>;
   rowBoundsByStableKey: Map<string, DiffSectionRowBounds>;
-}
-
-/** Build the planned row stream for one file section using the same shape as geometry measurement. */
-function buildPlannedSectionRows(
-  file: DiffFile,
-  layout: Exclude<LayoutMode, "auto">,
-  showHunkHeaders: boolean,
-  theme: AppTheme,
-  visibleAgentNotes: VisibleAgentNote[] = [],
-  expandedKeys: ReadonlySet<string> = EMPTY_EXPANDED_GAP_KEYS,
-  sourceStatus: FileSourceStatus | undefined = undefined,
-) {
-  const baseRows =
-    layout === "split" ? buildSplitRows(file, null, theme) : buildStackRows(file, null, theme);
-  const side = file.metadata.type === "deleted" ? "old" : "new";
-  const rows = expandCollapsedRows(baseRows, {
-    layout,
-    expandedKeys,
-    sourceStatus,
-    side,
-  });
-
-  return {
-    plannedRows: buildReviewRenderPlan({
-      fileId: file.id,
-      rows,
-      selectedHunkIndex: -1,
-      showHunkHeaders,
-      visibleAgentNotes,
-    }),
-    rows,
-  };
 }
 
 /** Fingerprint loaded source text so same-length edits invalidate geometry. */
@@ -106,16 +74,51 @@ const NOTE_AWARE_SECTION_GEOMETRY_CACHE = new WeakMap<
   Map<string, DiffSectionGeometry>
 >();
 
-/** Measure how many terminal rows one planned review row occupies for the current view settings. */
-function plannedRowHeight(
+interface DiffSectionRowHeightOptions {
+  layout: Exclude<LayoutMode, "auto">;
+  lineNumberDigits: number;
+  showHunkHeaders: boolean;
+  showLineNumbers: boolean;
+  theme: AppTheme;
+  width: number;
+  wrapLines: boolean;
+}
+
+/** Bundle the layout inputs needed to measure rows from a shared section row plan. */
+function buildDiffSectionRowHeightOptions(
+  rowPlan: DiffSectionRowPlan,
+  {
+    layout,
+    showHunkHeaders,
+    showLineNumbers,
+    theme,
+    width,
+    wrapLines,
+  }: Omit<DiffSectionRowHeightOptions, "lineNumberDigits">,
+): DiffSectionRowHeightOptions {
+  return {
+    layout,
+    lineNumberDigits: rowPlan.lineNumberDigits,
+    showHunkHeaders,
+    showLineNumbers,
+    theme,
+    width,
+    wrapLines,
+  };
+}
+
+/** Measure how many terminal rows one planned row occupies in a concrete section row plan. */
+function measurePlannedDiffSectionRowHeight(
   row: PlannedReviewRow,
-  showHunkHeaders: boolean,
-  layout: Exclude<LayoutMode, "auto">,
-  width: number,
-  lineNumberDigits: number,
-  showLineNumbers: boolean,
-  wrapLines: boolean,
-  theme: AppTheme,
+  {
+    layout,
+    lineNumberDigits,
+    showHunkHeaders,
+    showLineNumbers,
+    theme,
+    width,
+    wrapLines,
+  }: DiffSectionRowHeightOptions,
 ) {
   if (row.kind === "inline-note") {
     return measureAgentInlineNoteHeight({
@@ -175,21 +178,30 @@ export function measureDiffSectionGeometry(
     }
   }
 
-  const { plannedRows, rows } = buildPlannedSectionRows(
+  const sectionRowPlan = buildDiffSectionRowPlan({
+    expandedKeys,
     file,
     layout,
     showHunkHeaders,
+    sourceStatus,
     theme,
     visibleAgentNotes,
-    expandedKeys,
-    sourceStatus,
-  );
+  });
+  const { plannedRows } = sectionRowPlan;
   const hunkAnchorRows = new Map<number, number>();
   const hunkBounds = new Map<number, PlannedHunkBounds>();
   const rowBounds: DiffSectionRowBounds[] = [];
   const rowBoundsByKey = new Map<string, DiffSectionRowBounds>();
   const rowBoundsByStableKey = new Map<string, DiffSectionRowBounds>();
-  const lineNumberDigits = String(findMaxLineNumberInRows(rows, findMaxLineNumber(file))).length;
+  const lineNumberDigits = sectionRowPlan.lineNumberDigits;
+  const rowHeightOptions = buildDiffSectionRowHeightOptions(sectionRowPlan, {
+    layout,
+    showHunkHeaders,
+    showLineNumbers,
+    theme,
+    width,
+    wrapLines,
+  });
   let bodyHeight = 0;
 
   for (const row of plannedRows) {
@@ -197,16 +209,7 @@ export function measureDiffSectionGeometry(
       hunkAnchorRows.set(row.hunkIndex, bodyHeight);
     }
 
-    const height = plannedRowHeight(
-      row,
-      showHunkHeaders,
-      layout,
-      width,
-      lineNumberDigits,
-      showLineNumbers,
-      wrapLines,
-      theme,
-    );
+    const height = measurePlannedDiffSectionRowHeight(row, rowHeightOptions);
     const stableKeys = [
       row.stableKey,
       ...(row.kind === "diff-row" ? (row.stableAliasKeys ?? []) : []),

--- a/src/ui/diff/diffSectionRowPlan.ts
+++ b/src/ui/diff/diffSectionRowPlan.ts
@@ -1,0 +1,84 @@
+import type { DiffFile, LayoutMode } from "../../core/types";
+import type { VisibleAgentNote } from "../lib/agentAnnotations";
+import type { AppTheme } from "../themes";
+import { findMaxLineNumber, findMaxLineNumberInRows } from "./codeColumns";
+import { expandCollapsedRows, type FileSourceStatus } from "./expandCollapsedRows";
+import {
+  buildSplitRows,
+  buildStackRows,
+  type HighlightedDiffCode,
+  type RenderSpan,
+} from "./pierre";
+import { buildReviewRenderPlan, type PlannedReviewRow } from "./reviewRenderPlan";
+
+const EMPTY_EXPANDED_GAP_KEYS: ReadonlySet<string> = new Set();
+const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
+
+export interface DiffSectionRowPlan {
+  lineNumberDigits: number;
+  plannedRows: PlannedReviewRow[];
+}
+
+export interface BuildDiffSectionRowPlanOptions {
+  expandedKeys?: ReadonlySet<string>;
+  file: DiffFile | undefined;
+  highlightedDiff?: HighlightedDiffCode | null;
+  layout: Exclude<LayoutMode, "auto">;
+  showHunkHeaders: boolean;
+  sourceLineSpans?: (line: string | undefined, sourceLineNumber: number) => RenderSpan[];
+  sourceStatus?: FileSourceStatus | undefined;
+  theme: AppTheme;
+  visibleAgentNotes?: VisibleAgentNote[];
+}
+
+/** Build Pierre rows for one file using the selected terminal diff layout. */
+function buildBaseRows(
+  file: DiffFile,
+  layout: Exclude<LayoutMode, "auto">,
+  highlightedDiff: HighlightedDiffCode | null | undefined,
+  theme: AppTheme,
+) {
+  return layout === "split"
+    ? buildSplitRows(file, highlightedDiff ?? null, theme)
+    : buildStackRows(file, highlightedDiff ?? null, theme);
+}
+
+/** Build the shared file-level diff plan consumed by rendering and geometry measurement. */
+export function buildDiffSectionRowPlan({
+  expandedKeys = EMPTY_EXPANDED_GAP_KEYS,
+  file,
+  highlightedDiff = null,
+  layout,
+  showHunkHeaders,
+  sourceLineSpans,
+  sourceStatus,
+  theme,
+  visibleAgentNotes = EMPTY_VISIBLE_AGENT_NOTES,
+}: BuildDiffSectionRowPlanOptions): DiffSectionRowPlan {
+  if (!file) {
+    return {
+      lineNumberDigits: 1,
+      plannedRows: [],
+    };
+  }
+
+  const baseRows = buildBaseRows(file, layout, highlightedDiff, theme);
+  const expansionSide = file.metadata.type === "deleted" ? "old" : "new";
+  const rows = expandCollapsedRows(baseRows, {
+    layout,
+    expandedKeys,
+    sourceLineSpans,
+    sourceStatus,
+    side: expansionSide,
+  });
+
+  return {
+    lineNumberDigits: String(findMaxLineNumberInRows(rows, findMaxLineNumber(file))).length,
+    plannedRows: buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      showHunkHeaders,
+      visibleAgentNotes,
+    }),
+  };
+}

--- a/src/ui/diff/rowWindowing.test.ts
+++ b/src/ui/diff/rowWindowing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { DiffSectionGeometry } from "../lib/diffSectionGeometry";
+import type { DiffSectionGeometry } from "./diffSectionGeometry";
 import type { PlannedReviewRow } from "./reviewRenderPlan";
 import { resolveVisiblePlannedRowWindow } from "./rowWindowing";
 

--- a/src/ui/diff/rowWindowing.ts
+++ b/src/ui/diff/rowWindowing.ts
@@ -1,4 +1,4 @@
-import type { DiffSectionGeometry } from "../lib/diffSectionGeometry";
+import type { DiffSectionGeometry } from "./diffSectionGeometry";
 import type { PlannedReviewRow } from "./reviewRenderPlan";
 
 /** One visible slice within a file body, measured in file-local row units. */

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -23,7 +23,10 @@ import {
 } from "./keyboard";
 import { fitText, padText } from "./text";
 import { computeHunkRevealScrollTop } from "./hunkScroll";
-import { estimateDiffSectionBodyRows, measureDiffSectionGeometry } from "./diffSectionGeometry";
+import {
+  estimateDiffSectionBodyRows,
+  measureDiffSectionGeometry,
+} from "../diff/diffSectionGeometry";
 import { resizeSidebarWidth } from "./sidebar";
 import { availableThemes, resolveTheme } from "../themes";
 

--- a/src/ui/lib/viewportAnchor.test.ts
+++ b/src/ui/lib/viewportAnchor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { resolveTheme } from "../themes";
 import { buildInStreamFileHeaderHeights } from "./fileSectionLayout";
-import { measureDiffSectionGeometry } from "./diffSectionGeometry";
+import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { findViewportRowAnchor, resolveViewportRowAnchorTop } from "./viewportAnchor";
 import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
 

--- a/src/ui/lib/viewportAnchor.ts
+++ b/src/ui/lib/viewportAnchor.ts
@@ -1,5 +1,5 @@
 import type { DiffFile } from "../../core/types";
-import type { DiffSectionGeometry, DiffSectionRowBounds } from "./diffSectionGeometry";
+import type { DiffSectionGeometry, DiffSectionRowBounds } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts } from "./fileSectionLayout";
 
 /** Identify the rendered review row that currently owns the viewport top. */

--- a/src/ui/lib/viewportSelection.test.ts
+++ b/src/ui/lib/viewportSelection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
-import { measureDiffSectionGeometry } from "./diffSectionGeometry";
+import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts, buildInStreamFileHeaderHeights } from "./fileSectionLayout";
 import { findViewportCenteredHunkTarget } from "./viewportSelection";
 import { resolveTheme } from "../themes";

--- a/src/ui/lib/viewportSelection.ts
+++ b/src/ui/lib/viewportSelection.ts
@@ -1,5 +1,5 @@
 import type { DiffFile } from "../../core/types";
-import type { DiffSectionGeometry } from "./diffSectionGeometry";
+import type { DiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { findFileSectionAtOffset, type FileSectionLayout } from "./fileSectionLayout";
 
 export interface ViewportCenteredHunkTarget {


### PR DESCRIPTION
## Summary

- Add `diffSectionRowPlan` as the shared file-level row planning layer for diff sections.
- Move diff section geometry into `src/ui/diff/` so row planning, geometry, and windowing live together.
- Update rendering, geometry, copy-selection, viewport, and benchmark imports to use the new locations.

## Testing

- `bun run typecheck`
- `bun test src/ui/diff/diffSectionGeometry.test.ts src/ui/diff/rowWindowing.test.ts src/ui/components/panes/copySelection.test.ts src/ui/AppHost.scroll-regression.test.tsx`
- `bun run lint`
- `bun run format:check`

*This PR description was generated by Pi using OpenAI GPT-5 Codex*
