### PR TITLE
chore(release): prepare 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+## [0.15.1] - 2026-06-09
+
+### Fixed
+
+- Restored the `e` keyboard shortcut and menu hint for opening the selected file in `$EDITOR`.
+
 ## [0.15.0] - 2026-06-08
 
 ### Added
@@ -404,7 +410,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 - Stabilized diff repainting, active-hunk scrolling, syntax highlighting, pager stdin patch handling, and terminal cleanup on exit.
 
-[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/modem-dev/hunk/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/modem-dev/hunk/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/modem-dev/hunk/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/modem-dev/hunk/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/modem-dev/hunk/compare/v0.13.1...v0.14.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Bump hunkdiff to 0.15.1
- Move the restored editor shortcut fix into the 0.15.1 changelog section
- Update changelog comparison links for the new patch release

## Tests

- bun run format:check
- bun run typecheck
- bun test

*This PR description was generated by Pi using OpenAI GPT-5.1 Codex*