### PR TITLE
perf(ui): reduce Solid hunk navigation overhead

### DIFF
--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -86,6 +86,7 @@ import {
 } from "./copySelection";
 
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
+const EMPTY_VISIBLE_AGENT_NOTES_BY_FILE = new Map<string, VisibleAgentNote[]>();
 
 /**
  * Clamp one vertical scroll target into the currently reachable review-stream extent.
@@ -696,6 +697,11 @@ export function DiffPane(props: DiffPaneProps) {
   });
 
   const visibleAgentNotesByFile = createMemo(() => {
+    const notesByFile = allAgentNotesByFile();
+    if (notesByFile.size === 0) {
+      return EMPTY_VISIBLE_AGENT_NOTES_BY_FILE;
+    }
+
     const next = new Map<string, VisibleAgentNote[]>();
 
     const fileIdsToMeasure = new Set(visibleViewportFileIds());
@@ -706,7 +712,6 @@ export function DiffPane(props: DiffPaneProps) {
       fileIdsToMeasure.add(currentSelectedFileId);
     }
 
-    const notesByFile = allAgentNotesByFile();
     for (const fileId of fileIdsToMeasure) {
       const visibleNotes = notesByFile.get(fileId);
       if (visibleNotes && visibleNotes.length > 0) {
@@ -1675,12 +1680,12 @@ export function DiffPane(props: DiffPaneProps) {
       }
     };
 
-    // Run after this pane renders the selected section/hunk, then retry briefly while layout
-    // settles across a couple of repaint cycles.
+    // Run after this pane renders the selected section/hunk, then retry once on the next task so
+    // mounted row bounds can settle without stacking multiple delayed timers per navigation press.
     suppressViewportSelectionSync();
     scrollSelectionIntoView();
     pendingSelectionSettleRef.current = shouldTrackPinnedHeaderResettle;
-    const retryDelays = [0, 16, 48];
+    const retryDelays = [0];
     const timeouts = retryDelays.map((delay) => setTimeout(scrollSelectionIntoView, delay));
     const settleReset = shouldTrackPinnedHeaderResettle
       ? setTimeout(() => {

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -2,6 +2,7 @@ import { useRenderer } from "@opentui/solid";
 import {
   createEffect,
   createMemo,
+  createSelector,
   createSignal,
   For,
   Match,
@@ -235,6 +236,10 @@ export function PierreDiffView(props: PierreDiffViewProps) {
       clearHoveredRow();
     }
   };
+  // Only rows in the previous and next selected hunk need selection styling updates; using a
+  // selector avoids making every mounted row reactive to every hunk-index change.
+  const isSelectedHunk = createSelector(() => props.selectedHunkIndex);
+
   const visiblePlannedRowWindow = createMemo(() => {
     // Fall back to the full row list unless all three row-windowing inputs are ready:
     // - the complete planned row stream for this file
@@ -327,7 +332,7 @@ export function PierreDiffView(props: PierreDiffViewProps) {
                         wrapLines={wrapLines()}
                         codeHorizontalOffset={codeHorizontalOffset()}
                         theme={props.theme}
-                        selected={diffRow().row.hunkIndex === props.selectedHunkIndex}
+                        selected={isSelectedHunk(diffRow().row.hunkIndex)}
                         copySelectedRowRange={props.copySelectedRowRanges?.get(diffRow().key)}
                         copySelectedSide={props.copySelectedSide}
                         anchorId={diffRow().anchorId}

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -31,14 +31,15 @@ import type {
 import type { FileSourceStatus } from "../diff/expandCollapsedRows";
 import { selectGapForKeyboardToggle } from "../diff/expandCollapsedRows";
 import { trailingCollapsedLines } from "../diff/pierre";
-import { findNextHunkCursor } from "../lib/hunks";
+import { buildAnnotatedHunkCursors, buildHunkCursors, findNextHunkCursor } from "../lib/hunks";
 import { reviewNoteSource } from "../lib/agentAnnotations";
+import { buildSidebarEntries, filterReviewFiles, mergeFileAnnotationsByFileId } from "../lib/files";
 import {
-  buildReviewState,
   buildSelectedHunkSummary,
   findNextAnnotatedFile,
   type ReviewState,
   resolveReviewNavigationTarget,
+  resolveSelectedFile,
 } from "../lib/reviewState";
 
 /** Clamp one numeric index into an inclusive range. */
@@ -249,37 +250,31 @@ export function useReviewController({ files }: { files: Accessor<DiffFile[]> }):
     }
   });
 
