### PR TITLE
fix(ui): require click before theme mouse selection

### DIFF
--- a/.changeset/theme-selector-mouse.md
+++ b/.changeset/theme-selector-mouse.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Require an explicit click or keyboard action before previewing a theme from the theme selector, while keeping mouse-wheel navigation available inside the selector.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -447,6 +447,19 @@ export function App({
     [previewThemeSelectorItem, themeSelectorItems],
   );
 
+  const pickThemeSelectorItem = useCallback(
+    (index: number) => {
+      const item = themeSelectorItems[index];
+      if (!item) {
+        return;
+      }
+
+      setThemeSelectorIndex(index);
+      previewThemeSelectorItem(item);
+    },
+    [previewThemeSelectorItem, themeSelectorItems],
+  );
+
   const acceptThemeSelector = useCallback(() => {
     const item = themeSelectorItems[themeSelectorIndex];
     if (!item) {
@@ -1044,18 +1057,8 @@ export function App({
             terminalWidth={terminal.width}
             theme={baseTheme}
             onClose={closeThemeSelector}
-            onHoverItem={(index) => {
-              setThemeSelectorIndex(index);
-              const item = themeSelectorItems[index];
-              if (item) {
-                previewThemeSelectorItem(item);
-              }
-            }}
-            onSelectItem={(item) => {
-              themeSelectorOriginRef.current = null;
-              selectTheme(item.id);
-              setThemeSelectorOpen(false);
-            }}
+            onPickItem={pickThemeSelectorItem}
+            onScroll={moveThemeSelector}
           />
         </Suspense>
       ) : null}

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -734,7 +734,7 @@ describe("App interactions", () => {
         await setup.mockInput.typeText("t");
       });
       let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
-      expect(frame).toContain("↑/↓/Wheel preview  Click select  Enter accept  Esc cancel");
+      expect(frame).toContain("↑/↓/Tab preview  Enter accept  Esc cancel");
       expect(frame).toContain("›  github-dark-default");
       expect(frame).toContain("active");
 

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -734,7 +734,7 @@ describe("App interactions", () => {
         await setup.mockInput.typeText("t");
       });
       let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
-      expect(frame).toContain("↑/↓/Tab preview  Enter select  Esc cancel");
+      expect(frame).toContain("↑/↓/Wheel preview  Click select  Enter accept  Esc cancel");
       expect(frame).toContain("›  github-dark-default");
       expect(frame).toContain("active");
 
@@ -753,6 +753,83 @@ describe("App interactions", () => {
       );
       expect(frame).toContain("Theme: github-dark-dimmed");
       expect(frame).not.toContain("Theme selector");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("theme selector mouse hover does not preview and click selects without accepting", async () => {
+    const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
+      width: 240,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+      expect(frame).toContain("›  github-dark-default");
+
+      const lines = frame.split("\n");
+      const targetY = lines.findIndex((line) => line.includes("github-dark-dimmed"));
+      expect(targetY).toBeGreaterThanOrEqual(0);
+      const targetX = Math.max(0, lines[targetY]!.indexOf("github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockMouse.moveTo(targetX, targetY);
+      });
+      await flush(setup);
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("›  github-dark-default");
+      expect(frame).not.toContain("›  github-dark-dimmed");
+
+      await act(async () => {
+        await setup.mockMouse.click(targetX, targetY);
+      });
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      expect(frame).toContain("Theme selector");
+
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      frame = await waitForFrame(setup, (nextFrame) =>
+        nextFrame.includes("Theme: github-dark-dimmed"),
+      );
+      expect(frame).not.toContain("Theme selector");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("theme selector mouse wheel previews the next row", async () => {
+    const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
+      width: 240,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      const frame = await waitForFrame(setup, (nextFrame) =>
+        nextFrame.includes("›  github-dark-default"),
+      );
+      const selectedY = frame.split("\n").findIndex((line) => line.includes("github-dark-default"));
+      expect(selectedY).toBeGreaterThanOrEqual(0);
+
+      await act(async () => {
+        await setup.mockMouse.scroll(120, selectedY, "down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/components/chrome/ModalFrame.tsx
+++ b/src/ui/components/chrome/ModalFrame.tsx
@@ -8,6 +8,7 @@ export function ModalFrame({
   children,
   height,
   onClose,
+  onMouseScroll,
   terminalHeight,
   terminalWidth,
   theme,
@@ -17,6 +18,7 @@ export function ModalFrame({
   children: ReactNode;
   height: number;
   onClose?: () => void;
+  onMouseScroll?: (event: TuiMouseEvent) => void;
   terminalHeight: number;
   terminalWidth: number;
   theme: AppTheme;
@@ -55,6 +57,10 @@ export function ModalFrame({
           borderColor: theme.accent,
           backgroundColor: theme.panel,
           flexDirection: "column",
+        }}
+        onMouseScroll={(event: TuiMouseEvent) => {
+          event.stopPropagation();
+          onMouseScroll?.(event);
         }}
         onMouseUp={(event: TuiMouseEvent) => event.stopPropagation()}
       >

--- a/src/ui/components/chrome/ThemeSelectorDialog.tsx
+++ b/src/ui/components/chrome/ThemeSelectorDialog.tsx
@@ -28,8 +28,8 @@ export function ThemeSelectorDialog({
   terminalWidth,
   theme,
   onClose,
-  onHoverItem,
-  onSelectItem,
+  onPickItem,
+  onScroll,
 }: {
   items: ThemeSelectorItem[];
   selectedIndex: number;
@@ -37,8 +37,8 @@ export function ThemeSelectorDialog({
   terminalWidth: number;
   theme: AppTheme;
   onClose: () => void;
-  onHoverItem: (index: number) => void;
-  onSelectItem: (item: ThemeSelectorItem) => void;
+  onPickItem: (index: number) => void;
+  onScroll: (delta: number) => void;
 }) {
   const width = Math.min(82, Math.max(56, terminalWidth - 8));
   const modalHeight = Math.min(Math.max(12, terminalHeight - 4), 28);
@@ -60,10 +60,18 @@ export function ThemeSelectorDialog({
       title="Theme selector"
       width={width}
       onClose={onClose}
+      onMouseScroll={(event) => {
+        const direction = event.scroll?.direction;
+        if (direction === "up") {
+          onScroll(-1);
+        } else if (direction === "down") {
+          onScroll(1);
+        }
+      }}
     >
       <box style={{ width: "100%", height: 1 }}>
         <text fg={theme.muted}>
-          {fitText("↑/↓/Tab preview  Enter select  Esc cancel", bodyWidth)}
+          {fitText("↑/↓/Wheel preview  Click select  Enter accept  Esc cancel", bodyWidth)}
         </text>
       </box>
       <box style={{ width: "100%", height: 1 }} />
@@ -78,12 +86,9 @@ export function ThemeSelectorDialog({
           <box
             key={item.id}
             style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: bg }}
-            // Use movement, not enter/over, so palette preview rerenders do not reselect the row
-            // currently under a stationary mouse while the user navigates with the keyboard.
-            onMouseMove={() => onHoverItem(index)}
             onMouseUp={(event: TuiMouseEvent) => {
               event.stopPropagation();
-              onSelectItem(item);
+              onPickItem(index);
             }}
           >
             <text fg={fg}>{padText(marker, markerWidth)}</text>

--- a/src/ui/components/chrome/ThemeSelectorDialog.tsx
+++ b/src/ui/components/chrome/ThemeSelectorDialog.tsx
@@ -71,7 +71,7 @@ export function ThemeSelectorDialog({
     >
       <box style={{ width: "100%", height: 1 }}>
         <text fg={theme.muted}>
-          {fitText("↑/↓/Wheel preview  Click select  Enter accept  Esc cancel", bodyWidth)}
+          {fitText("↑/↓/Tab preview  Enter accept  Esc cancel", bodyWidth)}
         </text>
       </box>
       <box style={{ width: "100%", height: 1 }} />

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -41,6 +41,7 @@ describe("PTY chrome", () => {
       expect(themeSelector).toContain("Theme selector");
 
       await session.click(/github-light-default/);
+      await session.press("enter");
       const themeSelected = await harness.waitForSnapshot(
         session,
         (text) => text.includes("Adds bonus export.") && !text.includes("Theme selector"),


### PR DESCRIPTION
## Summary

- stop theme selector hover/mouse movement from selecting or previewing themes
- make mouse clicks select/preview the row while keeping Enter as the explicit accept action
- route mouse wheel over the selector to explicit theme-list navigation

## Validation

- `bun run format`
- `bun run typecheck`
- `bun run lint`
- `bun test src/ui/AppHost.interactions.test.tsx --test-name-pattern "theme selector"`
- `bun test test/pty/chrome.test.ts`

*This PR description was generated by Pi using OpenAI GPT-5*