### PR TITLE
chore(release): prepare 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.15.0] - 2026-06-08
+
+### Added
+
 - Show the newly selected theme in the footer status bar when switching themes.
 - Added Catppuccin Frappé and Macchiato as built-in themes, completing the four official Catppuccin flavors.
 - Added a Zenburn built-in theme (`theme = "zenburn"`), a warm low-contrast dark palette inspired by Jani Nurminen's original Zenburn. It also works as a custom-theme `base`.
@@ -396,7 +404,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Stabilized diff repainting, active-hunk scrolling, syntax highlighting, pager stdin patch handling, and terminal cleanup on exit.
 
-[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/modem-dev/hunk/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/modem-dev/hunk/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/modem-dev/hunk/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/modem-dev/hunk/compare/v0.13.0...v0.13.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Bump `hunkdiff` to `0.15.0`.
- Move the current Unreleased changelog entries into a dated `0.15.0` section.
- Reset Unreleased and update changelog compare links for the next cycle.

## Release highlights

- Sapling backend support for `hunk diff` and `hunk show`.
- Transparent background support via flag/config.
- New Catppuccin Frappé, Catppuccin Macchiato, and Zenburn themes, plus selected-theme footer display.
- Fixes for CJK/emoji split-scroll alignment, theme-aware syntax highlighting, and rapid-scroll diff windowing.

## Verification

- `bun run typecheck`
- `bun test`

*This PR description was generated by Pi using OpenAI GPT-5*