### PR TITLE
fix(session): resolve --repo selector to repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable user-visible changes to Hunk are documented in this file.
 ### Fixed
 
 - Honored `--transparent-bg` and `transparent_background` in static pager output, so captured pager hosts like LazyGit let translucent terminal backgrounds through on context lines, gutters, and hunk headers while added/removed rows keep their tinted backgrounds.
+- Resolved `hunk session ... --repo <path>` selectors to the containing repo root before matching, so `--repo .` (and any path inside the tree) targets the live session from a subdirectory instead of reporting no match.
 
 ## [0.15.1] - 2026-06-09
 

--- a/src/core/cli.test.ts
+++ b/src/core/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { parseCli } from "./cli";
@@ -284,6 +284,42 @@ describe("parseCli", () => {
     });
   });
 
+  test("resolves --repo from a subdirectory to the containing repo root", async () => {
+    const repoRoot = realpathSync.native(createTempDir("hunk-cli-repo-"));
+    mkdirSync(join(repoRoot, ".git"));
+    const subdir = join(repoRoot, "packages", "app");
+    mkdirSync(subdir, { recursive: true });
+
+    const parsed = await parseCli(["bun", "hunk", "session", "get", "--repo", subdir]);
+
+    expect(parsed).toMatchObject({
+      kind: "session",
+      action: "get",
+      selector: { repoRoot },
+    });
+  });
+
+  test("resolves --repo through a symlinked path to the canonical repo root", async () => {
+    const repoRoot = realpathSync.native(createTempDir("hunk-cli-symlink-"));
+    mkdirSync(join(repoRoot, ".git"));
+    const linkParent = realpathSync.native(createTempDir("hunk-cli-symlink-link-"));
+    const link = join(linkParent, "repo-link");
+    try {
+      symlinkSync(repoRoot, link, "dir");
+    } catch {
+      // Skip where symlink creation is unsupported (e.g. Windows without privilege).
+      return;
+    }
+
+    const parsed = await parseCli(["bun", "hunk", "session", "get", "--repo", link]);
+
+    expect(parsed).toMatchObject({
+      kind: "session",
+      action: "get",
+      selector: { repoRoot },
+    });
+  });
+
   test("parses session review by repo alias", async () => {
     const parsed = await parseCli(["bun", "hunk", "session", "review", "--repo", ".", "--json"]);
 
@@ -420,6 +456,30 @@ describe("parseCli", () => {
         options: {},
       },
       output: "json",
+    });
+  });
+
+  test("resolves session reload --repo from a subdirectory to the containing repo root", async () => {
+    const repoRoot = realpathSync.native(createTempDir("hunk-cli-reload-"));
+    mkdirSync(join(repoRoot, ".git"));
+    const subdir = join(repoRoot, "packages", "app");
+    mkdirSync(subdir, { recursive: true });
+
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "reload",
+      "--repo",
+      subdir,
+      "--",
+      "diff",
+    ]);
+
+    expect(parsed).toMatchObject({
+      kind: "session",
+      action: "reload",
+      selector: { repoRoot },
     });
   });
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { Command, Option } from "commander";
 import type {
@@ -12,6 +12,7 @@ import type {
   SessionCommentApplyItemInput,
 } from "./types";
 import { resolveBundledHunkReviewSkillPath } from "./paths";
+import { detectVcs } from "./vcs";
 import { resolveCliVersion } from "./version";
 
 /** Validate one requested layout mode from CLI input. */
@@ -309,6 +310,23 @@ function parseSessionCommentApplyPayload(raw: string): SessionCommentApplyItemIn
   });
 }
 
+/**
+ * Resolve a `--repo <path>` selector to the containing VCS toplevel.
+ *
+ * Sessions register under their repo root, so the selector must walk up from the
+ * given path to that root; otherwise a query run from a subdirectory would never
+ * match. The detected root is canonicalized through symlinks to mirror the
+ * session's registered repoRoot (git's `--show-toplevel` is realpath-canonical),
+ * so matching also holds under a symlinked ancestor like macOS `/tmp`. Falls back
+ * to the resolved path when it is not inside a known checkout.
+ */
+function resolveRepoSelectorRoot(repoPath: string): string {
+  const resolved = resolve(repoPath);
+  const repoRoot = detectVcs(resolved)?.repoRoot;
+  // The detected root always exists on disk, so realpath cannot throw here.
+  return repoRoot ? realpathSync.native(repoRoot) : resolved;
+}
+
 /** Normalize one explicit session selector from either session id or repo root. */
 function resolveExplicitSessionSelector(
   sessionId: string | undefined,
@@ -322,7 +340,7 @@ function resolveExplicitSessionSelector(
     throw new Error("Specify one live Hunk session with <session-id> or --repo <path>.");
   }
 
-  return sessionId ? { sessionId } : { repoRoot: resolve(repoRoot!) };
+  return sessionId ? { sessionId } : { repoRoot: resolveRepoSelectorRoot(repoRoot!) };
 }
 
 function resolveReloadSelector(
@@ -362,7 +380,7 @@ function resolveReloadSelector(
 
   if (repoRoot) {
     return {
-      selector: { repoRoot: resolve(repoRoot) },
+      selector: { repoRoot: resolveRepoSelectorRoot(repoRoot) },
       sourcePath: resolvedSource,
     };
   }


### PR DESCRIPTION
Sessions register under their git toplevel, so a --repo selector run from a subdirectory never matched.

Walk up to the containing repo root (and canonicalize through symlinks) so queries target the session from anywhere in the tree.

Closes #423.