### PR TITLE
fix(ui): cap expanded context source reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Capped inline context expansion source reads so huge files cannot freeze or exhaust memory when expanding unchanged lines.
+
 ## [0.14.0-beta.1] - 2026-05-24
 
 ### Fixed

--- a/src/core/fileSource.test.ts
+++ b/src/core/fileSource.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createFileSourceFetcher } from "./fileSource";
+import { createFileSourceFetcher, SourceTextTooLargeError } from "./fileSource";
 
 const tempDirs: string[] = [];
 
@@ -100,6 +100,22 @@ describe("createFileSourceFetcher", () => {
     expect(await fetcher.getFullText("old")).toBeNull();
   });
 
+  test("rejects fs source reads that exceed the configured byte cap", async () => {
+    const dir = createTempDir("hunk-source-fs-large-");
+    const target = join(dir, "large.txt");
+    writeFileSync(target, "0123456789\n");
+
+    const fetcher = createFileSourceFetcher(
+      {
+        old: { kind: "fs", absolutePath: target },
+        new: { kind: "none" },
+      },
+      { maxSourceBytes: 5 },
+    );
+
+    await expect(fetcher.getFullText("old")).rejects.toBeInstanceOf(SourceTextTooLargeError);
+  });
+
   test("reads git blob contents for both sides via `git show`", async () => {
     const repoRoot = createTempRepo("hunk-source-git-");
     const filePath = "note.txt";
@@ -138,6 +154,63 @@ describe("createFileSourceFetcher", () => {
 
     expect(await fetcher.getFullText("old")).toBe("staged\n");
     expect(await fetcher.getFullText("new")).toBe("working tree\n");
+  });
+
+  test("rejects git blob and index source reads that exceed the configured byte cap", async () => {
+    const repoRoot = createTempRepo("hunk-source-git-large-");
+    const filePath = "note.txt";
+
+    writeFileSync(join(repoRoot, filePath), "committed source\n");
+    git(repoRoot, "add", filePath);
+    git(repoRoot, "commit", "-m", "first");
+    writeFileSync(join(repoRoot, filePath), "staged source\n");
+    git(repoRoot, "add", filePath);
+
+    const fetcher = createFileSourceFetcher(
+      {
+        old: { kind: "git-blob", repoRoot, ref: "HEAD", path: filePath },
+        new: { kind: "git-index", repoRoot, path: filePath },
+      },
+      { maxSourceBytes: 5 },
+    );
+
+    await expect(fetcher.getFullText("old")).rejects.toBeInstanceOf(SourceTextTooLargeError);
+    await expect(fetcher.getFullText("new")).rejects.toBeInstanceOf(SourceTextTooLargeError);
+  });
+
+  test("treats oversized git stderr as a generic source failure", async () => {
+    const originalSpawn = Bun.spawn;
+    const mutableBun = Bun as unknown as { spawn: typeof Bun.spawn };
+
+    mutableBun.spawn = (() =>
+      originalSpawn(
+        [
+          process.execPath,
+          "--eval",
+          "process.stdout.write('small source\\n'); process.stderr.write('x'.repeat(70000));",
+        ],
+        {
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      )) as typeof Bun.spawn;
+
+    try {
+      const fetcher = createFileSourceFetcher({
+        old: { kind: "git-blob", repoRoot: process.cwd(), ref: "HEAD", path: "note.txt" },
+        new: { kind: "none" },
+      });
+
+      const loggedErrors = await captureConsoleErrors(async () => {
+        await expect(fetcher.getFullText("old")).resolves.toBeNull();
+      });
+
+      expect(String(loggedErrors[0]?.[0])).toContain("failed to collect Git source");
+      expect(String(loggedErrors[0]?.[1])).toContain("diagnostics exceeded");
+    } finally {
+      mutableBun.spawn = originalSpawn;
+    }
   });
 
   test("passes custom git executable through async git source reads", async () => {

--- a/src/core/fileSource.ts
+++ b/src/core/fileSource.ts
@@ -25,8 +25,19 @@ export interface FileSourceFetcher {
   getFullText(side: FileSourceSide): Promise<string | null>;
 }
 
+export const DEFAULT_SOURCE_TEXT_MAX_BYTES = 1_000_000;
+
+/** Raised when expanded-context source would require reading an unsafe amount of text. */
+export class SourceTextTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Source text exceeds ${maxBytes} bytes.`);
+    this.name = "SourceTextTooLargeError";
+  }
+}
+
 export interface FileSourceFetcherOptions {
   gitExecutable?: string;
+  maxSourceBytes?: number;
 }
 
 interface ResolvedSpecs {
@@ -65,15 +76,26 @@ function isExpectedMissingGitSource(stderr: string) {
   ].some((fragment) => normalized.includes(fragment));
 }
 
-async function readFsSpec(spec: Extract<FileSourceSpec, { kind: "fs" }>): Promise<string | null> {
+async function readFsSpec(
+  spec: Extract<FileSourceSpec, { kind: "fs" }>,
+  maxSourceBytes: number,
+): Promise<string | null> {
   try {
     const file = Bun.file(spec.absolutePath);
     if (!(await file.exists())) {
       return null;
     }
 
+    if (file.size > maxSourceBytes) {
+      throw new SourceTextTooLargeError(maxSourceBytes);
+    }
+
     return await file.text();
   } catch (error) {
+    if (error instanceof SourceTextTooLargeError) {
+      throw error;
+    }
+
     logSourceDiagnostic(`failed to read source file ${spec.absolutePath}`, error);
     return null;
   }
@@ -82,15 +104,63 @@ async function readFsSpec(spec: Extract<FileSourceSpec, { kind: "fs" }>): Promis
 function readGitBlobSpec(
   spec: Extract<FileSourceSpec, { kind: "git-blob" }>,
   gitExecutable = "git",
+  maxSourceBytes: number,
 ): Promise<string | null> {
-  return readGitObjectSpec(spec.repoRoot, `${spec.ref}:${spec.path}`, gitExecutable);
+  return readGitObjectSpec(
+    spec.repoRoot,
+    `${spec.ref}:${spec.path}`,
+    gitExecutable,
+    maxSourceBytes,
+  );
 }
 
 function readGitIndexSpec(
   spec: Extract<FileSourceSpec, { kind: "git-index" }>,
   gitExecutable = "git",
+  maxSourceBytes: number,
 ): Promise<string | null> {
-  return readGitObjectSpec(spec.repoRoot, `:${spec.path}`, gitExecutable);
+  return readGitObjectSpec(spec.repoRoot, `:${spec.path}`, gitExecutable, maxSourceBytes);
+}
+
+async function readStreamTextWithLimit(
+  stream: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+  onTooLarge?: () => void,
+  createLimitError: (maxBytes: number) => Error = (maxBytes) =>
+    new SourceTextTooLargeError(maxBytes),
+) {
+  if (!stream) {
+    return "";
+  }
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBytes) {
+      onTooLarge?.();
+      await reader.cancel().catch(() => undefined);
+      throw createLimitError(maxBytes);
+    }
+
+    chunks.push(value);
+  }
+
+  const combined = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(combined);
 }
 
 /** Read a blob-like Git object spec such as `HEAD:path` or `:path`. */
@@ -98,6 +168,7 @@ async function readGitObjectSpec(
   repoRoot: string,
   objectName: string,
   gitExecutable = "git",
+  maxSourceBytes: number,
 ): Promise<string | null> {
   let proc: Bun.ReadableSubprocess;
 
@@ -117,10 +188,21 @@ async function readGitObjectSpec(
   try {
     output = await Promise.all([
       proc.exited,
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
+      readStreamTextWithLimit(proc.stdout, maxSourceBytes, () => proc.kill()),
+      readStreamTextWithLimit(
+        proc.stderr,
+        64 * 1024,
+        undefined,
+        (maxBytes) => new Error(`Git source diagnostics exceeded ${maxBytes} bytes.`),
+      ),
     ]);
   } catch (error) {
+    if (error instanceof SourceTextTooLargeError) {
+      proc.kill();
+      await proc.exited.catch(() => undefined);
+      throw error;
+    }
+
     logSourceDiagnostic(`failed to collect Git source ${objectName}`, error);
     return null;
   }
@@ -139,27 +221,33 @@ async function readGitObjectSpec(
 
 async function readSpec(
   spec: FileSourceSpec,
-  { gitExecutable = "git" }: FileSourceFetcherOptions = {},
+  {
+    gitExecutable = "git",
+    maxSourceBytes = DEFAULT_SOURCE_TEXT_MAX_BYTES,
+  }: FileSourceFetcherOptions = {},
 ): Promise<string | null> {
   if (spec.kind === "none") {
     return null;
   }
 
   if (spec.kind === "fs") {
-    return readFsSpec(spec);
+    return readFsSpec(spec, maxSourceBytes);
   }
 
   if (spec.kind === "git-index") {
-    return readGitIndexSpec(spec, gitExecutable);
+    return readGitIndexSpec(spec, gitExecutable, maxSourceBytes);
   }
 
-  return readGitBlobSpec(spec, gitExecutable);
+  return readGitBlobSpec(spec, gitExecutable, maxSourceBytes);
 }
 
 /** Build a per-file source fetcher that caches each side's resolved text. */
 export function createFileSourceFetcher(
   specs: ResolvedSpecs,
-  { gitExecutable = "git" }: Readonly<FileSourceFetcherOptions> = {},
+  {
+    gitExecutable = "git",
+    maxSourceBytes = DEFAULT_SOURCE_TEXT_MAX_BYTES,
+  }: Readonly<FileSourceFetcherOptions> = {},
 ): FileSourceFetcher {
   const cache = new Map<FileSourceSide, string | null>();
 
@@ -169,7 +257,7 @@ export function createFileSourceFetcher(
         return cache.get(side) ?? null;
       }
 
-      const text = await readSpec(specs[side], { gitExecutable });
+      const text = await readSpec(specs[side], { gitExecutable, maxSourceBytes });
       cache.set(side, text);
       return text;
     },

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
+import { SourceTextTooLargeError } from "./fileSource";
 import { loadAppBootstrap } from "./loaders";
 import type { CliInput } from "./types";
 
@@ -338,6 +339,7 @@ describe("loadAppBootstrap", () => {
       deletions: 1,
     });
     expect(bootstrap.changeset.files[0]?.metadata.hunks).toHaveLength(0);
+    expect(bootstrap.changeset.files[0]?.sourceFetcher).toBeUndefined();
   });
 
   test("keeps generated large untracked files as skipped placeholders", async () => {
@@ -363,6 +365,7 @@ describe("loadAppBootstrap", () => {
     });
     expect(bootstrap.changeset.files[0]?.statsTruncated).toBe(false);
     expect(bootstrap.changeset.files[0]?.metadata.hunks).toHaveLength(0);
+    expect(bootstrap.changeset.files[0]?.sourceFetcher).toBeUndefined();
   });
 
   test("caps skipped untracked-file stats when byte-size detection would require a full huge read", async () => {
@@ -1559,6 +1562,32 @@ describe("loadAppBootstrap source fetcher attachment", () => {
     expect(file?.sourceFetcher).toBeDefined();
     expect(await file?.sourceFetcher?.getFullText("new")).toBe("second\n");
     expect(await file?.sourceFetcher?.getFullText("old")).toBe("first\n");
+  });
+
+  test("`hunk show <ref>` refuses to expand source blobs above the source cap", async () => {
+    const dir = createTempRepo("hunk-source-show-large-");
+    const lines = Array.from({ length: 130_000 }, (_, index) => `line ${index + 1}`);
+    writeFileSync(join(dir, "large.txt"), `${lines.join("\n")}\n`);
+    git(dir, "add", "large.txt");
+    git(dir, "commit", "-m", "initial");
+
+    lines[65_000] = "line 65001 changed";
+    writeFileSync(join(dir, "large.txt"), `${lines.join("\n")}\n`);
+    git(dir, "add", "large.txt");
+    git(dir, "commit", "-m", "change middle line");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "show",
+      ref: "HEAD",
+      options: { mode: "auto" },
+    });
+
+    const file = bootstrap.changeset.files[0];
+    expect(file?.sourceFetcher).toBeDefined();
+    expect(file?.metadata.hunks.length).toBeGreaterThan(0);
+    await expect(file?.sourceFetcher?.getFullText("new")).rejects.toBeInstanceOf(
+      SourceTextTooLargeError,
+    );
   });
 
   test("`hunk show <ref>` pins expansion sources after the ref moves", async () => {

--- a/src/ui/diff/expandCollapsedRows.test.ts
+++ b/src/ui/diff/expandCollapsedRows.test.ts
@@ -101,6 +101,23 @@ describe("expandCollapsedRows", () => {
     expect(collapsed.text.toLowerCase()).toContain("could not load");
   });
 
+  test("rewrites the label when source is too large to expand", () => {
+    const rows: DiffRow[] = [makeCollapsedRow("before", 0, [1, 3], [1, 3]), makeHunkHeader(0)];
+
+    const result = expandCollapsedRows(rows, {
+      layout: "split",
+      expandedKeys: new Set([gapKey("before", 0)]),
+      sourceStatus: { kind: "error", reason: "too-large" },
+      side: "new",
+    });
+
+    const collapsed = result[0];
+    if (!collapsed || collapsed.type !== "collapsed") {
+      throw new Error("expected first row to be collapsed");
+    }
+    expect(collapsed.text.toLowerCase()).toContain("source too large");
+  });
+
   test("inserts split-line context rows after the expanded collapsed row", () => {
     const rows: DiffRow[] = [makeCollapsedRow("before", 0, [1, 3], [1, 3]), makeHunkHeader(0)];
 

--- a/src/ui/diff/expandCollapsedRows.ts
+++ b/src/ui/diff/expandCollapsedRows.ts
@@ -13,7 +13,7 @@ export type ExpansionLayout = "split" | "stack";
 export type FileSourceStatus =
   | { kind: "loading" }
   | { kind: "loaded"; text: string }
-  | { kind: "error" };
+  | { kind: "error"; reason?: "too-large" };
 
 export interface ExpandCollapsedRowsOptions {
   layout: ExpansionLayout;
@@ -68,7 +68,11 @@ function loadingRowText(lineCount: number) {
   return `Loading ${lineCount} unchanged ${lineCount === 1 ? "line" : "lines"}…`;
 }
 
-function errorRowText(lineCount: number) {
+function errorRowText(lineCount: number, reason?: "too-large") {
+  if (reason === "too-large") {
+    return `Source too large to expand ${lineCount} unchanged ${lineCount === 1 ? "line" : "lines"}`;
+  }
+
   return `Could not load ${lineCount} unchanged ${lineCount === 1 ? "line" : "lines"}`;
 }
 
@@ -179,7 +183,7 @@ export function expandCollapsedRows(
     }
 
     if (sourceStatus?.kind === "error") {
-      result.push({ ...row, text: errorRowText(lineCount) });
+      result.push({ ...row, text: errorRowText(lineCount, sourceStatus.reason) });
       continue;
     }
 

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act, StrictMode, useEffect, useState } from "react";
+import { SourceTextTooLargeError } from "../../core/fileSource";
 import type { DiffFile } from "../../core/types";
 import {
   createTestDeferred,
@@ -717,6 +718,32 @@ describe("useReviewController", () => {
       expect(String(loggedErrors[0]?.[0])).toContain("alpha");
     } finally {
       console.error = originalConsoleError;
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("toggleGap marks over-limit source loads as too large", async () => {
+    const tooLargeFetcher = createTestSourceFetcher(() => {
+      throw new SourceTextTooLargeError(5);
+    });
+
+    const { controllerRef, setup } = await renderReviewController([
+      createAlphaFile(tooLargeFetcher),
+    ]);
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        expectValue(controllerRef.current).toggleGap("alpha", "before:0");
+      });
+      await flush(setup);
+
+      const status = expectValue(controllerRef.current).sourceStatusByFileId["alpha"];
+      expect(status).toEqual({ kind: "error", reason: "too-large" });
+    } finally {
       await act(async () => {
         setup.renderer.destroy();
       });

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -21,6 +21,7 @@ import {
   firstCommentTargetForHunk,
   resolveCommentTarget,
 } from "../../core/liveComments";
+import { SourceTextTooLargeError } from "../../core/fileSource";
 import type { AgentAnnotation, DiffFile, UserNoteLineTarget } from "../../core/types";
 import type {
   AppliedCommentBatchResult,
@@ -490,11 +491,17 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
             return;
           }
 
-          console.error(
-            `hunk: failed to load ${side} source for ${file.path} (${file.id}).`,
-            error,
-          );
-          setSettledStatus({ kind: "error" });
+          const reason = error instanceof SourceTextTooLargeError ? "too-large" : undefined;
+          if (reason !== "too-large") {
+            console.error(
+              `hunk: failed to load ${side} source for ${file.path} (${file.id}).`,
+              error,
+            );
+          }
+          setSettledStatus({
+            kind: "error",
+            reason,
+          });
         });
     },
     [allFiles],


### PR DESCRIPTION
## Summary

- Cap expandable source reads at 1MB for filesystem, Git blob, and Git index sources
- Kill over-limit `git show` source reads while streaming instead of buffering the whole blob
- Show a clear “Source too large to expand…” collapsed-row status instead of freezing the UI
- Add regression coverage for capped source reads and large-file expansion cases

## Test plan

- `bun test src/core/fileSource.test.ts src/core/loaders.test.ts src/ui/diff/expandCollapsedRows.test.ts src/ui/hooks/useReviewController.test.tsx`
- `bun run typecheck`

*This PR description was generated by Pi using OpenAI GPT-5*
