### PR TITLE
fix(config): allow Catppuccin custom theme bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed custom theme configuration so Catppuccin Latte and Mocha can be used as base themes.
+
 ## [0.14.0-beta.0] - 2026-05-24
 
 ### Added

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -144,6 +144,25 @@ describe("config resolution", () => {
     });
   });
 
+  test.each(["graphite", "midnight", "paper", "ember", "catppuccin-latte", "catppuccin-mocha"])(
+    "accepts custom theme base id: %s",
+    (base) => {
+      const home = createTempDir("hunk-config-home-");
+      mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+      writeFileSync(
+        join(home, ".config", "hunk", "config.toml"),
+        ["[custom_theme]", `base = "${base}"`].join("\n"),
+      );
+
+      const resolved = resolveConfiguredCliInput(createPatchPagerInput(), {
+        cwd: createTempDir("hunk-config-cwd-"),
+        env: { HOME: home },
+      });
+
+      expect(resolved.customTheme).toEqual({ base });
+    },
+  );
+
   test("rejects invalid custom theme base ids", () => {
     const home = createTempDir("hunk-config-home-");
     mkdirSync(join(home, ".config", "hunk"), { recursive: true });
@@ -157,7 +176,9 @@ describe("config resolution", () => {
         cwd: createTempDir("hunk-config-cwd-"),
         env: { HOME: home },
       }),
-    ).toThrow("Expected custom_theme.base to be one of: graphite, midnight, paper, ember.");
+    ).toThrow(
+      "Expected custom_theme.base to be one of: graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha.",
+    );
   });
 
   test("rejects invalid custom theme color values", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -12,7 +12,14 @@ import type {
   VcsMode,
 } from "./types";
 
-const BUILT_IN_THEME_IDS = ["graphite", "midnight", "paper", "ember"] as const;
+const BUILT_IN_THEME_IDS = [
+  "graphite",
+  "midnight",
+  "paper",
+  "ember",
+  "catppuccin-latte",
+  "catppuccin-mocha",
+] as const;
 const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
 const CUSTOM_THEME_COLOR_KEYS = [
   "background",


### PR DESCRIPTION
## Summary

- Allow `custom_theme.base` to use `catppuccin-latte` and `catppuccin-mocha`
- Cover accepted/rejected custom theme base id config resolution
- Add an Unreleased changelog entry

Closes #364.

## Test plan

- `bun test src/core/config.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
