### PR TITLE
perf: binary search diff windowing lookups

### DIFF
--- a/src/ui/diff/rowWindowing.test.ts
+++ b/src/ui/diff/rowWindowing.test.ts
@@ -138,4 +138,30 @@ describe("resolveVisiblePlannedRowWindow", () => {
     expect(window.bottomSpacerHeight).toBe(4);
     expect(window.plannedRows).toHaveLength(0);
   });
+
+  test("finds visible rows in a very large row-bound array", () => {
+    const rowBounds = Array.from({ length: 50_000 }, (_, index) => ({
+      key: `row:${index}`,
+      top: index,
+      height: 1,
+    }));
+    const plannedRows = rowBounds.map((row) => createTestPlannedRow(row.key));
+    const sectionGeometry = createTestSectionGeometry(rowBounds, rowBounds.length);
+
+    const window = resolveVisiblePlannedRowWindow({
+      plannedRows,
+      sectionGeometry,
+      visibleBodyBounds: { top: 30_000, height: 5 },
+    });
+
+    expect(window.topSpacerHeight).toBe(30_000);
+    expect(window.bottomSpacerHeight).toBe(19_995);
+    expect(window.plannedRows.map((row) => row.key)).toEqual([
+      "row:30000",
+      "row:30001",
+      "row:30002",
+      "row:30003",
+      "row:30004",
+    ]);
+  });
 });

--- a/src/ui/diff/rowWindowing.ts
+++ b/src/ui/diff/rowWindowing.ts
@@ -13,7 +13,10 @@ export interface VisiblePlannedRowWindow {
   topSpacerHeight: number;
 }
 