-  // The filter feeds an expensive review-state recompute. React deferred it via
-  // `useDeferredValue` to keep typing responsive; Solid's fine-grained updates
-  // recompute only the dependent memo, so we read the filter signal directly
-  // here instead of deferring. Behavior change: filter results now update
-  // synchronously with each keystroke rather than after a deferred pass.
-  const reviewState = createMemo(() =>
-    buildReviewState({
-      files: files(),
-      liveCommentsByFileId: mergeAnnotationMaps(liveCommentsByFileId(), userNotesByFileId()),
-      filterQuery: filter(),
-      selectedFileId: selectedFileId(),
-      selectedHunkIndex: selectedHunkIndex(),
-    }),
-  );
-
-  // `reviewState` recomputes on every selection change (it reads the selected file/hunk), which
-  // hands back fresh array references for these selection-independent lists. Without an equality
-  // guard that propagates downstream into expensive consumers (e.g. DiffPane re-measures every
-  // file's geometry on each hunk navigation). Compare by element identity so these only notify
-  // when the underlying list actually changes (filter edit, reload) — not on navigation.
+  // Compare file lists by element identity so selection-independent review-stream derivatives do
+  // not notify expensive consumers unless the actual stream changes (filter edit, reload, notes).
   const sameFileList = (a: DiffFile[], b: DiffFile[]) =>
     a === b || (a.length === b.length && a.every((file, index) => file === b[index]));
-  const allFiles = createMemo(() => reviewState().allFiles, undefined, { equals: sameFileList });
-  const visibleFiles = createMemo(() => reviewState().visibleFiles, undefined, {
+
+  const mergedAnnotationsByFileId = createMemo(() =>
+    mergeAnnotationMaps(liveCommentsByFileId(), userNotesByFileId()),
+  );
+  const allFiles = createMemo(
+    () => mergeFileAnnotationsByFileId(files(), mergedAnnotationsByFileId()),
+    undefined,
+    { equals: sameFileList },
+  );
+  // The filter feeds expensive sidebar and hunk-cursor derivations. Keep it independent from the
+  // selected file/hunk so normal `[`/`]` navigation does not rebuild the whole review stream.
+  const visibleFiles = createMemo(() => filterReviewFiles(allFiles(), filter()), undefined, {
     equals: sameFileList,
   });
-  const sidebarEntries = createMemo(() => reviewState().sidebarEntries);
-  const selectedFile = createMemo(() => reviewState().selectedFile);
-  const selectedHunk = createMemo(() => reviewState().selectedHunk);
-  const hunkCursors = createMemo(() => reviewState().hunkCursors);
-  const annotatedHunkCursors = createMemo(() => reviewState().annotatedHunkCursors);
+  const sidebarEntries = createMemo(() => buildSidebarEntries(visibleFiles()));
+  const selectedFile = createMemo(() =>
+    resolveSelectedFile(allFiles(), visibleFiles(), selectedFileId()),
+  );
+  const selectedHunk = createMemo(() => selectedFile()?.metadata.hunks[selectedHunkIndex()]);
+  const hunkCursors = createMemo(() => buildHunkCursors(visibleFiles()));
+  const annotatedHunkCursors = createMemo(() => buildAnnotatedHunkCursors(visibleFiles()));
 
   /** Update the selection and reveal intent together so diff scrolling stays explicit. */
   const selectHunk = (fileId: string, hunkIndex: number, options?: ReviewSelectionOptions) => {


### PR DESCRIPTION
## Summary

- Split Solid review-controller derivations so hunk selection changes no longer rebuild selection-independent file/sidebar state.
- Use Solid `createSelector` for selected-hunk row styling so only the old/new selected hunks react to selection changes.
- Trim selected-hunk reveal retries and skip visible agent-note planning when there are no notes.

## Benchmark notes

Autoresearch on the Solid branch reduced the Solid-vs-React `perf_score` from `18206.08` to `4657.90` in the local harness. Key kept-run metrics from the best run:

- Hunk nav median: `72.93ms` (`1.06x` React baseline)
- Hunk nav p95: `92.50ms` (`1.23x` React baseline)
- After-navigation heap: `1.19x` React baseline
- Large-stream scroll: `1.08x` React baseline

A later fresh 3-sample comparison against `origin/main` still shows React ahead overall, but the Solid port is substantially closer than the initial migration, especially on hunk navigation and retained heap.

## Verification

- `bun run typecheck`

*This PR description was generated by Pi using OpenAI GPT-5 Codex*