### PR TITLE
perf: precompute render span cell widths

### DIFF
--- a/src/lib/terminalText.ts
+++ b/src/lib/terminalText.ts
@@ -75,7 +75,7 @@ export function sanitizeTerminalSpans<T extends { text: string }>(spans: readonl
   for (const span of spans) {
     const text = sanitizeTerminalLine(span.text);
     if (text.length > 0) {
-      sanitized.push({ ...span, text } as T);
+      sanitized.push(text === span.text ? span : ({ ...span, text, cellWidth: undefined } as T));
     }
   }
   return sanitized;

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -10,6 +10,7 @@ import {
 import { formatHunkHeader } from "../../core/hunkHeader";
 import type { DiffFile, DiffLineMoveKind } from "../../core/types";
 import { blendHex, hexColorDistance } from "../lib/color";
+import { measureTextWidth } from "../lib/text";
 import { sanitizeTerminalLine } from "../../lib/terminalText";
 import { TRANSPARENT_BACKGROUND, type AppTheme } from "../themes";
 import { expandDiffTabs } from "./codeColumns";
@@ -78,6 +79,8 @@ export interface RenderSpan {
   text: string;
   fg?: string;
   bg?: string;
+  /** Cached terminal-cell width for sanitized span text. */
+  cellWidth?: number;
 }
 
 export interface SplitLineCell {
@@ -323,19 +326,27 @@ function normalizeHighlightedColor(color: string | undefined, theme: AppTheme) {
   return resolvedColor;
 }
 
+/** Build one styled span and measure it once while row construction has stable ownership. */
+function createRenderSpan(text: string, style: Pick<RenderSpan, "fg" | "bg"> = {}): RenderSpan {
+  return { ...style, text, cellWidth: measureTextWidth(text) };
+}
+
 /** Append a span while coalescing adjacent runs with identical colors. */
 function mergeSpan(target: RenderSpan[], next: RenderSpan) {
   if (next.text.length === 0) {
     return;
   }
 
+  const nextWidth = next.cellWidth ?? measureTextWidth(next.text);
   const previous = target[target.length - 1];
   if (previous && previous.fg === next.fg && previous.bg === next.bg) {
+    const previousWidth = previous.cellWidth ?? measureTextWidth(previous.text);
     previous.text += next.text;
+    previous.cellWidth = previousWidth + nextWidth;
     return;
   }
 
-  target.push(next);
+  target.push({ ...next, cellWidth: nextWidth });
 }
 
 /** Flatten one highlighted HAST line into terminal-friendly styled text spans. */
@@ -366,11 +377,7 @@ function flattenHighlightedLine(node: HastNode | undefined, theme: AppTheme, emp
       // Pierre injects a "\n" placeholder into empty line nodes so they aren't childless.
       // Strip it the same way cleanDiffLine does for the unhighlighted path, or the literal
       // newline ends up in the span text and breaks terminal row rendering.
-      mergeSpan(spans, {
-        text: tabify(cleanLastNewline(current.value)),
-        fg: inherited.fg,
-        bg: inherited.bg,
-      });
+      mergeSpan(spans, createRenderSpan(tabify(cleanLastNewline(current.value)), inherited));
       return;
     }
 
@@ -430,13 +437,13 @@ function makeSplitCell(
   let spans: RenderSpan[];
   if (highlightedLine === undefined) {
     const fallbackText = cleanDiffLine(rawLine);
-    spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+    spans = fallbackText.length > 0 ? [createRenderSpan(fallbackText)] : [];
   } else {
     spans = flattenHighlightedLine(highlightedLine, theme, wordDiffHighlightBg(kind, theme));
 
     if (spans.length === 0) {
       const fallbackText = cleanDiffLine(rawLine);
-      spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+      spans = fallbackText.length > 0 ? [createRenderSpan(fallbackText)] : [];
     }
   }
 
@@ -464,13 +471,13 @@ function makeStackCell(
   let spans: RenderSpan[];
   if (highlightedLine === undefined) {
     const fallbackText = cleanDiffLine(rawLine);
-    spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+    spans = fallbackText.length > 0 ? [createRenderSpan(fallbackText)] : [];
   } else {
     spans = flattenHighlightedLine(highlightedLine, theme, wordDiffHighlightBg(kind, theme));
 
     if (spans.length === 0) {
       const fallbackText = cleanDiffLine(rawLine);
-      spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+      spans = fallbackText.length > 0 ? [createRenderSpan(fallbackText)] : [];
     }
   }
 

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -46,11 +46,20 @@ export function fitText(text: string, width: number) {
   return `${sliceTextByWidth(safeText, 0, width - 1).text}…`;
 }
 
+/** Measure one render span, preferring widths planned during row construction. */
+function measureRenderSpanWidth(span: RenderSpan) {
+  return span.cellWidth ?? measureTextWidth(span.text);
+}
+
 /** Append a styled span while preserving color-run coalescing. */
 function appendRenderSpan(target: RenderSpan[], span: RenderSpan) {
   const previous = target.at(-1);
   if (previous && previous.fg === span.fg && previous.bg === span.bg) {
     previous.text += span.text;
+    previous.cellWidth =
+      previous.cellWidth !== undefined && span.cellWidth !== undefined
+        ? previous.cellWidth + span.cellWidth
+        : undefined;
   } else {
     target.push(span);
   }
@@ -75,7 +84,7 @@ function sliceSpansWindow(spans: RenderSpan[], offset: number, width: number) {
       break;
     }
 
-    const spanWidth = measureTextWidth(span.text);
+    const spanWidth = measureRenderSpanWidth(span);
     if (spanWidth === 0) {
       appendRenderSpan(sliced, span);
       continue;
@@ -96,6 +105,7 @@ function sliceSpansWindow(spans: RenderSpan[], offset: number, width: number) {
     const nextSpan = {
       ...span,
       text: visible.text,
+      cellWidth: visible.width,
     };
 
     appendRenderSpan(sliced, nextSpan);
@@ -142,7 +152,7 @@ function renderInlineSpans(
   let colPos = 0;
 
   for (const span of trimmed) {
-    const spanWidth = measureTextWidth(span.text);
+    const spanWidth = measureRenderSpanWidth(span);
     const spanStart = colPos;
     const spanEnd = colPos + spanWidth;
     colPos = spanEnd;
@@ -287,7 +297,7 @@ function wrapSpans(spans: RenderSpan[], width: number) {
   let remaining = width;
 
   for (const span of sanitizeTerminalSpans(spans)) {
-    const spanWidth = measureTextWidth(span.text);
+    const spanWidth = measureRenderSpanWidth(span);
     if (spanWidth === 0) {
       appendRenderSpan(current, span);
       continue;
@@ -315,6 +325,7 @@ function wrapSpans(spans: RenderSpan[], width: number) {
         const nextSpan = {
           ...span,
           text: forced.text,
+          cellWidth: forced.width,
         };
         current.push(nextSpan);
         offset += forced.width;
@@ -325,6 +336,7 @@ function wrapSpans(spans: RenderSpan[], width: number) {
       const nextSpan = {
         ...span,
         text: visible.text,
+        cellWidth: visible.width,
       };
       appendRenderSpan(current, nextSpan);
 


### PR DESCRIPTION
## Summary

- precompute terminal cell widths when Pierre render spans are constructed
- reuse planned span widths during render-window slicing and wrapping
- preserve behavior by clearing cached width metadata when sanitization changes span text

## Validation

- bun test src/lib/terminalText.test.ts src/ui/diff/pierre.test.ts src/ui/lib/ui-lib.test.ts
- bun run typecheck

*This PR description was generated by Pi using OpenAI GPT-5*