### PR TITLE
chore(release): prepare 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.14.1] - 2026-06-01
+
+### Added
+
 - Added local performance benchmarks for Hunk startup, loading, rendering, highlighting, navigation, memory, and optional competitor comparisons.
 
 ### Changed
@@ -378,7 +386,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Stabilized diff repainting, active-hunk scrolling, syntax highlighting, pager stdin patch handling, and terminal cleanup on exit.
 
-[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/modem-dev/hunk/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/modem-dev/hunk/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/modem-dev/hunk/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/modem-dev/hunk/compare/v0.12.1...v0.13.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Bump `hunkdiff` to `0.14.1`.
- Move the npm install fix into the `0.14.1` changelog section.
- Reset the Unreleased section and update changelog compare links.

## Verification

- `bun run typecheck`
- `bun run ./scripts/check-release-version.ts v0.14.1`

*This PR description was generated by Pi using GPT-5.1*
