### PR TITLE
fix(security): sanitize terminal-bound text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable user-visible changes to Hunk are documented in this file.
 ### Fixed
 
 - Capped inline context expansion source reads so huge files cannot freeze or exhaust memory when expanding unchanged lines.
+- Hardened terminal rendering against control-sequence injection from diffs, file paths, notes, expanded context, copied selections, and pager fallback output.
 
 ## [0.14.0-beta.1] - 2026-05-24
 

--- a/src/core/pager.test.ts
+++ b/src/core/pager.test.ts
@@ -17,6 +17,20 @@ function createClosingPager(code = 0) {
   return pager;
 }
 
+const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
+const CSI_CLEAR_SCREEN = "\x1b[2J";
+const DCS_PAYLOAD = "\x1bPqpayload\x1b\\";
+
+function expectNoUnsafeTerminalControls(text: string) {
+  expect(text).not.toContain(OSC52_CLIPBOARD);
+  expect(text).not.toContain(CSI_CLEAR_SCREEN);
+  expect(text).not.toContain(DCS_PAYLOAD);
+  expect(text).not.toContain("\x07");
+  expect(text).not.toContain("\r");
+  expect(text).not.toContain("\b");
+  expect(text).not.toContain("\x1b");
+}
+
 function createPagerDeps(overrides: Partial<PlainTextPagerDeps> = {}): PlainTextPagerDeps {
   return {
     stdout: {
@@ -142,6 +156,29 @@ describe("plain text pager fallback", () => {
     expect(spawnCalled).toBe(false);
   });
 
+  test("sanitizes terminal controls before writing plain text directly", async () => {
+    let written = "";
+
+    await pagePlainText(
+      `plain${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}\x07\rspoof\bhidden\x1b text`,
+      {},
+      createPagerDeps({
+        stdout: {
+          isTTY: false,
+          write(chunk) {
+            written += String(chunk);
+            return true;
+          },
+        },
+      }),
+    );
+
+    expect(written).toContain("plain");
+    expect(written).toContain("spoof");
+    expect(written).toContain("hidden");
+    expectNoUnsafeTerminalControls(written);
+  });
+
   test("spawns pager commands without a shell", async () => {
     const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
     pager.stdin = new PassThrough();
@@ -167,6 +204,33 @@ describe("plain text pager fallback", () => {
     );
 
     expect(written).toBe("needs pager");
+  });
+
+  test("sanitizes terminal controls before sending text to the pager", async () => {
+    const pager = new EventEmitter() as EventEmitter & { stdin: PassThrough };
+    pager.stdin = new PassThrough();
+    let written = "";
+    pager.stdin.on("data", (chunk) => {
+      written += String(chunk);
+    });
+
+    await pagePlainText(
+      `plain${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}\x07\rspoof\bhidden\x1b text`,
+      { PAGER: "less -R" },
+      createPagerDeps({
+        spawnImpl() {
+          queueMicrotask(() => {
+            pager.emit("close", 0);
+          });
+          return pager as never;
+        },
+      }),
+    );
+
+    expect(written).toContain("plain");
+    expect(written).toContain("spoof");
+    expect(written).toContain("hidden");
+    expectNoUnsafeTerminalControls(written);
   });
 
   test("passes shell metacharacters as pager arguments instead of evaluating them", async () => {

--- a/src/core/pager.ts
+++ b/src/core/pager.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { parse as parseShellCommand, type ParseEntry } from "shell-quote";
 import { stripTerminalControl } from "./patch/normalize";
+import { sanitizeTerminalText } from "../lib/terminalText";
 
 /** Detect whether generic pager stdin looks like a diff/patch that Hunk should review. */
 export function looksLikePatchInput(text: string) {
@@ -149,8 +150,10 @@ export async function pagePlainText(
     spawnImpl: spawn,
   },
 ) {
+  const safeText = sanitizeTerminalText(text);
+
   if (!deps.stdout.isTTY) {
-    deps.stdout.write(text);
+    deps.stdout.write(safeText);
     return;
   }
 
@@ -181,7 +184,7 @@ export async function pagePlainText(
     });
   });
 
-  pager.stdin?.end(text);
+  pager.stdin?.end(safeText);
   const code = await closeCode;
 
   if (spawnError || (typeof code === "number" && code !== 0)) {

--- a/src/lib/terminalText.test.ts
+++ b/src/lib/terminalText.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeTerminalSpans, sanitizeTerminalText } from "./terminalText";
+
+const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
+const OSC_ST = "\x1b]8;;https://example.test\x1b\\";
+const CSI_CLEAR_SCREEN = "\x1b[2J";
+const DCS_PAYLOAD = "\x1bPqpayload\x1b\\";
+const APC_PAYLOAD = "\x1b_payload\x1b\\";
+const PM_PAYLOAD = "\x1b^payload\x1b\\";
+const SOS_PAYLOAD = "\x1bXpayload\x1b\\";
+const C1_OSC = "\x9d52;c;SGVsbG8=\x07";
+const C1_CSI = "\x9b2J";
+const C1_DCS = "\x90payload\x9c";
+
+function expectNoUnsafeTerminalControls(text: string) {
+  expect(text).not.toContain("\x1b");
+  expect(text).not.toContain("\x07");
+  expect(text).not.toContain("\x08");
+  expect(text).not.toContain("\x0b");
+  expect(text).not.toContain("\x0c");
+  expect(text).not.toContain("\x0d");
+  expect(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/.test(text)).toBe(false);
+}
+
+describe("sanitizeTerminalText", () => {
+  test("removes terminal control strings without dropping surrounding text", () => {
+    const input = [
+      "before",
+      OSC52_CLIPBOARD,
+      OSC_ST,
+      CSI_CLEAR_SCREEN,
+      DCS_PAYLOAD,
+      APC_PAYLOAD,
+      PM_PAYLOAD,
+      SOS_PAYLOAD,
+      C1_OSC,
+      C1_CSI,
+      C1_DCS,
+      "after",
+    ].join("");
+
+    const output = sanitizeTerminalText(input);
+
+    expect(output).toContain("before");
+    expect(output).toContain("after");
+    expectNoUnsafeTerminalControls(output);
+  });
+
+  test("neutralizes visual spoofing controls", () => {
+    const output = sanitizeTerminalText("safe\rOVERWRITE\bhidden\x1b");
+
+    expect(output).toContain("safe");
+    expect(output).toContain("OVERWRITE");
+    expect(output).toContain("hidden");
+    expectNoUnsafeTerminalControls(output);
+  });
+
+  test("preserves ordinary multiline text and tabs when allowed", () => {
+    expect(sanitizeTerminalText("alpha\n\tbeta")).toBe("alpha\n\tbeta");
+  });
+
+  test("sanitizes span text while preserving styling metadata", () => {
+    const spans = [
+      { text: `before${OSC52_CLIPBOARD}`, fg: "#fff" },
+      { text: "\x1b[2J" },
+      { text: "after", bg: "#000" },
+    ];
+
+    const output = sanitizeTerminalSpans(spans);
+
+    expect(output).toEqual([
+      { text: "before", fg: "#fff" },
+      { text: "after", bg: "#000" },
+    ]);
+  });
+});

--- a/src/lib/terminalText.ts
+++ b/src/lib/terminalText.ts
@@ -1,0 +1,55 @@
+export interface SanitizeTerminalTextOptions {
+  /** Preserve line feeds for multiline text fields. Defaults to true. */
+  preserveNewlines?: boolean;
+  /** Preserve horizontal tabs for text fields that intentionally support them. Defaults to true. */
+  preserveTabs?: boolean;
+}
+
+const controlCodeRegex = /[\x00-\x1f\x7f-\x9f]/;
+// Keep these global regexes private and use them only with String#replace below.
+// Calling test/exec on shared /g regexes would make lastIndex stateful between calls.
+const sevenBitControlStrings =
+  /\x1b(?:\][\s\S]*?(?:\x07|\x1b\\|\x9c)|[PX^_][\s\S]*?(?:\x1b\\|\x9c)|\[[0-?]*[ -/]*[@-~])/g;
+const c1ControlStrings = /[\x90\x98\x9d\x9e\x9f][\s\S]*?(?:\x07|\x1b\\|\x9c)/g;
+const c1Csi = /\x9b[0-?]*[ -/]*[@-~]/g;
+
+/** Normalize untrusted terminal-bound text before rendering it in Hunk UI surfaces. */
+export function sanitizeTerminalText(
+  text: string,
+  { preserveNewlines = true, preserveTabs = true }: SanitizeTerminalTextOptions = {},
+) {
+  if (!controlCodeRegex.test(text)) {
+    return text;
+  }
+
+  const controlCharacters = preserveNewlines
+    ? preserveTabs
+      ? /[\x00-\x08\x0b-\x1f\x7f-\x9f]/g
+      : /[\x00-\x09\x0b-\x1f\x7f-\x9f]/g
+    : preserveTabs
+      ? /[\x00-\x08\x0a-\x1f\x7f-\x9f]/g
+      : /[\x00-\x1f\x7f-\x9f]/g;
+
+  return text
+    .replace(sevenBitControlStrings, "")
+    .replace(c1ControlStrings, "")
+    .replace(c1Csi, "")
+    .replace(controlCharacters, "");
+}
+
+/** Sanitize a single terminal row or cell where newlines must never be preserved. */
+export function sanitizeTerminalLine(text: string) {
+  return sanitizeTerminalText(text, { preserveNewlines: false, preserveTabs: true });
+}
+
+/** Sanitize render spans while preserving their non-text styling metadata. */
+export function sanitizeTerminalSpans<T extends { text: string }>(spans: readonly T[]): T[] {
+  const sanitized: T[] = [];
+  for (const span of spans) {
+    const text = sanitizeTerminalLine(span.text);
+    if (text.length > 0) {
+      sanitized.push({ ...span, text } as T);
+    }
+  }
+  return sanitized;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import {
   type JobControlSuspendSupport,
 } from "./core/jobControl";
 import { pagePlainText } from "./core/pager";
+import { sanitizeTerminalText } from "./lib/terminalText";
 import { shutdownSession } from "./core/shutdown";
 import { renderStaticDiffPager } from "./ui/staticDiffPager";
 import { prepareStartupPlan } from "./core/startup";
@@ -55,7 +56,7 @@ async function main() {
   }
 
   if (startupPlan.kind === "passthrough") {
-    process.stdout.write(startupPlan.text);
+    process.stdout.write(sanitizeTerminalText(startupPlan.text));
     process.exit(0);
   }
 

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -21,6 +21,20 @@ const { AppHost } = await import("./AppHost");
 const TEST_KEY_PAGE_UP = "\x1B[5~";
 const TEST_KEY_PAGE_DOWN = "\x1B[6~";
 
+const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
+const CSI_CLEAR_SCREEN = "\x1b[2J";
+const DCS_PAYLOAD = "\x1bPqpayload\x1b\\";
+
+function expectNoTerminalControls(text: string) {
+  expect(text).not.toContain(OSC52_CLIPBOARD);
+  expect(text).not.toContain(CSI_CLEAR_SCREEN);
+  expect(text).not.toContain(DCS_PAYLOAD);
+  expect(text).not.toContain("\x07");
+  expect(text).not.toContain("\r");
+  expect(text).not.toContain("\b");
+  expect(text).not.toContain("\x1b");
+}
+
 function createTestDiffFile(
   id: string,
   path: string,
@@ -518,6 +532,56 @@ function firstVisibleAddedLineNumber(frame: string) {
 }
 
 describe("App interactions", () => {
+  test("dynamic review output does not pass terminal controls from paths, notes, or diff content", async () => {
+    const payload = `${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}\x07\rspoof\bhidden\x1b`;
+    const file = createTestDiffFile(
+      "malicious",
+      `evil${payload}.ts`,
+      `export const value = "before${payload}";\n`,
+      `export const value = "after${payload}";\n`,
+    );
+    const bootstrap = createTestVcsAppBootstrap({
+      changesetId: "changeset:terminal-control-injection",
+      files: [
+        {
+          ...file,
+          agent: {
+            path: file.path,
+            summary: `summary${payload}`,
+            annotations: [
+              {
+                newRange: [1, 1],
+                summary: `annotation${payload}`,
+                rationale: `rationale${payload}`,
+              },
+            ],
+          },
+        },
+      ],
+      initialMode: "stack",
+    });
+
+    const setup = await testRender(<AppHost bootstrap={bootstrap} />, { width: 240, height: 24 });
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("a");
+      });
+      await flush(setup);
+      const frame = setup.captureCharFrame();
+
+      expect(frame).toContain("evil");
+      expect(frame).toContain("before");
+      expect(frame).toContain("after");
+      expectNoTerminalControls(frame);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("rapid hunk navigation and wheel scrolling do not recurse through viewport updates", async () => {
     const updateDepthErrors: string[] = [];
     const originalError = console.error;

--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -5,6 +5,7 @@ import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types"
 import { annotationRangeLabel, reviewNoteSource } from "../../lib/agentAnnotations";
 import { wrapText } from "../../lib/agentPopover";
 import { isEscapeKey, isSaveDraftNoteKey } from "../../lib/keyboard";
+import { sanitizeTerminalLine } from "../../../lib/terminalText";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
 
@@ -14,7 +15,7 @@ export function inlineNoteTitle(annotation: AgentAnnotation, noteIndex: number, 
   }
 
   const source = reviewNoteSource(annotation);
-  const author = annotation.author?.trim();
+  const author = sanitizeTerminalLine(annotation.author?.trim() ?? "");
   const label = source === "user" ? "Your note" : author ? `${author} note` : "Agent note";
   return noteCount > 1 ? `${label} ${noteIndex + 1}/${noteCount}` : label;
 }
@@ -56,7 +57,7 @@ function isNewlineKey(key: { ctrl?: boolean; name?: string; sequence?: string })
 
 /** Wrap text while preserving author-entered line breaks in review notes. */
 function wrapNoteText(text: string, width: number) {
-  return text.split("\n").flatMap((line) => wrapText(line, width));
+  return text.split("\n").flatMap((line) => wrapText(sanitizeTerminalLine(line), width));
 }
 
 function splitColumnWidths(width: number) {

--- a/src/ui/components/panes/copySelection.test.ts
+++ b/src/ui/components/panes/copySelection.test.ts
@@ -24,6 +24,20 @@ import {
   resolveSplitPaneWidths,
 } from "../../diff/codeColumns";
 
+const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
+const CSI_CLEAR_SCREEN = "\x1b[2J";
+const DCS_PAYLOAD = "\x1bPqpayload\x1b\\";
+
+function expectNoUnsafeTerminalControls(text: string) {
+  expect(text).not.toContain(OSC52_CLIPBOARD);
+  expect(text).not.toContain(CSI_CLEAR_SCREEN);
+  expect(text).not.toContain(DCS_PAYLOAD);
+  expect(text).not.toContain("\x07");
+  expect(text).not.toContain("\r");
+  expect(text).not.toContain("\b");
+  expect(text).not.toContain("\x1b");
+}
+
 function createDiffFile(): DiffFile {
   const metadata = parseDiffFromFile(
     {
@@ -55,16 +69,47 @@ function createDiffFile(): DiffFile {
   };
 }
 
+function createMaliciousDiffFile(): DiffFile {
+  const payload = `${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}\x07\rspoof\bhidden\x1b`;
+  const metadata = parseDiffFromFile(
+    {
+      name: `evil${payload}.ts`,
+      contents: `export const answer = "before${payload}";\n`,
+      cacheKey: "malicious-before",
+    },
+    {
+      name: `evil${payload}.ts`,
+      contents: `export const answer = "after${payload}";\n`,
+      cacheKey: "malicious-after",
+    },
+    { context: 3 },
+    true,
+  );
+
+  return {
+    id: "malicious",
+    path: `evil${payload}.ts`,
+    patch: "",
+    language: "typescript",
+    stats: {
+      additions: 1,
+      deletions: 1,
+    },
+    metadata,
+    agent: null,
+  };
+}
+
 function buildContext(
   layout: "stack" | "split" = "stack",
   width = 120,
+  file: DiffFile = createDiffFile(),
 ): {
   context: CopySelectionContext;
   fileSectionLayouts: ReturnType<typeof buildFileSectionLayouts>;
   sectionGeometry: ReturnType<typeof measureDiffSectionGeometry>[];
 } {
   const theme = resolveTheme("midnight", null);
-  const file = createDiffFile();
   const geometry = measureDiffSectionGeometry(file, layout, true, theme, [], width, true, false);
   const sectionGeometry = [geometry];
   const fileSectionLayouts = buildFileSectionLayouts([file], [geometry.bodyHeight]);
@@ -302,6 +347,27 @@ describe("renderCopySelectionText", () => {
 
     const text = renderCopySelectionText({ context, start, end });
     expect(text).toContain("example.ts");
+  });
+
+  test("does not include terminal controls from copied paths or code", () => {
+    const { context, fileSectionLayouts } = buildContext("stack", 160, createMaliciousDiffFile());
+    const start: CopySelectionPoint = {
+      kind: "pinned-header",
+      column: 0,
+      fileId: "malicious",
+      nextVisualRow: fileSectionLayouts[0]!.bodyTop,
+    };
+    const end: CopySelectionPoint = {
+      kind: "review-row",
+      column: context.width - 1,
+      visualRow: fileSectionLayouts[0]!.sectionBottom - 1,
+    };
+
+    const text = renderCopySelectionText({ context, start, end });
+    expect(text).toContain("evil");
+    expect(text).toContain("before");
+    expect(text).toContain("after");
+    expectNoUnsafeTerminalControls(text);
   });
 });
 

--- a/src/ui/diff/expandCollapsedRows.test.ts
+++ b/src/ui/diff/expandCollapsedRows.test.ts
@@ -31,6 +31,19 @@ function makeHunkHeader(hunkIndex: number): Extract<DiffRow, { type: "hunk-heade
 }
 
 const SOURCE = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"].join("\n") + "\n";
+const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
+const CSI_CLEAR_SCREEN = "\x1b[2J";
+const DCS_PAYLOAD = "\x1bPqpayload\x1b\\";
+
+function expectNoUnsafeTerminalControls(text: string) {
+  expect(text).not.toContain(OSC52_CLIPBOARD);
+  expect(text).not.toContain(CSI_CLEAR_SCREEN);
+  expect(text).not.toContain(DCS_PAYLOAD);
+  expect(text).not.toContain("\x07");
+  expect(text).not.toContain("\r");
+  expect(text).not.toContain("\b");
+  expect(text).not.toContain("\x1b");
+}
 
 describe("expandCollapsedRows", () => {
   test("returns rows unchanged when no gaps are expanded", () => {
@@ -250,6 +263,29 @@ describe("expandCollapsedRows", () => {
       throw new Error("expected stack-line context row");
     }
     expect(inserted.cell.spans[0]?.text).toBe("alpha");
+  });
+
+  test("does not pass terminal controls through expanded source rows", () => {
+    const sourceWithControls = `safe${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}\x07\rspoof\bhidden\x1b\nfollow\n`;
+    const rows: DiffRow[] = [makeCollapsedRow("before", 0, [1, 1], [1, 1]), makeHunkHeader(0)];
+
+    const result = expandCollapsedRows(rows, {
+      layout: "stack",
+      expandedKeys: new Set([gapKey("before", 0)]),
+      sourceStatus: { kind: "loaded", text: sourceWithControls },
+      side: "new",
+    });
+
+    const inserted = result[1];
+    if (!inserted || inserted.type !== "stack-line") {
+      throw new Error("expected one stack-line row");
+    }
+
+    const text = inserted.cell.spans.map((span) => span.text).join("");
+    expect(text).toContain("safe");
+    expect(text).toContain("spoof");
+    expect(text).toContain("hidden");
+    expectNoUnsafeTerminalControls(text);
   });
 
   test("expands tabs in source lines so terminal cells stay aligned", () => {

--- a/src/ui/diff/expandCollapsedRows.ts
+++ b/src/ui/diff/expandCollapsedRows.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalLine, sanitizeTerminalSpans } from "../../lib/terminalText";
 import { expandDiffTabs } from "./codeColumns";
 import type {
   CollapsedGapPosition,
@@ -84,7 +85,7 @@ function sliceLines(sourceText: string) {
 }
 
 function spansFor(line: string | undefined): RenderSpan[] {
-  const text = expandDiffTabs(line ?? "");
+  const text = expandDiffTabs(sanitizeTerminalLine(line ?? ""));
   return text.length > 0 ? [{ text }] : [];
 }
 
@@ -220,7 +221,9 @@ export function expandCollapsedRows(
       }
 
       const text = sourceLines[sourceLineNumber];
-      const spans = sourceLineSpans?.(text, sourceLineNumber) ?? spansFor(text);
+      const spans = sourceLineSpans
+        ? sanitizeTerminalSpans(sourceLineSpans(text, sourceLineNumber))
+        : spansFor(text);
 
       result.push(
         layout === "split"

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -10,6 +10,7 @@ import {
 import { formatHunkHeader } from "../../core/hunkHeader";
 import type { DiffFile } from "../../core/types";
 import { blendHex, hexColorDistance } from "../lib/color";
+import { sanitizeTerminalLine } from "../../lib/terminalText";
 import type { AppTheme } from "../themes";
 import { expandDiffTabs } from "./codeColumns";
 
@@ -141,7 +142,7 @@ export type DiffRow =
 
 /** Replace tabs with fixed spaces so terminal cell widths stay predictable. */
 function tabify(text: string) {
-  return expandDiffTabs(text);
+  return expandDiffTabs(sanitizeTerminalLine(text));
 }
 
 const EMPTY_STYLE_VALUES = new Map<string, string>();

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -24,24 +24,26 @@ import {
 import { type PlannedReviewRow } from "./reviewRenderPlan";
 import { inlineNoteTitle } from "../components/panes/AgentInlineNote";
 import { wrapText } from "../lib/agentPopover";
+import { sanitizeTerminalLine, sanitizeTerminalSpans } from "../../lib/terminalText";
 import { measureTextWidth, padText as padTextByWidth, sliceTextByWidth } from "../lib/text";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
 
 /** Clamp a label to one terminal row with an ellipsis. */
 export function fitText(text: string, width: number) {
+  const safeText = sanitizeTerminalLine(text);
   if (width <= 0) {
     return "";
   }
 
-  if (measureTextWidth(text) <= width) {
-    return text;
+  if (measureTextWidth(safeText) <= width) {
+    return safeText;
   }
 
   if (width === 1) {
     return "…";
   }
 
-  return `${sliceTextByWidth(text, 0, width - 1).text}…`;
+  return `${sliceTextByWidth(safeText, 0, width - 1).text}…`;
 }
 
 /** Append a styled span while preserving color-run coalescing. */
@@ -122,7 +124,11 @@ function renderInlineSpans(
   selectionTheme?: AppTheme,
   selectionColRange?: { start: number; end: number },
 ) {
-  const { spans: trimmed, usedWidth } = sliceSpansWindow(spans, horizontalOffset, width);
+  const { spans: trimmed, usedWidth } = sliceSpansWindow(
+    sanitizeTerminalSpans(spans),
+    horizontalOffset,
+    width,
+  );
   const needsBlending = selectionTheme && selectionColRange;
 
   // Build the final element list by splitting spans at selection boundaries so the highlight
@@ -297,7 +303,7 @@ function wrapSpans(spans: RenderSpan[], width: number) {
   let current = lines[0]!;
   let remaining = width;
 
-  for (const span of spans) {
+  for (const span of sanitizeTerminalSpans(spans)) {
     const spanWidth = measureTextWidth(span.text);
     if (spanWidth === 0) {
       appendRenderSpan(current, span);
@@ -418,7 +424,9 @@ function spansToPlainText(spans: RenderSpan[], width: number, horizontalOffset =
   }
 
   const visible = sliceTextByWidth(
-    spans.map((span) => span.text).join(""),
+    sanitizeTerminalSpans(spans)
+      .map((span) => span.text)
+      .join(""),
     Math.max(0, horizontalOffset),
     width,
   );
@@ -428,7 +436,9 @@ function spansToPlainText(spans: RenderSpan[], width: number, horizontalOffset =
 
 /** Flatten styled spans to their visible text content. */
 function spansText(spans: RenderSpan[]) {
-  return spans.map((span) => span.text).join("");
+  return sanitizeTerminalSpans(spans)
+    .map((span) => span.text)
+    .join("");
 }
 
 /** Return one cell's code text without rail, gutter, sign, or line-number decorations. */

--- a/src/ui/lib/agentPopover.ts
+++ b/src/ui/lib/agentPopover.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalLine } from "../../lib/terminalText";
 import { fitText } from "./text";
 
 function clamp(value: number, min: number, max: number) {
@@ -10,7 +11,7 @@ export function wrapText(text: string, width: number) {
     return [""];
   }
 
-  const normalized = text.trim().replace(/\s+/g, " ");
+  const normalized = sanitizeTerminalLine(text).trim().replace(/\s+/g, " ");
   if (normalized.length === 0) {
     return [""];
   }
@@ -52,7 +53,8 @@ export function wrapText(text: string, width: number) {
 /** Title shown above an agent note — author name if present, otherwise "AI note", with optional "i/n" suffix. */
 export function formatAgentNoteTitle(noteIndex: number, noteCount: number, author?: string) {
   if (author) {
-    return noteCount > 1 ? `${author} ${noteIndex + 1}/${noteCount}` : author;
+    const safeAuthor = sanitizeTerminalLine(author);
+    return noteCount > 1 ? `${safeAuthor} ${noteIndex + 1}/${noteCount}` : safeAuthor;
   }
   return noteCount > 1 ? `AI note ${noteIndex + 1}/${noteCount}` : "AI note";
 }

--- a/src/ui/lib/files.ts
+++ b/src/ui/lib/files.ts
@@ -2,6 +2,7 @@ import { basename, dirname } from "node:path/posix";
 import type { FileDiffMetadata } from "@pierre/diffs";
 import { normalizeDiffPath } from "../../core/diffPaths";
 import type { AgentAnnotation, DiffFile } from "../../core/types";
+import { sanitizeTerminalLine } from "../../lib/terminalText";
 
 export interface FileListEntry {
   kind: "file";
@@ -24,8 +25,10 @@ export type SidebarEntry = FileListEntry | FileGroupEntry;
 
 /** Build the filename-first label shown inside one sidebar row. */
 function sidebarFileName(file: DiffFile) {
-  const path = normalizeDiffPath(file.path) ?? file.path;
-  const previousPath = normalizeDiffPath(file.previousPath);
+  const path = sanitizeTerminalLine(normalizeDiffPath(file.path) ?? file.path);
+  const previousPath = file.previousPath
+    ? sanitizeTerminalLine(normalizeDiffPath(file.previousPath) ?? file.previousPath)
+    : undefined;
 
   if (!previousPath || previousPath === path) {
     return basename(path);
@@ -122,7 +125,7 @@ export function buildSidebarEntries(files: DiffFile[]): SidebarEntry[] {
   let activeGroup: string | null = null;
 
   files.forEach((file, index) => {
-    const path = normalizeDiffPath(file.path) ?? file.path;
+    const path = sanitizeTerminalLine(normalizeDiffPath(file.path) ?? file.path);
     const group = dirname(path);
     const nextGroup = group === "." ? null : group;
 
@@ -169,8 +172,10 @@ export function fileLabelParts(file: DiffFile | undefined): {
     return { filename: "No file selected", stateLabel: null };
   }
 
-  const path = normalizeDiffPath(file.path) ?? file.path;
-  const previousPath = normalizeDiffPath(file.previousPath);
+  const path = sanitizeTerminalLine(normalizeDiffPath(file.path) ?? file.path);
+  const previousPath = file.previousPath
+    ? sanitizeTerminalLine(normalizeDiffPath(file.previousPath) ?? file.previousPath)
+    : undefined;
   const baseLabel = previousPath && previousPath !== path ? `${previousPath} -> ${path}` : path;
 
   // Determine state label for special cases

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -1,4 +1,5 @@
 import stringWidth from "string-width";
+import { sanitizeTerminalLine } from "../../lib/terminalText";
 
 const printableAsciiRegex = /^[\u0020-\u007E]*$/;
 const graphemeSegmenter =
@@ -15,21 +16,26 @@ function textClusters(text: string) {
   return Array.from(graphemeSegmenter.segment(text), (segment) => segment.segment);
 }
 
+function measureSanitizedTextWidth(text: string) {
+  return printableAsciiRegex.test(text) ? text.length : stringWidth(text);
+}
+
 /** Measure text in terminal cells, treating CJK and emoji clusters as wide. */
 export function measureTextWidth(text: string) {
-  return printableAsciiRegex.test(text) ? text.length : stringWidth(text);
+  return measureSanitizedTextWidth(sanitizeTerminalLine(text));
 }
 
 /** Slice text by terminal cells without splitting wide or combining clusters. */
 export function sliceTextByWidth(text: string, offset: number, width: number) {
+  const safeText = sanitizeTerminalLine(text);
   const startOffset = Math.max(0, offset);
   const maxWidth = Math.max(0, width);
   if (maxWidth === 0) {
     return { text: "", width: 0 };
   }
 
-  if (printableAsciiRegex.test(text)) {
-    const sliced = text.slice(startOffset, startOffset + maxWidth);
+  if (printableAsciiRegex.test(safeText)) {
+    const sliced = safeText.slice(startOffset, startOffset + maxWidth);
     return { text: sliced, width: sliced.length };
   }
 
@@ -37,8 +43,8 @@ export function sliceTextByWidth(text: string, offset: number, width: number) {
   let usedWidth = 0;
   let visibleText = "";
 
-  for (const cluster of textClusters(text)) {
-    const clusterWidth = measureTextWidth(cluster);
+  for (const cluster of textClusters(safeText)) {
+    const clusterWidth = measureSanitizedTextWidth(cluster);
     const clusterStart = cursor;
     const clusterEnd = cursor + clusterWidth;
     cursor = clusterEnd;
@@ -62,19 +68,20 @@ export function sliceTextByWidth(text: string, offset: number, width: number) {
 
 /** Clamp text to a fixed width using a plain-dot terminal fallback marker. */
 export function fitText(text: string, width: number) {
+  const safeText = sanitizeTerminalLine(text);
   if (width <= 0) {
     return "";
   }
 
-  if (measureTextWidth(text) <= width) {
-    return text;
+  if (measureTextWidth(safeText) <= width) {
+    return safeText;
   }
 
   if (width === 1) {
     return ".";
   }
 
-  return `${sliceTextByWidth(text, 0, width - 1).text}.`;
+  return `${sliceTextByWidth(safeText, 0, width - 1).text}.`;
 }
 
 /** Clamp and then right-pad text to an exact width. */

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -5,6 +5,31 @@ function stripAnsi(text: string) {
   return text.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
+/** Remove Hunk's intentional SGR color codes while leaving unsafe controls visible. */
+function stripColorSgr(text: string) {
+  return text.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
+const CSI_CLEAR_SCREEN = "\x1b[2J";
+const DCS_PAYLOAD = "\x1bPqpayload\x1b\\";
+const APC_PAYLOAD = "\x1b_payload\x1b\\";
+const PM_PAYLOAD = "\x1b^payload\x1b\\";
+const SOS_PAYLOAD = "\x1bXpayload\x1b\\";
+
+function expectNoUnsafeTerminalControls(text: string) {
+  expect(text).not.toContain(OSC52_CLIPBOARD);
+  expect(text).not.toContain(CSI_CLEAR_SCREEN);
+  expect(text).not.toContain(DCS_PAYLOAD);
+  expect(text).not.toContain(APC_PAYLOAD);
+  expect(text).not.toContain(PM_PAYLOAD);
+  expect(text).not.toContain(SOS_PAYLOAD);
+  expect(text).not.toContain("\x07");
+  expect(text).not.toContain("\r");
+  expect(text).not.toContain("\b");
+  expect(text).not.toContain("\x1b");
+}
+
 describe("static diff pager", () => {
   test("renders diff-like stdin as non-interactive ANSI output", async () => {
     const patchText =
@@ -88,5 +113,60 @@ describe("static diff pager", () => {
     ).resolves.toBe(text);
     expect(warning).toContain("hunk: static pager render failed");
     expect(warning).toContain("falling back to raw diff");
+  });
+
+  test("does not pass terminal control sequences through malformed pager fallback", async () => {
+    const text = [
+      "diff --git incomplete",
+      `clipboard ${OSC52_CLIPBOARD}`,
+      `clear-screen ${CSI_CLEAR_SCREEN}`,
+      `device-control ${DCS_PAYLOAD}`,
+      "bell \x07",
+      "carriage\rspoof",
+      "backspace\bspoof",
+      "bare-escape \x1b",
+      "",
+    ].join("\n");
+
+    const output = stripColorSgr(
+      await renderStaticDiffPager(text, {}, { stderr: { write: () => true } }),
+    );
+
+    expectNoUnsafeTerminalControls(output);
+  });
+
+  test("does not pass terminal controls through parsed file paths or hunk headers", async () => {
+    const payload = `${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}${APC_PAYLOAD}${PM_PAYLOAD}${SOS_PAYLOAD}\x07\rspoof\bhidden\x1b`;
+    const patchText = [
+      `diff --git a/evil${payload}.ts b/evil${payload}.ts`,
+      `--- a/evil${payload}.ts`,
+      `+++ b/evil${payload}.ts`,
+      `@@ -1 +1 @@ ${payload}`,
+      "-const value = 1;",
+      "+const value = 2;",
+      "",
+    ].join("\n");
+
+    const output = stripColorSgr(await renderStaticDiffPager(patchText));
+
+    expect(output).toContain("evil");
+    expect(output).toContain("@@ -1 +1 @@");
+    expectNoUnsafeTerminalControls(output);
+  });
+
+  test("does not pass terminal control sequences through parsed diff content", async () => {
+    const patchText = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1 +1 @@",
+      `-safe${OSC52_CLIPBOARD}${CSI_CLEAR_SCREEN}${DCS_PAYLOAD}\x07\rspoof\bhidden\x1b`,
+      "+const value = 2;",
+      "",
+    ].join("\n");
+
+    const output = stripColorSgr(await renderStaticDiffPager(patchText));
+
+    expectNoUnsafeTerminalControls(output);
   });
 });

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -24,6 +24,7 @@ import {
   stackGutterText,
   stackRailColor,
 } from "./diff/rowStyle";
+import { sanitizeTerminalLine, sanitizeTerminalText } from "../lib/terminalText";
 import { resolveTheme, type AppTheme } from "./themes";
 
 const RESET = "\x1b[0m";
@@ -43,12 +44,13 @@ function ansiColor(kind: "fg" | "bg", hex: string | undefined) {
 
 /** Wrap one terminal text fragment in ANSI colors. */
 function colorText(text: string, fg?: string, bg?: string) {
-  if (!text) {
+  const safeText = sanitizeTerminalLine(text);
+  if (!safeText) {
     return "";
   }
 
   const prefix = `${ansiColor("fg", fg)}${ansiColor("bg", bg)}`;
-  return prefix ? `${prefix}${text}${RESET}` : text;
+  return prefix ? `${prefix}${safeText}${RESET}` : safeText;
 }
 
 /** Serialize highlighted code spans into ANSI text, preserving a row background when present. */
@@ -149,7 +151,9 @@ function fileStatusLabel(file: DiffFile) {
 /** Use an arrow label for renamed files so static output keeps important path metadata. */
 function fileDisplayPath(file: DiffFile) {
   const previousPath = file.previousPath ?? file.metadata.prevName;
-  return previousPath && previousPath !== file.path ? `${previousPath} → ${file.path}` : file.path;
+  return previousPath && previousPath !== file.path
+    ? `${sanitizeTerminalLine(previousPath)} → ${sanitizeTerminalLine(file.path)}`
+    : sanitizeTerminalLine(file.path);
 }
 
 function fileModeText(file: DiffFile) {
@@ -207,7 +211,9 @@ export interface StaticDiffPagerDeps {
 }
 
 function warnFallback(deps: StaticDiffPagerDeps, reason: string) {
-  deps.stderr?.write(`hunk: static pager render failed; falling back to raw diff (${reason}).\n`);
+  deps.stderr?.write(
+    `hunk: static pager render failed; falling back to raw diff (${sanitizeTerminalLine(reason)}).\n`,
+  );
 }
 
 /** Render diff-like pager stdin as colored static output, falling back to the original patch on failure. */
@@ -233,12 +239,12 @@ export async function renderStaticDiffPager(
 
     if (rendered.length === 0) {
       warnFallback(deps, "no files rendered");
-      return text;
+      return sanitizeTerminalText(text);
     }
 
     return `${rendered.join("\n\n")}\n`;
   } catch (error) {
     warnFallback(deps, fallbackMessage(error));
-    return text;
+    return sanitizeTerminalText(text);
   }
 }


### PR DESCRIPTION
## Summary

- Add a shared terminal text sanitizer for untrusted review/pager content
- Strip OSC/CSI/DCS/APC/PM/SOS, C1 controls, BEL, CR, BS, and bare ESC before terminal rendering
- Apply sanitization to diff rows, file labels, notes, expanded context, copy selections, static/plain pager output, and passthrough output
- Add regression coverage for static and dynamic terminal-control injection paths

## Test plan

- `bun test`
- `bun run typecheck`
- `bun run lint`
- Live tmux smoke test with malicious OSC/DCS/APC/CR/BS payload fixture

*This PR description was generated by Pi using OpenAI GPT-5*
