### PR TITLE
perf(ui): yield scroll updates and highlight work to input timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable user-visible changes to Hunk are documented in this file.
 
 ### Changed
 
+- Coalesced scroll-position React updates into a single per-frame read and shifted background syntax highlighting from microtasks to timers, so rapid wheel or held-arrow scrolling no longer produces visible jank from per-delta state updates or per-file highlight work starving input and render callbacks.
+
 ### Fixed
 
 ## [0.15.1] - 2026-06-09

--- a/benchmarks/large-stream.ts
+++ b/benchmarks/large-stream.ts
@@ -3,6 +3,7 @@ import { performance } from "perf_hooks";
 import React from "react";
 import { testRender } from "@opentui/react/test-utils";
 import { AppHost } from "../src/ui/AppHost";
+import { VIEWPORT_READ_COALESCE_MS } from "../src/ui/lib/viewportTiming";
 import {
   createLargeSplitStreamBootstrap,
   DEFAULT_FILE_COUNT,
@@ -14,7 +15,6 @@ const VIEWPORT = {
   height: 28,
 } as const;
 const SCROLL_TICKS = 4;
-const VIEWPORT_READ_COALESCE_MS = 16;
 const SCROLL_TARGET = {
   x: 170,
   y: 12,

--- a/benchmarks/large-stream.ts
+++ b/benchmarks/large-stream.ts
@@ -14,6 +14,7 @@ const VIEWPORT = {
   height: 28,
 } as const;
 const SCROLL_TICKS = 4;
+const VIEWPORT_READ_COALESCE_MS = 16;
 const SCROLL_TARGET = {
   x: 170,
   y: 12,
@@ -61,6 +62,11 @@ async function renderPass(setup: BenchmarkRenderer, passes = 1) {
   }
 }
 
+/** Lets DiffPane's timer-coalesced viewport read update React state. */
+async function flushCoalescedViewportRead() {
+  await Bun.sleep(VIEWPORT_READ_COALESCE_MS + 1);
+}
+
 async function flushSelectedHighlight(setup: BenchmarkRenderer) {
   for (let iteration = 0; iteration < 200; iteration += 1) {
     await renderPass(setup);
@@ -97,6 +103,7 @@ async function measureScrollTicksMs() {
 
     for (let index = 0; index < SCROLL_TICKS; index += 1) {
       setup.mockMouse.scroll(SCROLL_TARGET.x, SCROLL_TARGET.y, "down");
+      await flushCoalescedViewportRead();
       await setup.renderOnce();
     }
 

--- a/benchmarks/large-stream.ts
+++ b/benchmarks/large-stream.ts
@@ -2,7 +2,6 @@
 import { performance } from "perf_hooks";
 import React from "react";
 import { testRender } from "@opentui/react/test-utils";
-import { act } from "react";
 import { AppHost } from "../src/ui/AppHost";
 import {
   createLargeSplitStreamBootstrap,
@@ -23,6 +22,22 @@ const SELECTED_HIGHLIGHT_MARKER = "stream1_40";
 
 type BenchmarkRenderer = Awaited<ReturnType<typeof testRender>>;
 
+async function createBenchmarkRenderer() {
+  const setup = await testRender(
+    React.createElement(AppHost, {
+      bootstrap: createLargeSplitStreamBootstrap(),
+    }),
+    VIEWPORT,
+  );
+
+  // This script measures OpenTUI render-loop cost, not React test assertions. Keeping React's
+  // act environment enabled makes queued timer/microtask work drain through the test scheduler and
+  // can dominate the benchmark with harness time instead of frame time.
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+
+  return setup;
+}
+
 function frameHasHighlightedMarker(
   frame: { lines: Array<{ spans: Array<{ text: string }> }> },
   marker: string,
@@ -42,10 +57,7 @@ function frameHasHighlightedMarker(
 
 async function renderPass(setup: BenchmarkRenderer, passes = 1) {
   for (let index = 0; index < passes; index += 1) {
-    await act(async () => {
-      await setup.renderOnce();
-      await Bun.sleep(0);
-    });
+    await setup.renderOnce();
   }
 }
 
@@ -60,18 +72,11 @@ async function flushSelectedHighlight(setup: BenchmarkRenderer) {
 }
 
 async function destroyRenderer(setup: BenchmarkRenderer) {
-  await act(async () => {
-    setup.renderer.destroy();
-  });
+  setup.renderer.destroy();
 }
 
 async function measureFirstFrameMs() {
-  const setup = await testRender(
-    React.createElement(AppHost, {
-      bootstrap: createLargeSplitStreamBootstrap(),
-    }),
-    VIEWPORT,
-  );
+  const setup = await createBenchmarkRenderer();
   const start = performance.now();
 
   try {
@@ -84,23 +89,15 @@ async function measureFirstFrameMs() {
 }
 
 async function measureScrollTicksMs() {
-  const setup = await testRender(
-    React.createElement(AppHost, {
-      bootstrap: createLargeSplitStreamBootstrap(),
-    }),
-    VIEWPORT,
-  );
+  const setup = await createBenchmarkRenderer();
 
   try {
     await renderPass(setup, 2);
     const start = performance.now();
 
     for (let index = 0; index < SCROLL_TICKS; index += 1) {
-      await act(async () => {
-        await setup.mockMouse.scroll(SCROLL_TARGET.x, SCROLL_TARGET.y, "down");
-        await setup.renderOnce();
-        await Bun.sleep(0);
-      });
+      setup.mockMouse.scroll(SCROLL_TARGET.x, SCROLL_TARGET.y, "down");
+      await setup.renderOnce();
     }
 
     return performance.now() - start;

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -47,6 +47,7 @@ import {
 } from "../../lib/fileSectionLayout";
 import { diffHunkId, diffSectionId } from "../../lib/ids";
 import { findViewportCenteredHunkTarget } from "../../lib/viewportSelection";
+import { VIEWPORT_READ_COALESCE_MS } from "../../lib/viewportTiming";
 import {
   findViewportRowAnchor,
   resolveViewportRowAnchorTop,
@@ -568,7 +569,7 @@ export function DiffPane({
         } finally {
           scheduled = false;
         }
-      }, 16);
+      }, VIEWPORT_READ_COALESCE_MS);
     };
 
     readViewport();

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -268,10 +268,20 @@ export function DiffPane({
     [],
   );
   const [addNoteHoverClearSignal, setAddNoteHoverClearSignal] = useState(0);
+  const [addNoteHoverClearFileId, setAddNoteHoverClearFileId] = useState<string | null>(null);
+  const hoveredFileIdRef = useRef<string | null>(null);
 
   /** Hide hover-only row controls when content scrolls under a stationary mouse pointer. */
   const clearAddNoteHoverForScroll = useCallback(() => {
+    const hoveredFileId = hoveredFileIdRef.current;
+    if (!hoveredFileId) {
+      return;
+    }
+
+    setAddNoteHoverClearFileId(hoveredFileId);
     setAddNoteHoverClearSignal((current) => current + 1);
+    setHoveredFileId(null);
+    hoveredFileIdRef.current = null;
     onActiveAddNoteAffordanceChange?.(null);
   }, [onActiveAddNoteAffordanceChange]);
 
@@ -443,6 +453,12 @@ export function DiffPane({
   const lastViewportSelectionTopRef = useRef<number | null>(null);
   const lastViewportRowAnchorRef = useRef<ViewportRowAnchor | null>(null);
 
+  /** Track the currently hover-owned file without making scroll handlers depend on render state. */
+  const setHoveredFileForRowActions = useCallback((fileId: string) => {
+    hoveredFileIdRef.current = fileId;
+    setHoveredFileId(fileId);
+  }, []);
+
   /** Temporarily widen the mounted diff window while scroll input is arriving in bursts. */
   const activateRapidScrollOverscan = useCallback((overscanRows: number) => {
     if (overscanRows <= 0) {
@@ -495,6 +511,7 @@ export function DiffPane({
 
     let cancelled = false;
     let scheduled = false;
+    let scheduledViewportRead: ReturnType<typeof setTimeout> | null = null;
 
     const readViewport = () => {
       const nextTop = scrollBox.scrollTop ?? 0;
@@ -531,15 +548,16 @@ export function DiffPane({
     // useLayoutEffects in this pane scroll the box from inside React's commit phase.
     // Calling setScrollViewport directly from the listener can run setState while React
     // is already committing — which downstream layout effects can amplify into a render
-    // loop and trip React's max-update-depth guard. Coalesce listener events into a
-    // single microtask-deferred read so the setState is dispatched outside the emit
-    // call stack and repeated events between paints collapse into one update.
+    // loop and trip React's max-update-depth guard. Coalesce listener events into one
+    // timer-deferred read so rapid wheel/key bursts collapse into at most one React update
+    // per frame instead of turning every native scroll delta into a full review-stream render.
     const handleViewportChange = () => {
       if (scheduled) {
         return;
       }
       scheduled = true;
-      queueMicrotask(() => {
+      scheduledViewportRead = setTimeout(() => {
+        scheduledViewportRead = null;
         if (cancelled) {
           scheduled = false;
           return;
@@ -550,7 +568,7 @@ export function DiffPane({
         } finally {
           scheduled = false;
         }
-      });
+      }, 16);
     };
 
     readViewport();
@@ -560,6 +578,9 @@ export function DiffPane({
 
     return () => {
       cancelled = true;
+      if (scheduledViewportRead) {
+        clearTimeout(scheduledViewportRead);
+      }
       scrollBox.verticalScrollBar.off("change", handleViewportChange);
       scrollBox.viewport.off("layout-changed", handleViewportChange);
       scrollBox.viewport.off("resized", handleViewportChange);
@@ -1728,13 +1749,15 @@ export function DiffPane({
                       wrapLines={wrapLines}
                       theme={theme}
                       hoverActive={hoveredFileId === null || hoveredFileId === file.id}
-                      hoverClearSignal={addNoteHoverClearSignal}
+                      hoverClearSignal={
+                        addNoteHoverClearFileId === file.id ? addNoteHoverClearSignal : 0
+                      }
                       viewWidth={diffContentWidth}
                       visibleAgentNotes={
                         visibleAgentNotesByFile.get(file.id) ?? EMPTY_VISIBLE_AGENT_NOTES
                       }
                       visibleBodyBounds={visibleBodyBoundsByFile.get(file.id)}
-                      onHover={() => setHoveredFileId(file.id)}
+                      onHover={() => setHoveredFileForRowActions(file.id)}
                       onMouseScroll={clearAddNoteHoverForScroll}
                       onActiveAddNoteAffordanceChange={(affordance) =>
                         onActiveAddNoteAffordanceChange?.(

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -558,18 +558,20 @@ async function prepareHighlighter(
   });
 }
 
-/** Queue highlight rendering so startup work stays serialized in request order. */
+/** Queue highlight rendering so startup work stays serialized without starving input/render timers. */
 function queueHighlightedWork<T>(run: () => T) {
   const queued = queuedHighlightWork.then(
     () =>
       new Promise<T>((resolve, reject) => {
-        queueMicrotask(() => {
+        // Highlighting is CPU-heavy background work. Scheduling each serialized job as a timer,
+        // rather than a microtask, yields back to OpenTUI input and frame timers between files.
+        setTimeout(() => {
           try {
             resolve(run());
           } catch (error) {
             reject(error);
           }
-        });
+        }, 0);
       }),
   );
 

--- a/src/ui/lib/viewportTiming.ts
+++ b/src/ui/lib/viewportTiming.ts
@@ -1,0 +1,2 @@
+/** Delay used to coalesce imperative ScrollBox viewport reads to roughly one frame. */
+export const VIEWPORT_READ_COALESCE_MS = 16;


### PR DESCRIPTION
# Scroll Performance Improvements

## Summary

This change makes Hunk scrolling smoother by reducing how much React and background work runs for each scroll tick. The biggest improvement is visible when holding the down arrow key or continuously scrolling with the mouse wheel.

## What Changed

### 1. Batched scroll-position updates

File: `src/ui/components/panes/DiffPane.tsx`

Previously, every scroll change scheduled a `queueMicrotask` to mirror the OpenTUI scrollbox position into React state. During rapid mouse wheel or key-repeat scrolling, that could turn many tiny native scroll deltas into many React state updates and review-stream re-renders.

Now viewport reads are coalesced with a short frame timer:

```ts
scheduledViewportRead = setTimeout(() => {
  readViewport();
}, 16);
```

In simple terms: instead of doing React work for every scroll event, Hunk updates React at most about once per frame while scroll input is arriving.

### 2. Syntax highlighting yields to input/render timers

File: `src/ui/diff/pierre.ts`

Previously, serialized syntax highlighting work used `queueMicrotask`:

```ts
queueMicrotask(() => {
  resolve(run());
});
```

Highlighting is CPU-heavy background work. Microtasks run before timers, input, and render callbacks, so a long queue of highlight jobs could delay visible scrolling.

Now highlighting jobs use timer scheduling:

```ts
setTimeout(() => {
  resolve(run());
}, 0);
```

In simple terms: highlighting still runs in the background, but it yields between files so OpenTUI input and frame rendering get more chances to run.

### 3. Hover/add-note clearing is targeted

File: `src/ui/components/panes/DiffPane.tsx`

Previously, scrolling cleared hover/add-note affordances globally. The clear signal was passed to every visible file section, which could invalidate multiple memoized `DiffSection` renders.

Now Hunk tracks the currently hover-owned file:

```ts
const hoveredFileIdRef = useRef<string | null>(null);
```

On scroll, Hunk only clears hover state when a file actually owns hover actions, and only sends the clear signal to that file:

```tsx
hoverClearSignal={
  addNoteHoverClearFileId === file.id ? addNoteHoverClearSignal : 0
}
```

In simple terms: scrolling no longer tells every visible diff section to update just to hide one hover control.

### 4. Large-stream benchmark measures render cost more directly

File: `benchmarks/large-stream.ts`

The benchmark previously wrapped scroll/render work in React test `act()` and `Bun.sleep(0)`, which exaggerated scroll costs because it measured test-harness scheduling behavior.

The benchmark now avoids that artificial pattern and measures the OpenTUI render loop more directly. This did not directly fix production scrolling, but helped separate benchmark artifacts from real app scroll-path costs.

## Verification

Commands run:

```powershell
bun run typecheck
bun run lint -- src/ui/components/panes/DiffPane.tsx src/ui/diff/pierre.ts benchmarks/large-stream.ts
bun test src/ui/AppHost.scroll-regression.test.tsx
bun run bench:large-stream
```

Manual testing confirmed smoother continuous mouse-wheel scrolling and smoother held down-arrow scrolling.
