### PR TITLE
feat(ui): honor transparent background in static pager output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Fixed
 
+- Honored `--transparent-bg` and `transparent_background` in static pager output, so captured pager hosts like LazyGit let translucent terminal backgrounds through on context lines, gutters, and hunk headers while added/removed rows keep their tinted backgrounds.
+
 ## [0.15.1] - 2026-06-09
 
 ### Fixed

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -74,6 +74,23 @@ describe("static diff pager", () => {
     expect(output).toContain("\x1b[38;2;18;52;86m");
   });
 
+  test("keeps only added/removed backgrounds when transparent background is requested", async () => {
+    const patchText =
+      "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1,3 +1,3 @@\n const a = 1;\n-const value = 1;\n+const value = 2;\n const z = 3;\n";
+
+    const output = await renderStaticDiffPager(patchText, { transparentBackground: true });
+    const lines = output.split("\n");
+    const lineWith = (text: string) => lines.find((line) => stripAnsi(line).includes(text)) ?? "";
+
+    expect(stripAnsi(output)).toContain("a.ts modified +1 -1");
+    expect(output).toContain("\x1b[38;2;");
+    expect(lineWith("@@ -1,3 +1,3 @@")).not.toContain("\x1b[48;2;");
+    expect(lineWith("const a = 1;")).not.toContain("\x1b[48;2;");
+    expect(lineWith("const z = 3;")).not.toContain("\x1b[48;2;");
+    expect(lineWith("const value = 1;")).toContain("\x1b[48;2;55;37;38m");
+    expect(lineWith("const value = 2;")).toContain("\x1b[48;2;31;48;37m");
+  });
+
   test("shows semantic file metadata without raw patch headers", async () => {
     const patchText = [
       "diff --git a/new.txt b/new.txt",

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -25,7 +25,7 @@ import {
   stackRailColor,
 } from "./diff/rowStyle";
 import { sanitizeTerminalLine, sanitizeTerminalText } from "../lib/terminalText";
-import { resolveTheme, type AppTheme } from "./themes";
+import { resolveTheme, withTransparentSurfaces, type AppTheme } from "./themes";
 
 const RESET = "\x1b[0m";
 
@@ -232,7 +232,10 @@ export async function renderStaticDiffPager(
         pager: true,
       },
     });
-    const theme = resolveTheme(options.theme, null, deps.customTheme);
+    const resolvedTheme = resolveTheme(options.theme, null, deps.customTheme);
+    const theme = options.transparentBackground
+      ? withTransparentSurfaces(resolvedTheme)
+      : resolvedTheme;
     const rendered = await Promise.all(
       bootstrap.changeset.files.map((file) => renderStaticFile(file, theme, options)),
     );

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -5,6 +5,7 @@ import {
   resolveTheme,
   TRANSPARENT_BACKGROUND,
   withTransparentBackground,
+  withTransparentSurfaces,
 } from "./themes";
 
 describe("themes", () => {
@@ -158,5 +159,26 @@ describe("themes", () => {
     expect(transparent.removedSignColor).toBe(theme.removedSignColor);
     expect(transparent.syntaxColors).toBe(theme.syntaxColors);
     expect(theme.background).not.toBe(TRANSPARENT_BACKGROUND);
+  });
+
+  test("withTransparentSurfaces keeps added/removed row tints", () => {
+    const theme = resolveTheme("graphite", null);
+    const transparent = withTransparentSurfaces(theme);
+
+    expect(transparent).toMatchObject({
+      background: TRANSPARENT_BACKGROUND,
+      panel: TRANSPARENT_BACKGROUND,
+      panelAlt: TRANSPARENT_BACKGROUND,
+      contextBg: TRANSPARENT_BACKGROUND,
+      contextContentBg: TRANSPARENT_BACKGROUND,
+      lineNumberBg: TRANSPARENT_BACKGROUND,
+    });
+    expect(transparent.addedBg).toBe(theme.addedBg);
+    expect(transparent.removedBg).toBe(theme.removedBg);
+    expect(transparent.movedAddedBg).toBe(theme.movedAddedBg);
+    expect(transparent.movedRemovedBg).toBe(theme.movedRemovedBg);
+    expect(transparent.addedContentBg).toBe(theme.addedContentBg);
+    expect(transparent.removedContentBg).toBe(theme.removedContentBg);
+    expect(transparent.syntaxColors).toBe(theme.syntaxColors);
   });
 });

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -143,3 +143,20 @@ export function withTransparentBackground(theme: AppTheme): AppTheme {
     noteTitleBackground: TRANSPARENT_BACKGROUND,
   };
 }
+
+/**
+ * Return a copy of a theme whose neutral surfaces allow the terminal background through while
+ * added/removed row tints stay painted. Static pager hosts use this so diff rows keep their
+ * semantic backgrounds on translucent terminals.
+ */
+export function withTransparentSurfaces(theme: AppTheme): AppTheme {
+  return {
+    ...theme,
+    background: TRANSPARENT_BACKGROUND,
+    panel: TRANSPARENT_BACKGROUND,
+    panelAlt: TRANSPARENT_BACKGROUND,
+    contextBg: TRANSPARENT_BACKGROUND,
+    contextContentBg: TRANSPARENT_BACKGROUND,
+    lineNumberBg: TRANSPARENT_BACKGROUND,
+  };
+}


### PR DESCRIPTION
When using hunk as a pager in lazygit in a transparent-background terminal (Ghostty), the static ANSI output of the pager caused solid backgrounds on context lines and other non-diff elements.

This change uses a similar system as the TUI to mark surfaces as transparent in the pager output, but keeps +/- background tints painted so they're easier to see visually in diffs:

## Before / After

<table>
<tr>
 <td>
 <img width="1140" height="826" alt="CleanShot 2026-06-11 at 22 15 08@2x" src="https://github.com/user-attachments/assets/0a13826a-604b-4b2f-9470-87910f559462" />
 <td>
 <td>
 <img width="1150" height="864" alt="CleanShot 2026-06-11 at 22 16 25@2x" src="https://github.com/user-attachments/assets/36a8e502-8344-4bee-b8d4-fd6b93283c9c" />
 </td>
</table>


