### PR TITLE
fix(ui): cap diff geometry cache per file

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,6 +36,8 @@ bun run bench:non-ascii-stream
 bun run bench:huge-stream
 bun run bench:large-stream-profile
 bun run bench:memory
+bun run bench:navigation-memory
+bun run bench:resize-memory
 bun run bench:competitors
 ```
 
@@ -52,6 +54,8 @@ bun run bench:competitors
 - `huge-stream.ts` — opt-in huge tier (`--include-huge` or `HUNK_BENCH_INCLUDE_HUGE=1`): cold first frame, scroll-tick and hunk-navigation latency, and memory ceilings on ~1k files / 300k+ diff lines plus one giant ~50k-line file.
 - `large-stream-profile.ts` — optional local profiler for the main pure planning stages behind the large split-stream benchmark.
 - `memory.ts` — optional local RSS/heap profiler after fixture loading, planning, first frame, and next-hunk navigation.
+- `navigation-memory.ts` — optional local retained-memory profiler for repeated hunk navigation through a mounted review stream.
+- `resize-memory.ts` — optional local retained-memory profiler for repeated terminal-width changes through a mounted review stream; this targets geometry-cache retention across resize variants.
 - `competitors.ts` — optional local informational comparisons against `git diff --no-ext-diff`, `delta`, `difftastic`, and `diff-so-fancy` when installed.
 - `large-stream-fixture.ts` and `lib/fixtures.ts` — shared deterministic synthetic fixtures.
 
@@ -84,7 +88,7 @@ Each script prints `METRIC name=value` lines. `benchmarks/run.ts` repeats script
 ## Notes
 
 - These benchmarks are intentionally local-only for now. They are useful diagnostics, but CI proved too noisy and slow for PR gating.
-- The default local suite excludes optional memory profiling, pure-planning profiling, the huge fixture tier, and competitor comparisons. Run those focused scripts when deeper diagnostics are needed.
+- The default local suite excludes optional memory profiling, resize profiling, pure-planning profiling, the huge fixture tier, and competitor comparisons. Run those focused scripts when deeper diagnostics are needed.
 - Fixture tiers: the moderate tier (180 files × 120 lines) backs `large-stream.ts` and `interaction-latency.ts`; the huge tier (1,000 files × 300 lines + one 50,000-line file) backs `huge-stream.ts` and is opt-in because one sample can take minutes before hot-path fixes land.
 - Competitor comparisons are informational because installed tool versions and feature parity vary by environment.
 - Use `--samples 5` locally when validating borderline changes.

--- a/benchmarks/resize-memory.ts
+++ b/benchmarks/resize-memory.ts
@@ -1,0 +1,309 @@
+// Track retained memory while repeatedly resizing a mounted Hunk review stream.
+import { testRender } from "@opentui/react/test-utils";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import React from "react";
+import { AppHost } from "../src/ui/AppHost";
+import { createLargeSplitStreamBootstrap } from "./large-stream-fixture";
+
+type MemorySample = {
+  label: string;
+  step: number;
+  width: number;
+  rssBytes: number;
+  heapUsedBytes: number;
+  heapTotalBytes: number;
+  externalBytes: number;
+  arrayBuffersBytes: number;
+};
+
+type CliOptions = {
+  fileCount: number;
+  linesPerFile: number;
+  height: number;
+  widths: number[];
+  cycles: number;
+  gc: boolean;
+  maxHeapGrowthMb: number;
+  maxRssGrowthMb: number;
+  jsonOut?: string;
+};
+
+const defaultOptions: CliOptions = {
+  fileCount: 180,
+  linesPerFile: 120,
+  height: 28,
+  widths: [160, 200, 240, 280, 220, 180],
+  cycles: 2,
+  gc: true,
+  maxHeapGrowthMb: 384,
+  maxRssGrowthMb: 1024,
+};
+
+function parseNumberOption(name: string, value: string | undefined) {
+  if (value === undefined) {
+    throw new Error(`Missing value for ${name}.`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Expected ${name} to be a non-negative number.`);
+  }
+
+  return parsed;
+}
+
+function parseWidths(value: string | undefined) {
+  if (!value) {
+    throw new Error("Missing value for --widths.");
+  }
+
+  const widths = value.split(",").map((part) => {
+    const width = Number(part.trim());
+    if (!Number.isFinite(width) || width < 40) {
+      throw new Error("Expected --widths to be comma-separated terminal widths >= 40.");
+    }
+    return Math.trunc(width);
+  });
+
+  if (widths.length === 0) {
+    throw new Error("Expected --widths to include at least one width.");
+  }
+
+  return widths;
+}
+
+/** Parse a small flag set without pulling benchmark-only dependencies into the app. */
+function parseArgs(argv: string[]): CliOptions {
+  const options = { ...defaultOptions, widths: [...defaultOptions.widths] };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--help" || arg === "-h") {
+      console.log(
+        `Usage: bun run benchmarks/resize-memory.ts [options]\n\nOptions:\n  --file-count <n>          One-hunk files in the synthetic review (default ${defaultOptions.fileCount})\n  --lines-per-file <n>      Lines per synthetic file (default ${defaultOptions.linesPerFile})\n  --height <n>              Test renderer height (default ${defaultOptions.height})\n  --widths <csv>            Comma-separated resize widths (default ${defaultOptions.widths.join(",")})\n  --cycles <n>              Number of times to repeat the width sequence (default ${defaultOptions.cycles})\n  --no-gc                   Do not force Bun.gc before samples\n  --max-heap-growth-mb <n>  Fail if retained heap grows beyond this (default ${defaultOptions.maxHeapGrowthMb})\n  --max-rss-growth-mb <n>   Fail if RSS grows beyond this (default ${defaultOptions.maxRssGrowthMb})\n  --json-out <path>         Write full sample summary JSON\n`,
+      );
+      process.exit(0);
+    }
+
+    const next = () => argv[++index];
+    switch (arg) {
+      case "--file-count":
+        options.fileCount = parseNumberOption(arg, next());
+        break;
+      case "--lines-per-file":
+        options.linesPerFile = parseNumberOption(arg, next());
+        break;
+      case "--height":
+        options.height = parseNumberOption(arg, next());
+        break;
+      case "--widths":
+        options.widths = parseWidths(next());
+        break;
+      case "--cycles":
+        options.cycles = parseNumberOption(arg, next());
+        break;
+      case "--no-gc":
+        options.gc = false;
+        break;
+      case "--max-heap-growth-mb":
+        options.maxHeapGrowthMb = parseNumberOption(arg, next());
+        break;
+      case "--max-rss-growth-mb":
+        options.maxRssGrowthMb = parseNumberOption(arg, next());
+        break;
+      case "--json-out":
+        options.jsonOut = next();
+        if (!options.jsonOut) {
+          throw new Error("Missing value for --json-out.");
+        }
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  options.fileCount = Math.max(1, Math.trunc(options.fileCount));
+  options.linesPerFile = Math.max(1, Math.trunc(options.linesPerFile));
+  options.height = Math.max(10, Math.trunc(options.height));
+  options.cycles = Math.max(1, Math.trunc(options.cycles));
+  return options;
+}
+
+function maybeGc(enabled: boolean) {
+  if (enabled) {
+    Bun.gc(true);
+  }
+}
+
+function sampleMemory(label: string, step: number, width: number, options: CliOptions) {
+  maybeGc(options.gc);
+  const usage = process.memoryUsage();
+  return {
+    label,
+    step,
+    width,
+    rssBytes: usage.rss,
+    heapUsedBytes: usage.heapUsed,
+    heapTotalBytes: usage.heapTotal,
+    externalBytes: usage.external,
+    arrayBuffersBytes: usage.arrayBuffers,
+  } satisfies MemorySample;
+}
+
+function formatBytes(bytes: number) {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function percentile(values: number[], p: number) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index]!;
+}
+
+async function renderOnce(setup: Awaited<ReturnType<typeof testRender>>) {
+  await setup.renderOnce();
+  await Bun.sleep(0);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const samples: MemorySample[] = [];
+  const resizeDurationsMs: number[] = [];
+  const startedAt = performance.now();
+  const bootstrap = createLargeSplitStreamBootstrap({
+    fileCount: options.fileCount,
+    linesPerFile: options.linesPerFile,
+  });
+  const firstWidth = options.widths[0]!;
+
+  // This benchmark measures renderer/retained-memory behaviour directly. Avoid React act harness
+  // scheduling overhead so timings describe the resize path rather than test assertions.
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+
+  console.log(
+    `resize memory fixture files=${options.fileCount} lines=${options.linesPerFile} ` +
+      `widths=${options.widths.join(",")} cycles=${options.cycles} gc=${options.gc ? "on" : "off"}`,
+  );
+  samples.push(sampleMemory("after_bootstrap", 0, firstWidth, options));
+
+  const setup = await testRender(React.createElement(AppHost, { bootstrap }), {
+    width: firstWidth,
+    height: options.height,
+  });
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+
+  try {
+    await renderOnce(setup);
+    samples.push(sampleMemory("after_first_frame", 0, firstWidth, options));
+    console.log(
+      `resize=${(0).toString().padStart(3)} width=${firstWidth} ` +
+        `heap=${formatBytes(samples.at(-1)!.heapUsedBytes)} rss=${formatBytes(samples.at(-1)!.rssBytes)}`,
+    );
+
+    let step = 0;
+    for (let cycle = 0; cycle < options.cycles; cycle += 1) {
+      for (const width of options.widths) {
+        step += 1;
+        const resizeStart = performance.now();
+        setup.resize(width, options.height);
+        await renderOnce(setup);
+        await renderOnce(setup);
+        resizeDurationsMs.push(performance.now() - resizeStart);
+
+        const nextSample = sampleMemory("resize", step, width, options);
+        samples.push(nextSample);
+        console.log(
+          `resize=${step.toString().padStart(3)} width=${width} ` +
+            `heap=${formatBytes(nextSample.heapUsedBytes)} rss=${formatBytes(nextSample.rssBytes)} ` +
+            `external=${formatBytes(nextSample.externalBytes)}`,
+        );
+      }
+    }
+  } finally {
+    setup.renderer.destroy();
+  }
+
+  const baseline = samples.find((sample) => sample.label === "after_first_frame") ?? samples[0]!;
+  const resizeSamples = samples.filter((sample) => sample.label === "resize");
+  const peakHeap = Math.max(
+    ...resizeSamples.map((sample) => sample.heapUsedBytes),
+    baseline.heapUsedBytes,
+  );
+  const peakRss = Math.max(...resizeSamples.map((sample) => sample.rssBytes), baseline.rssBytes);
+  const finalSample = samples.at(-1)!;
+  const heapGrowthBytes = finalSample.heapUsedBytes - baseline.heapUsedBytes;
+  const rssGrowthBytes = finalSample.rssBytes - baseline.rssBytes;
+  const peakHeapGrowthBytes = peakHeap - baseline.heapUsedBytes;
+  const peakRssGrowthBytes = peakRss - baseline.rssBytes;
+  const resizeTotalMs = resizeDurationsMs.reduce((sum, value) => sum + value, 0);
+  const resizeP95Ms = percentile(resizeDurationsMs, 95);
+  const elapsedMs = performance.now() - startedAt;
+
+  console.log(`METRIC files=${options.fileCount}`);
+  console.log(`METRIC lines_per_file=${options.linesPerFile}`);
+  console.log(`METRIC resize_count=${resizeDurationsMs.length}`);
+  console.log(`METRIC resize_total_ms=${resizeTotalMs.toFixed(2)}`);
+  console.log(`METRIC resize_p95_ms=${resizeP95Ms.toFixed(2)}`);
+  console.log(`METRIC baseline_heap_used_bytes=${baseline.heapUsedBytes}`);
+  console.log(`METRIC final_heap_used_bytes=${finalSample.heapUsedBytes}`);
+  console.log(`METRIC peak_heap_used_bytes=${peakHeap}`);
+  console.log(`METRIC heap_growth_bytes=${heapGrowthBytes}`);
+  console.log(`METRIC peak_heap_growth_bytes=${peakHeapGrowthBytes}`);
+  console.log(`METRIC baseline_rss_bytes=${baseline.rssBytes}`);
+  console.log(`METRIC final_rss_bytes=${finalSample.rssBytes}`);
+  console.log(`METRIC peak_rss_bytes=${peakRss}`);
+  console.log(`METRIC rss_growth_bytes=${rssGrowthBytes}`);
+  console.log(`METRIC peak_rss_growth_bytes=${peakRssGrowthBytes}`);
+  console.log(`METRIC elapsed_ms=${elapsedMs.toFixed(2)}`);
+
+  const maxHeapGrowthBytes = options.maxHeapGrowthMb * 1024 * 1024;
+  const maxRssGrowthBytes = options.maxRssGrowthMb * 1024 * 1024;
+  const failures: string[] = [];
+  if (peakHeapGrowthBytes > maxHeapGrowthBytes) {
+    failures.push(
+      `peak heap growth ${formatBytes(peakHeapGrowthBytes)} exceeded ${options.maxHeapGrowthMb} MiB`,
+    );
+  }
+  if (peakRssGrowthBytes > maxRssGrowthBytes) {
+    failures.push(
+      `peak RSS growth ${formatBytes(peakRssGrowthBytes)} exceeded ${options.maxRssGrowthMb} MiB`,
+    );
+  }
+
+  if (options.jsonOut) {
+    const outPath = resolve(options.jsonOut);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(
+      outPath,
+      `${JSON.stringify(
+        {
+          options,
+          metrics: {
+            elapsedMs,
+            resizeTotalMs,
+            resizeP95Ms,
+            heapGrowthBytes,
+            peakHeapGrowthBytes,
+            rssGrowthBytes,
+            peakRssGrowthBytes,
+          },
+          samples,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`Wrote ${outPath}`);
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`resize memory budget failed: ${failures.join("; ")}`);
+  }
+}
+
+await main();

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "bench:large-stream-profile": "bun run benchmarks/large-stream-profile.ts",
     "bench:memory": "bun run benchmarks/memory.ts",
     "bench:navigation-memory": "bun run benchmarks/navigation-memory.ts",
+    "bench:resize-memory": "bun run benchmarks/resize-memory.ts",
     "bench:daemon-memory": "bun run scripts/daemon-memory-check.ts",
     "bench:competitors": "bun run benchmarks/competitors.ts",
     "nix:update-lock": "nix run .#update-bun-lock"

--- a/src/ui/diff/diffSectionGeometry.test.ts
+++ b/src/ui/diff/diffSectionGeometry.test.ts
@@ -57,6 +57,41 @@ describe("measureDiffSectionGeometry", () => {
     expect(differentAddNotePolicy).not.toBe(first);
   });
 
+  test("replaces stale width variants while retaining separate base and note slots", () => {
+    const file = createTestDiffFile();
+    const visibleAgentNotes: VisibleAgentNote[] = [
+      {
+        id: "annotation:example:0",
+        annotation: {
+          newRange: [1, 1],
+          rationale: "Keep a note-aware geometry slot.",
+          summary: "Explain",
+        },
+      },
+    ];
+
+    const width100 = measureDiffSectionGeometry(file, "split", true, theme, [], 100, true, false);
+    const noteWidth100 = measureDiffSectionGeometry(
+      file,
+      "split",
+      true,
+      theme,
+      visibleAgentNotes,
+      100,
+      true,
+      false,
+    );
+    const width101 = measureDiffSectionGeometry(file, "split", true, theme, [], 101, true, false);
+
+    expect(width101).not.toBe(width100);
+    expect(measureDiffSectionGeometry(file, "split", true, theme, [], 100, true, false)).not.toBe(
+      width100,
+    );
+    expect(
+      measureDiffSectionGeometry(file, "split", true, theme, visibleAgentNotes, 100, true, false),
+    ).toBe(noteWidth100);
+  });
+
   test("accounts for visible inline notes without moving the hunk anchor", () => {
     const file = createTestDiffFile();
     const visibleAgentNotes: VisibleAgentNote[] = [

--- a/src/ui/diff/diffSectionGeometry.ts
+++ b/src/ui/diff/diffSectionGeometry.ts
@@ -92,9 +92,48 @@ function expansionCacheKey(
   return `:${sortedKeys}:${statusKey}`;
 }
 
+interface SectionGeometryCacheEntry {
+  key: string;
+  geometry: DiffSectionGeometry;
+}
+
+interface SectionGeometryCacheSlots {
+  base?: SectionGeometryCacheEntry;
+  notes?: SectionGeometryCacheEntry;
+}
+
 // Cache geometry by immutable DiffFile object so hunk navigation can survive parent re-renders
 // without rebuilding every file section. Replaced file objects naturally drop from the WeakMap.
-const SECTION_GEOMETRY_CACHE = new WeakMap<DiffFile, Map<string, DiffSectionGeometry>>();
+// Keep one no-note and one note-aware variant: large row-bounds arrays from old terminal widths
+// are replaced on resize, while note rendering can still compare against a stable base geometry.
+const SECTION_GEOMETRY_CACHE = new WeakMap<DiffFile, SectionGeometryCacheSlots>();
+
+/** Resolve which bounded per-file cache slot owns one geometry variant. */
+function sectionGeometryCacheSlot(visibleAgentNotes: VisibleAgentNote[]) {
+  return visibleAgentNotes.length > 0 ? "notes" : "base";
+}
+
+/** Read one cached geometry entry when the exact active variant is still retained. */
+function getCachedSectionGeometry(
+  file: DiffFile,
+  slot: keyof SectionGeometryCacheSlots,
+  cacheKey: string,
+) {
+  const cached = SECTION_GEOMETRY_CACHE.get(file)?.[slot];
+  return cached?.key === cacheKey ? cached.geometry : null;
+}
+
+/** Store one geometry entry, replacing stale variants for the same slot. */
+function setCachedSectionGeometry(
+  file: DiffFile,
+  slot: keyof SectionGeometryCacheSlots,
+  cacheKey: string,
+  geometry: DiffSectionGeometry,
+) {
+  const cachedByFile = SECTION_GEOMETRY_CACHE.get(file) ?? {};
+  cachedByFile[slot] = { key: cacheKey, geometry };
+  SECTION_GEOMETRY_CACHE.set(file, cachedByFile);
+}
 
 interface DiffSectionRowHeightOptions {
   layout: Exclude<LayoutMode, "auto">;
@@ -198,8 +237,8 @@ export function measureDiffSectionGeometry(
   // participate in the cache key alongside the structural file/layout inputs. Expansion state
   // changes the row stream, so it has to participate too.
   const cacheKey = `${file.id}:${layout}:${showHunkHeaders ? 1 : 0}:${theme.id}:${width}:${showLineNumbers ? 1 : 0}:${wrapLines ? 1 : 0}:${reserveAddNoteColumn ? 1 : 0}${expansionCacheKey(expandedKeys, sourceStatus)}${notesCacheKey(visibleAgentNotes)}`;
-  const cachedByFile = SECTION_GEOMETRY_CACHE.get(file);
-  const cached = cachedByFile?.get(cacheKey);
+  const cacheSlot = sectionGeometryCacheSlot(visibleAgentNotes);
+  const cached = getCachedSectionGeometry(file, cacheSlot, cacheKey);
   if (cached) {
     return cached;
   }
@@ -289,9 +328,7 @@ export function measureDiffSectionGeometry(
     rowBoundsByStableKey,
   };
 
-  const nextCachedByFile = cachedByFile ?? new Map();
-  nextCachedByFile.set(cacheKey, geometry);
-  SECTION_GEOMETRY_CACHE.set(file, nextCachedByFile);
+  setCachedSectionGeometry(file, cacheSlot, cacheKey, geometry);
 
   return geometry;
 }


### PR DESCRIPTION
## Summary

- Bound cached diff-section geometry to one base slot and one note-aware slot per `DiffFile`, replacing stale width/layout variants instead of retaining every resize.
- Preserve the stable no-note geometry that note-aware rendering compares against, avoiding note-layout scroll drift.
- Add regression coverage that a new width evicts the previous base variant while note-aware geometry remains independently cached.

## Validation

- `bun run typecheck`
- `bun test`
- Manual stress: reopened the 900-file / 454k-line synthetic diff and resized through multiple widths with an RSS guard. The cache no longer retains every width variant, though very large reviews can still transiently peak while React/Bun rebuilds current-width geometry.

*This PR description was generated by Pi using OpenAI GPT-5*