### PR TITLE
ci: download only platform artifacts for releases

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -159,6 +159,7 @@ jobs:
       - name: Download platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: hunkdiff-*
           path: dist/release/artifacts
 
       - name: Show downloaded artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable user-visible changes to Hunk are documented in this file.
 ### Fixed
 
 - Fixed Windows launches from Cygwin, Git Bash, and WSL-style VCS paths by normalizing Unix-style repo roots before reusing them as subprocess working directories or filesystem roots.
+- Fixed release staging so benchmark comparison artifacts are not mistaken for platform binary artifacts.
 - Reduced hunk-navigation latency and memory growth on large reviews by keeping diff geometry memoized when the selected hunk changes.
 - Reduced scroll and hunk-navigation latency on large reviews by avoiding repeated separator measurement and preserving memoized offscreen/visible diff rows across viewport updates.
 - Reduced main diff pane rendering work on large reviews by virtualizing offscreen file sections behind exact-height spacers.


### PR DESCRIPTION
## Summary

- Restrict the release staging artifact download to `hunkdiff-*` platform artifacts.
- Keep the uploaded benchmark comparison artifact from being interpreted as a prebuilt platform package.
- Note the release-staging fix in the 0.15.3 changelog section.

## Tests

- `bun run format:check`
- `bun run typecheck`

*This PR description was generated by Pi using OpenAI GPT-5*
