### PR TITLE
perf: skip sanitizing trusted render spans

### DIFF
--- a/src/lib/terminalText.ts
+++ b/src/lib/terminalText.ts
@@ -73,9 +73,18 @@ export function sanitizeTerminalLine(text: string) {
 export function sanitizeTerminalSpans<T extends { text: string }>(spans: readonly T[]): T[] {
   const sanitized: T[] = [];
   for (const span of spans) {
+    // Pierre-built spans are already normalized with sanitizeTerminalLine before row planning.
+    // Trust only the explicit marker so external/test-authored spans still take the safe path.
+    if ((span as T & { terminalSafe?: true }).terminalSafe) {
+      if (span.text.length > 0) {
+        sanitized.push(span);
+      }
+      continue;
+    }
+
     const text = sanitizeTerminalLine(span.text);
     if (text.length > 0) {
-      sanitized.push({ ...span, text } as T);
+      sanitized.push(text === span.text ? span : ({ ...span, text, terminalSafe: undefined } as T));
     }
   }
   return sanitized;

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -78,6 +78,8 @@ export interface RenderSpan {
   text: string;
   fg?: string;
   bg?: string;
+  /** True when text was already normalized for terminal rendering. */
+  terminalSafe?: true;
 }
 
 export interface SplitLineCell {
@@ -332,6 +334,8 @@ function mergeSpan(target: RenderSpan[], next: RenderSpan) {
   const previous = target[target.length - 1];
   if (previous && previous.fg === next.fg && previous.bg === next.bg) {
     previous.text += next.text;
+    previous.terminalSafe =
+      previous.terminalSafe && next.terminalSafe ? previous.terminalSafe : undefined;
     return;
   }
 
@@ -370,6 +374,7 @@ function flattenHighlightedLine(node: HastNode | undefined, theme: AppTheme, emp
         text: tabify(cleanLastNewline(current.value)),
         fg: inherited.fg,
         bg: inherited.bg,
+        terminalSafe: true,
       });
       return;
     }
@@ -430,13 +435,13 @@ function makeSplitCell(
   let spans: RenderSpan[];
   if (highlightedLine === undefined) {
     const fallbackText = cleanDiffLine(rawLine);
-    spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+    spans = fallbackText.length > 0 ? [{ text: fallbackText, terminalSafe: true }] : [];
   } else {
     spans = flattenHighlightedLine(highlightedLine, theme, wordDiffHighlightBg(kind, theme));
 
     if (spans.length === 0) {
       const fallbackText = cleanDiffLine(rawLine);
-      spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+      spans = fallbackText.length > 0 ? [{ text: fallbackText, terminalSafe: true }] : [];
     }
   }
 
@@ -464,13 +469,13 @@ function makeStackCell(
   let spans: RenderSpan[];
   if (highlightedLine === undefined) {
     const fallbackText = cleanDiffLine(rawLine);
-    spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+    spans = fallbackText.length > 0 ? [{ text: fallbackText, terminalSafe: true }] : [];
   } else {
     spans = flattenHighlightedLine(highlightedLine, theme, wordDiffHighlightBg(kind, theme));
 
     if (spans.length === 0) {
       const fallbackText = cleanDiffLine(rawLine);
-      spans = fallbackText.length > 0 ? [{ text: fallbackText }] : [];
+      spans = fallbackText.length > 0 ? [{ text: fallbackText, terminalSafe: true }] : [];
     }
   }
 

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -51,6 +51,8 @@ function appendRenderSpan(target: RenderSpan[], span: RenderSpan) {
   const previous = target.at(-1);
   if (previous && previous.fg === span.fg && previous.bg === span.bg) {
     previous.text += span.text;
+    previous.terminalSafe =
+      previous.terminalSafe && span.terminalSafe ? previous.terminalSafe : undefined;
   } else {
     target.push(span);
   }


### PR DESCRIPTION
## Summary

- mark Pierre-built render spans as terminal-safe after source text is normalized
- skip repeated span sanitization for those trusted spans while keeping external/test-authored spans on the safe path
- clear the trust marker when merged spans mix safe and untrusted text

## Validation

- bun test src/lib/terminalText.test.ts src/ui/diff/pierre.test.ts src/ui/lib/ui-lib.test.ts
- bun run typecheck

*This PR description was generated by Pi using OpenAI GPT-5*