### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,42 @@
+name: Bug Report
+description: Report something that's broken
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you start:** Please read [CONTRIBUTING.md](https://github.com/modem-dev/hunk/blob/main/CONTRIBUTING.md).
+
+        Keep this concise and concrete. A short report with clear reproduction steps is much easier to investigate.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Be specific. Include error messages, screenshots, or terminal output if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps or commands that trigger the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect Hunk to do instead?
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: e.g. output from `hunk --version` or the npm package version
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussion
+    url: https://discord.gg/WZFjaP6Gt8
+    about: Ask questions or discuss ideas on Discord instead of opening an issue

--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -1,0 +1,34 @@
+name: Contribution Proposal
+description: Propose a change or feature before opening a larger PR
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you start:** Please read [CONTRIBUTING.md](https://github.com/modem-dev/hunk/blob/main/CONTRIBUTING.md).
+
+        Keep this concise and concrete. For larger changes, opening a proposal first helps confirm the approach before implementation.
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What do you want to change?
+      description: Be specific and concise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why?
+      description: What problem does this solve, or what workflow does it improve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: How? (optional)
+      description: Brief technical approach if you have one in mind.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -1,6 +1,6 @@
 name: Contribution Proposal
 description: Propose a change or feature before opening a larger PR
-labels: []
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

- Add concise bug report and contribution proposal issue forms
- Disable blank issues and route questions/discussion to Discord
- Ask contributors to read CONTRIBUTING.md without adding strict new-contributor warnings

## Validation

- Not run; GitHub issue template YAML only
- Pre-commit hook ran `oxfmt --write` on the staged YAML files

*This PR description was generated by Pi using GPT-5*