### PR TITLE
fix(ui): keep popups opaque in transparent mode

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -954,7 +954,7 @@ export function App({
             activeMenuSpec={activeMenuSpec}
             activeMenuWidth={activeMenuWidth}
             terminalWidth={terminal.width}
-            theme={activeTheme}
+            theme={baseTheme}
             onHoverItem={setActiveMenuItemIndex}
             onSelectItem={(entry) => {
               entry.action();
@@ -970,7 +970,7 @@ export function App({
             canRefresh={canRefreshCurrentInput}
             terminalHeight={terminal.height}
             terminalWidth={terminal.width}
-            theme={activeTheme}
+            theme={baseTheme}
             onClose={closeHelp}
           />
         </Suspense>

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -14,6 +14,7 @@ import type {
 import type { AppBootstrap, LayoutMode } from "../core/types";
 import { createTestVcsAppBootstrap } from "../../test/helpers/app-bootstrap";
 import { createTestDiffFile as buildTestDiffFile, lines } from "../../test/helpers/diff-helpers";
+import { resolveTheme } from "./themes";
 
 const { loadAppBootstrap } = await import("../core/loaders");
 const { AppHost } = await import("./AppHost");
@@ -449,6 +450,35 @@ async function waitForFrame(
   }
 
   return frame;
+}
+
+/** Convert captured RGBA output back into a #rrggbb color string for background assertions. */
+function capturedColorToHex(color: { buffer?: ArrayLike<number> } | undefined) {
+  const buffer = color?.buffer;
+  if (!buffer || buffer[0] == null || buffer[1] == null || buffer[2] == null) {
+    return null;
+  }
+
+  const componentToHex = (value: number) =>
+    Math.max(0, Math.min(255, Math.round(value * 255)))
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${componentToHex(buffer[0])}${componentToHex(buffer[1])}${componentToHex(buffer[2])}`;
+}
+
+/** Return whether rendered text has the expected inherited background color. */
+function hasLineWithBackground(
+  frame: ReturnType<Awaited<ReturnType<typeof testRender>>["captureSpans"]>,
+  text: string,
+  backgroundColor: string,
+) {
+  return frame.lines.some((line) =>
+    line.spans.map((span) => span.text).join("").includes(text) &&
+      line.spans.some(
+        (span) => capturedColorToHex(span.bg)?.toLowerCase() === backgroundColor.toLowerCase(),
+      ),
+  );
 }
 
 /** Open the top-level Theme menu and wait for the expected active light theme marker. */
@@ -2360,6 +2390,48 @@ describe("App interactions", () => {
       frame = setup.captureCharFrame();
       expect(frame).toContain("Toggle files/filter focus");
       expect(frame).not.toContain("Controls help");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("transparent background keeps menus and help dialog opaque", async () => {
+    const bootstrap = createBootstrap();
+    bootstrap.input.options.transparentBackground = true;
+    const theme = resolveTheme(bootstrap.initialTheme, null);
+    const setup = await testRender(<AppHost bootstrap={bootstrap} />, {
+      width: 220,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.pressKey("F10");
+      });
+      const menuFrame = await waitForFrame(
+        setup,
+        (frame) => frame.includes("Toggle files/filter focus"),
+        12,
+      );
+      expect(menuFrame).toContain("Toggle files/filter focus");
+      expect(
+        hasLineWithBackground(setup.captureSpans(), "Toggle files/filter focus", theme.accentMuted),
+      ).toBe(true);
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("left");
+      });
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      const helpFrame = await waitForFrame(setup, (frame) => frame.includes("Navigation"), 12);
+      expect(helpFrame).toContain("Controls help");
+      expect(hasLineWithBackground(setup.captureSpans(), "Navigation", theme.panel)).toBe(true);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -13,6 +13,7 @@ import type {
 } from "../hunk-session/types";
 import type { AppBootstrap, LayoutMode } from "../core/types";
 import { createTestVcsAppBootstrap } from "../../test/helpers/app-bootstrap";
+import { capturedTestColorToHex } from "../../test/helpers/test-color-helpers";
 import { createTestDiffFile as buildTestDiffFile, lines } from "../../test/helpers/diff-helpers";
 import { resolveTheme } from "./themes";
 
@@ -452,33 +453,36 @@ async function waitForFrame(
   return frame;
 }
 
-/** Convert captured RGBA output back into a #rrggbb color string for background assertions. */
-function capturedColorToHex(color: { buffer?: ArrayLike<number> } | undefined) {
-  const buffer = color?.buffer;
-  if (!buffer || buffer[0] == null || buffer[1] == null || buffer[2] == null) {
-    return null;
-  }
-
-  const componentToHex = (value: number) =>
-    Math.max(0, Math.min(255, Math.round(value * 255)))
-      .toString(16)
-      .padStart(2, "0");
-
-  return `#${componentToHex(buffer[0])}${componentToHex(buffer[1])}${componentToHex(buffer[2])}`;
-}
-
 /** Return whether rendered text has the expected inherited background color. */
 function hasLineWithBackground(
   frame: ReturnType<Awaited<ReturnType<typeof testRender>>["captureSpans"]>,
   text: string,
   backgroundColor: string,
 ) {
-  return frame.lines.some((line) =>
-    line.spans.map((span) => span.text).join("").includes(text) &&
-      line.spans.some(
-        (span) => capturedColorToHex(span.bg)?.toLowerCase() === backgroundColor.toLowerCase(),
-      ),
-  );
+  return frame.lines.some((line) => {
+    const lineText = line.spans.map((span) => span.text).join("");
+    const matchStart = lineText.indexOf(text);
+
+    if (matchStart < 0) {
+      return false;
+    }
+
+    const matchEnd = matchStart + text.length;
+    let spanStart = 0;
+    const matchingSpans = line.spans.filter((span) => {
+      const spanEnd = spanStart + span.text.length;
+      const overlapsMatch = spanStart < matchEnd && spanEnd > matchStart;
+      spanStart = spanEnd;
+      return overlapsMatch;
+    });
+
+    return (
+      matchingSpans.length > 0 &&
+      matchingSpans.every(
+        (span) => capturedTestColorToHex(span.bg)?.toLowerCase() === backgroundColor.toLowerCase(),
+      )
+    );
+  });
 }
 
 /** Open the top-level Theme menu and wait for the expected active light theme marker. */
@@ -2418,8 +2422,9 @@ describe("App interactions", () => {
         12,
       );
       expect(menuFrame).toContain("Toggle files/filter focus");
+      expect(menuFrame).toContain("Focus filter");
       expect(
-        hasLineWithBackground(setup.captureSpans(), "Toggle files/filter focus", theme.accentMuted),
+        hasLineWithBackground(setup.captureSpans(), "Focus filter", theme.panel),
       ).toBe(true);
 
       await act(async () => {

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -2423,9 +2423,7 @@ describe("App interactions", () => {
       );
       expect(menuFrame).toContain("Toggle files/filter focus");
       expect(menuFrame).toContain("Focus filter");
-      expect(
-        hasLineWithBackground(setup.captureSpans(), "Focus filter", theme.panel),
-      ).toBe(true);
+      expect(hasLineWithBackground(setup.captureSpans(), "Focus filter", theme.panel)).toBe(true);
 
       await act(async () => {
         await setup.mockInput.pressArrow("left");

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -4,6 +4,7 @@ import { testRender } from "@opentui/react/test-utils";
 import { act, createRef, useEffect, useState, type ReactNode } from "react";
 import type { AppBootstrap, DiffFile } from "../../core/types";
 import { createTestVcsAppBootstrap } from "../../../test/helpers/app-bootstrap";
+import { capturedTestColorToHex } from "../../../test/helpers/test-color-helpers";
 import {
   createTestDiffFile as buildTestDiffFile,
   createTestSourceFetcher,
@@ -372,21 +373,6 @@ function frameHasHighlightedMarker(
   });
 }
 
-/** Convert captured RGBA output back into a #rrggbb color string for contrast assertions. */
-function capturedColorToHex(color: { buffer?: ArrayLike<number> } | undefined) {
-  const buffer = color?.buffer;
-  if (!buffer || buffer[0] == null || buffer[1] == null || buffer[2] == null) {
-    return null;
-  }
-
-  const componentToHex = (value: number) =>
-    Math.max(0, Math.min(255, Math.round(value * 255)))
-      .toString(16)
-      .padStart(2, "0");
-
-  return `#${componentToHex(buffer[0])}${componentToHex(buffer[1])}${componentToHex(buffer[2])}`;
-}
-
 /** Measure the rendered background contrast between one word-diff span and its surrounding line. */
 function renderedWordDiffBackgroundDistance(
   frame: { lines: Array<{ spans: Array<{ text: string; bg?: { buffer?: ArrayLike<number> } }> }> },
@@ -398,8 +384,8 @@ function renderedWordDiffBackgroundDistance(
       continue;
     }
 
-    const wordBg = capturedColorToHex(line.spans[spanIndex]?.bg);
-    const surroundingBg = capturedColorToHex(line.spans[spanIndex - 1]?.bg);
+    const wordBg = capturedTestColorToHex(line.spans[spanIndex]?.bg);
+    const surroundingBg = capturedTestColorToHex(line.spans[spanIndex - 1]?.bg);
     if (!wordBg || !surroundingBg) {
       continue;
     }
@@ -685,7 +671,7 @@ describe("UI components", () => {
       const hasAddedBgSpacer = line?.spans.some(
         (span) =>
           span.text === " ".repeat(3) &&
-          capturedColorToHex(span.bg)?.toLowerCase() === theme.addedBg.toLowerCase(),
+          capturedTestColorToHex(span.bg)?.toLowerCase() === theme.addedBg.toLowerCase(),
       );
 
       expect(hasAddedBgSpacer).toBe(true);
@@ -724,7 +710,7 @@ describe("UI components", () => {
         await setup.renderOnce();
       });
       const panelAltWidth = setup.captureSpans().lines[0]?.spans.reduce((total, span) => {
-        return capturedColorToHex(span.bg)?.toLowerCase() === theme.panelAlt.toLowerCase()
+        return capturedTestColorToHex(span.bg)?.toLowerCase() === theme.panelAlt.toLowerCase()
           ? total + span.text.length
           : total;
       }, 0);

--- a/test/helpers/test-color-helpers.ts
+++ b/test/helpers/test-color-helpers.ts
@@ -1,0 +1,14 @@
+/** Convert captured RGBA output back into a #rrggbb color string for render assertions. */
+export function capturedTestColorToHex(color: { buffer?: ArrayLike<number> } | undefined) {
+  const buffer = color?.buffer;
+  if (!buffer || buffer[0] == null || buffer[1] == null || buffer[2] == null) {
+    return null;
+  }
+
+  const componentToHex = (value: number) =>
+    Math.max(0, Math.min(255, Math.round(value * 255)))
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${componentToHex(buffer[0])}${componentToHex(buffer[1])}${componentToHex(buffer[2])}`;
+}


### PR DESCRIPTION
:wave: (hope these are welcome)

* keep menu dropdowns and the help dialog on the base theme so transparent background only applies to review/app surfaces
* add interaction coverage for transparent mode to verify menu and help backgrounds stay readable