### PR TITLE
feat(ui): prompt to save view preferences on quit

### DIFF
--- a/.changeset/save-view-preferences-on-quit.md
+++ b/.changeset/save-view-preferences-on-quit.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Offer to save changed view preferences to the user config on quit, including theme, layout, line numbers, wrapping, hunk headers, agent notes, and copy decorations. The prompt also includes a “never ask” option that persists `prompt_save_view_preferences = false`.

--- a/.changeset/save-view-preferences-on-quit.md
+++ b/.changeset/save-view-preferences-on-quit.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Offer to save changed view preferences to the user config on quit, including theme, layout, line numbers, wrapping, hunk headers, agent notes, and copy decorations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ CLI input
 
 - `App` should remain the orchestration shell for app state, navigation, layout mode, theme, filtering, and pane coordination.
 - Pane rendering should live in dedicated components.
+- Confirmation prompts with a small set of choices should reuse `ConfirmDialog` (body rows plus a clickable key-legend action row) instead of composing `ModalFrame` with a hand-rolled footer; keyboard handling for its actions stays in `useAppKeyboardShortcuts`.
 - New UI work should extend existing components or add new ones, not grow `App` back into a monolith.
 - Shared formatting, ids, and small derivations belong in helper modules, not repeated inline.
 - Prefer one implementation path per feature instead of separate "old" and "new" codepaths that duplicate behavior.

--- a/README.md
+++ b/README.md
@@ -131,12 +131,14 @@ line_numbers = true
 wrap_lines = false
 menu_bar = true
 agent_notes = false
