### PR TITLE
chore(release): include latest fixes in 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,14 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
-- Added timeouts to `hunk session *` daemon capability and API calls so unresponsive daemons fail instead of hanging indefinitely.
-- Updated OpenTUI so light and dark theme backgrounds render without the native renderer's color shift.
-- Prevented Git watch polling from taking optional index locks while discovering untracked files.
-
 ## [0.15.1] - 2026-06-09
 
 ### Fixed
 
 - Restored the `e` keyboard shortcut and menu hint for opening the selected file in `$EDITOR`.
+- Added timeouts to `hunk session *` daemon capability and API calls so unresponsive daemons fail instead of hanging indefinitely.
+- Updated OpenTUI so light and dark theme backgrounds render without the native renderer's color shift.
+- Prevented Git watch polling from taking optional index locks while discovering untracked files.
 
 ## [0.15.0] - 2026-06-08
 


### PR DESCRIPTION
## Summary

- Move the current unreleased fixes into the 0.15.1 changelog section.
- Keep package version at 0.15.1 so current main can be tagged as v0.15.1 after merge.

## Verification

- `/home/bentlegen/Projects/hunk-b/node_modules/.bin/oxfmt --check /tmp/hunk-release-0.15.1/CHANGELOG.md`

*This PR description was generated by Pi using OpenAI GPT-5 Codex*