### PR TITLE
fix(git): avoid optional status locks in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Prevented Git watch polling from taking optional index locks while discovering untracked files.
+
 ## [0.15.1] - 2026-06-09
 
 ### Fixed

--- a/src/core/git.test.ts
+++ b/src/core/git.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   buildGitDiffArgs,
   buildGitStashShowArgs,
+  buildGitStatusArgs,
   resolveGitDiffEndpoints,
   runGitText,
 } from "./git";
@@ -82,6 +83,16 @@ describe("git command helpers", () => {
     });
 
     expect(args).toContain("--no-ext-diff");
+  });
+
+  test("prevents optional index locks while discovering untracked files", () => {
+    expect(buildGitStatusArgs(makeGitInput())).toEqual([
+      "--no-optional-locks",
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+    ]);
   });
 
   test("reports a friendly error when git is not installed or not on PATH", () => {

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -142,8 +142,8 @@ export function buildGitDiffNumstatArgs(input: VcsCommandInput) {
 }
 
 /** Build the porcelain status query used to discover untracked files for working-tree review. */
-function buildGitStatusArgs(input: VcsCommandInput) {
-  const args = ["status", "--porcelain=v1", "-z", "--untracked-files=all"];
+export function buildGitStatusArgs(input: VcsCommandInput) {
+  const args = ["--no-optional-locks", "status", "--porcelain=v1", "-z", "--untracked-files=all"];
 
   appendGitPathspecs(args, input.pathspecs);
   return args;


### PR DESCRIPTION
## Summary

- Run Git's untracked-file status query with `--no-optional-locks` so watch polling does not refresh the index under an optional lock.
- Add coverage for the exact status argv used by working-tree untracked discovery.
- Document the user-visible fix in the changelog.

Fixes #398.

## Testing

- `bun test src/core/git.test.ts`
- `bun run typecheck`
- `bun test`
- Manual watch-mode check with a wrapper `git` executable confirmed `hunk diff --watch` now invokes `git --no-optional-locks status --porcelain=v1 -z --untracked-files=all` for status polling.

*This PR description was generated by Pi using OpenAI GPT-5*