+prompt_save_view_preferences = true
 transparent_background = false
 ```
 
 `theme = "auto"` and `--theme auto` query the terminal background at startup, choose `github-light-default` for light backgrounds and `github-dark-default` for dark backgrounds, and fall back to `github-dark-default` if the terminal does not answer.
 Older theme ids such as `graphite` and `paper` remain accepted as compatibility aliases.
 `exclude_untracked` affects Git/Sapling working-tree `hunk diff` sessions only.
+`prompt_save_view_preferences = false` disables the quit prompt for saving changed view preferences.
 `transparent_background` can also be written as `transparentBackground`.
 
 Custom themes can inherit from any built-in theme and override only the colors you care about:

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliInput } from "./types";
-import { resolveConfiguredCliInput } from "./config";
+import { resolveConfiguredCliInput, saveGlobalViewPreferences } from "./config";
 import { loadAppBootstrap } from "./loaders";
 
 const tempDirs: string[] = [];
@@ -44,6 +44,56 @@ function createPatchPagerInput(overrides: Partial<CliInput["options"]> = {}): Cl
 
 afterEach(() => {
   cleanupTempDirs();
+});
+
+describe("config persistence", () => {
+  test("writes accepted view preferences to user config without disturbing tables", () => {
+    const home = createTempDir("hunk-save-config-home-");
+    const configPath = join(home, ".config", "hunk", "config.toml");
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        "# personal defaults",
+        'theme = "github-dark-default"',
+        "wrap_lines = false",
+        "",
+        "[custom_theme]",
+        'label = "Keep me"',
+      ].join("\n"),
+    );
+
+    const savedPath = saveGlobalViewPreferences(
+      {
+        mode: "split",
+        theme: "dracula",
+        showLineNumbers: false,
+        wrapLines: true,
+        showHunkHeaders: false,
+        showAgentNotes: true,
+        copyDecorations: true,
+      },
+      { env: { HOME: home } },
+    );
+
+    expect(savedPath).toBe(configPath);
+    expect(readFileSync(configPath, "utf8")).toBe(
+      [
+        "# personal defaults",
+        'theme = "dracula"',
+        "wrap_lines = true",
+        'mode = "split"',
+        "line_numbers = false",
+        "hunk_headers = false",
+        "agent_notes = true",
+        "copy_decorations = true",
+        "",
+        "[custom_theme]",
+        'label = "Keep me"',
+        "",
+      ].join("\n"),
+    );
+  });
 });
 
 describe("config resolution", () => {
@@ -87,6 +137,7 @@ describe("config resolution", () => {
     });
 
     expect(resolved.repoConfigPath).toBe(join(repo, ".hunk", "config.toml"));
+    expect(resolved.viewPreferencesConfigPath).toBe(join(repo, ".hunk", "config.toml"));
     expect(resolved.input.options).toMatchObject({
       pager: true,
       mode: "stack",
@@ -271,6 +322,7 @@ describe("config resolution", () => {
     });
 
     expect(resolved.repoConfigPath).toBeUndefined();
+    expect(resolved.viewPreferencesConfigPath).toBe(join(home, ".config", "hunk", "config.toml"));
     expect(resolved.input.options.theme).toBe("github-dark-default");
   });
 

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliInput } from "./types";
-import { resolveConfiguredCliInput } from "./config";
+import {
+  resolveConfiguredCliInput,
+  saveGlobalViewPreferences,
+  saveViewPreferencesPromptPreference,
+} from "./config";
 import { loadAppBootstrap } from "./loaders";
 
 const tempDirs: string[] = [];
@@ -46,6 +50,78 @@ afterEach(() => {
   cleanupTempDirs();
 });
 
+describe("config persistence", () => {
+  test("writes accepted view preferences to user config without disturbing tables", () => {
+    const home = createTempDir("hunk-save-config-home-");
+    const configPath = join(home, ".config", "hunk", "config.toml");
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        "# personal defaults",
+        'theme = "github-dark-default"',
+        "wrap_lines = false",
+        "",
+        "[custom_theme]",
+        'label = "Keep me"',
+      ].join("\n"),
+    );
+
+    const savedPath = saveGlobalViewPreferences(
+      {
+        mode: "split",
+        theme: "dracula",
+        showLineNumbers: false,
+        wrapLines: true,
+        showHunkHeaders: false,
+        showMenuBar: false,
+        showAgentNotes: true,
+        copyDecorations: true,
+      },
+      { env: { HOME: home } },
+    );
+
+    expect(savedPath).toBe(configPath);
+    expect(readFileSync(configPath, "utf8")).toBe(
+      [
+        "# personal defaults",
+        'theme = "dracula"',
+        "wrap_lines = true",
+        'mode = "split"',
+        "line_numbers = false",
+        "hunk_headers = false",
+        "menu_bar = false",
+        "agent_notes = true",
+        "copy_decorations = true",
+        "",
+        "[custom_theme]",
+        'label = "Keep me"',
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("writes the view preferences prompt setting without disturbing tables", () => {
+    const home = createTempDir("hunk-save-config-home-");
+    const configPath = join(home, ".config", "hunk", "config.toml");
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(configPath, ["# personal defaults", "", "[custom_theme]"].join("\n"));
+
+    const savedPath = saveViewPreferencesPromptPreference(false, { env: { HOME: home } });
+
+    expect(savedPath).toBe(configPath);
+    expect(readFileSync(configPath, "utf8")).toBe(
+      [
+        "# personal defaults",
+        "prompt_save_view_preferences = false",
+        "",
+        "[custom_theme]",
+        "",
+      ].join("\n"),
+    );
+  });
+});
+
 describe("config resolution", () => {
   test("merges global, repo, pager, command, and CLI overrides in the right order", () => {
     const home = createTempDir("hunk-config-home-");
@@ -60,6 +136,7 @@ describe("config resolution", () => {
         "line_numbers = false",
         "transparentBackground = true",
         "color_moved = true",
+        "prompt_save_view_preferences = false",
         "",
         "[patch]",
         'mode = "split"',
@@ -88,6 +165,7 @@ describe("config resolution", () => {
     });
 
     expect(resolved.repoConfigPath).toBe(join(repo, ".hunk", "config.toml"));
+    expect(resolved.viewPreferencesConfigPath).toBe(join(repo, ".hunk", "config.toml"));
     expect(resolved.input.options).toMatchObject({
       pager: true,
       mode: "stack",
@@ -97,6 +175,7 @@ describe("config resolution", () => {
       menuBar: false,
       hunkHeaders: false,
       agentNotes: true,
+      promptSaveViewPreferences: false,
       transparentBackground: true,
       colorMoved: true,
     });
@@ -296,6 +375,7 @@ describe("config resolution", () => {
     });
 
     expect(resolved.repoConfigPath).toBeUndefined();
+    expect(resolved.viewPreferencesConfigPath).toBe(join(home, ".config", "hunk", "config.toml"));
     expect(resolved.input.options.theme).toBe("github-dark-default");
   });
 

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { CliInput } from "./types";
 import {
+  diffPersistedViewPreferences,
   resolveConfiguredCliInput,
   saveGlobalViewPreferences,
   saveViewPreferencesPromptPreference,
@@ -119,6 +120,37 @@ describe("config persistence", () => {
         "",
       ].join("\n"),
     );
+  });
+
+  test("diffs view preference snapshots as the TOML assignments a save would rewrite", () => {
+    const initial = {
+      mode: "auto",
+      theme: "github-dark-default",
+      showLineNumbers: false,
+      wrapLines: false,
+      showHunkHeaders: false,
+      showMenuBar: true,
+      showAgentNotes: true,
+      copyDecorations: false,
+    } as const;
+
+    expect(diffPersistedViewPreferences(initial, { ...initial })).toEqual([]);
+    expect(
+      diffPersistedViewPreferences(initial, {
+        ...initial,
+        mode: "split",
+        theme: "github-dark-dimmed",
+        showLineNumbers: true,
+      }),
+    ).toEqual([
+      {
+        configKey: "theme",
+        previousValue: '"github-dark-default"',
+        nextValue: '"github-dark-dimmed"',
+      },
+      { configKey: "mode", previousValue: '"auto"', nextValue: '"split"' },
+      { configKey: "line_numbers", previousValue: "false", nextValue: "true" },
+    ]);
   });
 });
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { BUNDLED_SHIKI_THEME_IDS } from "../ui/lib/shikiThemes";
 import { normalizeBuiltInThemeId } from "../ui/themes";
 import { resolveGlobalConfigPath } from "./paths";
@@ -74,6 +74,19 @@ const DEFAULT_VIEW_PREFERENCES: PersistedViewPreferences = {
   copyDecorations: false,
 };
 
+const PERSISTED_VIEW_PREFERENCE_KEYS: Array<{
+  configKey: string;
+  value: (preferences: PersistedViewPreferences) => string | boolean | undefined;
+}> = [
+  { configKey: "theme", value: (preferences) => preferences.theme },
+  { configKey: "mode", value: (preferences) => preferences.mode },
+  { configKey: "line_numbers", value: (preferences) => preferences.showLineNumbers },
+  { configKey: "wrap_lines", value: (preferences) => preferences.wrapLines },
+  { configKey: "hunk_headers", value: (preferences) => preferences.showHunkHeaders },
+  { configKey: "agent_notes", value: (preferences) => preferences.showAgentNotes },
+  { configKey: "copy_decorations", value: (preferences) => preferences.copyDecorations },
+];
+
 interface ConfigResolutionOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -84,10 +97,52 @@ interface HunkConfigResolution {
   customTheme?: CustomThemeConfig;
   globalConfigPath?: string;
   repoConfigPath?: string;
+  viewPreferencesConfigPath?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Serialize one primitive TOML preference value. */
+function serializeTomlPreferenceValue(value: string | boolean) {
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  return JSON.stringify(value);
+}
+
+/** Update one top-level TOML key while preserving sections and unrelated comments. */
+function upsertTopLevelTomlValue(source: string, key: string, value: string | boolean) {
+  const lines = source.length > 0 ? source.split("\n") : [];
+  const serialized = serializeTomlPreferenceValue(value);
+  const assignment = `${key} = ${serialized}`;
+  let firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
+  if (firstTableIndex < 0) {
+    firstTableIndex = lines.length;
+  }
+
+  const keyPattern = new RegExp(`^\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=`);
+  for (let index = 0; index < firstTableIndex; index += 1) {
+    if (keyPattern.test(lines[index] ?? "")) {
+      lines[index] = assignment;
+      return `${lines.join("\n").replace(/\n*$/, "")}\n`;
+    }
+  }
+
+  let insertAt = firstTableIndex;
+  const hasTableSpacer = insertAt > 0 && lines[insertAt - 1] === "";
+  if (hasTableSpacer) {
+    insertAt -= 1;
+  }
+  lines.splice(
+    insertAt,
+    0,
+    assignment,
+    ...(hasTableSpacer || insertAt === lines.length ? [] : [""]),
+  );
+  return `${lines.join("\n").replace(/\n*$/, "")}\n`;
 }
 
 /** Accept only the layout names Hunk already supports. */
@@ -302,6 +357,37 @@ function readTomlRecord(path: string) {
   return parsed;
 }
 
+/** Persist accepted in-app view preferences to the selected Hunk config file. */
+export function saveGlobalViewPreferences(
+  preferences: PersistedViewPreferences,
+  {
+    configPath: configuredPath,
+    env = process.env,
+  }: Pick<ConfigResolutionOptions, "env"> & { configPath?: string } = {},
+) {
+  const configPath = configuredPath ?? resolveGlobalConfigPath(env);
+  if (!configPath) {
+    throw new Error("Could not resolve a config path because HOME/XDG_CONFIG_HOME is unset.");
+  }
+
+  let source = "";
+  if (fs.existsSync(configPath)) {
+    source = fs.readFileSync(configPath, "utf8");
+  }
+
+  let nextSource = source;
+  for (const key of PERSISTED_VIEW_PREFERENCE_KEYS) {
+    const value = key.value(preferences);
+    if (value !== undefined) {
+      nextSource = upsertTopLevelTomlValue(nextSource, key.configKey, value);
+    }
+  }
+
+  fs.mkdirSync(dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, nextSource);
+  return configPath;
+}
+
 /** Resolve CLI input against global and repo-local config files. */
 export function resolveConfiguredCliInput(
   input: CliInput,
@@ -373,5 +459,9 @@ export function resolveConfiguredCliInput(
     customTheme: resolvedCustomTheme,
     globalConfigPath: userConfigPath,
     repoConfigPath,
+    // Persist in the repo config only when the repo already has one; otherwise keep personal view
+    // choices user-scoped so Hunk does not create project policy files from an interactive prompt.
+    viewPreferencesConfigPath:
+      repoConfigPath && fs.existsSync(repoConfigPath) ? repoConfigPath : userConfigPath,
   };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { BUNDLED_SHIKI_THEME_IDS } from "../ui/lib/shikiThemes";
 import { normalizeBuiltInThemeId } from "../ui/themes";
 import { resolveGlobalConfigPath } from "./paths";
@@ -75,6 +75,21 @@ const DEFAULT_VIEW_PREFERENCES: PersistedViewPreferences = {
   copyDecorations: false,
 };
 
+const VIEW_PREFERENCES_PROMPT_CONFIG_KEY = "prompt_save_view_preferences";
+const PERSISTED_VIEW_PREFERENCE_KEYS: Array<{
+  configKey: string;
+  value: (preferences: PersistedViewPreferences) => string | boolean | undefined;
+}> = [
+  { configKey: "theme", value: (preferences) => preferences.theme },
+  { configKey: "mode", value: (preferences) => preferences.mode },
+  { configKey: "line_numbers", value: (preferences) => preferences.showLineNumbers },
+  { configKey: "wrap_lines", value: (preferences) => preferences.wrapLines },
+  { configKey: "hunk_headers", value: (preferences) => preferences.showHunkHeaders },
+  { configKey: "menu_bar", value: (preferences) => preferences.showMenuBar },
+  { configKey: "agent_notes", value: (preferences) => preferences.showAgentNotes },
+  { configKey: "copy_decorations", value: (preferences) => preferences.copyDecorations },
+];
+
 interface ConfigResolutionOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -85,10 +100,52 @@ interface HunkConfigResolution {
   customTheme?: CustomThemeConfig;
   globalConfigPath?: string;
   repoConfigPath?: string;
+  viewPreferencesConfigPath?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Serialize one primitive TOML preference value. */
+function serializeTomlPreferenceValue(value: string | boolean) {
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+
+  return JSON.stringify(value);
+}
+
+/** Update one top-level TOML key while preserving sections and unrelated comments. */
+function upsertTopLevelTomlValue(source: string, key: string, value: string | boolean) {
+  const lines = source.length > 0 ? source.split("\n") : [];
+  const serialized = serializeTomlPreferenceValue(value);
+  const assignment = `${key} = ${serialized}`;
+  let firstTableIndex = lines.findIndex((line) => /^\s*\[/.test(line));
+  if (firstTableIndex < 0) {
+    firstTableIndex = lines.length;
+  }
+
+  const keyPattern = new RegExp(`^\\s*${key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*=`);
+  for (let index = 0; index < firstTableIndex; index += 1) {
+    if (keyPattern.test(lines[index] ?? "")) {
+      lines[index] = assignment;
+      return `${lines.join("\n").replace(/\n*$/, "")}\n`;
+    }
+  }
+
+  let insertAt = firstTableIndex;
+  const hasTableSpacer = insertAt > 0 && lines[insertAt - 1] === "";
+  if (hasTableSpacer) {
+    insertAt -= 1;
+  }
+  lines.splice(
+    insertAt,
+    0,
+    assignment,
+    ...(hasTableSpacer || insertAt === lines.length ? [] : [""]),
+  );
+  return `${lines.join("\n").replace(/\n*$/, "")}\n`;
 }
 
 /** Accept only the layout names Hunk already supports. */
@@ -240,6 +297,7 @@ function readConfigPreferences(source: Record<string, unknown>): CommonOptions {
     menuBar: normalizeBoolean(source.menu_bar),
     agentNotes: normalizeBoolean(source.agent_notes),
     copyDecorations: normalizeBoolean(source.copy_decorations),
+    promptSaveViewPreferences: normalizeBoolean(source[VIEW_PREFERENCES_PROMPT_CONFIG_KEY]),
     transparentBackground:
       normalizeBoolean(source.transparentBackground) ??
       normalizeBoolean(source.transparent_background),
@@ -264,6 +322,8 @@ function mergeOptions(base: CommonOptions, overrides: CommonOptions): CommonOpti
     menuBar: overrides.menuBar ?? base.menuBar,
     agentNotes: overrides.agentNotes ?? base.agentNotes,
     copyDecorations: overrides.copyDecorations ?? base.copyDecorations,
+    promptSaveViewPreferences:
+      overrides.promptSaveViewPreferences ?? base.promptSaveViewPreferences,
     transparentBackground: overrides.transparentBackground ?? base.transparentBackground,
     colorMoved: overrides.colorMoved ?? base.colorMoved,
   };
@@ -305,6 +365,67 @@ function readTomlRecord(path: string) {
   return parsed;
 }
 
+/** Read a config file if it already exists. */
+function readConfigSource(configPath: string) {
+  return fs.existsSync(configPath) ? fs.readFileSync(configPath, "utf8") : "";
+}
+
+/** Resolve the config file path used for interactive persistence. */
+function resolveWritableConfigPath(configuredPath: string | undefined, env: NodeJS.ProcessEnv) {
+  const configPath = configuredPath ?? resolveGlobalConfigPath(env);
+  if (!configPath) {
+    throw new Error("Could not resolve a config path because HOME/XDG_CONFIG_HOME is unset.");
+  }
+
+  return configPath;
+}
+
+/** Write an updated config source after ensuring the parent directory exists. */
+function writeConfigSource(configPath: string, source: string) {
+  fs.mkdirSync(dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, source);
+}
+
+/** Persist accepted in-app view preferences to the selected Hunk config file. */
+export function saveGlobalViewPreferences(
+  preferences: PersistedViewPreferences,
+  {
+    configPath: configuredPath,
+    env = process.env,
+  }: Pick<ConfigResolutionOptions, "env"> & { configPath?: string } = {},
+) {
+  const configPath = resolveWritableConfigPath(configuredPath, env);
+  let nextSource = readConfigSource(configPath);
+  for (const key of PERSISTED_VIEW_PREFERENCE_KEYS) {
+    const value = key.value(preferences);
+    if (value !== undefined) {
+      nextSource = upsertTopLevelTomlValue(nextSource, key.configKey, value);
+    }
+  }
+
+  writeConfigSource(configPath, nextSource);
+  return configPath;
+}
+
+/** Persist whether Hunk should prompt before discarding changed view preferences. */
+export function saveViewPreferencesPromptPreference(
+  promptSaveViewPreferences: boolean,
+  {
+    configPath: configuredPath,
+    env = process.env,
+  }: Pick<ConfigResolutionOptions, "env"> & { configPath?: string } = {},
+) {
+  const configPath = resolveWritableConfigPath(configuredPath, env);
+  const nextSource = upsertTopLevelTomlValue(
+    readConfigSource(configPath),
+    VIEW_PREFERENCES_PROMPT_CONFIG_KEY,
+    promptSaveViewPreferences,
+  );
+
+  writeConfigSource(configPath, nextSource);
+  return configPath;
+}
+
 /** Resolve CLI input against global and repo-local config files. */
 export function resolveConfiguredCliInput(
   input: CliInput,
@@ -331,6 +452,7 @@ export function resolveConfiguredCliInput(
     menuBar: DEFAULT_VIEW_PREFERENCES.showMenuBar,
     agentNotes: DEFAULT_VIEW_PREFERENCES.showAgentNotes,
     copyDecorations: DEFAULT_VIEW_PREFERENCES.copyDecorations,
+    promptSaveViewPreferences: true,
     transparentBackground: false,
   };
 
@@ -362,6 +484,7 @@ export function resolveConfiguredCliInput(
     menuBar: resolvedOptions.menuBar ?? DEFAULT_VIEW_PREFERENCES.showMenuBar,
     agentNotes: resolvedOptions.agentNotes ?? DEFAULT_VIEW_PREFERENCES.showAgentNotes,
     copyDecorations: resolvedOptions.copyDecorations ?? DEFAULT_VIEW_PREFERENCES.copyDecorations,
+    promptSaveViewPreferences: resolvedOptions.promptSaveViewPreferences ?? true,
     transparentBackground: resolvedOptions.transparentBackground ?? false,
     colorMoved: resolvedOptions.colorMoved,
   };
@@ -378,5 +501,9 @@ export function resolveConfiguredCliInput(
     customTheme: resolvedCustomTheme,
     globalConfigPath: userConfigPath,
     repoConfigPath,
+    // Persist in the repo config only when the repo already has one; otherwise keep personal view
+    // choices user-scoped so Hunk does not create project policy files from an interactive prompt.
+    viewPreferencesConfigPath:
+      repoConfigPath && fs.existsSync(repoConfigPath) ? repoConfigPath : userConfigPath,
   };
 }

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -386,6 +386,41 @@ function writeConfigSource(configPath: string, source: string) {
   fs.writeFileSync(configPath, source);
 }
 
+/** One view preference the quit prompt would rewrite, as TOML assignment text. */
+export interface ViewPreferenceChange {
+  configKey: string;
+  previousValue: string;
+  nextValue: string;
+}
+
+/**
+ * Diff two view-preference snapshots into the TOML assignments
+ * `saveGlobalViewPreferences` would rewrite, so prompt UI and persistence
+ * stay derived from the same key table.
+ */
+export function diffPersistedViewPreferences(
+  previous: PersistedViewPreferences,
+  next: PersistedViewPreferences,
+): ViewPreferenceChange[] {
+  const changes: ViewPreferenceChange[] = [];
+  for (const key of PERSISTED_VIEW_PREFERENCE_KEYS) {
+    const previousValue = key.value(previous);
+    const nextValue = key.value(next);
+    if (previousValue === nextValue) {
+      continue;
+    }
+
+    changes.push({
+      configKey: key.configKey,
+      previousValue:
+        previousValue === undefined ? "unset" : serializeTomlPreferenceValue(previousValue),
+      nextValue: nextValue === undefined ? "unset" : serializeTomlPreferenceValue(nextValue),
+    });
+  }
+
+  return changes;
+}
+
 /** Persist accepted in-app view preferences to the selected Hunk config file. */
 export function saveGlobalViewPreferences(
   preferences: PersistedViewPreferences,

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -232,6 +232,7 @@ export async function prepareStartupPlan(
   }
 
   bootstrap.initialThemeMode = initialThemeMode ?? bootstrap.initialThemeMode;
+  bootstrap.viewPreferencesConfigPath = configured.viewPreferencesConfigPath;
 
   controllingTerminal ??= usesPipedPatchInputImpl(cliInput) ? openControllingTerminalImpl() : null;
 

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -258,6 +258,7 @@ export async function prepareStartupPlan(
   }
 
   bootstrap.initialThemeMode = initialThemeMode ?? bootstrap.initialThemeMode;
+  bootstrap.viewPreferencesConfigPath = configured.viewPreferencesConfigPath;
 
   controllingTerminal ??= usesPipedPatchInputImpl(cliInput) ? openControllingTerminalImpl() : null;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -95,6 +95,7 @@ export interface CommonOptions {
   menuBar?: boolean;
   agentNotes?: boolean;
   copyDecorations?: boolean;
+  promptSaveViewPreferences?: boolean;
   transparentBackground?: boolean;
   colorMoved?: boolean;
 }
@@ -389,4 +390,5 @@ export interface AppBootstrap {
   initialShowMenuBar?: boolean;
   initialShowAgentNotes?: boolean;
   initialCopyDecorations?: boolean;
+  viewPreferencesConfigPath?: string;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -366,4 +366,5 @@ export interface AppBootstrap {
   initialShowHunkHeaders?: boolean;
   initialShowAgentNotes?: boolean;
   initialCopyDecorations?: boolean;
+  viewPreferencesConfigPath?: string;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,11 @@ import {
 } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState, useRef } from "react";
-import { saveGlobalViewPreferences, saveViewPreferencesPromptPreference } from "../core/config";
+import {
+  diffPersistedViewPreferences,
+  saveGlobalViewPreferences,
+  saveViewPreferencesPromptPreference,
+} from "../core/config";
 import type {
   AppBootstrap,
   CliInput,
@@ -16,7 +20,7 @@ import type {
 import { canReloadInput, computeWatchSignature } from "../core/watch";
 import type { HunkSessionBrokerClient, ReloadedSessionResult } from "../hunk-session/types";
 import { MenuBar } from "./components/chrome/MenuBar";
-import { ModalFrame } from "./components/chrome/ModalFrame";
+import { ConfirmDialog, confirmDialogHeight } from "./components/chrome/ConfirmDialog";
 import { StatusBar } from "./components/chrome/StatusBar";
 import { DiffPane } from "./components/panes/DiffPane";
 import { SidebarPane } from "./components/panes/SidebarPane";
@@ -214,50 +218,23 @@ export function App({
     ],
   );
   const initialViewPreferencesRef = useRef(currentViewPreferences);
-  const changedViewPreferenceLines = useMemo(() => {
-    const initial = initialViewPreferencesRef.current;
-    const changes: string[] = [];
-    if (currentViewPreferences.theme !== initial.theme) {
-      changes.push(
-        `Theme: ${initial.theme ?? "default"} → ${currentViewPreferences.theme ?? "default"}`,
-      );
-    }
-    if (currentViewPreferences.mode !== initial.mode) {
-      changes.push(`Layout: ${initial.mode} → ${currentViewPreferences.mode}`);
-    }
-    if (currentViewPreferences.showLineNumbers !== initial.showLineNumbers) {
-      changes.push(
-        `Line numbers: ${initial.showLineNumbers ? "on" : "off"} → ${currentViewPreferences.showLineNumbers ? "on" : "off"}`,
-      );
-    }
-    if (currentViewPreferences.wrapLines !== initial.wrapLines) {
-      changes.push(
-        `Line wrapping: ${initial.wrapLines ? "on" : "off"} → ${currentViewPreferences.wrapLines ? "on" : "off"}`,
-      );
-    }
-    if (currentViewPreferences.showHunkHeaders !== initial.showHunkHeaders) {
-      changes.push(
-        `Hunk headers: ${initial.showHunkHeaders ? "shown" : "hidden"} → ${currentViewPreferences.showHunkHeaders ? "shown" : "hidden"}`,
-      );
-    }
-    if (currentViewPreferences.showMenuBar !== initial.showMenuBar) {
-      changes.push(
-        `Menu bar: ${initial.showMenuBar ? "shown" : "hidden"} → ${currentViewPreferences.showMenuBar ? "shown" : "hidden"}`,
-      );
-    }
-    if (currentViewPreferences.showAgentNotes !== initial.showAgentNotes) {
-      changes.push(
-        `Agent notes: ${initial.showAgentNotes ? "shown" : "hidden"} → ${currentViewPreferences.showAgentNotes ? "shown" : "hidden"}`,
-      );
-    }
-    if (currentViewPreferences.copyDecorations !== initial.copyDecorations) {
-      changes.push(
-        `Copy decorations: ${initial.copyDecorations ? "on" : "off"} → ${currentViewPreferences.copyDecorations ? "on" : "off"}`,
-      );
-    }
-    return changes;
-  }, [currentViewPreferences]);
-  const hasUnsavedViewPreferences = changedViewPreferenceLines.length > 0;
+  const changedViewPreferences = useMemo(
+    () => diffPersistedViewPreferences(initialViewPreferencesRef.current, currentViewPreferences),
+    [currentViewPreferences],
+  );
+  // Render each change as the -/+ pair of TOML assignments the save would rewrite,
+  // with the key column aligned across all changed preferences.
+  const viewPreferenceDiffLines = useMemo(() => {
+    const keyWidth = changedViewPreferences.reduce(
+      (width, change) => Math.max(width, change.configKey.length),
+      0,
+    );
+    return changedViewPreferences.flatMap((change) => [
+      { removed: true, text: `- ${change.configKey.padEnd(keyWidth)} = ${change.previousValue}` },
+      { removed: false, text: `+ ${change.configKey.padEnd(keyWidth)} = ${change.nextValue}` },
+    ]);
+  }, [changedViewPreferences]);
+  const hasUnsavedViewPreferences = changedViewPreferences.length > 0;
   const viewPreferencesConfigLabel = useMemo(() => {
     const path = bootstrap.viewPreferencesConfigPath ?? "~/.config/hunk/config.toml";
     return process.env.HOME && path.startsWith(process.env.HOME)
@@ -1274,8 +1251,14 @@ export function App({
       ) : null}
 
       {!pagerMode && saveConfigPromptOpen ? (
-        <ModalFrame
-          height={Math.min(16, Math.max(12, changedViewPreferenceLines.length + 9))}
+        <ConfirmDialog
+          actions={[
+            { keyLabel: "enter/s", label: "save", run: saveViewPreferencesAndQuit },
+            { keyLabel: "d", label: "discard", run: discardViewPreferencesAndQuit },
+            { keyLabel: "n", label: "never ask", run: neverAskToSaveViewPreferencesAndQuit },
+            { keyLabel: "esc", label: "cancel", run: closeSaveConfigPrompt },
+          ]}
+          height={confirmDialogHeight(4 + viewPreferenceDiffLines.length)}
           terminalHeight={terminal.height}
           terminalWidth={terminal.width}
           theme={baseTheme}
@@ -1284,48 +1267,29 @@ export function App({
           onClose={closeSaveConfigPrompt}
         >
           <box style={{ width: "100%", height: 1 }}>
-            <text fg={baseTheme.text}>
-              Save your local view changes to {viewPreferencesConfigLabel}?
+            <text fg={baseTheme.muted}>
+              You changed {changedViewPreferences.length} view{" "}
+              {changedViewPreferences.length === 1 ? "setting" : "settings"} during this review.
+            </text>
+          </box>
+          <box style={{ width: "100%", height: 1 }}>
+            <text fg={baseTheme.muted}>
+              Save {changedViewPreferences.length === 1 ? "it" : "them"} to your config before
+              quitting?
             </text>
           </box>
           <box style={{ width: "100%", height: 1 }} />
-          {changedViewPreferenceLines.map((line) => (
-            <box key={line} style={{ width: "100%", height: 1 }}>
-              <text fg={baseTheme.muted}>{line}</text>
+          <box style={{ width: "100%", height: 1 }}>
+            <text fg={baseTheme.badgeNeutral}>{viewPreferencesConfigLabel}</text>
+          </box>
+          {viewPreferenceDiffLines.map((line) => (
+            <box key={line.text} style={{ width: "100%", height: 1 }}>
+              <text fg={line.removed ? baseTheme.badgeRemoved : baseTheme.badgeAdded}>
+                {line.text}
+              </text>
             </box>
           ))}
-          <box style={{ width: "100%", height: 1 }} />
-          <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
-            <box
-              onMouseUp={(event: TuiMouseEvent) => {
-                event.stopPropagation();
-                saveViewPreferencesAndQuit();
-              }}
-            >
-              <text fg={baseTheme.accent}>[Enter/s] Save</text>
-            </box>
-            <text fg={baseTheme.muted}> </text>
-            <box
-              onMouseUp={(event: TuiMouseEvent) => {
-                event.stopPropagation();
-                discardViewPreferencesAndQuit();
-              }}
-            >
-              <text fg={baseTheme.badgeNeutral}>[d] Discard</text>
-            </box>
-            <text fg={baseTheme.muted}> </text>
-            <box
-              onMouseUp={(event: TuiMouseEvent) => {
-                event.stopPropagation();
-                neverAskToSaveViewPreferencesAndQuit();
-              }}
-            >
-              <text fg={baseTheme.badgeRemoved}>[n] Never ask</text>
-            </box>
-            <text fg={baseTheme.muted}> </text>
-            <text fg={baseTheme.muted}>[Esc] Cancel</text>
-          </box>
-        </ModalFrame>
+        </ConfirmDialog>
       ) : null}
 
       {!pagerMode && themeSelectorState.open ? (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,10 +5,18 @@ import {
 } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState, useRef } from "react";
-import type { AppBootstrap, CliInput, LayoutMode, UserNoteLineTarget } from "../core/types";
+import { saveGlobalViewPreferences, saveViewPreferencesPromptPreference } from "../core/config";
+import type {
+  AppBootstrap,
+  CliInput,
+  LayoutMode,
+  PersistedViewPreferences,
+  UserNoteLineTarget,
+} from "../core/types";
 import { canReloadInput, computeWatchSignature } from "../core/watch";
 import type { HunkSessionBrokerClient, ReloadedSessionResult } from "../hunk-session/types";
 import { MenuBar } from "./components/chrome/MenuBar";
+import { ModalFrame } from "./components/chrome/ModalFrame";
 import { StatusBar } from "./components/chrome/StatusBar";
 import { DiffPane } from "./components/panes/DiffPane";
 import { SidebarPane } from "./components/panes/SidebarPane";
@@ -147,6 +155,7 @@ export function App({
   const [forceSidebarOpen, setForceSidebarOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showAgentSkill, setShowAgentSkill] = useState(false);
+  const [saveConfigPromptOpen, setSaveConfigPromptOpen] = useState(false);
   const [focusArea, setFocusArea] = useState<FocusArea>("files");
   const [activeAddNoteTarget, setActiveAddNoteTarget] = useState<ActiveAddNoteTarget | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(34);
@@ -182,6 +191,79 @@ export function App({
       })),
     [activeTheme.id, themeOptions],
   );
+  const currentViewPreferences = useMemo<PersistedViewPreferences>(
+    () => ({
+      mode: layoutMode,
+      theme: themeId,
+      showLineNumbers,
+      wrapLines,
+      showHunkHeaders,
+      showMenuBar,
+      showAgentNotes,
+      copyDecorations,
+    }),
+    [
+      copyDecorations,
+      layoutMode,
+      showAgentNotes,
+      showHunkHeaders,
+      showLineNumbers,
+      showMenuBar,
+      themeId,
+      wrapLines,
+    ],
+  );
+  const initialViewPreferencesRef = useRef(currentViewPreferences);
+  const changedViewPreferenceLines = useMemo(() => {
+    const initial = initialViewPreferencesRef.current;
+    const changes: string[] = [];
+    if (currentViewPreferences.theme !== initial.theme) {
+      changes.push(
+        `Theme: ${initial.theme ?? "default"} → ${currentViewPreferences.theme ?? "default"}`,
+      );
+    }
+    if (currentViewPreferences.mode !== initial.mode) {
+      changes.push(`Layout: ${initial.mode} → ${currentViewPreferences.mode}`);
+    }
+    if (currentViewPreferences.showLineNumbers !== initial.showLineNumbers) {
+      changes.push(
+        `Line numbers: ${initial.showLineNumbers ? "on" : "off"} → ${currentViewPreferences.showLineNumbers ? "on" : "off"}`,
+      );
+    }
+    if (currentViewPreferences.wrapLines !== initial.wrapLines) {
+      changes.push(
+        `Line wrapping: ${initial.wrapLines ? "on" : "off"} → ${currentViewPreferences.wrapLines ? "on" : "off"}`,
+      );
+    }
+    if (currentViewPreferences.showHunkHeaders !== initial.showHunkHeaders) {
+      changes.push(
+        `Hunk headers: ${initial.showHunkHeaders ? "shown" : "hidden"} → ${currentViewPreferences.showHunkHeaders ? "shown" : "hidden"}`,
+      );
+    }
+    if (currentViewPreferences.showMenuBar !== initial.showMenuBar) {
+      changes.push(
+        `Menu bar: ${initial.showMenuBar ? "shown" : "hidden"} → ${currentViewPreferences.showMenuBar ? "shown" : "hidden"}`,
+      );
+    }
+    if (currentViewPreferences.showAgentNotes !== initial.showAgentNotes) {
+      changes.push(
+        `Agent notes: ${initial.showAgentNotes ? "shown" : "hidden"} → ${currentViewPreferences.showAgentNotes ? "shown" : "hidden"}`,
+      );
+    }
+    if (currentViewPreferences.copyDecorations !== initial.copyDecorations) {
+      changes.push(
+        `Copy decorations: ${initial.copyDecorations ? "on" : "off"} → ${currentViewPreferences.copyDecorations ? "on" : "off"}`,
+      );
+    }
+    return changes;
+  }, [currentViewPreferences]);
+  const hasUnsavedViewPreferences = changedViewPreferenceLines.length > 0;
+  const viewPreferencesConfigLabel = useMemo(() => {
+    const path = bootstrap.viewPreferencesConfigPath ?? "~/.config/hunk/config.toml";
+    return process.env.HOME && path.startsWith(process.env.HOME)
+      ? `~${path.slice(process.env.HOME.length)}`
+      : path;
+  }, [bootstrap.viewPreferencesConfigPath]);
   // App computes layout geometry below this hook call, so the controller reads
   // the current values through a ref instead of a render-time parameter.
   const noteGeometryRef = useRef<AgentNoteGeometrySnapshot | null>(null);
@@ -660,10 +742,66 @@ export function App({
     };
   }, [bootstrap.input, refreshCurrentInput, watchEnabled]);
 
-  /** Leave the app through the shared shutdown path. */
-  const requestQuit = useCallback(() => {
+  /** Save current view preferences to user config and then leave the app. */
+  const saveViewPreferencesAndQuit = useCallback(() => {
+    try {
+      const configPath = saveGlobalViewPreferences(currentViewPreferences, {
+        configPath: bootstrap.viewPreferencesConfigPath,
+      });
+      initialViewPreferencesRef.current = currentViewPreferences;
+      showSessionNotice(`Saved view preferences to ${configPath}`);
+      setTimeout(onQuit, 120);
+    } catch (error) {
+      showSessionNotice(
+        error instanceof Error ? error.message : "Failed to save view preferences.",
+      );
+    }
+  }, [bootstrap.viewPreferencesConfigPath, currentViewPreferences, onQuit, showSessionNotice]);
+
+  /** Leave the app without writing view preference changes. */
+  const discardViewPreferencesAndQuit = useCallback(() => {
+    setSaveConfigPromptOpen(false);
     onQuit();
   }, [onQuit]);
+
+  /** Persist the user's choice to stop prompting about view preference changes. */
+  const neverAskToSaveViewPreferencesAndQuit = useCallback(() => {
+    try {
+      const configPath = saveViewPreferencesPromptPreference(false, {
+        configPath: bootstrap.viewPreferencesConfigPath,
+      });
+      showSessionNotice(`Won't ask to save view preferences again (${configPath})`);
+      setTimeout(onQuit, 120);
+    } catch (error) {
+      showSessionNotice(
+        error instanceof Error ? error.message : "Failed to save prompt preference.",
+      );
+    }
+  }, [bootstrap.viewPreferencesConfigPath, onQuit, showSessionNotice]);
+
+  /** Leave the app through the shared shutdown path, prompting before discarding view changes. */
+  const requestQuit = useCallback(() => {
+    if (
+      !pagerMode &&
+      bootstrap.input.options.promptSaveViewPreferences !== false &&
+      hasUnsavedViewPreferences
+    ) {
+      setShowHelp(false);
+      setSaveConfigPromptOpen(true);
+      return;
+    }
+
+    onQuit();
+  }, [
+    bootstrap.input.options.promptSaveViewPreferences,
+    hasUnsavedViewPreferences,
+    onQuit,
+    pagerMode,
+  ]);
+
+  const closeSaveConfigPrompt = useCallback(() => {
+    setSaveConfigPromptOpen(false);
+  }, []);
 
   /** Close the modal keyboard help overlay. */
   const closeHelp = useCallback(() => {
@@ -854,6 +992,11 @@ export function App({
     openThemeSelector,
     pagerMode,
     requestQuit,
+    saveConfigPromptOpen,
+    saveViewPreferencesAndQuit,
+    discardViewPreferencesAndQuit,
+    neverAskToSaveViewPreferencesAndQuit,
+    closeSaveConfigPrompt,
     scrollCodeHorizontally,
     saveDraftNote,
     scrollDiff,
@@ -1128,6 +1271,61 @@ export function App({
             onClose={closeHelp}
           />
         </Suspense>
+      ) : null}
+
+      {!pagerMode && saveConfigPromptOpen ? (
+        <ModalFrame
+          height={Math.min(16, Math.max(12, changedViewPreferenceLines.length + 9))}
+          terminalHeight={terminal.height}
+          terminalWidth={terminal.width}
+          theme={baseTheme}
+          title="Save view preferences?"
+          width={68}
+          onClose={closeSaveConfigPrompt}
+        >
+          <box style={{ width: "100%", height: 1 }}>
+            <text fg={baseTheme.text}>
+              Save your local view changes to {viewPreferencesConfigLabel}?
+            </text>
+          </box>
+          <box style={{ width: "100%", height: 1 }} />
+          {changedViewPreferenceLines.map((line) => (
+            <box key={line} style={{ width: "100%", height: 1 }}>
+              <text fg={baseTheme.muted}>{line}</text>
+            </box>
+          ))}
+          <box style={{ width: "100%", height: 1 }} />
+          <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
+            <box
+              onMouseUp={(event: TuiMouseEvent) => {
+                event.stopPropagation();
+                saveViewPreferencesAndQuit();
+              }}
+            >
+              <text fg={baseTheme.accent}>[Enter/s] Save</text>
+            </box>
+            <text fg={baseTheme.muted}> </text>
+            <box
+              onMouseUp={(event: TuiMouseEvent) => {
+                event.stopPropagation();
+                discardViewPreferencesAndQuit();
+              }}
+            >
+              <text fg={baseTheme.badgeNeutral}>[d] Discard</text>
+            </box>
+            <text fg={baseTheme.muted}> </text>
+            <box
+              onMouseUp={(event: TuiMouseEvent) => {
+                event.stopPropagation();
+                neverAskToSaveViewPreferencesAndQuit();
+              }}
+            >
+              <text fg={baseTheme.badgeRemoved}>[n] Never ask</text>
+            </box>
+            <text fg={baseTheme.muted}> </text>
+            <text fg={baseTheme.muted}>[Esc] Cancel</text>
+          </box>
+        </ModalFrame>
       ) : null}
 
       {!pagerMode && themeSelectorState.open ? (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1254,7 +1254,7 @@ export function App({
         <ConfirmDialog
           actions={[
             { keyLabel: "enter/s", label: "save", run: saveViewPreferencesAndQuit },
-            { keyLabel: "d", label: "discard", run: discardViewPreferencesAndQuit },
+            { keyLabel: "q", label: "discard", run: discardViewPreferencesAndQuit },
             { keyLabel: "n", label: "never ask", run: neverAskToSaveViewPreferencesAndQuit },
             { keyLabel: "esc", label: "cancel", run: closeSaveConfigPrompt },
           ]}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,10 +5,18 @@ import {
 } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState, useRef } from "react";
-import type { AppBootstrap, CliInput, LayoutMode, UserNoteLineTarget } from "../core/types";
+import { saveGlobalViewPreferences } from "../core/config";
+import type {
+  AppBootstrap,
+  CliInput,
+  LayoutMode,
+  PersistedViewPreferences,
+  UserNoteLineTarget,
+} from "../core/types";
 import { canReloadInput, computeWatchSignature } from "../core/watch";
 import type { HunkSessionBrokerClient, ReloadedSessionResult } from "../hunk-session/types";
 import { MenuBar } from "./components/chrome/MenuBar";
+import { ModalFrame } from "./components/chrome/ModalFrame";
 import { StatusBar } from "./components/chrome/StatusBar";
 import { DiffPane } from "./components/panes/DiffPane";
 import { SidebarPane } from "./components/panes/SidebarPane";
@@ -139,6 +147,7 @@ export function App({
   const [sidebarVisible, setSidebarVisible] = useState(() => !pagerMode);
   const [forceSidebarOpen, setForceSidebarOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [saveConfigPromptOpen, setSaveConfigPromptOpen] = useState(false);
   const [focusArea, setFocusArea] = useState<FocusArea>("files");
   const [activeAddNoteTarget, setActiveAddNoteTarget] = useState<ActiveAddNoteTarget | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(34);
@@ -174,6 +183,72 @@ export function App({
       })),
     [activeTheme.id, themeOptions],
   );
+  const currentViewPreferences = useMemo<PersistedViewPreferences>(
+    () => ({
+      mode: layoutMode,
+      theme: themeId,
+      showLineNumbers,
+      wrapLines,
+      showHunkHeaders,
+      showAgentNotes,
+      copyDecorations,
+    }),
+    [
+      copyDecorations,
+      layoutMode,
+      showAgentNotes,
+      showHunkHeaders,
+      showLineNumbers,
+      themeId,
+      wrapLines,
+    ],
+  );
+  const initialViewPreferencesRef = useRef(currentViewPreferences);
+  const changedViewPreferenceLines = useMemo(() => {
+    const initial = initialViewPreferencesRef.current;
+    const changes: string[] = [];
+    if (currentViewPreferences.theme !== initial.theme) {
+      changes.push(
+        `Theme: ${initial.theme ?? "default"} → ${currentViewPreferences.theme ?? "default"}`,
+      );
+    }
+    if (currentViewPreferences.mode !== initial.mode) {
+      changes.push(`Layout: ${initial.mode} → ${currentViewPreferences.mode}`);
+    }
+    if (currentViewPreferences.showLineNumbers !== initial.showLineNumbers) {
+      changes.push(
+        `Line numbers: ${initial.showLineNumbers ? "on" : "off"} → ${currentViewPreferences.showLineNumbers ? "on" : "off"}`,
+      );
+    }
+    if (currentViewPreferences.wrapLines !== initial.wrapLines) {
+      changes.push(
+        `Line wrapping: ${initial.wrapLines ? "on" : "off"} → ${currentViewPreferences.wrapLines ? "on" : "off"}`,
+      );
+    }
+    if (currentViewPreferences.showHunkHeaders !== initial.showHunkHeaders) {
+      changes.push(
+        `Hunk headers: ${initial.showHunkHeaders ? "shown" : "hidden"} → ${currentViewPreferences.showHunkHeaders ? "shown" : "hidden"}`,
+      );
+    }
+    if (currentViewPreferences.showAgentNotes !== initial.showAgentNotes) {
+      changes.push(
+        `Agent notes: ${initial.showAgentNotes ? "shown" : "hidden"} → ${currentViewPreferences.showAgentNotes ? "shown" : "hidden"}`,
+      );
+    }
+    if (currentViewPreferences.copyDecorations !== initial.copyDecorations) {
+      changes.push(
+        `Copy decorations: ${initial.copyDecorations ? "on" : "off"} → ${currentViewPreferences.copyDecorations ? "on" : "off"}`,
+      );
+    }
+    return changes;
+  }, [currentViewPreferences]);
+  const hasUnsavedViewPreferences = changedViewPreferenceLines.length > 0;
+  const viewPreferencesConfigLabel = useMemo(() => {
+    const path = bootstrap.viewPreferencesConfigPath ?? "~/.config/hunk/config.toml";
+    return process.env.HOME && path.startsWith(process.env.HOME)
+      ? `~${path.slice(process.env.HOME.length)}`
+      : path;
+  }, [bootstrap.viewPreferencesConfigPath]);
   const review = useReviewController({ files: bootstrap.changeset.files });
   const filteredFiles = review.visibleFiles;
   const selectedFile = review.selectedFile;
@@ -630,10 +705,42 @@ export function App({
     };
   }, [bootstrap.input, refreshCurrentInput, watchEnabled]);
 
-  /** Leave the app through the shared shutdown path. */
-  const requestQuit = useCallback(() => {
+  /** Save current view preferences to user config and then leave the app. */
+  const saveViewPreferencesAndQuit = useCallback(() => {
+    try {
+      const configPath = saveGlobalViewPreferences(currentViewPreferences, {
+        configPath: bootstrap.viewPreferencesConfigPath,
+      });
+      initialViewPreferencesRef.current = currentViewPreferences;
+      showSessionNotice(`Saved view preferences to ${configPath}`);
+      setTimeout(onQuit, 120);
+    } catch (error) {
+      showSessionNotice(
+        error instanceof Error ? error.message : "Failed to save view preferences.",
+      );
+    }
+  }, [bootstrap.viewPreferencesConfigPath, currentViewPreferences, onQuit, showSessionNotice]);
+
+  /** Leave the app without writing view preference changes. */
+  const discardViewPreferencesAndQuit = useCallback(() => {
+    setSaveConfigPromptOpen(false);
     onQuit();
   }, [onQuit]);
+
+  /** Leave the app through the shared shutdown path, prompting before discarding view changes. */
+  const requestQuit = useCallback(() => {
+    if (!pagerMode && hasUnsavedViewPreferences) {
+      setShowHelp(false);
+      setSaveConfigPromptOpen(true);
+      return;
+    }
+
+    onQuit();
+  }, [hasUnsavedViewPreferences, onQuit, pagerMode]);
+
+  const closeSaveConfigPrompt = useCallback(() => {
+    setSaveConfigPromptOpen(false);
+  }, []);
 
   /** Close the modal keyboard help overlay. */
   const closeHelp = useCallback(() => {
@@ -795,6 +902,10 @@ export function App({
     openThemeSelector,
     pagerMode,
     requestQuit,
+    saveConfigPromptOpen,
+    saveViewPreferencesAndQuit,
+    discardViewPreferencesAndQuit,
+    closeSaveConfigPrompt,
     scrollCodeHorizontally,
     saveDraftNote,
     scrollDiff,
@@ -1051,6 +1162,52 @@ export function App({
             onClose={closeHelp}
           />
         </Suspense>
+      ) : null}
+
+      {!pagerMode && saveConfigPromptOpen ? (
+        <ModalFrame
+          height={Math.min(16, Math.max(11, changedViewPreferenceLines.length + 8))}
+          terminalHeight={terminal.height}
+          terminalWidth={terminal.width}
+          theme={baseTheme}
+          title="Save view preferences?"
+          width={68}
+          onClose={closeSaveConfigPrompt}
+        >
+          <box style={{ width: "100%", height: 1 }}>
+            <text fg={baseTheme.text}>
+              Save your local view changes to {viewPreferencesConfigLabel}?
+            </text>
+          </box>
+          <box style={{ width: "100%", height: 1 }} />
+          {changedViewPreferenceLines.map((line) => (
+            <box key={line} style={{ width: "100%", height: 1 }}>
+              <text fg={baseTheme.muted}>{line}</text>
+            </box>
+          ))}
+          <box style={{ width: "100%", height: 1 }} />
+          <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
+            <box
+              onMouseUp={(event: TuiMouseEvent) => {
+                event.stopPropagation();
+                saveViewPreferencesAndQuit();
+              }}
+            >
+              <text fg={baseTheme.accent}>[Enter/s] Save and quit</text>
+            </box>
+            <text fg={baseTheme.muted}> </text>
+            <box
+              onMouseUp={(event: TuiMouseEvent) => {
+                event.stopPropagation();
+                discardViewPreferencesAndQuit();
+              }}
+            >
+              <text fg={baseTheme.badgeNeutral}>[d] Discard</text>
+            </box>
+            <text fg={baseTheme.muted}> </text>
+            <text fg={baseTheme.muted}>[Esc] Cancel</text>
+          </box>
+        </ModalFrame>
       ) : null}
 
       {!pagerMode && themeSelectorState.open ? (

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -3426,6 +3426,7 @@ describe("App interactions", () => {
         nextFrame.includes("Save view preferences?"),
       );
       expect(frame).toContain("You changed 1 view setting during this review.");
+      expect(frame).toContain("q discard");
       expect(frame).toContain("n never ask");
       expect(frame).toContain('- theme = "github-dark-default"');
       expect(frame).toContain('+ theme = "github-dark-dimmed"');
@@ -3433,8 +3434,9 @@ describe("App interactions", () => {
       expect(frame).not.toContain("wrap_lines =");
       expect(quit).toHaveBeenCalledTimes(0);
 
+      // A second "q" quits and discards.
       await act(async () => {
-        await setup.mockInput.typeText("d");
+        await setup.mockInput.typeText("q");
         await setup.renderOnce();
       });
       expect(quit).toHaveBeenCalledTimes(1);

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -3425,11 +3425,12 @@ describe("App interactions", () => {
       let frame = await waitForFrame(setup, (nextFrame) =>
         nextFrame.includes("Save view preferences?"),
       );
-      expect(frame).toContain("Save your local view changes");
-      expect(frame).toContain("[n] Never ask");
-      expect(frame).toContain("Theme: github-dark-default → github-dark-dimmed");
-      expect(frame).not.toContain("Line numbers:");
-      expect(frame).not.toContain("Line wrapping:");
+      expect(frame).toContain("You changed 1 view setting during this review.");
+      expect(frame).toContain("n never ask");
+      expect(frame).toContain('- theme = "github-dark-default"');
+      expect(frame).toContain('+ theme = "github-dark-dimmed"');
+      expect(frame).not.toContain("line_numbers =");
+      expect(frame).not.toContain("wrap_lines =");
       expect(quit).toHaveBeenCalledTimes(0);
 
       await act(async () => {
@@ -3548,6 +3549,87 @@ describe("App interactions", () => {
       expect(quit).toHaveBeenCalledTimes(1);
       expect(readFileSync(join(configHome, "hunk", "config.toml"), "utf8")).toContain(
         "prompt_save_view_preferences = false",
+      );
+    } finally {
+      if (previousXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+      }
+      rmSync(configHome, { recursive: true, force: true });
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit prompt actions respond to mouse clicks", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-save-view-config-"));
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configHome;
+    const quit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createSingleFileBootstrap()} onQuit={quit} />,
+      {
+        width: 240,
+        height: 24,
+      },
+    );
+
+    /** Click the first frame cell where the given footer label starts. */
+    const clickLabel = async (label: string) => {
+      const lines = setup.captureCharFrame().split("\n");
+      const targetY = lines.findIndex((line) => line.includes(label));
+      expect(targetY).toBeGreaterThanOrEqual(0);
+      const targetX = lines[targetY]!.indexOf(label);
+      await act(async () => {
+        await setup.mockMouse.click(targetX, targetY);
+      });
+    };
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Save view preferences?"));
+
+      await clickLabel("esc cancel");
+      const cancelled = await waitForFrame(
+        setup,
+        (nextFrame) => !nextFrame.includes("Save view preferences?"),
+      );
+      expect(cancelled).not.toContain("Save view preferences?");
+      expect(quit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Save view preferences?"));
+
+      await clickLabel("enter/s save");
+      await act(async () => {
+        await Bun.sleep(140);
+      });
+      await flush(setup);
+
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(readFileSync(join(configHome, "hunk", "config.toml"), "utf8")).toContain(
+        'theme = "github-dark-dimmed"',
       );
     } finally {
       if (previousXdgConfigHome === undefined) {

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
@@ -3383,6 +3383,217 @@ describe("App interactions", () => {
       );
       expect(frame).toContain("second.ts");
       expect((frame.match(/first\.ts/g) ?? []).length).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit prompts to save changed view preferences", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-save-view-config-"));
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configHome;
+    const quit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createSingleFileBootstrap()} onQuit={quit} />,
+      {
+        width: 240,
+        height: 24,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      let frame = await waitForFrame(setup, (nextFrame) =>
+        nextFrame.includes("Save view preferences?"),
+      );
+      expect(frame).toContain("Save your local view changes");
+      expect(frame).toContain("[n] Never ask");
+      expect(frame).toContain("Theme: github-dark-default → github-dark-dimmed");
+      expect(frame).not.toContain("Line numbers:");
+      expect(frame).not.toContain("Line wrapping:");
+      expect(quit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.typeText("d");
+        await setup.renderOnce();
+      });
+      expect(quit).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previousXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+      }
+      rmSync(configHome, { recursive: true, force: true });
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit prompt saves changed view preferences", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-save-view-config-"));
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configHome;
+    const quit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createSingleFileBootstrap()} onQuit={quit} />,
+      {
+        width: 240,
+        height: 24,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Save view preferences?"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+        await Bun.sleep(140);
+      });
+      await flush(setup);
+
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(readFileSync(join(configHome, "hunk", "config.toml"), "utf8")).toContain(
+        'theme = "github-dark-dimmed"',
+      );
+    } finally {
+      if (previousXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+      }
+      rmSync(configHome, { recursive: true, force: true });
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit prompt can disable future view preference prompts", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-save-view-config-"));
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configHome;
+    const quit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createSingleFileBootstrap()} onQuit={quit} />,
+      {
+        width: 240,
+        height: 24,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Save view preferences?"));
+      await act(async () => {
+        await setup.mockInput.typeText("n");
+        await Bun.sleep(140);
+      });
+      await flush(setup);
+
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(readFileSync(join(configHome, "hunk", "config.toml"), "utf8")).toContain(
+        "prompt_save_view_preferences = false",
+      );
+    } finally {
+      if (previousXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+      }
+      rmSync(configHome, { recursive: true, force: true });
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit skips the save prompt when configured not to ask", async () => {
+    const quit = mock(() => undefined);
+    const bootstrap = createSingleFileBootstrap();
+    bootstrap.input.options.promptSaveViewPreferences = false;
+    const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={quit} />, {
+      width: 240,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await flush(setup);
+
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(setup.captureCharFrame()).not.toContain("Save view preferences?");
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, mock, test } from "bun:test";
@@ -3219,6 +3219,121 @@ describe("App interactions", () => {
       expect(frame).toContain("second.ts");
       expect((frame.match(/first\.ts/g) ?? []).length).toBe(1);
     } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit prompts to save changed view preferences", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-save-view-config-"));
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configHome;
+    const quit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createSingleFileBootstrap()} onQuit={quit} />,
+      {
+        width: 240,
+        height: 24,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      let frame = await waitForFrame(setup, (nextFrame) =>
+        nextFrame.includes("Save view preferences?"),
+      );
+      expect(frame).toContain("Save your local view changes");
+      expect(frame).toContain("Theme: github-dark-default → github-dark-dimmed");
+      expect(frame).not.toContain("Line numbers:");
+      expect(frame).not.toContain("Line wrapping:");
+      expect(quit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.typeText("d");
+        await setup.renderOnce();
+      });
+      expect(quit).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previousXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+      }
+      rmSync(configHome, { recursive: true, force: true });
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit prompt saves changed view preferences", async () => {
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-save-view-config-"));
+    const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = configHome;
+    const quit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createSingleFileBootstrap()} onQuit={quit} />,
+      {
+        width: 240,
+        height: 24,
+      },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
+
+      await act(async () => {
+        await setup.mockInput.pressArrow("down");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme: github-dark-dimmed"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Save view preferences?"));
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+        await Bun.sleep(140);
+      });
+      await flush(setup);
+
+      expect(quit).toHaveBeenCalledTimes(1);
+      expect(readFileSync(join(configHome, "hunk", "config.toml"), "utf8")).toContain(
+        'theme = "github-dark-dimmed"',
+      );
+    } finally {
+      if (previousXdgConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+      }
+      rmSync(configHome, { recursive: true, force: true });
       await act(async () => {
         setup.renderer.destroy();
       });

--- a/src/ui/AppHost.tsx
+++ b/src/ui/AppHost.tsx
@@ -55,6 +55,7 @@ export function AppHost({
         cwd,
         customTheme: configured.customTheme,
       });
+      nextBootstrap.viewPreferencesConfigPath = configured.viewPreferencesConfigPath;
       const nextSnapshot = createInitialSessionSnapshot(nextBootstrap);
 
       let sessionId = "local-session";

--- a/src/ui/components/chrome/ConfirmDialog.tsx
+++ b/src/ui/components/chrome/ConfirmDialog.tsx
@@ -1,0 +1,106 @@
+import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
+import type { ReactNode } from "react";
+import { useState } from "react";
+import type { AppTheme } from "../../themes";
+import { ModalFrame } from "./ModalFrame";
+
+/** One confirm choice: its footer key legend, label, and the action it runs. */
+export interface ConfirmDialogAction {
+  /** Keyboard legend shown in the footer, e.g. "enter/s", "d", "esc". */
+  keyLabel: string;
+  /** Short lowercase verb phrase, e.g. "save" or "never ask". */
+  label: string;
+  /** Run the choice. Invoked on mouse click; keyboard routing stays with the caller. */
+  run: () => void;
+}
+
+/** Rows ConfirmDialog adds around the body: ModalFrame chrome plus spacer and action row. */
+const CONFIRM_DIALOG_CHROME_ROWS = 7;
+
+/** Modal height for a ConfirmDialog whose body renders the given number of rows. */
+export function confirmDialogHeight(bodyRows: number) {
+  return bodyRows + CONFIRM_DIALOG_CHROME_ROWS;
+}
+
+/**
+ * Hunk's standard confirm modal shape: a ModalFrame with arbitrary body rows and
+ * one bottom action legend (`key label · key label · …`).
+ *
+ * Actions are mouse-clickable and highlight on hover. Keyboard shortcuts for the
+ * same actions are intentionally not handled here — wire them through
+ * useAppKeyboardShortcuts so all key handling stays in one place, and keep each
+ * action's `keyLabel` in sync with the keys that hook accepts.
+ *
+ * New confirmation prompts should reuse this component instead of composing
+ * ModalFrame with a hand-rolled footer. Size it with
+ * `confirmDialogHeight(bodyRows)` where `bodyRows` counts the 1-row boxes the
+ * body renders.
+ */
+export function ConfirmDialog({
+  actions,
+  children,
+  height,
+  onClose,
+  terminalHeight,
+  terminalWidth,
+  theme,
+  title,
+  width,
+}: {
+  actions: ConfirmDialogAction[];
+  children: ReactNode;
+  height: number;
+  /** Invoked by the frame's backdrop click and [Esc] affordance. */
+  onClose?: () => void;
+  terminalHeight: number;
+  terminalWidth: number;
+  theme: AppTheme;
+  title: string;
+  width: number;
+}) {
+  const [hoveredActionKey, setHoveredActionKey] = useState<string | null>(null);
+
+  return (
+    <ModalFrame
+      height={height}
+      terminalHeight={terminalHeight}
+      terminalWidth={terminalWidth}
+      theme={theme}
+      title={title}
+      width={width}
+      onClose={onClose}
+    >
+      {children}
+      <box style={{ width: "100%", height: 1 }} />
+      <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
+        {actions.map((action, index) => {
+          const hovered = hoveredActionKey === action.keyLabel;
+          return (
+            <box key={action.keyLabel} style={{ flexDirection: "row" }}>
+              {index > 0 ? <text fg={theme.badgeNeutral}> · </text> : null}
+              <box
+                style={{
+                  flexDirection: "row",
+                  paddingLeft: 1,
+                  paddingRight: 1,
+                  backgroundColor: hovered ? theme.accentMuted : undefined,
+                }}
+                onMouseOver={() => setHoveredActionKey(action.keyLabel)}
+                onMouseOut={() =>
+                  setHoveredActionKey((current) => (current === action.keyLabel ? null : current))
+                }
+                onMouseUp={(event: TuiMouseEvent) => {
+                  event.stopPropagation();
+                  action.run();
+                }}
+              >
+                <text fg={theme.accent}>{action.keyLabel}</text>
+                <text fg={hovered ? theme.text : theme.muted}> {action.label}</text>
+              </box>
+            </box>
+          );
+        })}
+      </box>
+    </ModalFrame>
+  );
+}

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -308,7 +308,8 @@ export function useAppKeyboardShortcuts({
       return true;
     }
 
-    if (key.name === "d" || key.sequence === "d") {
+    // "q" again quits and discards, so a double-tap of the quit key always exits.
+    if (key.name === "q" || key.sequence === "q") {
       discardViewPreferencesAndQuit();
       return true;
     }

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -62,6 +62,10 @@ export interface UseAppKeyboardShortcutsOptions {
   openThemeSelector: () => void;
   pagerMode: boolean;
   requestQuit: () => void;
+  saveConfigPromptOpen: boolean;
+  saveViewPreferencesAndQuit: () => void;
+  discardViewPreferencesAndQuit: () => void;
+  closeSaveConfigPrompt: () => void;
   scrollCodeHorizontally: (delta: number) => void;
   scrollDiff: (delta: number, unit: ScrollUnit) => void;
   saveDraftNote: () => void;
@@ -103,6 +107,10 @@ export function useAppKeyboardShortcuts({
   openThemeSelector,
   pagerMode,
   requestQuit,
+  saveConfigPromptOpen,
+  saveViewPreferencesAndQuit,
+  discardViewPreferencesAndQuit,
+  closeSaveConfigPrompt,
   scrollCodeHorizontally,
   saveDraftNote,
   scrollDiff,
@@ -126,12 +134,14 @@ export function useAppKeyboardShortcuts({
   const focusAreaRef = useRef(focusArea);
   const pagerModeRef = useRef(pagerMode);
   const showHelpRef = useRef(showHelp);
+  const saveConfigPromptOpenRef = useRef(saveConfigPromptOpen);
   const themeSelectorOpenRef = useRef(themeSelectorOpen);
 
   activeMenuIdRef.current = activeMenuId;
   focusAreaRef.current = focusArea;
   pagerModeRef.current = pagerMode;
   showHelpRef.current = showHelp;
+  saveConfigPromptOpenRef.current = saveConfigPromptOpen;
   themeSelectorOpenRef.current = themeSelectorOpen;
 
   const resolveJumpShortcut = (key: KeyEvent): JumpShortcut | null => {
@@ -257,6 +267,30 @@ export function useAppKeyboardShortcuts({
     }
 
     closeHelp();
+    return true;
+  };
+
+  const handleSaveConfigPromptShortcut = (key: KeyEvent) => {
+    if (!saveConfigPromptOpenRef.current) {
+      return false;
+    }
+
+    consumeKey(key);
+    if (key.name === "return" || key.name === "enter" || key.name === "s" || key.sequence === "s") {
+      saveViewPreferencesAndQuit();
+      return true;
+    }
+
+    if (key.name === "d" || key.sequence === "d" || key.name === "n" || key.sequence === "n") {
+      discardViewPreferencesAndQuit();
+      return true;
+    }
+
+    if (isEscapeKey(key)) {
+      closeSaveConfigPrompt();
+      return true;
+    }
+
     return true;
   };
 
@@ -557,6 +591,10 @@ export function useAppKeyboardShortcuts({
 
     if (pagerModeRef.current) {
       handlePagerShortcut(key);
+      return;
+    }
+
+    if (handleSaveConfigPromptShortcut(key)) {
       return;
     }
 

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -71,6 +71,11 @@ export interface UseAppKeyboardShortcutsOptions {
   openThemeSelector: () => void;
   pagerMode: boolean;
   requestQuit: () => void;
+  saveConfigPromptOpen: boolean;
+  saveViewPreferencesAndQuit: () => void;
+  discardViewPreferencesAndQuit: () => void;
+  neverAskToSaveViewPreferencesAndQuit: () => void;
+  closeSaveConfigPrompt: () => void;
   scrollCodeHorizontally: (delta: number) => void;
   scrollDiff: (delta: number, unit: ScrollUnit) => void;
   saveDraftNote: () => void;
@@ -115,6 +120,11 @@ export function useAppKeyboardShortcuts({
   openThemeSelector,
   pagerMode,
   requestQuit,
+  saveConfigPromptOpen,
+  saveViewPreferencesAndQuit,
+  discardViewPreferencesAndQuit,
+  neverAskToSaveViewPreferencesAndQuit,
+  closeSaveConfigPrompt,
   scrollCodeHorizontally,
   saveDraftNote,
   scrollDiff,
@@ -141,6 +151,7 @@ export function useAppKeyboardShortcuts({
   const pagerModeRef = useRef(pagerMode);
   const showAgentSkillRef = useRef(showAgentSkill);
   const showHelpRef = useRef(showHelp);
+  const saveConfigPromptOpenRef = useRef(saveConfigPromptOpen);
   const themeSelectorOpenRef = useRef(themeSelectorOpen);
 
   activeMenuIdRef.current = activeMenuId;
@@ -148,6 +159,7 @@ export function useAppKeyboardShortcuts({
   pagerModeRef.current = pagerMode;
   showAgentSkillRef.current = showAgentSkill;
   showHelpRef.current = showHelp;
+  saveConfigPromptOpenRef.current = saveConfigPromptOpen;
   themeSelectorOpenRef.current = themeSelectorOpen;
 
   const resolveJumpShortcut = (key: KeyEvent): JumpShortcut | null => {
@@ -283,6 +295,35 @@ export function useAppKeyboardShortcuts({
     }
 
     return false;
+  };
+
+  const handleSaveConfigPromptShortcut = (key: KeyEvent) => {
+    if (!saveConfigPromptOpenRef.current) {
+      return false;
+    }
+
+    consumeKey(key);
+    if (key.name === "return" || key.name === "enter" || key.name === "s" || key.sequence === "s") {
+      saveViewPreferencesAndQuit();
+      return true;
+    }
+
+    if (key.name === "d" || key.sequence === "d") {
+      discardViewPreferencesAndQuit();
+      return true;
+    }
+
+    if (key.name === "n" || key.sequence === "n") {
+      neverAskToSaveViewPreferencesAndQuit();
+      return true;
+    }
+
+    if (isEscapeKey(key)) {
+      closeSaveConfigPrompt();
+      return true;
+    }
+
+    return true;
   };
 
   const handleThemeSelectorShortcut = (key: KeyEvent) => {
@@ -576,6 +617,10 @@ export function useAppKeyboardShortcuts({
   };
 
   useKeyboard((key: KeyEvent) => {
+    if (handleSaveConfigPromptShortcut(key)) {
+      return;
+    }
+
     if (handleMenuToggleShortcut(key)) {
       return;
     }

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createPtyHarness } from "./harness";
 
 const harness = createPtyHarness();
@@ -73,6 +76,51 @@ describe("PTY chrome", () => {
       expect(helpDialog).toContain("g / G");
     } finally {
       session.close();
+    }
+  });
+
+  test("quit prompt shows the config diff and saves preferences on mouse click", async () => {
+    // Own the config home instead of the shared harness one so the test can
+    // assert what the save action wrote.
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-tuistory-save-view-"));
+    const fixture = harness.createMultiHunkFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after],
+      cols: 120,
+      rows: 24,
+      env: { XDG_CONFIG_HOME: configHome },
+    });
+
+    try {
+      await session.waitForText(/line60/, { timeout: 15_000 });
+
+      await session.press("t");
+      await session.waitForText(/Theme selector/, { timeout: 5_000 });
+      await session.press("down");
+      await session.waitForText(/›\s+github-dark-dimmed/, { timeout: 5_000 });
+      await session.press("enter");
+      await harness.waitForSnapshot(session, (text) => !text.includes("Theme selector"), 5_000);
+
+      await session.press("q");
+      const prompt = await session.waitForText(/Save view preferences\?/, { timeout: 5_000 });
+      expect(prompt).toContain('- theme = "github-dark-default"');
+      expect(prompt).toContain('+ theme = "github-dark-dimmed"');
+      expect(prompt).toContain("enter/s save");
+
+      await session.click(/enter\/s save/);
+
+      // The save handler writes the config and quits shortly after; poll the
+      // file instead of the (soon dead) PTY session.
+      const configPath = join(configHome, "hunk", "config.toml");
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline && !existsSync(configPath)) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      expect(readFileSync(configPath, "utf8")).toContain('theme = "github-dark-dimmed"');
+    } finally {
+      session.close();
+      rmSync(configHome, { recursive: true, force: true });
     }
   });
 

--- a/test/smoke/tty.test.ts
+++ b/test/smoke/tty.test.ts
@@ -254,7 +254,7 @@ describe("TTY render smoke", () => {
     const output = await runTtySmoke({
       mode: "split",
       longWrapFixture: true,
-      inputCommand: `(sleep 2; printf w; sleep 1; printf q)`,
+      inputCommand: `(sleep 2; printf w; sleep 1; printf q; sleep 1; printf q)`,
     });
 
     expect(output).toContain("wrapped line for");
@@ -269,7 +269,7 @@ describe("TTY render smoke", () => {
     const output = await runTtySmoke({
       mode: "split",
       longWrapFixture: true,
-      inputCommand: `(sleep 2; printf www; sleep 1; printf q)`,
+      inputCommand: `(sleep 2; printf www; sleep 1; printf q; sleep 1; printf q)`,
     });
 
     expect(output).toContain("wrapped line for");


### PR DESCRIPTION
## Summary

- prompt on quit when local view preferences changed
- save accepted preferences to the config file that will affect the next launch
- render the changed preferences as the literal `-`/`+` TOML diff the save would write to the config file, derived from the same key table `saveGlobalViewPreferences` persists with
- footer action legend (`enter/s save · q discard · n never ask · esc cancel`) is mouse-clickable with a hover highlight, alongside the existing keyboard shortcuts; pressing `q` a second time quits and discards
- extract the modal shape into a reusable `ConfirmDialog` component (body rows + key-legend actions) and document it in agent guidance so future confirmation prompts reuse it

## Verification

- `bun run typecheck`
- `bun test src/core/config.test.ts src/ui/AppHost.interactions.test.tsx --test-name-pattern 'config persistence|merges global|defaults unspecified|quit prompt'` (includes a mouse-click test for the prompt actions)
- `bun run test:integration` (new PTY test drives the live TUI: change theme, quit, click save, assert the written config)
- `bun run lint` / `bun run format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
