### PR TITLE
test: cover actionable non-script gaps

### DIFF
--- a/src/core/patch/chunks.test.ts
+++ b/src/core/patch/chunks.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { FileDiffMetadata } from "@pierre/diffs";
+import { findPatchChunk, splitPatchIntoFileChunks } from "./chunks";
+
+function createMetadata(name?: string, prevName?: string): FileDiffMetadata {
+  return { name, prevName } as FileDiffMetadata;
+}
+
+describe("patch chunk helpers", () => {
+  // Intent: non-git unified diffs still split into stable per-file chunks.
+  test("splits plain unified multi-file patches without git headers", () => {
+    const chunks = splitPatchIntoFileChunks(
+      [
+        "--- a/alpha.txt",
+        "+++ b/alpha.txt",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+        "--- a/beta.txt",
+        "+++ b/beta.txt",
+        "@@ -1 +1 @@",
+        "-left",
+        "+right",
+        "",
+      ].join("\n"),
+    );
+
+    expect(chunks).toEqual([
+      "--- a/alpha.txt\n+++ b/alpha.txt\n@@ -1 +1 @@\n-old\n+new\n",
+      "--- a/beta.txt\n+++ b/beta.txt\n@@ -1 +1 @@\n-left\n+right\n",
+    ]);
+  });
+
+  // Intent: fallback matching works by current or previous path when index lookup misses.
+  test("matches fallback chunks by normalized current or previous path", () => {
+    const chunks = [
+      "diff --git a/old-name.ts b/new-name.ts\n--- a/old-name.ts\n+++ b/new-name.ts\n",
+    ];
+
+    expect(findPatchChunk(createMetadata("b/new-name.ts"), chunks, 3)).toBe(chunks[0]!);
+    expect(findPatchChunk(createMetadata(undefined, "a/old-name.ts"), chunks, 3)).toBe(chunks[0]!);
+  });
+
+  // Intent: unmatched metadata returns an empty patch instead of a misleading chunk.
+  test("returns an empty chunk when neither index nor path matches", () => {
+    expect(
+      findPatchChunk(createMetadata("missing.ts"), ["diff --git a/other.ts b/other.ts\n"], 2),
+    ).toBe("");
+  });
+});

