### PR TITLE
fix: pin pierre diffs dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Fixed npm installs by pinning `@pierre/diffs` to the version Hunk is tested with instead of allowing the broken `1.2.6` release.
+
 ## [0.14.0] - 2026-05-26
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hunk",
       "dependencies": {
-        "@pierre/diffs": "^1.2.2",
+        "@pierre/diffs": "1.2.2",
         "bun": "^1.3.10",
         "commander": "^14.0.3",
         "diff": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "nix:update-lock": "nix run .#update-bun-lock"
   },
   "dependencies": {
-    "@pierre/diffs": "^1.2.2",
+    "@pierre/diffs": "1.2.2",
     "bun": "^1.3.10",
     "commander": "^14.0.3",
     "diff": "^8.0.3",


### PR DESCRIPTION
## Summary

- Pin `@pierre/diffs` to `1.2.2` instead of allowing newer `1.x` releases.
- Document the npm install fix in the changelog.

## Why

Fresh `npm i -g hunkdiff` resolves the previous semver range to `@pierre/diffs@1.2.6`, which was published with `catalog:` dependency specifiers that npm cannot install.

## Verification

- `bun run typecheck`
- `bun test scripts/prebuilt-package-helpers.test.ts`
- Local npm pack + global install smoke with `npm@11.5.1`

*This PR description was generated by Pi using GPT-5.1*
