### PR TITLE
fix(session): allow CLI to clear user notes

### DIFF
--- a/.changeset/bright-notes-wink.md
+++ b/.changeset/bright-notes-wink.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Allow session comment cleanup commands to remove human `c` notes: `comment rm` accepts `user:*` note ids, and `comment clear --include-user`/`--all` clears user notes alongside live agent comments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Allowed `hunk session comment rm` to remove human `c` notes by `user:*` id, and added `hunk session comment clear --include-user`/`--all` to clear human notes alongside live agent comments.
 - Fixed Windows launches from Cygwin, Git Bash, and WSL-style VCS paths by normalizing Unix-style repo roots before reusing them as subprocess working directories or filesystem roots.
 - Fixed release staging so benchmark comparison artifacts are not mistaken for platform binary artifacts.
 - Reduced hunk-navigation latency and memory growth on large reviews by keeping diff geometry memoized when the selected hunk changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Fixed
 
-- Allowed `hunk session comment rm` to remove human `c` notes by `user:*` id, and added `hunk session comment clear --include-user`/`--all` to clear human notes alongside live agent comments.
 - Fixed Windows launches from Cygwin, Git Bash, and WSL-style VCS paths by normalizing Unix-style repo roots before reusing them as subprocess working directories or filesystem roots.
 - Fixed release staging so benchmark comparison artifacts are not mistaken for platform binary artifacts.
 - Reduced hunk-navigation latency and memory growth on large reviews by keeping diff geometry memoized when the selected hunk changes.

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -108,7 +108,10 @@ For comment cleanup and inspection, use:
 hunk session comment list --repo .
 hunk session comment rm --repo . <comment-id>
 hunk session comment clear --repo . --file README.md --yes
