### PR TITLE
fix: restore edit-selected-file keyboard shortcut (e key)

### DIFF
--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -48,6 +48,7 @@ export function HelpDialog({
         ["a", "toggle AI notes"],
         ["z", "toggle unchanged context"],
         ["l / w / m", "lines / wrap / metadata"],
+        ["e", "open file in $EDITOR"],
       ],
     },
     {

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2235,13 +2235,13 @@ describe("UI components", () => {
     const frame = await captureFrame(
       <HelpDialog
         canRefresh={true}
-        terminalHeight={38}
+        terminalHeight={39}
         terminalWidth={76}
         theme={theme}
         onClose={() => {}}
       />,
       76,
-      38,
+      39,
     );
 
     const expectedRows = [

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2268,6 +2268,7 @@ describe("UI components", () => {
       "a               toggle AI notes",
       "z               toggle unchanged context",
       "l / w / m       lines / wrap / metadata",
+      "e               open file in $EDITOR",
       "Review",
       "/               focus file filter",
       "c               create review note",

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -108,6 +108,7 @@ export function useAppKeyboardShortcuts({
   toggleGapForSelectedHunk,
   toggleHelp,
   toggleHunkHeaders,
+  triggerEditSelectedFile,
   toggleLineNumbers,
   toggleLineWrap,
   toggleSidebar,
@@ -463,6 +464,11 @@ export function useAppKeyboardShortcuts({
 
     if (key.name === "z" || key.sequence === "z") {
       runAndCloseMenu(toggleGapForSelectedHunk);
+      return;
+    }
+
+    if (key.name === "e" || key.sequence === "e") {
+      runAndCloseMenu(triggerEditSelectedFile);
       return;
     }
 

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -87,6 +87,7 @@ export function buildAppMenus({
     {
       kind: "item",
       label: "Open file in editor",
+      hint: "e",
       action: triggerEditSelectedFile,
     },
   ];


### PR DESCRIPTION
Re-add support for the 'e' key to open the selected file in $EDITOR. Update help dialog to document the restored shortcut.

prolly from a silent merge conflict of #310 and #303