### PR TITLE
chore(release): adopt changesets

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,31 @@
+# Changesets
+
+Hunk uses [Changesets](https://github.com/changesets/changesets) for release-note fragments and npm version preparation.
+
+For user-visible changes, add a changeset instead of editing `CHANGELOG.md` directly:
+
+```bash
+bun run changeset
+```
+
+Select `hunkdiff` and choose the semver bump that matches the shipped CLI/package change:
+
+- `patch` for fixes and small behavior changes
+- `minor` for new user-facing features
+- `major` for breaking changes
+
+`package.json` intentionally lists `"."` in `workspaces` so Changesets can discover the root `hunkdiff` package. Keep that entry unless Hunk moves the publishable package out of the repository root.
+
+For maintenance-only PRs that should not appear in release notes, create an empty changeset:
+
+```bash
+bun run changeset -- --empty
+```
+
+Release prep runs:
+
+```bash
+bun run release:version
+```
+
+That consumes the pending `.changeset/*.md` files, updates `CHANGELOG.md`, and bumps package versions for the release commit.

--- a/.changeset/chilly-diffs-dance.md
+++ b/.changeset/chilly-diffs-dance.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Adopt Changesets for release-note fragments so pull requests can avoid conflicting `CHANGELOG.md` edits.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": [
+    "@hunk/session-broker",
+    "@hunk/session-broker-bun",
+    "@hunk/session-broker-core",
+    "@hunk/session-broker-node"
+  ]
+}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -27,6 +27,25 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
         run: .github/scripts/detect-code-changes.sh "$BASE_SHA" "$HEAD_SHA"
 
+  changeset-status:
+    name: Release-note changeset
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.10
+
+      - name: Verify release-note changeset
+        run: bun run changeset:status -- --since=origin/main
+
   windows-compat:
     name: Windows compatibility
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,13 +132,10 @@ CLI input
 
 ## releases
 
-- Maintain the top-level `CHANGELOG.md` as the source of truth for user-visible changes.
-- Keep upcoming work under `## [Unreleased]` with these subsections:
-  - `### Added`
-  - `### Changed`
-  - `### Fixed`
-- Append to existing subsections instead of creating duplicates.
-- When cutting a release, move the relevant unreleased entries into a new immutable version section and start a fresh `## [Unreleased]` section.
+- Use Changesets for user-visible release notes. Add a `.changeset/*.md` entry with `bun run changeset` instead of editing `CHANGELOG.md` directly.
+- Target the public `hunkdiff` package in changesets. Use `patch` for fixes and small behavior changes, `minor` for new user-facing features, and `major` for breaking changes.
+- For maintenance-only PRs that should not appear in release notes, add an empty changeset with `bun run changeset -- --empty`.
+- Keep the top-level `CHANGELOG.md` as the released changelog artifact. It is updated during release prep with `bun run release:version`, not by normal feature/fix PRs.
 - Use the released changelog section as the starting point for the GitHub release body.
 - GitHub releases should follow this format:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-All notable user-visible changes to Hunk are documented in this file.
-
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-
 ## [0.15.3] - 2026-06-13
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,4 +154,19 @@ Key rules:
 
 - The npm package name is `hunkdiff`.
 - The installed CLI command remains `hunk`.
+- Add a Changeset for user-visible changes instead of editing `CHANGELOG.md` directly:
+
+  ```bash
+  bun run changeset
+  ```
+
+  Select `hunkdiff`, then choose `patch` for fixes and small behavior changes, `minor` for new user-facing features, or `major` for breaking changes.
+
+- For maintenance-only PRs that should not appear in release notes, add an empty changeset:
+
+  ```bash
+  bun run changeset -- --empty
+  ```
+
+- Release prep runs `bun run release:version` to consume pending changesets, update `CHANGELOG.md`, and bump package versions.
 - The automated prebuilt publish workflow lives in `.github/workflows/release-prebuilt-npm.yml`.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hunkdiff": "./bin/hunk.cjs"
   },
   "workspaces": [
+    ".",
     "packages/*"
   ],
   "files": [
@@ -58,6 +59,9 @@
     "format:check": "oxfmt --check .",
     "lint": "oxlint . --deny-warnings",
     "lint:fix": "oxlint . --fix",
+    "changeset": "bunx @changesets/cli@2.31.0",
+    "changeset:status": "bunx @changesets/cli@2.31.0 status",
+    "release:version": "bunx @changesets/cli@2.31.0 version",
     "prepare": "simple-git-hooks",
     "test": "\"${npm_execpath:-bun}\" test ./src ./packages ./scripts ./test/cli ./test/session",
     "test:integration": "\"${npm_execpath:-bun}\" test ./test/pty",


### PR DESCRIPTION
## Summary

- Add a Changesets setup for Hunk release-note fragments and version prep.
- Document the new workflow for contributors and agents: add `.changeset/*.md` instead of editing `CHANGELOG.md` in normal PRs, or use an empty changeset for maintenance-only work.
- Add a PR CI check that verifies changed code has a pending changeset.
- Move the currently unreleased changelog notes into changeset fragments so the next `bun run release:version` can generate the release section without reintroducing the shared `CHANGELOG.md` conflict point.

## Verification

- `bun run changeset:status -- --since=origin/main`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test`

*This PR description was generated by Pi using OpenAI GPT-5*