+hunk session comment clear --repo . --all --yes # also clears human `c` notes
 ```
+
+Agents can remove or bulk-clear human notes for cleanup, but cannot create or edit them through the session CLI.
 
 ## Session targeting
 

--- a/src/core/cli.test.ts
+++ b/src/core/cli.test.ts
@@ -717,6 +717,29 @@ describe("parseCli", () => {
     });
   });
 
+  test("parses session comment rm with a repo selector", async () => {
+    const repo = createTempDir("hunk-cli-rm-repo-");
+    mkdirSync(join(repo, ".git"));
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "comment",
+      "rm",
+      "--repo",
+      repo,
+      "user:1",
+    ]);
+
+    expect(parsed).toEqual({
+      kind: "session",
+      action: "comment-rm",
+      selector: { repoRoot: realpathSync.native(repo) },
+      commentId: "user:1",
+      output: "text",
+    });
+  });
+
   test("parses session comment clear", async () => {
     const parsed = await parseCli([
       "bun",
@@ -735,6 +758,28 @@ describe("parseCli", () => {
       action: "comment-clear",
       selector: { sessionId: "session-1" },
       filePath: "README.md",
+      confirmed: true,
+      output: "text",
+    });
+  });
+
+  test("parses session comment clear with user notes included", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "comment",
+      "clear",
+      "session-1",
+      "--all",
+      "--yes",
+    ]);
+
+    expect(parsed).toEqual({
+      kind: "session",
+      action: "comment-clear",
+      selector: { sessionId: "session-1" },
+      includeUser: true,
       confirmed: true,
       output: "text",
     });
@@ -827,7 +872,7 @@ describe("parseCli", () => {
   test("rejects session comment clear without confirmation", async () => {
     await expect(
       parseCli(["bun", "hunk", "session", "comment", "clear", "session-1"]),
-    ).rejects.toThrow("Pass --yes to clear live comments.");
+    ).rejects.toThrow("Pass --yes to clear comments.");
   });
 
   test("parses stash show mode", async () => {

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -630,7 +630,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
           "  hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
           "  hunk session comment list (<session-id> | --repo <path>) [--type <live|all|ai|agent|user>]",
           "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
-          "  hunk session comment clear (<session-id> | --repo <path>) --yes",
+          "  hunk session comment clear (<session-id> | --repo <path>) [--include-user|--all] --yes",
         ].join("\n") + "\n",
     };
   }
@@ -904,7 +904,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
             "  hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
             "  hunk session comment list (<session-id> | --repo <path>) [--file <path>] [--type <live|all|ai|agent|user>]",
             "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
-            "  hunk session comment clear (<session-id> | --repo <path>) [--file <path>] --yes",
+            "  hunk session comment clear (<session-id> | --repo <path>) [--file <path>] [--include-user|--all] --yes",
           ].join("\n") + "\n",
       };
     }
@@ -1112,27 +1112,18 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
 
     if (commentSubcommand === "rm") {
       const command = new Command("session comment rm")
-        .description("remove one live inline review note")
-        .argument("[sessionId]")
-        .argument("<commentId>")
+        .description("remove one inline review note")
+        .argument("[targets...]", "<session-id> <comment-id>, or <comment-id> with --repo")
         .option("--repo <path>", "target the live session whose repo root matches this path")
         .option("--json", "emit structured JSON");
 
-      let parsedSessionId: string | undefined;
-      let parsedCommentId = "";
+      let parsedTargets: string[] = [];
       let parsedOptions: { repo?: string; json?: boolean } = {};
 
-      command.action(
-        (
-          sessionId: string | undefined,
-          commentId: string,
-          options: { repo?: string; json?: boolean },
-        ) => {
-          parsedSessionId = sessionId;
-          parsedCommentId = commentId;
-          parsedOptions = options;
-        },
-      );
+      command.action((targets: string[], options: { repo?: string; json?: boolean }) => {
+        parsedTargets = targets;
+        parsedOptions = options;
+      });
 
       if (commentRest.includes("--help") || commentRest.includes("-h")) {
         return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
@@ -1140,28 +1131,44 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
 
       await parseStandaloneCommand(command, commentRest);
 
+      const expectedTargetCount = parsedOptions.repo ? 1 : 2;
+      if (parsedTargets.length !== expectedTargetCount) {
+        throw new Error(
+          parsedOptions.repo
+            ? "Specify exactly one comment id with --repo <path>."
+            : "Specify a session id and comment id, or pass --repo <path> with one comment id.",
+        );
+      }
+
+      const parsedSessionId = parsedOptions.repo ? undefined : parsedTargets[0];
+      const parsedCommentId = parsedOptions.repo ? parsedTargets[0] : parsedTargets[1];
+
       return {
         kind: "session",
         action: "comment-rm",
         output: resolveJsonOutput(parsedOptions),
         selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
-        commentId: parsedCommentId,
+        commentId: parsedCommentId ?? "",
       };
     }
 
     if (commentSubcommand === "clear") {
       const command = new Command("session comment clear")
-        .description("clear live inline review notes")
+        .description("clear inline review notes")
         .argument("[sessionId]")
         .option("--repo <path>", "target the live session whose repo root matches this path")
         .option("--file <path>", "clear only one diff file's comments")
-        .option("--yes", "confirm destructive live comment clearing")
+        .option("--include-user", "also clear human notes created with the TUI `c` action")
+        .option("--all", "clear both live agent comments and human user notes")
+        .option("--yes", "confirm destructive comment clearing")
         .option("--json", "emit structured JSON");
 
       let parsedSessionId: string | undefined;
       let parsedOptions: {
         repo?: string;
         file?: string;
+        includeUser?: boolean;
+        all?: boolean;
         yes?: boolean;
         json?: boolean;
       } = {};
@@ -1172,6 +1179,8 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
           options: {
             repo?: string;
             file?: string;
+            includeUser?: boolean;
+            all?: boolean;
             yes?: boolean;
             json?: boolean;
           },
@@ -1187,7 +1196,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
 
       await parseStandaloneCommand(command, commentRest);
       if (!parsedOptions.yes) {
-        throw new Error("Pass --yes to clear live comments.");
+        throw new Error("Pass --yes to clear comments.");
       }
 
       return {
@@ -1196,6 +1205,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         output: resolveJsonOutput(parsedOptions),
         selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
         filePath: parsedOptions.file,
+        ...(parsedOptions.includeUser || parsedOptions.all ? { includeUser: true } : {}),
         confirmed: true,
       };
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -278,6 +278,7 @@ export interface SessionCommentClearCommandInput {
   output: SessionCommandOutput;
   selector: SessionSelectorInput;
   filePath?: string;
+  includeUser?: boolean;
   confirmed: boolean;
 }
 

--- a/src/hunk-session/bridge.test.ts
+++ b/src/hunk-session/bridge.test.ts
@@ -132,7 +132,7 @@ describe("createHunkSessionBridge", () => {
       type: "command",
       requestId: "clear-1",
       command: "clear_comments",
-      input: { sessionId: "session-1", filePath: "src/example.ts" },
+      input: { sessionId: "session-1", filePath: "src/example.ts", includeUser: true },
     });
 
     expect(handlers.navigateToLocation).toHaveBeenCalledTimes(1);
@@ -143,5 +143,8 @@ describe("createHunkSessionBridge", () => {
     );
     expect(handlers.removeLiveComment).toHaveBeenCalledTimes(1);
     expect(handlers.clearLiveComments).toHaveBeenCalledTimes(1);
+    expect(handlers.clearLiveComments).toHaveBeenCalledWith("src/example.ts", {
+      includeUser: true,
+    });
   });
 });

--- a/src/hunk-session/bridge.ts
+++ b/src/hunk-session/bridge.ts
@@ -20,7 +20,10 @@ export interface HunkSessionBridgeHandlers {
     requestId: string,
     options?: { revealMode?: "none" | "first" },
   ) => AppliedCommentBatchResult;
-  clearLiveComments: (filePath?: string) => ClearedCommentsResult;
+  clearLiveComments: (
+    filePath?: string,
+    options?: { includeUser?: boolean },
+  ) => ClearedCommentsResult;
   navigateToLocation: (
     input: Extract<HunkSessionServerMessage, { command: "navigate_to_hunk" }>["input"],
   ) => NavigatedSelectionResult;
@@ -74,7 +77,9 @@ export function createHunkSessionBridge(handlers: HunkSessionBridgeHandlers) {
         case "remove_comment":
           return handlers.removeLiveComment(message.input.commentId);
         case "clear_comments":
-          return handlers.clearLiveComments(message.input.filePath);
+          return handlers.clearLiveComments(message.input.filePath, {
+            includeUser: message.input.includeUser,
+          });
       }
     },
   };

--- a/src/hunk-session/cli.ts
+++ b/src/hunk-session/cli.ts
@@ -204,6 +204,7 @@ class HttpHunkSessionCliClient implements HunkSessionCliClient {
         action: "comment-clear",
         selector: input.selector,
         filePath: input.filePath,
+        includeUser: input.includeUser,
       })
     ).result;
   }
@@ -450,7 +451,8 @@ export function formatRemoveCommentOutput(
   selector: SessionSelectorInput,
   result: RemovedCommentResult,
 ) {
-  return `Removed live comment ${result.commentId} from ${describeSessionSelector(selector)}. Remaining comments: ${result.remainingCommentCount}.\n`;
+  const label = result.source === "user" ? "user note" : "live comment";
+  return `Removed ${label} ${result.commentId} from ${describeSessionSelector(selector)}. Remaining comments: ${result.remainingCommentCount}.\n`;
 }
 
 export function formatNoteListOutput(
@@ -480,5 +482,6 @@ export function formatClearCommentsOutput(
   const scope = result.filePath
     ? `${result.filePath} in ${describeSessionSelector(selector)}`
     : describeSessionSelector(selector);
-  return `Cleared ${result.removedCount} live comments from ${scope}. Remaining comments: ${result.remainingCommentCount}.\n`;
+  const label = result.includeUser ? "comments" : "live comments";
+  return `Cleared ${result.removedCount} ${label} from ${scope}. Remaining comments: ${result.remainingCommentCount}.\n`;
 }

--- a/src/hunk-session/types.ts
+++ b/src/hunk-session/types.ts
@@ -98,6 +98,7 @@ export interface RemoveCommentToolInput extends SessionTargetInput {
 
 export interface ClearCommentsToolInput extends SessionTargetInput {
   filePath?: string;
+  includeUser?: boolean;
 }
 
 export interface SessionLiveCommentSummary {
@@ -151,12 +152,18 @@ export interface RemovedCommentResult {
   commentId: string;
   removed: boolean;
   remainingCommentCount: number;
+  source?: ReviewNoteSource;
 }
 
 export interface ClearedCommentsResult {
   removedCount: number;
   remainingCommentCount: number;
   filePath?: string;
+  includeUser?: boolean;
+  removedLiveCommentCount?: number;
+  removedUserNoteCount?: number;
+  remainingLiveCommentCount?: number;
+  remainingUserNoteCount?: number;
 }
 
 export interface ReloadedSessionResult {

--- a/src/session-broker/brokerServer.test.ts
+++ b/src/session-broker/brokerServer.test.ts
@@ -291,7 +291,7 @@ describe("Hunk session daemon server", () => {
       expect(capabilities.status).toBe(200);
       await expect(capabilities.json()).resolves.toMatchObject({
         version: 1,
-        daemonVersion: 3,
+        daemonVersion: 4,
         actions: [
           "list",
           "get",

--- a/src/session-broker/brokerServer.ts
+++ b/src/session-broker/brokerServer.ts
@@ -357,6 +357,7 @@ async function handleSessionApiRequest(state: HunkSessionBrokerState, request: R
             input: {
               ...input.selector,
               filePath: input.filePath,
+              includeUser: input.includeUser,
             },
             timeoutMessage: "Timed out waiting for the session to clear the requested comments.",
           }),

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -31,7 +31,7 @@ export const HUNK_SESSION_API_VERSION = 1;
  * Version daemon/session compatibility separately from the HTTP action surface so newer Hunk
  * builds can refresh an older daemon even when it still exposes the same API endpoints.
  */
-export const HUNK_SESSION_DAEMON_VERSION = 3;
+export const HUNK_SESSION_DAEMON_VERSION = 4;
 
 export type SessionDaemonAction =
   | "list"
@@ -117,6 +117,7 @@ export type SessionDaemonRequest =
       action: "comment-clear";
       selector: SessionCommentClearCommandInput["selector"];
       filePath?: string;
+      includeUser?: boolean;
     };
 
 export type SessionDaemonResponse =

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -570,6 +570,51 @@ describe("useReviewController", () => {
       await flush(setup);
 
       await act(async () => {
+        const result = expectValue(controllerRef.current).removeLiveComment("comment-1");
+        expect(result).toMatchObject({
+          commentId: "comment-1",
+          removed: true,
+          remainingCommentCount: 1,
+          source: "agent",
+        });
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).liveCommentSummaries).toEqual([]);
+      expect(expectValue(controllerRef.current).userNotesByFileId.alpha).toHaveLength(1);
+
+      await act(async () => {
+        expectValue(controllerRef.current).addLiveComment(
+          { filePath: "alpha.ts", hunkIndex: 0, summary: "Default clear agent note" },
+          "comment-2",
+        );
+      });
+      await flush(setup);
+
+      await act(async () => {
+        const result = expectValue(controllerRef.current).clearLiveComments();
+        expect(result).toMatchObject({
+          removedCount: 1,
+          remainingCommentCount: 1,
+          removedLiveCommentCount: 1,
+          removedUserNoteCount: 0,
+          remainingUserNoteCount: 1,
+        });
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).liveCommentSummaries).toEqual([]);
+      expect(expectValue(controllerRef.current).userNotesByFileId.alpha).toHaveLength(1);
+
+      await act(async () => {
+        expectValue(controllerRef.current).addLiveComment(
+          { filePath: "alpha.ts", hunkIndex: 0, summary: "Inclusive clear agent note" },
+          "comment-3",
+        );
+      });
+      await flush(setup);
+
+      await act(async () => {
         const result = expectValue(controllerRef.current).clearLiveComments(undefined, {
           includeUser: true,
         });

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -524,11 +524,66 @@ describe("useReviewController", () => {
       ]);
 
       await act(async () => {
-        expectValue(controllerRef.current).removeUserNote(savedNoteId);
+        const result = expectValue(controllerRef.current).removeLiveComment(savedNoteId);
+        expect(result).toMatchObject({
+          commentId: savedNoteId,
+          removed: true,
+          remainingCommentCount: 0,
+          source: "user",
+        });
       });
       await flush(setup);
 
       expect(expectValue(controllerRef.current).userNotesByFileId.alpha).toBeUndefined();
+      expect(expectValue(controllerRef.current).reviewNoteSummaries).toEqual([]);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("session clear can include human user notes", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        const controller = expectValue(controllerRef.current);
+        controller.addLiveComment(
+          { filePath: "alpha.ts", hunkIndex: 0, summary: "Agent cleanup note" },
+          "comment-1",
+        );
+        controller.startUserNote("alpha", 0);
+      });
+      await flush(setup);
+
+      await act(async () => {
+        expectValue(controllerRef.current).updateDraftNote("Human cleanup note.");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        expectValue(controllerRef.current).saveDraftNote();
+      });
+      await flush(setup);
+
+      await act(async () => {
+        const result = expectValue(controllerRef.current).clearLiveComments(undefined, {
+          includeUser: true,
+        });
+        expect(result).toMatchObject({
+          removedCount: 2,
+          remainingCommentCount: 0,
+          removedLiveCommentCount: 1,
+          removedUserNoteCount: 1,
+        });
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).liveCommentSummaries).toEqual([]);
+      expect(expectValue(controllerRef.current).userNotesByFileId).toEqual({});
       expect(expectValue(controllerRef.current).reviewNoteSummaries).toEqual([]);
     } finally {
       await act(async () => {

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -83,6 +83,11 @@ function removeKeys<T>(record: Record<string, T>, keys: ReadonlySet<string>): Re
   return changed ? next : record;
 }
 
+/** Count array-backed entries in a file-id keyed note map. */
+function countFileMapItems<T>(record: Record<string, T[]>) {
+  return Object.values(record).reduce((sum, items) => sum + items.length, 0);
+}
+
 export interface UserReviewNote extends AgentAnnotation {
   id: string;
   source: "user";
@@ -158,7 +163,10 @@ export interface ReviewController {
     options?: { revealMode?: "none" | "first" },
   ) => AppliedCommentBatchResult;
   clearFilter: () => void;
-  clearLiveComments: (filePath?: string) => ClearedCommentsResult;
+  clearLiveComments: (
+    filePath?: string,
+    options?: { includeUser?: boolean },
+  ) => ClearedCommentsResult;
   navigateToLocation: (input: NavigateToHunkToolInput) => NavigatedSelectionResult;
   removeLiveComment: (commentId: string) => RemovedCommentResult;
   cancelDraftNote: () => void;
@@ -652,11 +660,38 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     [allFiles, selectHunk],
   );
 
-  /** Remove one live comment by id and report how many remain. */
+  /** Remove one daemon-addressable comment, including human notes by stable `user:*` id. */
   const removeLiveComment = useCallback(
     (commentId: string): RemovedCommentResult => {
+      if (commentId.startsWith("user:")) {
+        let removed = false;
+        const next: Record<string, UserReviewNote[]> = {};
+
+        for (const [fileId, notes] of Object.entries(userNotesByFileId)) {
+          const filtered = notes.filter((note) => note.id !== commentId);
+          if (filtered.length !== notes.length) {
+            removed = true;
+          }
+          if (filtered.length > 0) {
+            next[fileId] = filtered;
+          }
+        }
+
+        if (!removed) {
+          throw new Error(`No user note matches id ${commentId}.`);
+        }
+
+        setUserNotesByFileId(next);
+        return {
+          commentId,
+          removed: true,
+          remainingCommentCount: countFileMapItems(liveCommentsByFileId) + countFileMapItems(next),
+          source: "user",
+        };
+      }
+
       let removed = false;
-      let remainingCommentCount = 0;
+      let remainingLiveCommentCount = 0;
       const next: Record<string, LiveComment[]> = {};
 
       for (const [fileId, comments] of Object.entries(liveCommentsByFileId)) {
@@ -667,7 +702,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
 
         if (filtered.length > 0) {
           next[fileId] = filtered;
-          remainingCommentCount += filtered.length;
+          remainingLiveCommentCount += filtered.length;
         }
       }
 
@@ -679,55 +714,87 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
       return {
         commentId,
         removed: true,
-        remainingCommentCount,
+        remainingCommentCount: remainingLiveCommentCount,
+        source: "agent",
       };
     },
-    [liveCommentsByFileId],
+    [liveCommentsByFileId, userNotesByFileId],
   );
 
-  /** Clear all live comments, or only the comments attached to one specific file. */
+  /** Clear live comments, optionally including human notes, globally or for one file. */
   const clearLiveComments = useCallback(
-    (filePath?: string): ClearedCommentsResult => {
-      let removedCount = 0;
-      let remainingCommentCount = 0;
+    (filePath?: string, options: { includeUser?: boolean } = {}): ClearedCommentsResult => {
+      const file = filePath ? findDiffFileByPath(allFiles, filePath) : undefined;
+      if (filePath && !file) {
+        throw new Error(`No diff file matches ${filePath}.`);
+      }
 
-      if (filePath) {
-        const file = findDiffFileByPath(allFiles, filePath);
-        if (!file) {
-          throw new Error(`No diff file matches ${filePath}.`);
-        }
+      let removedLiveCommentCount = 0;
+      let remainingLiveCommentCount = 0;
+      let nextLiveCommentsByFileId: Record<string, LiveComment[]> = liveCommentsByFileId;
 
-        const next: Record<string, LiveComment[]> = {};
+      if (file) {
+        nextLiveCommentsByFileId = {};
         for (const [fileId, comments] of Object.entries(liveCommentsByFileId)) {
           if (fileId === file.id) {
-            removedCount = comments.length;
+            removedLiveCommentCount = comments.length;
             continue;
           }
 
-          next[fileId] = comments;
-          remainingCommentCount += comments.length;
-        }
-
-        if (removedCount > 0) {
-          setLiveCommentsByFileId(next);
+          nextLiveCommentsByFileId[fileId] = comments;
+          remainingLiveCommentCount += comments.length;
         }
       } else {
-        removedCount = Object.values(liveCommentsByFileId).reduce(
-          (sum, comments) => sum + comments.length,
-          0,
-        );
-        if (removedCount > 0) {
-          setLiveCommentsByFileId({});
+        removedLiveCommentCount = countFileMapItems(liveCommentsByFileId);
+        remainingLiveCommentCount = 0;
+        nextLiveCommentsByFileId = {};
+      }
+
+      if (removedLiveCommentCount > 0) {
+        setLiveCommentsByFileId(nextLiveCommentsByFileId);
+      }
+
+      let removedUserNoteCount = 0;
+      let remainingUserNoteCount = countFileMapItems(userNotesByFileId);
+      let nextUserNotesByFileId = userNotesByFileId;
+
+      if (options.includeUser) {
+        if (file) {
+          nextUserNotesByFileId = {};
+          remainingUserNoteCount = 0;
+          for (const [fileId, notes] of Object.entries(userNotesByFileId)) {
+            if (fileId === file.id) {
+              removedUserNoteCount = notes.length;
+              continue;
+            }
+
+            nextUserNotesByFileId[fileId] = notes;
+            remainingUserNoteCount += notes.length;
+          }
+        } else {
+          removedUserNoteCount = countFileMapItems(userNotesByFileId);
+          remainingUserNoteCount = 0;
+          nextUserNotesByFileId = {};
+        }
+
+        if (removedUserNoteCount > 0) {
+          setUserNotesByFileId(nextUserNotesByFileId);
         }
       }
 
       return {
-        removedCount,
-        remainingCommentCount,
+        removedCount: removedLiveCommentCount + removedUserNoteCount,
+        remainingCommentCount:
+          remainingLiveCommentCount + (options.includeUser ? remainingUserNoteCount : 0),
         filePath,
+        includeUser: options.includeUser,
+        removedLiveCommentCount,
+        removedUserNoteCount,
+        remainingLiveCommentCount,
+        remainingUserNoteCount,
       };
     },
-    [allFiles, liveCommentsByFileId],
+    [allFiles, liveCommentsByFileId, userNotesByFileId],
   );
 
   /** Start a human-authored draft note at the selected or requested hunk. */

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -714,7 +714,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
       return {
         commentId,
         removed: true,
-        remainingCommentCount: remainingLiveCommentCount,
+        remainingCommentCount: remainingLiveCommentCount + countFileMapItems(userNotesByFileId),
         source: "agent",
       };
     },
@@ -784,8 +784,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
 
       return {
         removedCount: removedLiveCommentCount + removedUserNoteCount,
-        remainingCommentCount:
-          remainingLiveCommentCount + (options.includeUser ? remainingUserNoteCount : 0),
+        remainingCommentCount: remainingLiveCommentCount + remainingUserNoteCount,
         filePath,
         includeUser: options.includeUser,
         removedLiveCommentCount,


### PR DESCRIPTION
## Summary

- allow `hunk session comment rm --repo <path> user:*` to remove human `c` notes by stable note id
- add `comment clear --include-user` / `--all` to clear human notes alongside live agent comments
- thread the new clear mode through the session daemon bridge and bump daemon compatibility

Fixes #382.

## Testing

- `bun run format`
- `bun run typecheck`
- `bun test`
- tmux manual automation:
  - file-pair session: create human notes in tmux, remove by `user:*`, recreate with live agent note, clear with `--all`
  - repo session x3: target via `--repo`, verify `rm` removes `user:*`, default `clear --yes` leaves human notes, and `clear --include-user --yes` removes them

*This PR description was generated by Pi using OpenAI GPT-5*
