### PR TITLE
fix(ui): stabilize wrapped diff row hover layout

### DIFF
--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -758,11 +758,11 @@ describe("App interactions", () => {
       });
       await settleWrapToggle(setup);
 
-      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("coverage';"));
-      // Assert on a suffix fragment that only appears once the long line has actually wrapped;
-      // this is more stable than expecting the full sentence to remain on one terminal row.
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("age';"));
+      // Assert on suffix fragments that only appear once the long line has actually wrapped;
+      // wrapped rows reserve the add-note column, so exact word boundaries can vary by width.
       expect(frame).toContain("wrapped line");
-      expect(frame).toContain("coverage';");
+      expect(frame).toContain("age';");
 
       await act(async () => {
         await setup.mockInput.typeText("w");
@@ -777,9 +777,9 @@ describe("App interactions", () => {
       });
       await settleWrapToggle(setup);
 
-      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("coverage';"));
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("age';"));
       expect(frame).toContain("wrapped line");
-      expect(frame).toContain("coverage';");
+      expect(frame).toContain("age';");
     } finally {
       await act(async () => {
         setup.renderer.destroy();
@@ -1027,8 +1027,8 @@ describe("App interactions", () => {
       await settleWrapToggle(setup);
 
       frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("overage';"));
-      expect(frame).toContain("this is a very");
-      expect(frame).toContain("long wrapped line");
+      expect(frame).toContain("this is a ve");
+      expect(frame).toContain("ry long wrapped line");
       expect(frame).toContain("overage';");
 
       await act(async () => {

--- a/src/ui/components/panes/DiffFileHeaderRow.tsx
+++ b/src/ui/components/panes/DiffFileHeaderRow.tsx
@@ -55,6 +55,7 @@ export function DiffFileHeaderRow({
         <text fg={theme.badgeAdded}>{additionsText}</text>
         <text fg={theme.muted}> </text>
         <text fg={theme.badgeRemoved}>{deletionsText}</text>
+        <text fg={theme.muted}> </text>
       </box>
     </box>
   );

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -542,6 +542,7 @@ export function DiffPane({
           wrapLines,
           expandedGapsByFileId[file.id] ?? EMPTY_EXPANDED_GAP_KEYS,
           sourceStatusByFileId[file.id],
+          Boolean(onStartUserNoteAtHunk),
         ),
       ),
     [
@@ -549,6 +550,7 @@ export function DiffPane({
       expandedGapsByFileId,
       files,
       layout,
+      onStartUserNoteAtHunk,
       showHunkHeaders,
       showLineNumbers,
       sourceStatusByFileId,
@@ -618,6 +620,7 @@ export function DiffPane({
           wrapLines,
           expandedGapsByFileId[file.id] ?? EMPTY_EXPANDED_GAP_KEYS,
           sourceStatusByFileId[file.id],
+          Boolean(onStartUserNoteAtHunk),
         );
       }),
     [
@@ -627,6 +630,7 @@ export function DiffPane({
       expandedGapsByFileId,
       files,
       layout,
+      onStartUserNoteAtHunk,
       showHunkHeaders,
       showLineNumbers,
       sourceStatusByFileId,
@@ -1694,8 +1698,10 @@ export function DiffPane({
                           affordance ? { ...affordance, fileId: file.id } : null,
                         )
                       }
-                      onStartUserNoteAtHunk={(hunkIndex, target) =>
-                        onStartUserNoteAtHunk?.(file.id, hunkIndex, target)
+                      onStartUserNoteAtHunk={
+                        onStartUserNoteAtHunk
+                          ? (hunkIndex, target) => onStartUserNoteAtHunk(file.id, hunkIndex, target)
+                          : undefined
                       }
                       onSelect={() => onSelectFile(file.id)}
                       onToggleGap={(gapKey) => onToggleGap(file.id, gapKey)}

--- a/src/ui/components/panes/copySelection.ts
+++ b/src/ui/components/panes/copySelection.ts
@@ -158,7 +158,7 @@ function renderFileHeaderCopyText({
 }) {
   const additionsText = `+${file.stats.additions}${file.statsTruncated ? "+" : ""}`;
   const deletionsText = `-${file.stats.deletions}`;
-  const statsText = `${additionsText} ${deletionsText}`.padStart(headerStatsWidth);
+  const statsText = `${additionsText} ${deletionsText} `.padStart(headerStatsWidth);
   const { filename, stateLabel } = fileLabelParts(file);
   const label = `${fitText(
     filename,

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -24,6 +24,7 @@ const { DiffPane } = await import("./panes/DiffPane");
 const { MenuDropdown } = await import("./chrome/MenuDropdown");
 const { StatusBar } = await import("./chrome/StatusBar");
 const { DiffSectionPlaceholder } = await import("./panes/DiffSectionPlaceholder");
+const { DiffFileHeaderRow } = await import("./panes/DiffFileHeaderRow");
 const { PierreDiffView } = await import("../diff/PierreDiffView");
 const { DiffRowView } = await import("../diff/renderRows");
 
@@ -517,6 +518,31 @@ describe("UI components", () => {
     expect(frame.indexOf("alpha.ts")).toBeLessThan(frame.indexOf("beta.ts"));
   });
 
+  test("DiffFileHeaderRow leaves one column after line counts", async () => {
+    const theme = resolveTheme("midnight", null);
+    const frame = await captureFrame(
+      <DiffFileHeaderRow
+        file={createTestDiffFile(
+          "stats-align",
+          "stats-align.ts",
+          lines("export const value = 1;"),
+          lines("export const value = 2;", "export const next = 3;"),
+        )}
+        headerLabelWidth={20}
+        headerStatsWidth={8}
+        theme={theme}
+      />,
+      40,
+      2,
+    );
+    const firstLine = frame.split("\n")[0] ?? "";
+    const statsIndex = firstLine.indexOf("+2 -1");
+
+    expect(statsIndex).toBeGreaterThanOrEqual(0);
+    expect(firstLine[statsIndex + "+2 -1".length]).toBe(" ");
+    expect(firstLine[statsIndex + "+2 -1".length + 1]).toBe(" ");
+  });
+
   test("DiffRowView renders a clickable add-note affordance for a hovered diff row", async () => {
     const theme = resolveTheme("midnight", null);
     const startUserNote = mock(() => undefined);
@@ -568,6 +594,142 @@ describe("UI components", () => {
         await setup.mockMouse.click(addNoteX + 1, addNoteY);
       });
       expect(startUserNote).toHaveBeenCalledWith(0, { side: "new", line: 2 });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("DiffRowView keeps wrapped text stable when showing the add-note affordance", async () => {
+    const theme = resolveTheme("midnight", null);
+    const row = {
+      type: "stack-line" as const,
+      key: "alpha:line:hover-wrap",
+      fileId: "alpha",
+      hunkIndex: 0,
+      cell: {
+        kind: "addition" as const,
+        sign: "+" as const,
+        newLineNumber: 2,
+        spans: [{ text: "abcdefghij klmnopqrst uvwxyz" }],
+      },
+    };
+    const renderRow = (showAddNoteBadge: boolean) =>
+      captureFrame(
+        <DiffRowView
+          row={row}
+          width={24}
+          lineNumberDigits={1}
+          showLineNumbers={true}
+          showHunkHeaders={true}
+          wrapLines={true}
+          codeHorizontalOffset={0}
+          theme={theme}
+          selected={false}
+          showAddNoteBadge={showAddNoteBadge}
+          onStartUserNoteAtHunk={() => {}}
+        />,
+        32,
+        5,
+      );
+    const normalize = (frame: string) =>
+      frame
+        .replace("[+]", "")
+        .split("\n")
+        .map((line) => line.trimEnd())
+        .filter(Boolean);
+
+    const hiddenFrame = await renderRow(false);
+    const shownFrame = await renderRow(true);
+
+    expect(normalize(shownFrame)).toEqual(normalize(hiddenFrame));
+  });
+
+  test("DiffRowView fills the reserved wrapped add-note column with row background", async () => {
+    const theme = resolveTheme("midnight", null);
+    const setup = await testRender(
+      <DiffRowView
+        row={{
+          type: "stack-line",
+          key: "alpha:line:hover-wrap-bg",
+          fileId: "alpha",
+          hunkIndex: 0,
+          cell: {
+            kind: "addition",
+            sign: "+",
+            newLineNumber: 2,
+            spans: [{ text: "abcdefghij klmnopqrst uvwxyz" }],
+          },
+        }}
+        width={24}
+        lineNumberDigits={1}
+        showLineNumbers={true}
+        showHunkHeaders={true}
+        wrapLines={true}
+        codeHorizontalOffset={0}
+        theme={theme}
+        selected={false}
+        onStartUserNoteAtHunk={() => {}}
+      />,
+      { width: 32, height: 5 },
+    );
+
+    try {
+      await act(async () => {
+        await setup.renderOnce();
+      });
+      const line = setup
+        .captureSpans()
+        .lines.find((nextLine) => nextLine.spans.some((span) => span.text.includes("abcdefghij")));
+      const hasAddedBgSpacer = line?.spans.some(
+        (span) =>
+          span.text === " ".repeat(3) &&
+          capturedColorToHex(span.bg)?.toLowerCase() === theme.addedBg.toLowerCase(),
+      );
+
+      expect(hasAddedBgSpacer).toBe(true);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("DiffRowView keeps metadata row background within the measured row width", async () => {
+    const theme = resolveTheme("midnight", null);
+    const setup = await testRender(
+      <DiffRowView
+        row={{
+          type: "hunk-header",
+          key: "alpha:hunk:0",
+          fileId: "alpha",
+          hunkIndex: 0,
+          text: "@@ -1 +1 @@",
+        }}
+        width={24}
+        lineNumberDigits={1}
+        showLineNumbers={true}
+        showHunkHeaders={true}
+        wrapLines={true}
+        codeHorizontalOffset={0}
+        theme={theme}
+        selected={false}
+      />,
+      { width: 32, height: 2 },
+    );
+
+    try {
+      await act(async () => {
+        await setup.renderOnce();
+      });
+      const panelAltWidth = setup.captureSpans().lines[0]?.spans.reduce((total, span) => {
+        return capturedColorToHex(span.bg)?.toLowerCase() === theme.panelAlt.toLowerCase()
+          ? total + span.text.length
+          : total;
+      }, 0);
+
+      expect(panelAltWidth).toBe(24);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/diff/diffSectionGeometry.ts
+++ b/src/ui/diff/diffSectionGeometry.ts
@@ -79,6 +79,7 @@ interface DiffSectionRowHeightOptions {
   lineNumberDigits: number;
   showHunkHeaders: boolean;
   showLineNumbers: boolean;
+  reserveAddNoteColumn: boolean;
   theme: AppTheme;
   width: number;
   wrapLines: boolean;
@@ -91,6 +92,7 @@ function buildDiffSectionRowHeightOptions(
     layout,
     showHunkHeaders,
     showLineNumbers,
+    reserveAddNoteColumn,
     theme,
     width,
     wrapLines,
@@ -100,6 +102,7 @@ function buildDiffSectionRowHeightOptions(
     layout,
     lineNumberDigits: rowPlan.lineNumberDigits,
     showHunkHeaders,
+    reserveAddNoteColumn,
     showLineNumbers,
     theme,
     width,
@@ -114,6 +117,7 @@ function measurePlannedDiffSectionRowHeight(
     layout,
     lineNumberDigits,
     showHunkHeaders,
+    reserveAddNoteColumn,
     showLineNumbers,
     theme,
     width,
@@ -137,6 +141,7 @@ function measurePlannedDiffSectionRowHeight(
     showHunkHeaders,
     wrapLines,
     theme,
+    reserveAddNoteColumn,
   );
 }
 
@@ -152,6 +157,7 @@ export function measureDiffSectionGeometry(
   wrapLines = false,
   expandedKeys: ReadonlySet<string> = EMPTY_EXPANDED_GAP_KEYS,
   sourceStatus: FileSourceStatus | undefined = undefined,
+  reserveAddNoteColumn = false,
 ): DiffSectionGeometry {
   if (file.metadata.hunks.length === 0) {
     return {
@@ -169,7 +175,7 @@ export function measureDiffSectionGeometry(
   // Width, wrapping, and line-number visibility all affect rendered row heights, so they must
   // participate in the cache key alongside the structural file/layout inputs. Expansion state
   // changes the row stream, so it has to participate too.
-  const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}${expansionCacheKey(expandedKeys, sourceStatus)}`;
+  const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}:${reserveAddNoteColumn ? 1 : 0}${expansionCacheKey(expandedKeys, sourceStatus)}`;
   if (visibleAgentNotes.length > 0) {
     const cachedByNotes = NOTE_AWARE_SECTION_GEOMETRY_CACHE.get(visibleAgentNotes);
     const cached = cachedByNotes?.get(cacheKey);
@@ -197,6 +203,7 @@ export function measureDiffSectionGeometry(
   const rowHeightOptions = buildDiffSectionRowHeightOptions(sectionRowPlan, {
     layout,
     showHunkHeaders,
+    reserveAddNoteColumn,
     showLineNumbers,
     theme,
     width,

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -113,6 +113,11 @@ function sliceSpansWindow(spans: RenderSpan[], offset: number, width: number) {
 const marker = diffRailMarker;
 const addNoteBadgeText = "[+]";
 
+/** Reserve the hover affordance column in wrapped rows so hover cannot reflow code. */
+function wrappedAddNoteReserveWidth(wrapLines: boolean, reserveAddNoteColumn = false) {
+  return wrapLines && reserveAddNoteColumn ? addNoteBadgeText.length : 0;
+}
+
 /** Render a fixed-width inline span sequence for one diff cell. */
 function renderInlineSpans(
   spans: RenderSpan[],
@@ -1166,7 +1171,7 @@ function renderHeaderRow(
         key={row.key}
         id={anchorId}
         style={{
-          width: "100%",
+          width,
           height: 1,
           backgroundColor: theme.panelAlt,
         }}
@@ -1197,7 +1202,7 @@ function renderHeaderRow(
       key={row.key}
       id={anchorId}
       style={{
-        width: "100%",
+        width,
         height: 1,
         flexDirection: "row",
         backgroundColor: theme.panelAlt,
@@ -1258,6 +1263,21 @@ function renderAddNoteButton(
   );
 }
 
+/** Fill the reserved wrapped-row hover column so row backgrounds do not visibly shrink. */
+function renderAddNoteSpacer(key: string, width: number, bg: string) {
+  if (width <= 0) {
+    return null;
+  }
+
+  return (
+    <box key={key} style={{ width, height: 1 }}>
+      <text>
+        <span bg={bg}>{" ".repeat(width)}</span>
+      </text>
+    </box>
+  );
+}
+
 /** Measure how many terminal rows one rendered diff row occupies. */
 export function measureRenderedRowHeight(
   row: DiffRow,
@@ -1267,6 +1287,7 @@ export function measureRenderedRowHeight(
   showHunkHeaders: boolean,
   wrapLines: boolean,
   theme: AppTheme,
+  reserveAddNoteColumn = false,
 ) {
   if (row.type === "hunk-header") {
     return showHunkHeaders ? 1 : 0;
@@ -1282,6 +1303,7 @@ export function measureRenderedRowHeight(
     }
 
     const markerWidth = 1;
+    const hoverReserveWidth = wrappedAddNoteReserveWidth(wrapLines, reserveAddNoteColumn);
     const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
     const leftLayout = buildWrappedSplitCell(
       row.left,
@@ -1293,7 +1315,7 @@ export function measureRenderedRowHeight(
     );
     const rightLayout = buildWrappedSplitCell(
       row.right,
-      rightWidth,
+      Math.max(0, rightWidth - hoverReserveWidth),
       lineNumberDigits,
       showLineNumbers,
       markerWidth,
@@ -1313,7 +1335,7 @@ export function measureRenderedRowHeight(
 
   const layout = buildWrappedStackCell(
     row.cell,
-    width,
+    Math.max(0, width - wrappedAddNoteReserveWidth(wrapLines, reserveAddNoteColumn)),
     lineNumberDigits,
     showLineNumbers,
     marker().length,
@@ -1343,6 +1365,7 @@ function renderRow(
   onToggleGap?: (gapKey: string) => void,
 ) {
   const hasCopySelection = !!copySelectedRowRange;
+  const reserveAddNoteColumn = Boolean(onStartUserNoteAtHunk);
 
   // For split rows, the user's drag is anchored to one column-half of the diff. Apply the
   // selection-highlight blend only to that side so it is clear which file (A or B) the
@@ -1387,7 +1410,8 @@ function renderRow(
           : undefined;
 
     // Reserve fixed columns for the diff rails, center separator slot, and hover affordance.
-    const addBadgeWidth = showAddNoteBadge ? addNoteBadgeText.length : 0;
+    const addBadgeWidth =
+      showAddNoteBadge || (wrapLines && reserveAddNoteColumn) ? addNoteBadgeText.length : 0;
     const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
     const rightRenderWidth = Math.max(0, rightWidth - (guideOnNewSide ? 1 : 0) - addBadgeWidth);
     const leftPrefix = {
@@ -1510,7 +1534,7 @@ function renderRow(
               >
                 <box
                   style={{
-                    width: showBadgeOnLine ? Math.max(0, width - addBadgeWidth) : "100%",
+                    width: addBadgeWidth > 0 ? Math.max(0, width - addBadgeWidth) : "100%",
                     height: 1,
                   }}
                 >
@@ -1552,7 +1576,11 @@ function renderRow(
                       addNoteTarget,
                       onStartUserNoteAtHunk,
                     )
-                  : null}
+                  : renderAddNoteSpacer(
+                      `${row.key}:add-note-spacer:${index}`,
+                      addBadgeWidth,
+                      rightLayout.palette.contentBg,
+                    )}
               </box>
             );
           })}
@@ -1568,7 +1596,8 @@ function renderRow(
         : row.cell.oldLineNumber !== undefined
           ? { side: "old", line: row.cell.oldLineNumber }
           : undefined;
-    const addBadgeWidth = showAddNoteBadge ? addNoteBadgeText.length : 0;
+    const addBadgeWidth =
+      showAddNoteBadge || (wrapLines && reserveAddNoteColumn) ? addNoteBadgeText.length : 0;
     const contentWidth = Math.max(0, width - (guideOnNewSide ? 1 : 0) - addBadgeWidth);
     const prefix = {
       text: guideOnOldSide ? "│" : marker(),
@@ -1649,7 +1678,7 @@ function renderRow(
               >
                 <box
                   style={{
-                    width: showBadgeOnLine ? Math.max(0, width - addBadgeWidth) : "100%",
+                    width: addBadgeWidth > 0 ? Math.max(0, width - addBadgeWidth) : "100%",
                     height: 1,
                   }}
                 >
@@ -1679,7 +1708,11 @@ function renderRow(
                       addNoteTarget,
                       onStartUserNoteAtHunk,
                     )
-                  : null}
+                  : renderAddNoteSpacer(
+                      `${row.key}:add-note-spacer:${index}`,
+                      addBadgeWidth,
+                      layout.palette.contentBg,
+                    )}
               </box>
             );
           })}

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -432,7 +432,8 @@ describe("PTY layout", () => {
         5_000,
       );
 
-      expect(wrapped).toContain("this is a very long");
+      expect(wrapped).toContain("this is a very lo");
+      expect(wrapped).toContain("wrapped line");
       expect(wrapped).toContain("ge';");
 
       await session.press("w");

--- a/test/smoke/tty.test.ts
+++ b/test/smoke/tty.test.ts
@@ -250,8 +250,8 @@ describe("TTY render smoke", () => {
       inputCommand: `(sleep 2; printf w; sleep 1; printf q)`,
     });
 
-    expect(output).toContain("very long wrapped line for tty s");
-    expect(output).toContain("moke coverage';");
+    expect(output).toContain("wrapped line for");
+    expect(output).toContain("tty smoke coverage';");
   });
 
   ttyTest("regular mode can toggle wrapped lines on, off, and on again", async () => {
@@ -265,8 +265,8 @@ describe("TTY render smoke", () => {
       inputCommand: `(sleep 2; printf www; sleep 1; printf q)`,
     });
 
-    expect(output).toContain("very long wrapped line for tty s");
-    expect(output).toContain("moke coverage';");
+    expect(output).toContain("wrapped line for");
+    expect(output).toContain("tty smoke coverage';");
   });
 
   ttyTest(
@@ -310,8 +310,8 @@ describe("TTY render smoke", () => {
       inputCommand: `(sleep 2; printf w; sleep 1; printf q)`,
     });
 
-    expect(output).toContain("very long wrapped line for tty smo");
-    expect(output).toContain("ke coverage';");
+    expect(output).toContain("wrapped line for t");
+    expect(output).toContain("ty smoke coverage';");
   });
 
   ttyTest("stdin patch mode auto-enters pager mode and can quit from terminal input", async () => {


### PR DESCRIPTION
## Summary

- Reserve wrapped-row add-note space so hover does not reflow wrapped diff text
- Fill reserved hover columns with the row background and align metadata/header backgrounds to the diff content width
- Nudge file header line-count stats left by one column and keep copied header text aligned

## Tests

- `bun run typecheck`
- `bun test src/ui/components/ui-components.test.tsx src/ui/components/panes/copySelection.test.ts`

*This PR description was generated by Pi using OpenAI GPT-5 (2026-05-25)*
