### PR TITLE
fix(build): prevent caller bunfig autoload

### DIFF
--- a/.changeset/no-bunfig-autoload.md
+++ b/.changeset/no-bunfig-autoload.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Prevent standalone Hunk binaries from loading `bunfig.toml` files from the caller's working directory.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -21,7 +21,10 @@ in
       mkdir -p .bun-tmp .bun-install
       BUN_TMPDIR=$PWD/.bun-tmp \
       BUN_INSTALL=$PWD/.bun-install \
-      ${bun}/bin/bun build --compile "./src/main.tsx" --outfile "hunk-bin"
+      ${bun}/bin/bun build --compile \
+        --no-compile-autoload-bunfig \
+        "./src/main.tsx" \
+        --outfile "hunk-bin"
       runHook postBuild
     '';
 

--- a/scripts/build-bin.ts
+++ b/scripts/build-bin.ts
@@ -13,7 +13,15 @@ mkdirSync(distDir, { recursive: true });
 rmSync(legacyOutfile, { force: true });
 
 const proc = Bun.spawnSync(
-  ["bun", "build", "--compile", path.join(repoRoot, "src", "main.tsx"), "--outfile", outfile],
+  [
+    "bun",
+    "build",
+    "--compile",
+    "--no-compile-autoload-bunfig",
+    path.join(repoRoot, "src", "main.tsx"),
+    "--outfile",
+    outfile,
+  ],
   {
     cwd: repoRoot,
     stdin: "inherit",


### PR DESCRIPTION
Add Bun's compile-time autoload disabling flag to the standalone binary build paths so distributed Hunk executables do not load bunfig.toml from the directory they are launched in.

Kept the change scoped to bunfig.toml autoloading, did not add `--no-compile-autoload-dotenv` because loading the dotenv might actually be desirable.