### PR TITLE
persist human review notes to a JSON sidecar via --store-notes

### DIFF
--- a/.changeset/persist-review-notes.md
+++ b/.changeset/persist-review-notes.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add an opt-in `--store-notes <path>` flag that persists human review notes to a JSON sidecar (cwd-relative). Notes survive closing the TUI and can be read back off disk by an agent. Omitting the flag keeps notes in-memory only, preserving current behavior.

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -139,6 +139,19 @@ hunk patch change.patch --agent-context notes.json
 
 For a compact real example, see [`examples/3-agent-review-demo/agent-context.json`](../examples/3-agent-review-demo/agent-context.json).
 
+## Reverse workflow: persist human review notes for an agent
+
+`--agent-context` loads agent → human notes into the diff. `--store-notes` does the reverse: it persists the **human** notes you write in the TUI (the `c` notes) to a JSON sidecar so an agent can pick them up after you close the review.
+
+```bash
+hunk diff <merge-base> --store-notes .hunk/notes.json
+```
+
+- The path is resolved relative to the current working directory. Omit the flag to keep notes in-memory only (the default).
+- Notes are written through on every change and seeded back on the next run with the same path, so a review resumes where you left off.
+- The sidecar is a JSON object keyed by file id, each value an array of notes (`id`, `filePath`, `side`, `line`, `summary`, …) that an agent can read directly off disk — no daemon or live session required.
+- The file is **not** auto-ignored by git; point `--store-notes` at an already-ignored location (for example a `.hunk/` directory you gitignore) if you don't want the notes tracked.
+
 ## Practical defaults
 
 - start with `hunk session review --repo . --json`

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -58,6 +58,7 @@ function buildCommonOptions(
     mode?: LayoutMode;
     theme?: string;
     agentContext?: string;
+    storeNotes?: string;
     pager?: boolean;
     watch?: boolean;
     transparentBackground?: boolean;
@@ -68,6 +69,7 @@ function buildCommonOptions(
     mode: options.mode,
     theme: options.theme,
     agentContext: options.agentContext,
+    storeNotes: options.storeNotes,
     pager: options.pager ? true : undefined,
     watch: options.watch ? true : undefined,
     excludeUntracked: resolveBooleanFlag(argv, "--exclude-untracked", "--no-exclude-untracked"),
@@ -85,6 +87,10 @@ function applyCommonOptions(command: Command) {
     .option("--mode <mode>", "layout mode: auto, split, stack", parseLayoutMode)
     .option("--theme <theme>", "named theme override")
     .option("--agent-context <path>", "JSON sidecar with agent rationale")
+    .option(
+      "--store-notes <path>",
+      "persist review notes to a JSON sidecar at <path> (cwd-relative)",
+    )
     .option("--pager", "use pager-style chrome and controls")
     .option("--line-numbers", "show line numbers")
     .option("--no-line-numbers", "hide line numbers")

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -516,6 +516,34 @@ describe("config resolution", () => {
     expect(bootstrap.initialCopyDecorations).toBe(false);
   });
 
+  test("--store-notes resolves the sidecar path against cwd; omitting it disables persistence", async () => {
+    const repo = createTempDir("hunk-store-notes-");
+    createRepo(repo);
+
+    const before = join(repo, "before.ts");
+    const after = join(repo, "after.ts");
+    writeFileSync(before, "export const alpha = 1;\n");
+    writeFileSync(after, "export const alpha = 2;\n");
+
+    const withFlag = await loadAppBootstrap(
+      resolveConfiguredCliInput(
+        { kind: "diff", left: before, right: after, options: { storeNotes: ".hunk/notes.json" } },
+        { cwd: repo, env: { HOME: repo } },
+      ).input,
+      { cwd: repo },
+    );
+    expect(withFlag.userNotesSidecarPath).toBe(join(repo, ".hunk", "notes.json"));
+
+    const withoutFlag = await loadAppBootstrap(
+      resolveConfiguredCliInput(
+        { kind: "diff", left: before, right: after, options: {} },
+        { cwd: repo, env: { HOME: repo } },
+      ).input,
+      { cwd: repo },
+    );
+    expect(withoutFlag.userNotesSidecarPath).toBeUndefined();
+  });
+
   test("loadAppBootstrap carries the configured custom theme into the UI bootstrap", async () => {
     const home = createTempDir("hunk-config-home-");
     const repo = createTempDir("hunk-config-repo-");

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -319,6 +319,7 @@ export function resolveConfiguredCliInput(
     // renderer theme-mode detection for their initial palette.
     theme: "github-dark-default",
     agentContext: input.options.agentContext,
+    storeNotes: input.options.storeNotes,
     pager: input.options.pager ?? false,
     watch: input.options.watch ?? false,
     excludeUntracked: false,
@@ -346,6 +347,7 @@ export function resolveConfiguredCliInput(
   resolvedOptions = {
     ...resolvedOptions,
     agentContext: input.options.agentContext,
+    storeNotes: input.options.storeNotes,
     pager: input.options.pager ?? false,
     watch: input.options.watch ?? resolvedOptions.watch ?? false,
     excludeUntracked: resolvedOptions.excludeUntracked ?? false,

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -452,6 +452,9 @@ export async function loadAppBootstrap(
   return {
     input,
     changeset,
+    userNotesSidecarPath: input.options.storeNotes
+      ? resolvePath(cwd, input.options.storeNotes)
+      : undefined,
     initialMode: input.options.mode ?? "auto",
     initialTheme: input.options.theme,
     customTheme,

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -12,6 +12,7 @@ import {
 import type { AppBootstrap, CliInput, ParsedCliInput, SessionCommandInput } from "./types";
 import { canReloadInput } from "./watch";
 import { parseCli } from "./cli";
+import { userNotesWriteWarning } from "./userNotesStore";
 
 export type StartupPlan =
   | {
@@ -232,6 +233,15 @@ export async function prepareStartupPlan(
   }
 
   bootstrap.initialThemeMode = initialThemeMode ?? bootstrap.initialThemeMode;
+
+  // Warn before the TUI takes the screen if --store-notes points somewhere we
+  // cannot write, so review notes are not silently lost on save.
+  if (bootstrap.userNotesSidecarPath) {
+    const warning = userNotesWriteWarning(bootstrap.userNotesSidecarPath);
+    if (warning) {
+      process.stderr.write(`${warning}\n`);
+    }
+  }
 
   controllingTerminal ??= usesPipedPatchInputImpl(cliInput) ? openControllingTerminalImpl() : null;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -91,6 +91,8 @@ export interface CommonOptions {
   wrapLines?: boolean;
   hunkHeaders?: boolean;
   agentNotes?: boolean;
+  /** Path for the human-notes JSON sidecar; when set, notes persist there. */
+  storeNotes?: string;
   copyDecorations?: boolean;
   transparentBackground?: boolean;
   colorMoved?: boolean;
@@ -357,6 +359,8 @@ export type ParsedCliInput =
 export interface AppBootstrap {
   input: CliInput;
   changeset: Changeset;
+  /** Absolute path to the human-notes JSON sidecar, when --store-notes was passed. */
+  userNotesSidecarPath?: string;
   initialMode: LayoutMode;
   initialTheme?: string;
   initialThemeMode?: TerminalThemeMode;

--- a/src/core/userNotesStore.test.ts
+++ b/src/core/userNotesStore.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { UserReviewNote } from "../ui/hooks/useReviewController";
+import { readUserNotes, userNotesWriteWarning, writeUserNotes } from "./userNotesStore";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function createTempDir(prefix: string) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function note(id: string, summary: string): UserReviewNote {
+  return {
+    id,
+    source: "user",
+    filePath: "src/foo.ts",
+    hunkIndex: 0,
+    side: "new",
+    line: 1,
+    summary,
+    author: "user",
+    editable: true,
+  } as UserReviewNote;
+}
+
+describe("userNotesStore", () => {
+  test("writeUserNotes round-trips through readUserNotes, creating missing dirs", () => {
+    const root = createTempDir("hunk-notes-");
+    const path = join(root, ".hunk", "notes.json");
+    const map = { "repo:0:src/foo.ts": [note("user:1", "first"), note("user:2", "second")] };
+
+    writeUserNotes(path, map);
+
+    expect(readUserNotes(path)).toEqual(map);
+  });
+
+  test("readUserNotes tolerates a missing or malformed sidecar", () => {
+    const root = createTempDir("hunk-notes-");
+    expect(readUserNotes(join(root, "absent.json"))).toEqual({});
+
+    const malformed = join(root, "bad.json");
+    writeFileSync(malformed, "{ not json");
+    expect(readUserNotes(malformed)).toEqual({});
+  });
+
+  test("readUserNotes drops entries that are not plausible note arrays", () => {
+    const root = createTempDir("hunk-notes-");
+    const path = join(root, "notes.json");
+    writeFileSync(path, JSON.stringify({ good: [note("user:1", "ok")], bad: [{ nope: true }] }));
+
+    expect(Object.keys(readUserNotes(path))).toEqual(["good"]);
+  });
+
+  describe("userNotesWriteWarning", () => {
+    test("no warning when the sidecar is missing but an ancestor is writable", () => {
+      const root = createTempDir("hunk-notes-");
+      expect(userNotesWriteWarning(join(root, ".hunk", "notes.json"))).toBeUndefined();
+    });
+
+    test("no warning when the sidecar already exists and is writable (prior review)", () => {
+      const root = createTempDir("hunk-notes-");
+      const path = join(root, "notes.json");
+      writeUserNotes(path, { "repo:0:src/foo.ts": [note("user:1", "prior")] });
+
+      expect(userNotesWriteWarning(path)).toBeUndefined();
+    });
+
+    test("warns when an existing sidecar is read-only", () => {
+      const root = createTempDir("hunk-notes-");
+      const path = join(root, "notes.json");
+      writeFileSync(path, "{}");
+      chmodSync(path, 0o444);
+
+      const warning = userNotesWriteWarning(path);
+      expect(warning).toContain(path);
+      expect(warning).toContain("not be saved");
+    });
+  });
+});

--- a/src/core/userNotesStore.test.ts
+++ b/src/core/userNotesStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { UserReviewNote } from "../ui/hooks/useReviewController";
@@ -45,6 +45,18 @@ describe("userNotesStore", () => {
     writeUserNotes(path, map);
 
     expect(readUserNotes(path)).toEqual(map);
+  });
+
+  test("writeUserNotes replaces existing notes atomically without leaving temp litter", () => {
+    const root = createTempDir("hunk-notes-");
+    const path = join(root, "notes.json");
+
+    writeUserNotes(path, { "repo:0:src/foo.ts": [note("user:1", "first")] });
+    writeUserNotes(path, { "repo:0:src/bar.ts": [note("user:2", "second")] });
+
+    // Full replacement, and the temp sibling used for the atomic rename is gone.
+    expect(readUserNotes(path)).toEqual({ "repo:0:src/bar.ts": [note("user:2", "second")] });
+    expect(readdirSync(root).filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
 
   test("readUserNotes tolerates a missing or malformed sidecar", () => {

--- a/src/core/userNotesStore.ts
+++ b/src/core/userNotesStore.ts
@@ -5,9 +5,20 @@
  * path so they survive closing the TUI and can be read back by an AI agent
  * directly off disk. Every disk operation is best-effort: a read failure yields
  * an empty map and a write failure is swallowed, so persistence never crashes
- * the review UI. Set `HUNK_DEBUG=1` to surface swallowed errors on stderr.
+ * the review UI. Writes go through a temp sibling + atomic rename so an
+ * interrupted write (SIGTERM, OOM, power loss) can never truncate an existing
+ * sidecar and lose prior notes. Set `HUNK_DEBUG=1` to surface swallowed errors.
  */
-import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  accessSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 import type { UserReviewNote } from "../ui/hooks/useReviewController";
 
@@ -85,13 +96,28 @@ export function readUserNotes(path: string): UserNotesMap {
   return map;
 }
 
-/** Persist human notes to the caller-supplied sidecar path, creating parent dirs. */
+/**
+ * Persist human notes to the caller-supplied sidecar path, creating parent dirs.
+ *
+ * The payload is written to a temp sibling and then `renameSync`d into place.
+ * `rename(2)` is atomic on POSIX, so a crash mid-write leaves the previous
+ * sidecar intact rather than a truncated file that `readUserNotes` would discard
+ * — preserving the durability the feature promises.
+ */
 export function writeUserNotes(path: string, map: UserNotesMap): void {
+  const tempPath = `${path}.${process.pid}.tmp`;
   try {
     mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, JSON.stringify(map, null, 2), { encoding: "utf8" });
+    writeFileSync(tempPath, JSON.stringify(map, null, 2), { encoding: "utf8" });
+    renameSync(tempPath, path);
   } catch (error) {
-    // Best-effort: a write failure must never crash the review UI.
+    // Best-effort: a write failure must never crash the review UI. Drop any
+    // partial temp file so a failed write can't litter the sidecar directory.
+    try {
+      rmSync(tempPath, { force: true });
+    } catch {
+      // ignore cleanup failure
+    }
     debugUserNotesError("write", path, error);
   }
 }

--- a/src/core/userNotesStore.ts
+++ b/src/core/userNotesStore.ts
@@ -1,0 +1,97 @@
+/**
+ * Disk persistence for human-authored review notes ("c" notes).
+ *
+ * Notes are mirrored to the JSON sidecar at the caller-supplied `--store-notes`
+ * path so they survive closing the TUI and can be read back by an AI agent
+ * directly off disk. Every disk operation is best-effort: a read failure yields
+ * an empty map and a write failure is swallowed, so persistence never crashes
+ * the review UI. Set `HUNK_DEBUG=1` to surface swallowed errors on stderr.
+ */
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { UserReviewNote } from "../ui/hooks/useReviewController";
+
+export type UserNotesMap = Record<string, UserReviewNote[]>;
+
+/** Walk up from a path to the closest ancestor directory that already exists. */
+function nearestExistingDir(path: string): string {
+  let dir = dirname(path);
+  while (!existsSync(dir) && dirname(dir) !== dir) {
+    dir = dirname(dir);
+  }
+  return dir;
+}
+
+/**
+ * Best-effort startup heads-up: return a warning when the sidecar at `path`
+ * cannot be written, else undefined. Existence is fine — only un-writability
+ * warns. An existing sidecar must itself be writable; a missing one needs its
+ * nearest existing ancestor writable so `mkdir -p` can create the rest. This is
+ * a UX signal only; the write path stays fault-tolerant regardless.
+ */
+export function userNotesWriteWarning(path: string): string | undefined {
+  const target = existsSync(path) ? path : nearestExistingDir(path);
+  try {
+    accessSync(target, constants.W_OK);
+    return undefined;
+  } catch {
+    return `hunk: cannot write review notes to ${path}; notes from this session will not be saved.`;
+  }
+}
+
+/** Emit a swallowed-error diagnostic only when the user opted into debug output. */
+function debugUserNotesError(action: string, path: string, error: unknown): void {
+  if (process.env.HUNK_DEBUG === "1") {
+    process.stderr.write(`hunk: failed to ${action} user notes at ${path}: ${String(error)}\n`);
+  }
+}
+
+/** Return whether one parsed value is an array of plausible user notes. */
+function isUserNoteArray(value: unknown): value is UserReviewNote[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as { id?: unknown }).id === "string" &&
+        typeof (entry as { summary?: unknown }).summary === "string",
+    )
+  );
+}
+
+/** Read persisted human notes, tolerating a missing or malformed sidecar file. */
+export function readUserNotes(path: string): UserNotesMap {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      debugUserNotesError("read", path, error);
+    }
+    return {};
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+
+  const map: UserNotesMap = {};
+  for (const [fileId, notes] of Object.entries(parsed as Record<string, unknown>)) {
+    if (isUserNoteArray(notes)) {
+      map[fileId] = notes;
+    }
+  }
+  return map;
+}
+
+/** Persist human notes to the caller-supplied sidecar path, creating parent dirs. */
+export function writeUserNotes(path: string, map: UserNotesMap): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(map, null, 2), { encoding: "utf8" });
+  } catch (error) {
+    // Best-effort: a write failure must never crash the review UI.
+    debugUserNotesError("write", path, error);
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -178,7 +178,10 @@ export function App({
       })),
     [activeTheme.id, themeOptions],
   );
-  const review = useReviewController({ files: bootstrap.changeset.files });
+  const review = useReviewController({
+    files: bootstrap.changeset.files,
+    userNotesSidecarPath: bootstrap.userNotesSidecarPath,
+  });
   const filteredFiles = review.visibleFiles;
   const selectedFile = review.selectedFile;
   const selectedHunkIndex = review.selectedHunkIndex;

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act, StrictMode, useEffect, useState } from "react";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { SourceTextTooLargeError } from "../../core/fileSource";
 import type { DiffFile } from "../../core/types";
 import {
@@ -9,7 +12,12 @@ import {
   createTestSourceFetcher,
   lines,
 } from "../../../test/helpers/diff-helpers";
-import { useReviewController, type ReviewController } from "./useReviewController";
+import { readUserNotes, writeUserNotes } from "../../core/userNotesStore";
+import {
+  useReviewController,
+  type ReviewController,
+  type UserReviewNote,
+} from "./useReviewController";
 
 /** Build a DiffFile with real parsed hunks using the controller's preferred defaults. */
 function createDiffFile(
@@ -88,13 +96,15 @@ function ReviewControllerHarness({
   initialFiles,
   onController,
   onSetFiles,
+  userNotesSidecarPath,
 }: {
   initialFiles: DiffFile[];
   onController: (controller: ReviewController) => void;
   onSetFiles?: (setFiles: (nextFiles: DiffFile[]) => void) => void;
+  userNotesSidecarPath?: string;
 }) {
   const [files, setFiles] = useState(initialFiles);
-  const controller = useReviewController({ files });
+  const controller = useReviewController({ files, userNotesSidecarPath });
 
   useEffect(() => {
     onController(controller);
@@ -110,13 +120,17 @@ function ReviewControllerHarness({
 /** Render the controller hook and expose its latest state to tests. */
 async function renderReviewController(
   initialFiles: DiffFile[],
-  { strictMode = false }: { strictMode?: boolean } = {},
+  {
+    strictMode = false,
+    userNotesSidecarPath,
+  }: { strictMode?: boolean; userNotesSidecarPath?: string } = {},
 ) {
   const controllerRef: { current: ReviewController | null } = { current: null };
   const setFilesRef: { current: ((nextFiles: DiffFile[]) => void) | null } = { current: null };
   const harness = (
     <ReviewControllerHarness
       initialFiles={initialFiles}
+      userNotesSidecarPath={userNotesSidecarPath}
       onController={(nextController) => {
         controllerRef.current = nextController;
       }}
@@ -1080,6 +1094,161 @@ describe("useReviewController", () => {
       await act(async () => {
         setup.renderer.destroy();
       });
+    }
+  });
+});
+
+describe("useReviewController note persistence", () => {
+  function seedNote(id: string, summary: string): UserReviewNote {
+    return {
+      id,
+      source: "user",
+      filePath: "alpha.ts",
+      hunkIndex: 0,
+      side: "new",
+      line: 1,
+      summary,
+      author: "user",
+      editable: true,
+    } as UserReviewNote;
+  }
+
+  async function saveUserNote(
+    controllerRef: { current: ReviewController | null },
+    setup: Awaited<ReturnType<typeof renderReviewController>>["setup"],
+    body: string,
+  ) {
+    await act(async () => {
+      expectValue(controllerRef.current).startUserNote("alpha", 0);
+    });
+    await flush(setup);
+    await act(async () => {
+      expectValue(controllerRef.current).updateDraftNote(body);
+    });
+    await flush(setup);
+    let savedId = "";
+    await act(async () => {
+      savedId = expectValue(controllerRef.current).saveDraftNote()?.id ?? "";
+    });
+    await flush(setup);
+    return savedId;
+  }
+
+  test("seeds user notes from the sidecar on mount", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-controller-notes-"));
+    const path = join(dir, "notes.json");
+    const seeded = { alpha: [seedNote("user:seeded", "from a prior review")] };
+    writeUserNotes(path, seeded);
+
+    const { controllerRef, setup } = await renderReviewController([createAlphaFile()], {
+      userNotesSidecarPath: path,
+    });
+    try {
+      await flush(setup);
+      expect(expectValue(controllerRef.current).userNotesByFileId).toEqual(seeded);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes saved notes through to the sidecar, creating missing dirs", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-controller-notes-"));
+    const path = join(dir, ".hunk", "notes.json");
+
+    const { controllerRef, setup } = await renderReviewController([createAlphaFile()], {
+      userNotesSidecarPath: path,
+    });
+    try {
+      await flush(setup);
+      const savedId = await saveUserNote(controllerRef, setup, "persist me");
+
+      expect(savedId).toStartWith("user:");
+      // Disk mirrors in-memory state after the write-through.
+      expect(readUserNotes(path)).toEqual(expectValue(controllerRef.current).userNotesByFileId);
+      expect(readUserNotes(path).alpha).toHaveLength(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("removeUserNote and removeLiveComment write removals through to the sidecar", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-controller-notes-"));
+    const path = join(dir, "notes.json");
+
+    const { controllerRef, setup } = await renderReviewController([createAlphaFile()], {
+      userNotesSidecarPath: path,
+    });
+    try {
+      await flush(setup);
+
+      const firstId = await saveUserNote(controllerRef, setup, "remove via removeUserNote");
+      await act(async () => {
+        expectValue(controllerRef.current).removeUserNote(firstId);
+      });
+      await flush(setup);
+      expect(readUserNotes(path)).toEqual({});
+
+      const secondId = await saveUserNote(controllerRef, setup, "remove via removeLiveComment");
+      await act(async () => {
+        expectValue(controllerRef.current).removeLiveComment(secondId);
+      });
+      await flush(setup);
+      expect(readUserNotes(path)).toEqual({});
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("clearLiveComments({ includeUser }) is written through to the sidecar", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-controller-notes-"));
+    const path = join(dir, "notes.json");
+
+    const { controllerRef, setup } = await renderReviewController([createAlphaFile()], {
+      userNotesSidecarPath: path,
+    });
+    try {
+      await flush(setup);
+      await saveUserNote(controllerRef, setup, "clear me");
+      expect(readUserNotes(path).alpha).toHaveLength(1);
+
+      await act(async () => {
+        expectValue(controllerRef.current).clearLiveComments(undefined, { includeUser: true });
+      });
+      await flush(setup);
+      expect(readUserNotes(path)).toEqual({});
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not touch disk when no sidecar path is configured", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-controller-notes-"));
+    const path = join(dir, "notes.json");
+
+    const { controllerRef, setup } = await renderReviewController([createAlphaFile()]);
+    try {
+      await flush(setup);
+      await saveUserNote(controllerRef, setup, "in-memory only");
+
+      expect(expectValue(controllerRef.current).userNotesByFileId.alpha).toHaveLength(1);
+      expect(existsSync(path)).toBe(false);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -22,6 +22,7 @@ import {
   resolveCommentTarget,
 } from "../../core/liveComments";
 import { SourceTextTooLargeError } from "../../core/fileSource";
+import { readUserNotes, writeUserNotes } from "../../core/userNotesStore";
 import type { AgentAnnotation, DiffFile, UserNoteLineTarget } from "../../core/types";
 import type {
   AppliedCommentBatchResult,
@@ -184,7 +185,17 @@ export interface ReviewController {
 }
 
 /** Own the shared review stream state used by both the UI and session bridge. */
-export function useReviewController({ files }: { files: DiffFile[] }): ReviewController {
+export function useReviewController({
+  files,
+  userNotesSidecarPath,
+}: {
+  files: DiffFile[];
+  /**
+   * When set, human notes are seeded from and written through to this JSON
+   * sidecar so they survive closing the TUI. Omit to keep notes in-memory only.
+   */
+  userNotesSidecarPath?: string;
+}): ReviewController {
   const [filter, setFilter] = useState("");
   const [selectedFileId, setSelectedFileId] = useState(files[0]?.id ?? "");
   const [selectedHunkIndex, setSelectedHunkIndex] = useState(0);
@@ -194,7 +205,20 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
   const [liveCommentsByFileId, setLiveCommentsByFileId] = useState<Record<string, LiveComment[]>>(
     {},
   );
-  const [userNotesByFileId, setUserNotesByFileId] = useState<Record<string, UserReviewNote[]>>({});
+  const [userNotesByFileId, setUserNotesByFileId] = useState<Record<string, UserReviewNote[]>>(() =>
+    userNotesSidecarPath ? readUserNotes(userNotesSidecarPath) : {},
+  );
+  // Write through to the sidecar at the point of each mutation so notes persist
+  // without a state-mirroring effect; the seed above is the only disk read.
+  const commitUserNotes = useCallback(
+    (next: Record<string, UserReviewNote[]>) => {
+      setUserNotesByFileId(next);
+      if (userNotesSidecarPath) {
+        writeUserNotes(userNotesSidecarPath, next);
+      }
+    },
+    [userNotesSidecarPath],
+  );
   const [draftNote, setDraftNote] = useState<DraftReviewNote | null>(null);
   const [expandedGapsByFileId, setExpandedGapsByFileId] = useState<
     Record<string, ReadonlySet<string>>
@@ -681,7 +705,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
           throw new Error(`No user note matches id ${commentId}.`);
         }
 
-        setUserNotesByFileId(next);
+        commitUserNotes(next);
         return {
           commentId,
           removed: true,
@@ -718,7 +742,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         source: "agent",
       };
     },
-    [liveCommentsByFileId, userNotesByFileId],
+    [liveCommentsByFileId, userNotesByFileId, commitUserNotes],
   );
 
   /** Clear live comments, optionally including human notes, globally or for one file. */
@@ -778,7 +802,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         }
 
         if (removedUserNoteCount > 0) {
-          setUserNotesByFileId(nextUserNotesByFileId);
+          commitUserNotes(nextUserNotesByFileId);
         }
       }
 
@@ -793,7 +817,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         remainingUserNoteCount,
       };
     },
-    [allFiles, liveCommentsByFileId, userNotesByFileId],
+    [allFiles, liveCommentsByFileId, userNotesByFileId, commitUserNotes],
   );
 
   /** Start a human-authored draft note at the selected or requested hunk. */
@@ -869,13 +893,13 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
       editable: true,
     };
 
-    setUserNotesByFileId((notesByFile) => ({
-      ...notesByFile,
-      [draftNote.fileId]: [...(notesByFile[draftNote.fileId] ?? []), savedNote],
-    }));
+    commitUserNotes({
+      ...userNotesByFileId,
+      [draftNote.fileId]: [...(userNotesByFileId[draftNote.fileId] ?? []), savedNote],
+    });
     setDraftNote(null);
     return savedNote;
-  }, [draftNote]);
+  }, [draftNote, userNotesByFileId, commitUserNotes]);
 
   /** Remove one in-memory user note by id. */
   const removeUserNote = useCallback(
@@ -897,9 +921,9 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         throw new Error(`No user note matches id ${noteId}.`);
       }
 
-      setUserNotesByFileId(next);
+      commitUserNotes(next);
     },
-    [userNotesByFileId],
+    [userNotesByFileId, commitUserNotes],
   );
 
   /** Count all currently tracked live comments, including ones hidden by the active filter. */

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -208,10 +208,18 @@ export function useReviewController({
   const [userNotesByFileId, setUserNotesByFileId] = useState<Record<string, UserReviewNote[]>>(() =>
     userNotesSidecarPath ? readUserNotes(userNotesSidecarPath) : {},
   );
+  // Lets a functional commit read the latest notes when saves batch before a re-render.
+  const userNotesRef = useRef(userNotesByFileId);
   // Write through to the sidecar at the point of each mutation so notes persist
   // without a state-mirroring effect; the seed above is the only disk read.
   const commitUserNotes = useCallback(
-    (next: Record<string, UserReviewNote[]>) => {
+    (
+      update:
+        | Record<string, UserReviewNote[]>
+        | ((prev: Record<string, UserReviewNote[]>) => Record<string, UserReviewNote[]>),
+    ) => {
+      const next = typeof update === "function" ? update(userNotesRef.current) : update;
+      userNotesRef.current = next;
       setUserNotesByFileId(next);
       if (userNotesSidecarPath) {
         writeUserNotes(userNotesSidecarPath, next);
@@ -893,13 +901,14 @@ export function useReviewController({
       editable: true,
     };
 
-    commitUserNotes({
-      ...userNotesByFileId,
-      [draftNote.fileId]: [...(userNotesByFileId[draftNote.fileId] ?? []), savedNote],
-    });
+    // Functional form: a closure snapshot would drop a save batched before re-render.
+    commitUserNotes((prev) => ({
+      ...prev,
+      [draftNote.fileId]: [...(prev[draftNote.fileId] ?? []), savedNote],
+    }));
     setDraftNote(null);
     return savedNote;
-  }, [draftNote, userNotesByFileId, commitUserNotes]);
+  }, [draftNote, commitUserNotes]);
 
   /** Remove one in-memory user note by id. */
   const removeUserNote = useCallback(


### PR DESCRIPTION
## What
Opt-in `--store-notes <path>` (cwd-relative) persists human `c` review notes to a JSON sidecar keyed by file id, readable directly off disk.

## Why
Human notes currently die with the session, so an agent can't pick up your review after you quit — the reverse of `--agent-context`. Addresses #113 (persist notes past quit; suggests a `.hunk/` sidecar).

## Behavior
Opt-in; default behavior unchanged. Disk I/O is best-effort and never crashes the UI; startup warning if the path isn't writable. Includes tests, `docs/agent-workflows.md`, and a `minor` changeset.
