### PR TITLE
fix(ui): preserve CJK scroll alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Preserved split diff alignment when horizontal scrolling starts inside a wide CJK or emoji character.
 - Made diff syntax highlighting follow the active theme: keyword, function, number, and variable token colors now resolve to the configured theme's palette (including custom themes) in both light and dark, instead of passing through Pierre's built-in syntax colors.
 - Expanded the diff window during rapid scrolling bursts so large reviews keep real rows mounted instead of falling back to blank placeholder regions.
 

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -53,6 +53,11 @@ export function sliceTextByWidth(text: string, offset: number, width: number) {
       continue;
     }
     if (clusterStart < startOffset) {
+      const hiddenCellWidth = Math.min(clusterEnd, startOffset + maxWidth) - startOffset;
+      if (hiddenCellWidth > 0) {
+        visibleText += " ".repeat(hiddenCellWidth);
+        usedWidth += hiddenCellWidth;
+      }
       continue;
     }
     if (usedWidth + clusterWidth > maxWidth) {

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -315,6 +315,8 @@ describe("ui helpers", () => {
     expect(measureTextWidth("日本語")).toBe(6);
     expect(sliceTextByWidth("a日本b", 1, 4)).toEqual({ text: "日本", width: 4 });
     expect(sliceTextByWidth("a日本b", 2, 4)).toEqual({ text: " 本b", width: 4 });
+    expect(sliceTextByWidth("日本b", 3, 3)).toEqual({ text: " b", width: 2 });
+    expect(sliceTextByWidth("日", 1, 1)).toEqual({ text: " ", width: 1 });
     expect(fitText("日本語", 5)).toBe("日本.");
     expect(measureTextWidth(padText("日本", 6))).toBe(6);
   });

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -314,7 +314,7 @@ describe("ui helpers", () => {
   test("text helpers measure and slice wide characters by terminal cells", () => {
     expect(measureTextWidth("日本語")).toBe(6);
     expect(sliceTextByWidth("a日本b", 1, 4)).toEqual({ text: "日本", width: 4 });
-    expect(sliceTextByWidth("a日本b", 2, 4)).toEqual({ text: "本b", width: 3 });
+    expect(sliceTextByWidth("a日本b", 2, 4)).toEqual({ text: " 本b", width: 4 });
     expect(fitText("日本語", 5)).toBe("日本.");
     expect(measureTextWidth(padText("日本", 6))).toBe(6);
   });


### PR DESCRIPTION
## Summary

- Preserve the blank half-cell when horizontal scrolling starts inside a fullwidth CJK/emoji grapheme.
- Add regression coverage for `sliceTextByWidth("a日本b", 2, 4)` so subsequent content no longer shifts left.
- Document the user-visible fix in the changelog.

## Testing

- `bun test src/ui/lib/ui-lib.test.ts`
- `bun run typecheck`
- `bun run format:check`

This ports the still-relevant alignment edge case from #287 without taking the stale broader CJK implementation.

*This PR description was generated by Pi using OpenAI GPT-5*