--- a/src/hunk-session/sessionRegistration.test.ts
+++ b/src/hunk-session/sessionRegistration.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile } from "../../test/helpers/diff-helpers";
+import type { AppBootstrap } from "../core/types";
+import { SESSION_BROKER_REGISTRATION_VERSION } from "@hunk/session-broker-core";
+import {
+  createInitialSessionSnapshot,
+  createSessionRegistration,
+  updateSessionRegistration,
+} from "./sessionRegistration";
+
+function createBootstrap(overrides: Partial<AppBootstrap> = {}): AppBootstrap {
+  const file = createTestDiffFile({
+    id: "file-1",
+    path: "src/example.ts",
+    previousPath: "src/old-example.ts",
+    before: "export const value = 1;\n",
+    after: "export const value = 2;\n",
+  });
+
+  return {
+    input: { kind: "vcs", staged: false, options: {} },
+    changeset: {
+      id: "changeset-1",
+      title: "working tree",
+      sourceLabel: "/repo",
+      files: [
+        {
+          ...file,
+          patch: "@@ -1 +1 @@\n-export const value = 1;\n+export const value = 2;\n",
+        },
+      ],
+    },
+    initialMode: "split",
+    initialShowAgentNotes: true,
+    ...overrides,
+  };
+}
+
+describe("session registration", () => {
+  // Intent: registration preserves daemon-facing repo, file, patch, and hunk metadata.
+  test("createSessionRegistration exports review files with hunks and repo-root selection", () => {
+    const registration = createSessionRegistration(createBootstrap());
+
+    expect(registration).toMatchObject({
+      registrationVersion: SESSION_BROKER_REGISTRATION_VERSION,
+      pid: process.pid,
+      cwd: process.cwd(),
+      repoRoot: "/repo",
+      info: {
+        inputKind: "vcs",
+        title: "working tree",
+        sourceLabel: "/repo",
+        files: [
+          {
+            id: "file-1",
+            path: "src/example.ts",
+            previousPath: "src/old-example.ts",
+            additions: 1,
+            deletions: 1,
+            hunkCount: 1,
+            patch: "@@ -1 +1 @@\n-export const value = 1;\n+export const value = 2;\n",
+          },
+        ],
+      },
+    });
+    expect(registration.sessionId).toBeString();
+    expect(registration.launchedAt).toBeString();
+    expect(registration.info.files[0]?.hunks[0]).toMatchObject({
+      index: 0,
+      oldRange: [1, 1],
+      newRange: [1, 1],
+    });
+  });
+
+  // Intent: reloads refresh review metadata without changing the live session identity.
+  test("updateSessionRegistration preserves identity while refreshing input metadata", () => {
+    const current = createSessionRegistration(createBootstrap());
+    const nextBootstrap = createBootstrap({
+      input: { kind: "patch", file: "change.patch", options: {} },
+      changeset: {
+        id: "changeset-2",
+        title: "patch file",
+        sourceLabel: "change.patch",
+        files: [],
+      },
+    });
+
+    const updated = updateSessionRegistration(current, nextBootstrap);
+
+    expect(updated.sessionId).toBe(current.sessionId);
+    expect(updated.pid).toBe(current.pid);
+    expect(updated.repoRoot).toBeUndefined();
+    expect(updated.info).toEqual({
+      inputKind: "patch",
+      title: "patch file",
+      sourceLabel: "change.patch",
+      files: [],
+    });
+  });
+
+  // Intent: initial snapshots expose first-hunk focus and configured note visibility.
+  test("createInitialSessionSnapshot starts with the first hunk and note visibility", () => {
+    const snapshot = createInitialSessionSnapshot(createBootstrap());
+
+    expect(snapshot.state).toMatchObject({
+      selectedFileId: "file-1",
+      selectedFilePath: "src/example.ts",
+      selectedHunkIndex: 0,
+      selectedHunkOldRange: [1, 1],
+      selectedHunkNewRange: [1, 1],
+      showAgentNotes: true,
+      liveCommentCount: 0,
+      liveComments: [],
+      reviewNoteCount: 0,
+      reviewNotes: [],
+    });
+  });
+
+  // Intent: empty reviews still publish a valid, explicit daemon snapshot.
+  test("createInitialSessionSnapshot handles empty changesets", () => {
+    const snapshot = createInitialSessionSnapshot(
+      createBootstrap({
+        changeset: {
+          id: "empty",
+          title: "empty",
+          sourceLabel: "/repo",
+          files: [],
+        },
+        initialShowAgentNotes: false,
+      }),
+    );
+
+    expect(snapshot.state).toEqual({
+      selectedFileId: undefined,
+      selectedFilePath: undefined,
+      selectedHunkIndex: 0,
+      selectedHunkOldRange: undefined,
+      selectedHunkNewRange: undefined,
+      showAgentNotes: false,
+      liveCommentCount: 0,
+      liveComments: [],
+      reviewNoteCount: 0,
+      reviewNotes: [],
+    });
+  });
+});

--- a/src/session/commands.test.ts
+++ b/src/session/commands.test.ts
@@ -932,6 +932,123 @@ describe("session command compatibility checks", () => {
       },
     });
   });
