### PR TITLE
feat(ui): add Zenburn built-in theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable user-visible changes to Hunk are documented in this file.
 ### Added
 
 - Show the newly selected theme in the footer status bar when switching themes.
+- Added a Zenburn built-in theme (`theme = "zenburn"`), a warm low-contrast dark palette inspired by Jani Nurminen's original Zenburn. It also works as a custom-theme `base`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can persist preferences to a config file:
 Example:
 
 ```toml
-theme = "graphite"   # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha, custom
+theme = "graphite"   # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha, zenburn, custom
 mode = "auto"        # auto, split, stack
 vcs = "git"          # git, jj
 watch = false
@@ -137,7 +137,7 @@ Custom themes can inherit from any built-in base theme and override only the col
 theme = "custom"
 
 [custom_theme]
-base = "graphite"    # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha
+base = "graphite"    # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha, zenburn
 label = "My Theme"
 accent = "#7fd1ff"
 panel = "#10161d"

--- a/docs/opentui-component.md
+++ b/docs/opentui-component.md
@@ -190,19 +190,19 @@ If you need direct access to Pierre's parser, `parsePatchFiles(...)` is still re
 
 ## Common props
 
-| Prop                 | Type                                                                                         | Default      | Notes                                                                               |
-| -------------------- | -------------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
-| `layout`             | `"split" \| "stack"`                                                                         | `"split"`    | Chooses side-by-side or stacked rendering.                                          |
-| `width`              | `number`                                                                                     | —            | Required content width in terminal columns.                                         |
-| `theme`              | `"graphite" \| "midnight" \| "paper" \| "ember" \| "catppuccin-latte" \| "catppuccin-mocha"` | `"graphite"` | Matches Hunk's built-in themes.                                                     |
-| `showLineNumbers`    | `boolean`                                                                                    | `true`       | Toggles line-number columns.                                                        |
-| `showHunkHeaders`    | `boolean`                                                                                    | `true`       | Toggles `@@ ... @@` hunk header rows.                                               |
-| `showFileSeparators` | `boolean`                                                                                    | `true`       | Toggles separator rows between files in `HunkReviewStream`.                         |
-| `wrapLines`          | `boolean`                                                                                    | `false`      | Wraps long lines instead of clipping horizontally.                                  |
-| `horizontalOffset`   | `number`                                                                                     | `0`          | Scroll offset for non-wrapped code rows.                                            |
-| `highlight`          | `boolean`                                                                                    | `true`       | Enables syntax highlighting.                                                        |
-| `selectedHunkIndex`  | `number`                                                                                     | `0`          | Highlights one hunk as the active target for single-file components.                |
-| `scrollable`         | `boolean`                                                                                    | `true`       | `HunkDiffView` only; primitives should be wrapped in OpenTUI scrollbox when needed. |
+| Prop                 | Type                                                                                                      | Default      | Notes                                                                               |
+| -------------------- | --------------------------------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `layout`             | `"split" \| "stack"`                                                                                      | `"split"`    | Chooses side-by-side or stacked rendering.                                          |
+| `width`              | `number`                                                                                                  | —            | Required content width in terminal columns.                                         |
+| `theme`              | `"graphite" \| "midnight" \| "paper" \| "ember" \| "catppuccin-latte" \| "catppuccin-mocha" \| "zenburn"` | `"graphite"` | Matches Hunk's built-in themes.                                                     |
+| `showLineNumbers`    | `boolean`                                                                                                 | `true`       | Toggles line-number columns.                                                        |
+| `showHunkHeaders`    | `boolean`                                                                                                 | `true`       | Toggles `@@ ... @@` hunk header rows.                                               |
+| `showFileSeparators` | `boolean`                                                                                                 | `true`       | Toggles separator rows between files in `HunkReviewStream`.                         |
+| `wrapLines`          | `boolean`                                                                                                 | `false`      | Wraps long lines instead of clipping horizontally.                                  |
+| `horizontalOffset`   | `number`                                                                                                  | `0`          | Scroll offset for non-wrapped code rows.                                            |
+| `highlight`          | `boolean`                                                                                                 | `true`       | Enables syntax highlighting.                                                        |
+| `selectedHunkIndex`  | `number`                                                                                                  | `0`          | Highlights one hunk as the active target for single-file components.                |
+| `scrollable`         | `boolean`                                                                                                 | `true`       | `HunkDiffView` only; primitives should be wrapped in OpenTUI scrollbox when needed. |
 
 ## Other exports
 

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -144,24 +144,29 @@ describe("config resolution", () => {
     });
   });
 
-  test.each(["graphite", "midnight", "paper", "ember", "catppuccin-latte", "catppuccin-mocha"])(
-    "accepts custom theme base id: %s",
-    (base) => {
-      const home = createTempDir("hunk-config-home-");
-      mkdirSync(join(home, ".config", "hunk"), { recursive: true });
-      writeFileSync(
-        join(home, ".config", "hunk", "config.toml"),
-        ["[custom_theme]", `base = "${base}"`].join("\n"),
-      );
+  test.each([
+    "graphite",
+    "midnight",
+    "paper",
+    "ember",
+    "catppuccin-latte",
+    "catppuccin-mocha",
+    "zenburn",
+  ])("accepts custom theme base id: %s", (base) => {
+    const home = createTempDir("hunk-config-home-");
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(
+      join(home, ".config", "hunk", "config.toml"),
+      ["[custom_theme]", `base = "${base}"`].join("\n"),
+    );
 
-      const resolved = resolveConfiguredCliInput(createPatchPagerInput(), {
-        cwd: createTempDir("hunk-config-cwd-"),
-        env: { HOME: home },
-      });
+    const resolved = resolveConfiguredCliInput(createPatchPagerInput(), {
+      cwd: createTempDir("hunk-config-cwd-"),
+      env: { HOME: home },
+    });
 
-      expect(resolved.customTheme).toEqual({ base });
-    },
-  );
+    expect(resolved.customTheme).toEqual({ base });
+  });
 
   test("rejects invalid custom theme base ids", () => {
     const home = createTempDir("hunk-config-home-");
@@ -177,7 +182,7 @@ describe("config resolution", () => {
         env: { HOME: home },
       }),
     ).toThrow(
-      "Expected custom_theme.base to be one of: graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha.",
+      "Expected custom_theme.base to be one of: graphite, midnight, paper, ember, catppuccin-latte, catppuccin-mocha, zenburn.",
     );
   });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -19,6 +19,7 @@ const BUILT_IN_THEME_IDS = [
   "ember",
   "catppuccin-latte",
   "catppuccin-mocha",
+  "zenburn",
 ] as const;
 const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
 const CUSTOM_THEME_COLOR_KEYS = [

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -162,6 +162,7 @@ describe("OpenTUI public components", () => {
       "ember",
       "catppuccin-latte",
       "catppuccin-mocha",
+      "zenburn",
     ]);
   });
 });

--- a/src/opentui/themes.ts
+++ b/src/opentui/themes.ts
@@ -5,6 +5,7 @@ export const HUNK_DIFF_THEME_NAMES = [
   "ember",
   "catppuccin-latte",
   "catppuccin-mocha",
+  "zenburn",
 ] as const;
 
 export type HunkDiffThemeName = (typeof HUNK_DIFF_THEME_NAMES)[number];

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -195,7 +195,15 @@ describe("ui helpers", () => {
       menus.theme
         .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
         .map((entry) => entry.label),
-    ).toEqual(["Graphite", "Midnight", "Paper", "Ember", "Catppuccin Latte", "Catppuccin Mocha"]);
+    ).toEqual([
+      "Graphite",
+      "Midnight",
+      "Paper",
+      "Ember",
+      "Catppuccin Latte",
+      "Catppuccin Mocha",
+      "Zenburn",
+    ]);
     expect(
       menus.theme.some(
         (entry) => entry.kind === "item" && entry.label === "Graphite" && entry.checked,
@@ -249,6 +257,7 @@ describe("ui helpers", () => {
       "Ember",
       "Catppuccin Latte",
       "Catppuccin Mocha",
+      "Zenburn",
       "My Theme",
     ]);
     expect(

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -90,4 +90,21 @@ describe("themes", () => {
       punctuation: CATPPUCCIN_PALETTES.mocha.overlay2,
     });
   });
+
+  test("resolves Zenburn by theme id with its tuned dark palette", () => {
+    const zenburn = resolveTheme("zenburn", null);
+
+    expect(zenburn.id).toBe("zenburn");
+    expect(zenburn.label).toBe("Zenburn");
+    expect(zenburn.appearance).toBe("dark");
+    expect(zenburn.background).toBe("#3f3f3f");
+    expect(zenburn.text).toBe("#dcdccc");
+    expect(zenburn.syntaxColors).toMatchObject({
+      keyword: "#f0dfaf",
+      string: "#dca3a3",
+      comment: "#60b48a",
+      function: "#94bff3",
+      type: "#94bff3",
+    });
+  });
 });

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -7,6 +7,7 @@ import { MIDNIGHT_THEME } from "./themes/midnight";
 import { PAPER_THEME } from "./themes/paper";
 import { withLazySyntaxStyle } from "./themes/syntax";
 import type { AppTheme, ThemeBase } from "./themes/types";
+import { ZENBURN_THEME } from "./themes/zenburn";
 
 export { CATPPUCCIN_PALETTES } from "./themes/catppuccin";
 export type { AppTheme, SyntaxColors, ThemeBase } from "./themes/types";
@@ -18,6 +19,7 @@ export const THEMES: AppTheme[] = [
   EMBER_THEME,
   CATPPUCCIN_LATTE_THEME,
   CATPPUCCIN_MOCHA_THEME,
+  ZENBURN_THEME,
 ];
 
 /** Return the built-in theme by id so config-defined themes can inherit from it. */

--- a/src/ui/themes/zenburn.ts
+++ b/src/ui/themes/zenburn.ts
@@ -1,0 +1,57 @@
+import { withLazySyntaxStyle } from "./syntax";
+import type { AppTheme } from "./types";
+
+/**
+ * Zenburn — a warm, low-contrast dark theme by @ramin, inspired by and slightly
+ * modified from the original Zenburn by Jani Nurminen. Warm off-white text,
+ * cyan-blue functions and types, sage comments, and dusty-red strings.
+ */
+export const ZENBURN_THEME: AppTheme = withLazySyntaxStyle(
+  {
+    id: "zenburn",
+    label: "Zenburn",
+    appearance: "dark",
+    background: "#3f3f3f",
+    panel: "#3a3a3a",
+    panelAlt: "#313633",
+    border: "#4d4d4d",
+    accent: "#93e0e3",
+    accentMuted: "#709080",
+    text: "#dcdccc",
+    muted: "#709080",
+    addedBg: "#2e3d30",
+    removedBg: "#43302f",
+    contextBg: "#393939",
+    addedContentBg: "#3a4d3c",
+    removedContentBg: "#553a39",
+    contextContentBg: "#3f3f3f",
+    addedSignColor: "#60b48a",
+    removedSignColor: "#dca3a3",
+    lineNumberBg: "#3a3a3a",
+    lineNumberFg: "#709080",
+    selectedHunk: "#4a554d",
+    badgeAdded: "#60b48a",
+    badgeRemoved: "#dca3a3",
+    badgeNeutral: "#c3bf9f",
+    fileNew: "#60b48a",
+    fileDeleted: "#dca3a3",
+    fileRenamed: "#e0cf9f",
+    fileModified: "#e0cf9f",
+    fileUntracked: "#8cd0d3",
+    noteBorder: "#dc8cc3",
+    noteBackground: "#3a3340",
+    noteTitleBackground: "#46394e",
+    noteTitleText: "#f0e6f5",
+  },
+  {
+    default: "#dcdccc",
+    keyword: "#f0dfaf",
+    string: "#dca3a3",
+    comment: "#60b48a",
+    number: "#8cd0d3",
+    function: "#94bff3",
+    property: "#c3bf9f",
+    type: "#94bff3",
+    punctuation: "#dcdccc",
+  },
+);


### PR DESCRIPTION
## Summary

Adds the classic **Zenburn** (https://en.wikipedia.org/wiki/Wikipedia:Zenburn) as a built-in theme (`theme = "zenburn"`), also usable as a `[custom_theme]` base. 

Encouraged to submit after an online interaction with @benvinegar showing my personal config to use the theme.

```
A warm, low-contrast dark palette — by @ramin, inspired by and slightly modified from the original [Zenburn (https://github.com/jnurmine/Zenburn) by Jani Nurminen. Warm off-white text, cyan-blue functions and types, sage comments, dusty-red strings.
```

  ## Changes

  - New `src/ui/themes/zenburn.ts`, following the existing single-theme pattern (ember/graphite).
  - Registered in `THEMES` and `BUILT_IN_THEME_IDS` (works as a custom-theme `base`).
  - Added to the `hunkdiff/opentui` theme-name union and the component docs.
  - README + CHANGELOG updated; theme/config/opentui tests extended for the new id and label.

  ## Validation

  `typecheck`, `oxlint`, and `oxfmt --check` clean; theme, config, and opentui suites pass.

  ## Screenshot

<img width="1621" height="575" alt="zenburn" src="https://github.com/user-attachments/assets/57148653-b3de-431e-999c-701e33dff126" />

Pairs with. the fix from https://github.com/modem-dev/hunk/pull/393 to allow the theme to be more accurate across keywords

## Follow ups

- personally would be inclined to alphabet sort the themes in some of this, and organize some imports, but wanted to scope this to JUST the theme as much as possible. Would be happy to follow up with some sorting if welcome

Thank you!