### PR TITLE
docs: explain how to get Hunk skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ git diff --no-color | hunk patch -          # review a patch from stdin
 A good generic prompt is:
 
 ```text
-Load the Hunk skill and use it for this review.
+Load the Hunk skill and use it for this review. Run `hunk skill path` to get the skill path.
 ```
 
 For the full live-session and `--agent-context` workflow guide, see [docs/agent-workflows.md](docs/agent-workflows.md).


### PR DESCRIPTION
The README copy-paste prompt should tell agents how to find the bundled Hunk review skill, not just ask them to load it. This keeps the quick-start agent workflow self-contained and matches the fuller agent workflow guide.

It also matches the prompt in agent-workflows.md: https://github.com/modem-dev/hunk/blob/main/docs/agent-workflows.md?plain=1#L17