-/** Find the first row whose bottom edge is after the visible top boundary. */
+/**
+ * Find the first row whose bottom edge is after the visible top boundary.
+ * Requires row bounds to be sorted by non-decreasing row bottom.
+ */
 function findFirstRowWithBottomAfter(rowBounds: DiffSectionGeometry["rowBounds"], top: number) {
   let low = 0;
   let high = rowBounds.length - 1;
@@ -34,7 +37,10 @@ function findFirstRowWithBottomAfter(rowBounds: DiffSectionGeometry["rowBounds"]
   return result;
 }
 
-/** Find the last row whose top edge is before the visible bottom boundary. */
+/**
+ * Find the last row whose top edge is before the visible bottom boundary.
+ * Requires row bounds to be sorted by non-decreasing row top.
+ */
 function findLastRowWithTopBefore(rowBounds: DiffSectionGeometry["rowBounds"], bottom: number) {
   let low = 0;
   let high = rowBounds.length - 1;
@@ -128,6 +134,8 @@ export function resolveVisiblePlannedRowWindow({
     firstVisibleIndex = -1;
   }
 
+  // firstVisibleIndex > lastVisibleIndex should not happen with sorted row bounds, but keep the
+  // empty-window fallback defensive in case an upstream geometry invariant is ever broken.
   if (firstVisibleIndex < 0 || lastVisibleIndex < 0 || firstVisibleIndex > lastVisibleIndex) {
     const topSpacerHeight = Math.min(sectionGeometry.bodyHeight, minVisibleTop);
 

--- a/src/ui/diff/rowWindowing.ts
+++ b/src/ui/diff/rowWindowing.ts
@@ -13,6 +13,62 @@ export interface VisiblePlannedRowWindow {
   topSpacerHeight: number;
 }
 
+/** Find the first row whose bottom edge is after the visible top boundary. */
+function findFirstRowWithBottomAfter(rowBounds: DiffSectionGeometry["rowBounds"], top: number) {
+  let low = 0;
+  let high = rowBounds.length - 1;
+  let result = rowBounds.length;
+
+  while (low <= high) {
+    const mid = (low + high) >>> 1;
+    const rowBoundsEntry = rowBounds[mid]!;
+
+    if (rowBoundsEntry.top + rowBoundsEntry.height > top) {
+      result = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return result;
+}
+
+/** Find the last row whose top edge is before the visible bottom boundary. */
+function findLastRowWithTopBefore(rowBounds: DiffSectionGeometry["rowBounds"], bottom: number) {
+  let low = 0;
+  let high = rowBounds.length - 1;
+  let result = -1;
+
+  while (low <= high) {
+    const mid = (low + high) >>> 1;
+    const rowBoundsEntry = rowBounds[mid]!;
+
+    if (rowBoundsEntry.top < bottom) {
+      result = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return result;
+}
+
+/** Return whether one measured row overlaps the requested closed-open visible interval. */
+function rowOverlapsVisibleRange(
+  rowBounds: DiffSectionGeometry["rowBounds"][number],
+  minVisibleTop: number,
+  maxVisibleBottom: number,
+) {
+  if (rowBounds.height <= 0) {
+    return false;
+  }
+
+  const rowBottom = rowBounds.top + rowBounds.height;
+  return rowBottom > minVisibleTop && rowBounds.top < maxVisibleBottom;
+}
+
 /**
  * Slice planned rows down to the visible body range while preserving total section height.
  *
@@ -44,29 +100,35 @@ export function resolveVisiblePlannedRowWindow({
     visibleBodyBounds.top + Math.max(0, visibleBodyBounds.height),
   );
 
-  let firstVisibleIndex = -1;
-  let lastVisibleIndex = -1;
-
-  for (let index = 0; index < sectionGeometry.rowBounds.length; index += 1) {
-    const rowBounds = sectionGeometry.rowBounds[index]!;
-    if (rowBounds.height <= 0) {
-      continue;
-    }
-
-    const rowBottom = rowBounds.top + rowBounds.height;
-    // Treat each row as the half-open interval [row.top, row.bottom). If that interval does not
-    // overlap the visible file-body interval, the row can stay unmounted.
-    if (rowBottom <= minVisibleTop || rowBounds.top >= maxVisibleBottom) {
-      continue;
-    }
-
-    if (firstVisibleIndex < 0) {
-      firstVisibleIndex = index;
-    }
-    lastVisibleIndex = index;
+  let firstVisibleIndex = findFirstRowWithBottomAfter(sectionGeometry.rowBounds, minVisibleTop);
+  while (
+    firstVisibleIndex < sectionGeometry.rowBounds.length &&
+    !rowOverlapsVisibleRange(
+      sectionGeometry.rowBounds[firstVisibleIndex]!,
+      minVisibleTop,
+      maxVisibleBottom,
+    )
+  ) {
+    firstVisibleIndex += 1;
   }
 
-  if (firstVisibleIndex < 0 || lastVisibleIndex < 0) {
+  let lastVisibleIndex = findLastRowWithTopBefore(sectionGeometry.rowBounds, maxVisibleBottom);
+  while (
+    lastVisibleIndex >= 0 &&
+    !rowOverlapsVisibleRange(
+      sectionGeometry.rowBounds[lastVisibleIndex]!,
+      minVisibleTop,
+      maxVisibleBottom,
+    )
+  ) {
+    lastVisibleIndex -= 1;
+  }
+
+  if (firstVisibleIndex >= sectionGeometry.rowBounds.length) {
+    firstVisibleIndex = -1;
+  }
+
+  if (firstVisibleIndex < 0 || lastVisibleIndex < 0 || firstVisibleIndex > lastVisibleIndex) {
     const topSpacerHeight = Math.min(sectionGeometry.bodyHeight, minVisibleTop);
 
     return {

--- a/src/ui/lib/fileSectionLayout.test.ts
+++ b/src/ui/lib/fileSectionLayout.test.ts
@@ -54,5 +54,24 @@ describe("fileSectionLayout helpers", () => {
       "gamma",
     ]);
     expect(Array.from(collectIntersectingFileSectionIds(layouts, 20, 24))).toEqual([]);
+    expect(Array.from(collectIntersectingFileSectionIds(layouts, 10, 6))).toEqual([]);
+  });
+
+  test("collectIntersectingFileSectionIds handles large ordered layout lists", () => {
+    const manyLayouts: FileSectionLayout[] = Array.from({ length: 10_000 }, (_, index) => ({
+      fileId: `file:${index}`,
+      sectionIndex: index,
+      sectionTop: index * 3,
+      headerTop: index * 3,
+      bodyTop: index * 3,
+      bodyHeight: 2,
+      sectionBottom: index * 3 + 2,
+    }));
+
+    expect(Array.from(collectIntersectingFileSectionIds(manyLayouts, 15_000, 15_006))).toEqual([
+      "file:5000",
+      "file:5001",
+      "file:5002",
+    ]);
   });
 });

--- a/src/ui/lib/fileSectionLayout.ts
+++ b/src/ui/lib/fileSectionLayout.ts
@@ -96,6 +96,30 @@ export function findFileSectionAtOffset(fileSectionLayouts: FileSectionLayout[],
   return lastSection;
 }
 
+/** Find the first section whose bottom edge can intersect a range starting at `minY`. */
+function findFirstPotentiallyIntersectingSectionIndex(
+  fileSectionLayouts: FileSectionLayout[],
+  minY: number,
+) {
+  let low = 0;
+  let high = fileSectionLayouts.length - 1;
+  let result = fileSectionLayouts.length;
+
+  while (low <= high) {
+    const mid = (low + high) >>> 1;
+    const layout = fileSectionLayouts[mid]!;
+
+    if (layout.sectionBottom >= minY) {
+      result = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return result;
+}
+
 /** Collect every file section that intersects one absolute review-stream range. */
 export function collectIntersectingFileSectionIds(
   fileSectionLayouts: FileSectionLayout[],
@@ -103,11 +127,20 @@ export function collectIntersectingFileSectionIds(
   maxY: number,
 ) {
   const next = new Set<string>();
+  if (fileSectionLayouts.length === 0 || maxY < minY) {
+    return next;
+  }
 
-  for (const layout of fileSectionLayouts) {
-    if (layout.sectionBottom >= minY && layout.sectionTop <= maxY) {
-      next.add(layout.fileId);
+  // Layouts are ordered by stream position. Binary-search to the first section that can overlap
+  // the range, then only walk the visible/overscan run instead of every file in huge reviews.
+  const startIndex = findFirstPotentiallyIntersectingSectionIndex(fileSectionLayouts, minY);
+  for (let index = startIndex; index < fileSectionLayouts.length; index += 1) {
+    const layout = fileSectionLayouts[index]!;
+    if (layout.sectionTop > maxY) {
+      break;
     }
+
+    next.add(layout.fileId);
   }
 
   return next;


### PR DESCRIPTION
## Summary

- use binary search to find the first file section that can intersect a viewport/overscan range
- use binary search to find row-window slice boundaries inside a file body
- keep zero-height structural rows attached to visible row slices
- add large-list coverage for both lookup paths

## Benchmark notes

With `@pierre/diffs` kept at the current main version (`1.1.19`), focused local benchmarks were broadly neutral on default fixtures:

- `large-stream/cold_first_frame_ms`: `58.18ms → 59.60ms`
- `large-stream/windowed_scroll_ticks_ms`: `595.0ms → 605.3ms`
- `render-layout/large_single_file_review_plan_ms`: `15.53ms → 11.59ms`

The expected benefit is mostly for pathological huge review streams / huge file body windows where the old paths scanned from the beginning.

## Validation

- `bun install` to restore main's locked Pierre version before measuring this branch
- `bun test src/ui/lib/fileSectionLayout.test.ts src/ui/diff/rowWindowing.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run bench -- --samples 3 --script render-layout.ts --script large-stream.ts --out /tmp/hunk-perf/windowing-only-1.1.19.json`

*This PR description was generated by Pi using OpenAI GPT-5*
