### PR TITLE
test(pty): backport filter/notes/layout coverage from solid branch

### DIFF
--- a/.changeset/pty-coverage-backport.md
+++ b/.changeset/pty-coverage-backport.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add PTY regression coverage for filter Escape clearing, fresh draft-note open/cancel, and first-frame multi-file fill. Test-only; no user-visible change.

--- a/test/pty/filter-escape.test.ts
+++ b/test/pty/filter-escape.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+
+/** PTY launches slow down as the suite mounts many renderers in one process; give startup headroom. */
+setDefaultTimeout(20_000);
+
+describe("filter escape clearing (PTY)", () => {
+  test("a second Escape clears a re-typed no-match filter query", async () => {
+    const fixture = harness.createSidebarJumpRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 220,
+      rows: 12,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, { timeout: 15_000 });
+
+      // Open filter, type a no-match query.
+      await session.type("/");
+      await harness.waitForSnapshot(
+        session,
+        (t) => t.includes("filter: type to filter files"),
+        5_000,
+      );
+      await session.type("zzz");
+      await harness.waitForSnapshot(session, (t) => t.includes("No files match"), 5_000);
+
+      // First Escape clears the text (keeps the input focused / placeholder shown).
+      await session.press("escape");
+      await harness.waitForSnapshot(
+        session,
+        (t) => t.includes("filter: type to filter files"),
+        5_000,
+      );
+
+      // Re-type a no-match query.
+      await session.type("zzz");
+      await harness.waitForSnapshot(session, (t) => t.includes("No files match"), 5_000);
+
+      // Second Escape must clear again, just like the first.
+      await session.press("escape");
+      const cleared = await harness.waitForSnapshot(
+        session,
+        (t) => t.includes("filter: type to filter files") && t.includes("alphaOnly = true"),
+        5_000,
+      );
+
+      expect(cleared).toContain("filter: type to filter files");
+      expect(cleared).toContain("alphaOnly = true");
+      expect(cleared).not.toContain("No files match");
+    } finally {
+      session.close();
+    }
+  });
+});

--- a/test/pty/filter-escape.test.ts
+++ b/test/pty/filter-escape.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { createPtyHarness } from "./harness";
 
 const harness = createPtyHarness();
 
 /** PTY launches slow down as the suite mounts many renderers in one process; give startup headroom. */
 setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
 
 describe("filter escape clearing (PTY)", () => {
   test("a second Escape clears a re-typed no-match filter query", async () => {

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -12,6 +12,37 @@ afterEach(() => {
 });
 
 describe("PTY layout", () => {
+  test("the first frame fills the viewport bottom with the next file section", async () => {
+    // The first review frame must fill the whole viewport: when the leading file overflows just
+    // enough, the start of the next file has to render at the bottom without any scroll input.
+    // Locks in the user-visible contract — a multi-file first paint fills to the bottom edge.
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 28,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      // first.ts overflows just enough that second.ts must peek at the bottom of the first frame.
+      const firstFrame = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("second.ts") && text.includes("line17 = 117"),
+        8_000,
+      );
+
+      expect(firstFrame).toContain("second.ts");
+      expect(firstFrame).toContain("line17 = 117");
+    } finally {
+      session.close();
+    }
+  });
+
   test("split rows keep the center separator aligned after wide characters", async () => {
     const fixture = harness.createWideCharacterFilePair();
     const session = await harness.launchHunk({

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -74,7 +74,12 @@ describe("PTY notes", () => {
       });
 
       await session.press("c");
-      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      const freshDraft = await session.waitForText(/Draft note/, { timeout: 5_000 });
+      // The "c" that opened the note must not be inserted into the editor. A fresh, empty draft
+      // shows its placeholder; if the opening keystroke leaked in, the editor would hold "c" and
+      // the placeholder would be gone.
+      expect(freshDraft).toContain("Write a note");
+
       await session.type("Please cover this edge case.");
 
       const draftBeforeNewline = await session.waitForText(/Please cover this edge case\./, {
@@ -153,6 +158,38 @@ describe("PTY notes", () => {
       await sleep(250);
       const afterKeyboardIdle = await session.text({ immediate: true });
       expect(afterKeyboardIdle).not.toContain("[+]");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a single Escape cancels a freshly opened empty draft note", async () => {
+    const fixture = harness.createMultiHunkFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      cols: 120,
+      rows: 20,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Theme\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      // Open an empty draft via the keyboard and immediately cancel it. The very first Escape must
+      // close it — a regression once required two presses because the focus area had not yet
+      // settled to the note when the first Escape arrived.
+      await session.press("c");
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+
+      await session.press("escape");
+      const cancelled = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("Draft note"),
+        5_000,
+      );
+
+      expect(cancelled).not.toContain("Draft note");
     } finally {
       session.close();
     }


### PR DESCRIPTION
## What's this

Backports three PTY test additions from the SolidJS migration branch (`migrate/solidjs-opentui`) onto `main`. These tests drive the **launched binary** through a real terminal, so they assert product behavior independent of the React vs Solid renderer — the contracts hold on `main` today.

## Coverage added

- **`filter-escape.test.ts`** (new) — a second Escape clears a re-typed no-match filter query
- **`notes.test.ts`** (2 cases) — the `c` that opens a note doesn't leak into the editor; a single Escape cancels a freshly opened empty draft
- **`layout.test.ts`** (1 case) — a multi-file first paint fills to the bottom edge (next file peeks)

## Notes

- No harness changes needed — `main`'s PTY harness launches the React app directly (the Solid branch's `--preload` flag is not required here).
- All fixtures used already exist on `main`'s harness.
- The `layout` case was originally motivated by a Solid-specific first-layout race; its comment was rewritten to state the framework-agnostic contract only.
- Test-only; empty changeset.

## Verification

`bun test test/pty/filter-escape.test.ts test/pty/notes.test.ts test/pty/layout.test.ts` → **24 pass / 0 fail** against the React build on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)