+
+  // Intent: session list uses a cheap no-daemon fallback without creating a client.
+  test("list reports an empty session set when no daemon is available", async () => {
+    setSessionCommandTestHooks({
+      createClient: () => {
+        throw new Error("list should not create a client without a daemon");
+      },
+      resolveDaemonAvailability: async () => false,
+    });
+
+    const output = await runSessionCommand({
+      kind: "session",
+      action: "list",
+      output: "text",
+    } satisfies SessionCommandInput);
+
+    expect(output).toBe("No active Hunk sessions.\n");
+  });
+
+  // Intent: remaining command branches dispatch to the daemon and keep text output stable.
+  test("routes remaining session actions through the daemon and formats text output", async () => {
+    const selector: SessionSelectorInput = { sessionId: "session-1" };
+    const calls: string[] = [];
+
+    setSessionCommandTestHooks({
+      createClient: () =>
+        createClient({
+          navigateToHunk: async (input) => {
+            calls.push("navigate");
+            expect(input.selector).toEqual(selector);
+            expect(input.filePath).toBe("README.md");
+            expect(input.hunkNumber).toBe(1);
+            return { fileId: "file-1", filePath: "README.md", hunkIndex: 0 };
+          },
+          listComments: async (input) => {
+            calls.push("comment-list");
+            expect(input.selector).toEqual(selector);
+            return [
+              {
+                commentId: "comment-1",
+                filePath: "README.md",
+                hunkIndex: 0,
+                side: "new",
+                line: 2,
+                summary: "Explain this line",
+                author: "agent",
+                createdAt: "2026-05-10T00:00:00.000Z",
+              },
+            ];
+          },
+          removeComment: async (input) => {
+            calls.push("comment-rm");
+            expect(input.selector).toEqual(selector);
+            expect(input.commentId).toBe("comment-1");
+            return {
+              commentId: "comment-1",
+              removed: true,
+              remainingCommentCount: 1,
+            };
+          },
+          clearComments: async (input) => {
+            calls.push("comment-clear");
+            expect(input.selector).toEqual(selector);
+            expect(input.filePath).toBe("README.md");
+            return {
+              filePath: "README.md",
+              removedCount: 2,
+              remainingCommentCount: 0,
+            };
+          },
+        }),
+      resolveDaemonAvailability: async () => true,
+    });
+
+    expect(
+      await runSessionCommand({
+        kind: "session",
+        action: "navigate",
+        selector,
+        filePath: "README.md",
+        hunkNumber: 1,
+        output: "text",
+      } satisfies SessionCommandInput),
+    ).toBe("Focused README.md hunk 1 in session session-1.\n");
+
+    expect(
+      await runSessionCommand({
+        kind: "session",
+        action: "comment-list",
+        selector,
+        output: "text",
+      } satisfies SessionCommandInput),
+    ).toContain("comment-1  README.md:2 (new)");
+
+    expect(
+      await runSessionCommand({
+        kind: "session",
+        action: "comment-rm",
+        selector,
+        commentId: "comment-1",
+        output: "text",
+      } satisfies SessionCommandInput),
+    ).toBe("Removed live comment comment-1 from session session-1. Remaining comments: 1.\n");
+
+    expect(
+      await runSessionCommand({
+        kind: "session",
+        action: "comment-clear",
+        selector,
+        filePath: "README.md",
+        confirmed: true,
+        output: "text",
+      } satisfies SessionCommandInput),
+    ).toBe("Cleared 2 live comments from README.md in session session-1. Remaining comments: 0.\n");
+
+    expect(calls).toEqual(["navigate", "comment-list", "comment-rm", "comment-clear"]);
+  });
 });
 
 describe("session list includes terminal metadata", () => {

--- a/src/ui/lib/reviewState.test.ts
+++ b/src/ui/lib/reviewState.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { createTestAgentFileContext, createTestDiffFile } from "../../../test/helpers/diff-helpers";
+import {
+  buildSelectedHunkSummary,
+  findNextAnnotatedFile,
+  resolveReviewNavigationTarget,
+} from "./reviewState";
+
+function createAnnotatedFile(id: string, path: string) {
+  return createTestDiffFile({
+    id,
+    path,
+    before: "const value = 1;\nconst stable = true;\n",
+    after: "const value = 2;\nconst stable = true;\n",
+    agent: createTestAgentFileContext(path, {
+      annotations: [{ newRange: [1, 1], summary: `Explain ${path}` }],
+    }),
+  });
+}
+
+describe("review state helpers", () => {
+  // Intent: stale selections keep their requested index without inventing ranges.
+  test("buildSelectedHunkSummary preserves stale out-of-range selections", () => {
+    const file = createTestDiffFile();
+
+    expect(buildSelectedHunkSummary(file, 99)).toEqual({ index: 99 });
+  });
+
+  // Intent: annotated-file navigation wraps predictably and handles no-note streams.
+  test("findNextAnnotatedFile wraps through annotated files and handles empty streams", () => {
+    const alpha = createAnnotatedFile("alpha", "alpha.ts");
+    const beta = createTestDiffFile({ id: "beta", path: "beta.ts", agent: null });
+    const gamma = createAnnotatedFile("gamma", "gamma.ts");
+
+    expect(findNextAnnotatedFile([alpha, beta, gamma], "alpha", 1)).toBe(gamma);
+    expect(findNextAnnotatedFile([alpha, beta, gamma], "gamma", 1)).toBe(alpha);
+    expect(findNextAnnotatedFile([alpha, beta, gamma], undefined, -1)).toBe(gamma);
+    expect(findNextAnnotatedFile([beta], "beta", 1)).toBeNull();
+  });
+
+  // Intent: comment navigation targets the next noted hunk and scrolls to the note.
+  test("resolveReviewNavigationTarget follows annotated comment navigation", () => {
+    const alpha = createAnnotatedFile("alpha", "alpha.ts");
+    const gamma = createAnnotatedFile("gamma", "gamma.ts");
+
+    const target = resolveReviewNavigationTarget({
+      allFiles: [alpha, gamma],
+      visibleFiles: [alpha, gamma],
+      currentFileId: "alpha",
+      currentHunkIndex: 0,
+      input: { commentDirection: "next" },
+    });
+
+    expect(target).toEqual({ file: gamma, hunkIndex: 0, scrollToNote: true });
+  });
+
+  // Intent: absolute navigation supports both hunk index and side+line addressing.
+  test("resolveReviewNavigationTarget resolves paths by explicit hunk or side and line", () => {
+    const file = createTestDiffFile({ id: "alpha", path: "src/alpha.ts" });
+
+    expect(
+      resolveReviewNavigationTarget({
+        allFiles: [file],
+        visibleFiles: [file],
+        currentFileId: "alpha",
+        currentHunkIndex: 0,
+        input: { filePath: "src/alpha.ts", hunkIndex: 0 },
+      }),
+    ).toEqual({ file, hunkIndex: 0, scrollToNote: false });
+
+    expect(
+      resolveReviewNavigationTarget({
+        allFiles: [file],
+        visibleFiles: [file],
+        currentFileId: "alpha",
+        currentHunkIndex: 0,
+        input: { filePath: "src/alpha.ts", side: "new", line: 1 },
+      }),
+    ).toEqual({ file, hunkIndex: 0, scrollToNote: false });
+  });
+
+  // Intent: invalid agent navigation requests fail before mutating review state.
+  test("resolveReviewNavigationTarget rejects missing and invalid targets", () => {
+    const file = createTestDiffFile({ id: "alpha", path: "src/alpha.ts" });
+    const baseInput = {
+      allFiles: [file],
+      visibleFiles: [file],
+      currentFileId: "alpha",
+      currentHunkIndex: 0,
+    };
+
+    expect(() =>
+      resolveReviewNavigationTarget({
+        ...baseInput,
+        input: { commentDirection: "next" },
+      }),
+    ).toThrow("No annotated hunks");
+    expect(() => resolveReviewNavigationTarget({ ...baseInput, input: {} })).toThrow(
+      "navigate requires --file",
+    );
+    expect(() =>
+      resolveReviewNavigationTarget({
+        ...baseInput,
+        input: { filePath: "missing.ts", hunkIndex: 0 },
+      }),
+    ).toThrow("No diff file matches missing.ts");
+    expect(() =>
+      resolveReviewNavigationTarget({ ...baseInput, input: { filePath: "src/alpha.ts" } }),
+    ).toThrow("hunkIndex or both side and line");
+    expect(() =>
+      resolveReviewNavigationTarget({
+        ...baseInput,
+        input: { filePath: "src/alpha.ts", hunkIndex: 20 },
+      }),
+    ).toThrow("No diff hunk");
+  });
+});


### PR DESCRIPTION
## Summary

- add focused coverage for patch chunk splitting and fallback matching
- cover session registration exports, reload metadata refreshes, and initial snapshot defaults
- cover review-state navigation helpers and remaining session command dispatch branches

## Testing

- bun test src/core/patch/chunks.test.ts src/hunk-session/sessionRegistration.test.ts src/ui/lib/reviewState.test.ts src/session/commands.test.ts
- bun run typecheck
- bun run lint
- bun run format:check

*This PR description was generated by Pi using OpenAI GPT-5*