### PR TITLE
docs: document auto theme selection

### DIFF
--- a/.changeset/auto-theme-docs.md
+++ b/.changeset/auto-theme-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document automatic theme selection in README config docs. Docs-only; no user-visible CLI/package behavior change.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can persist preferences to a config file:
 Example:
 
 ```toml
-theme = "graphite"   # graphite, midnight, paper, ember, catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, catppuccin-mocha, zenburn, custom
+theme = "graphite"   # auto, graphite, midnight, paper, ember, catppuccin-latte, catppuccin-frappe, catppuccin-macchiato, catppuccin-mocha, zenburn, custom
 mode = "auto"        # auto, split, stack
 vcs = "git"          # git, jj, sl
 watch = false
@@ -131,6 +131,7 @@ transparent_background = false
 ```
 
 `exclude_untracked` affects Git/Sapling working-tree `hunk diff` sessions only.
+`theme = "auto"` and `--theme auto` query the terminal background at startup, choose `paper` for light backgrounds and `graphite` for dark backgrounds, and fall back to `graphite` if the terminal does not answer.
 `transparent_background` can also be written as `transparentBackground`.
 
 Custom themes can inherit from any built-in base theme and override only the colors you care about:

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ agent_notes = false
 transparent_background = false
 ```
 
-`exclude_untracked` affects Git/Sapling working-tree `hunk diff` sessions only.
 `theme = "auto"` and `--theme auto` query the terminal background at startup, choose `paper` for light backgrounds and `graphite` for dark backgrounds, and fall back to `graphite` if the terminal does not answer.
+`exclude_untracked` affects Git/Sapling working-tree `hunk diff` sessions only.
 `transparent_background` can also be written as `transparentBackground`.
 
 Custom themes can inherit from any built-in base theme and override only the colors you care about:


### PR DESCRIPTION
Document the existing auto theme mode in the README config section so users can discover it from both config and CLI usage.

Call out the exact fallback behavior: Hunk queries the terminal background at startup, chooses Paper for light backgrounds, Graphite for dark backgrounds, and falls back to Graphite if the terminal does not answer.