### PR TITLE
perf: upgrade pierre diffs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hunk",
       "dependencies": {
-        "@pierre/diffs": "^1.1.19",
+        "@pierre/diffs": "^1.2.2",
         "bun": "^1.3.10",
         "commander": "^14.0.3",
         "diff": "^8.0.3",
@@ -250,9 +250,9 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.19", "", { "dependencies": { "@pierre/theme": "0.0.28", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-eYyDW69heXd7i9zdkWogGYosHzoYF2dstV6uDcmnQAf72uRChs3hrpf/7ym/ayTiwD8a+TQ7oZ5vNNb0tstJvA=="],
+    "@pierre/diffs": ["@pierre/diffs@1.2.2", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ=="],
 
-    "@pierre/theme": ["@pierre/theme@0.0.28", "", {}, "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw=="],
+    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
 
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 

--- a/nix/bun.lock.nix
+++ b/nix/bun.lock.nix
@@ -369,13 +369,13 @@
     url = "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.56.0.tgz";
     hash = "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ==";
   };
-  "@pierre/diffs@1.1.19" = fetchurl {
-    url = "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.1.19.tgz";
-    hash = "sha512-eYyDW69heXd7i9zdkWogGYosHzoYF2dstV6uDcmnQAf72uRChs3hrpf/7ym/ayTiwD8a+TQ7oZ5vNNb0tstJvA==";
+  "@pierre/diffs@1.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.2.tgz";
+    hash = "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==";
   };
-  "@pierre/theme@0.0.28" = fetchurl {
-    url = "https://registry.npmjs.org/@pierre/theme/-/theme-0.0.28.tgz";
-    hash = "sha512-1j/H/fECBuc9dEvntdWI+l435HZapw+RCJTlqCA6BboQ5TjlnE005j/ROWutXIs8aq5OAc82JI2Kwk4A1WWBgw==";
+  "@pierre/theme@1.0.3" = fetchurl {
+    url = "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz";
+    hash = "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==";
   };
   "@shikijs/core@3.23.0" = fetchurl {
     url = "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz";

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "nix:update-lock": "nix run .#update-bun-lock"
   },
   "dependencies": {
-    "@pierre/diffs": "^1.1.19",
+    "@pierre/diffs": "^1.2.2",
     "bun": "^1.3.10",
     "commander": "^14.0.3",
     "diff": "^8.0.3",

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -183,10 +183,12 @@ function parseStyleValue(styleValue: unknown) {
 const RESERVED_PIERRE_TOKEN_COLORS = {
   dark: {
     "#ff6762": "keyword",
+    "#ff855e": "keyword",
     "#5ecc71": "string",
   },
   light: {
     "#d52c36": "keyword",
+    "#d5512f": "keyword",
     "#199f43": "string",
   },
 } as const;


### PR DESCRIPTION
## Summary

- upgrade `@pierre/diffs` from `^1.1.19` to `^1.2.2`
- extend reserved syntax-color remapping for the updated Pierre markdown token colors
- keep the benchmark-driven parser speedup isolated from Hunk windowing changes

## Benchmark notes

Local `bun run bench -- --samples 3` showed parser-focused wins versus the pre-upgrade baseline:

- `bootstrap-load/git_parse_patch_ms`: `15.30ms → 6.26ms`
- `changeset-parse/balanced_changeset_parse_patch_ms`: `6.77ms → 3.47ms`
- `changeset-parse/large_single_file_parse_patch_ms`: `2.68ms → 1.19ms`

`large-stream/cold_first_frame_ms` was noisier/slower in the same run, so this PR keeps only the dependency upgrade for focused review.

## Validation

- `bun test src/ui/diff/pierre.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run bench -- --samples 3 --out /tmp/hunk-perf/final.json`

*This PR description was generated by Pi using OpenAI GPT-5*
