### PR TITLE
test(pty): stabilize flaky PTY interactions

### DIFF
--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -306,7 +306,9 @@ describe("PTY notes", () => {
       );
       expect(whileFocused).toContain("Draft note");
 
-      await session.type("\x1b");
+      // Keyboard cancellation is covered above; click the explicit control here so this test can
+      // focus on whether app-level shortcuts are blocked only while the composer is active.
+      await session.click(/Cancel \(Esc\)/);
       await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
       await session.press("]");
       const afterCancel = await harness.waitForSnapshot(

--- a/test/pty/pager.test.ts
+++ b/test/pty/pager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import type { Session } from "tuistory";
 import { createPtyHarness } from "./harness";
 
 const harness = createPtyHarness();
@@ -9,6 +10,35 @@ setDefaultTimeout(20_000);
 afterEach(() => {
   harness.cleanup();
 });
+
+/** Retry PTY wheel ticks one at a time so slow CI does not drop a whole scroll burst. */
+async function scrollWheelUntil(
+  session: Session,
+  direction: "down" | "up",
+  predicate: (text: string) => boolean,
+) {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    if (direction === "down") {
+      await session.scrollDown(1);
+    } else {
+      await session.scrollUp(1);
+    }
+
+    try {
+      return await harness.waitForSnapshot(session, predicate, 700);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error(`Timed out waiting for pager wheel scroll ${direction}.`);
+}
 
 describe("PTY pager", () => {
   test("pager mode hides chrome and pages forward on space", async () => {
@@ -155,22 +185,20 @@ describe("PTY pager", () => {
       expect(initial).not.toContain("before_12");
 
       await session.waitIdle({ timeout: 200 });
-      await session.scrollDown(10);
-      const scrolled = await harness.waitForSnapshot(
+      const scrolled = await scrollWheelUntil(
         session,
+        "down",
         (text) => !text.includes("before_01") && text.includes("before_12"),
-        5_000,
       );
 
       expect(scrolled).not.toContain("View  Navigate  Theme  Agent  Help");
       expect(scrolled).not.toContain("before_01");
       expect(scrolled).toContain("before_12");
 
-      await session.scrollUp(10);
-      const restored = await harness.waitForSnapshot(
+      const restored = await scrollWheelUntil(
         session,
+        "up",
         (text) => text.includes("before_01") && !text.includes("before_12"),
-        5_000,
       );
 
       expect(restored).toContain("before_01");
@@ -196,11 +224,10 @@ describe("PTY pager", () => {
       expect(initial).not.toContain("before_12");
 
       await session.waitIdle({ timeout: 200 });
-      await session.scrollDown(10);
-      const scrolled = await harness.waitForSnapshot(
+      const scrolled = await scrollWheelUntil(
         session,
+        "down",
         (text) => !text.includes("before_01") && text.includes("before_12"),
-        5_000,
       );
 
       expect(scrolled).toContain("before_12");
@@ -226,22 +253,20 @@ describe("PTY pager", () => {
       expect(initial).not.toContain("before_12");
 
       await session.waitIdle({ timeout: 200 });
-      await session.scrollDown(10);
-      const scrolled = await harness.waitForSnapshot(
+      const scrolled = await scrollWheelUntil(
         session,
+        "down",
         (text) => !text.includes("before_01") && text.includes("before_12"),
-        5_000,
       );
 
       expect(scrolled).not.toContain("View  Navigate  Theme  Agent  Help");
       expect(scrolled).not.toContain("before_01");
       expect(scrolled).toContain("before_12");
 
-      await session.scrollUp(10);
-      const restored = await harness.waitForSnapshot(
+      const restored = await scrollWheelUntil(
         session,
+        "up",
         (text) => text.includes("before_01") && !text.includes("before_12"),
-        5_000,
       );
 
       expect(restored).toContain("before_01");
@@ -297,22 +322,20 @@ describe("PTY pager", () => {
       expect(initial).not.toContain("before_12");
 
       await session.waitIdle({ timeout: 200 });
-      await session.scrollDown(10);
-      const scrolled = await harness.waitForSnapshot(
+      const scrolled = await scrollWheelUntil(
         session,
+        "down",
         (text) => !text.includes("before_01") && text.includes("before_12"),
-        5_000,
       );
 
       expect(scrolled).not.toContain("View  Navigate  Theme  Agent  Help");
       expect(scrolled).not.toContain("before_01");
       expect(scrolled).toContain("before_12");
 
-      await session.scrollUp(10);
-      const restored = await harness.waitForSnapshot(
+      const restored = await scrollWheelUntil(
         session,
+        "up",
         (text) => text.includes("before_01") && !text.includes("before_12"),
-        5_000,
       );
 
       expect(restored).toContain("before_01");

--- a/test/pty/pager.test.ts
+++ b/test/pty/pager.test.ts
@@ -4,8 +4,8 @@ import { createPtyHarness } from "./harness";
 
 const harness = createPtyHarness();
 
-/** Give PTY-backed startup and redraws enough headroom for slower CI machines. */
-setDefaultTimeout(20_000);
+/** Give PTY-backed startup, redraws, and wheel retries enough headroom for slower CI machines. */
+setDefaultTimeout(45_000);
 
 afterEach(() => {
   harness.cleanup();
@@ -17,7 +17,7 @@ async function scrollWheelUntil(
   direction: "down" | "up",
   predicate: (text: string) => boolean,
 ) {
-  let lastError: unknown;
+  let lastErrorMessage = `Timed out waiting for pager wheel scroll ${direction}.`;
 
   for (let attempt = 0; attempt < 12; attempt += 1) {
     if (direction === "down") {
@@ -29,15 +29,11 @@ async function scrollWheelUntil(
     try {
       return await harness.waitForSnapshot(session, predicate, 700);
     } catch (error) {
-      lastError = error;
+      lastErrorMessage = error instanceof Error ? error.message : String(error);
     }
   }
 
-  if (lastError instanceof Error) {
-    throw lastError;
-  }
-
-  throw new Error(`Timed out waiting for pager wheel scroll ${direction}.`);
+  throw new Error(lastErrorMessage);
 }
 
 describe("PTY pager", () => {


### PR DESCRIPTION
## Summary

- Stabilize flaky PTY mouse-wheel assertions by retrying pager wheel ticks one at a time
- Give pager wheel retry tests enough timeout headroom for slow CI runs
- Stabilize the note-focus PTY test by using the explicit cancel control after verifying shortcuts are blocked while the draft composer is active

## Context

Main CI was intermittently failing in PTY integration tests. The original failure was pager wheel scrolling; after that was addressed, CI exposed another unrelated PTY timing flake in the note-focus cancellation test.

## Verification

- `bun test ./test/pty/pager.test.ts` (5x)
- `bun test ./test/pty/notes.test.ts -t "draft note focus blocks app shortcuts until cancelled"`
- `bun run test:integration`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`

*This PR description was generated by Pi using GPT-5*
