### PR TITLE
feat(theme): load a VS Code/Shiki theme JSON for syntax highlighting

### DIFF
--- a/.changeset/custom-syntax-theme-json.md
+++ b/.changeset/custom-syntax-theme-json.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add `custom_theme.syntax_theme` to load a full VS Code / Shiki theme JSON for source-accurate syntax highlighting. The referenced theme is registered with the highlighter and drives code coloring, so any VS Code theme renders exactly as it would in the editor instead of being approximated by the nine `[custom_theme.syntax]` tokens.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ variable = "#eef4ff"
 
 All custom theme colors must use `#rrggbb` hex values. Press `t` in the app, or choose `View -> Themes…`, to open the theme selector.
 
+For source-accurate syntax highlighting, point `syntax_theme` at a VS Code / Shiki theme JSON file. Hunk loads it and hands it to its Shiki-based highlighter, so any VS Code theme colors your code exactly as that theme would:
+
+```toml
+[custom_theme]
+base = "catppuccin-mocha"
+syntax_theme = "shades-of-purple.json"   # absolute, or relative to this config file
+```
+
+When `syntax_theme` is set it drives code highlighting; the `[custom_theme.syntax]` colors then only refine tokens that would otherwise collide with diff add/remove backgrounds.
+
 ### Git integration
 
 Set Hunk as your Git pager so `git diff` and `git show` open in Hunk automatically:

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -269,6 +269,24 @@ describe("config resolution", () => {
     ).toThrow("Expected custom_theme.syntax_theme to point at a file.");
   });
 
+  test("rejects a custom_theme.syntax_theme that is not valid JSON", () => {
+    const home = createTempDir("hunk-config-home-");
+    const hunkDir = join(home, ".config", "hunk");
+    mkdirSync(hunkDir, { recursive: true });
+    writeFileSync(join(hunkDir, "broken.json"), "{ not valid json }");
+    writeFileSync(
+      join(hunkDir, "config.toml"),
+      ["[custom_theme]", 'syntax_theme = "broken.json"'].join("\n"),
+    );
+
+    expect(() =>
+      resolveConfiguredCliInput(createPatchPagerInput(), {
+        cwd: createTempDir("hunk-config-cwd-"),
+        env: { HOME: home },
+      }),
+    ).toThrow("to be valid JSON:");
+  });
+
   test("rejects a custom_theme.syntax_theme JSON without a name", () => {
     const home = createTempDir("hunk-config-home-");
     const hunkDir = join(home, ".config", "hunk");

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -221,6 +221,72 @@ describe("config resolution", () => {
     ).toThrow("Expected custom_theme.accent to be a hex color like #112233.");
   });
 
+  test("loads a custom_theme.syntax_theme JSON relative to the config file", () => {
+    const home = createTempDir("hunk-config-home-");
+    const hunkDir = join(home, ".config", "hunk");
+    mkdirSync(hunkDir, { recursive: true });
+    writeFileSync(
+      join(hunkDir, "my-theme.json"),
+      JSON.stringify({ name: "My VS Code Theme", type: "dark", tokenColors: [] }),
+    );
+    writeFileSync(
+      join(hunkDir, "config.toml"),
+      [
+        'theme = "custom"',
+        "",
+        "[custom_theme]",
+        'base = "github-dark-default"',
+        'syntax_theme = "my-theme.json"',
+      ].join("\n"),
+    );
+
+    const resolved = resolveConfiguredCliInput(createPatchPagerInput(), {
+      cwd: createTempDir("hunk-config-cwd-"),
+      env: { HOME: home },
+    });
+
+    expect(resolved.customTheme?.syntaxThemePath).toBe("my-theme.json");
+    expect(resolved.customTheme?.syntaxThemeData).toEqual({
+      name: "My VS Code Theme",
+      type: "dark",
+      tokenColors: [],
+    });
+  });
+
+  test("rejects a custom_theme.syntax_theme that does not exist", () => {
+    const home = createTempDir("hunk-config-home-");
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(
+      join(home, ".config", "hunk", "config.toml"),
+      ["[custom_theme]", 'syntax_theme = "missing.json"'].join("\n"),
+    );
+
+    expect(() =>
+      resolveConfiguredCliInput(createPatchPagerInput(), {
+        cwd: createTempDir("hunk-config-cwd-"),
+        env: { HOME: home },
+      }),
+    ).toThrow("Expected custom_theme.syntax_theme to point at a file.");
+  });
+
+  test("rejects a custom_theme.syntax_theme JSON without a name", () => {
+    const home = createTempDir("hunk-config-home-");
+    const hunkDir = join(home, ".config", "hunk");
+    mkdirSync(hunkDir, { recursive: true });
+    writeFileSync(join(hunkDir, "nameless.json"), JSON.stringify({ type: "dark" }));
+    writeFileSync(
+      join(hunkDir, "config.toml"),
+      ["[custom_theme]", 'syntax_theme = "nameless.json"'].join("\n"),
+    );
+
+    expect(() =>
+      resolveConfiguredCliInput(createPatchPagerInput(), {
+        cwd: createTempDir("hunk-config-cwd-"),
+        env: { HOME: home },
+      }),
+    ).toThrow('to be a Shiki theme with a non-empty "name".');
+  });
+
   test("rejects theme = custom when no [custom_theme] table is configured", () => {
     const home = createTempDir("hunk-config-home-");
     mkdirSync(join(home, ".config", "hunk"), { recursive: true });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { BUNDLED_SHIKI_THEME_IDS } from "../ui/lib/shikiThemes";
 import { normalizeBuiltInThemeId } from "../ui/themes";
 import { resolveGlobalConfigPath } from "./paths";
@@ -8,6 +8,7 @@ import type {
   CliInput,
   CommonOptions,
   CustomSyntaxColorsConfig,
+  CustomSyntaxThemeData,
   CustomThemeConfig,
   LayoutMode,
   PersistedViewPreferences,
@@ -161,8 +162,52 @@ function readCustomSyntaxColors(
   return Object.keys(syntax).length > 0 ? syntax : undefined;
 }
 
+/**
+ * Load and validate a full Shiki theme JSON referenced by `custom_theme.syntax_theme`.
+ * The path may be absolute or relative to the config file that declared it. We read it
+ * eagerly so a bad path fails fast at config time rather than silently dropping
+ * highlighting later.
+ */
+function readCustomSyntaxTheme(
+  value: unknown,
+  configPath: string | undefined,
+): CustomSyntaxThemeData | undefined {
+  const rawPath = normalizeString(value);
+  if (rawPath === undefined) {
+    return undefined;
+  }
+
+  const basis = configPath ? dirname(configPath) : process.cwd();
+  const themePath = isAbsolute(rawPath) ? rawPath : resolve(basis, rawPath);
+
+  if (!fs.existsSync(themePath)) {
+    throw new Error(`Expected custom_theme.syntax_theme to point at a file. Missing: ${themePath}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(themePath, "utf8"));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Expected custom_theme.syntax_theme (${themePath}) to be valid JSON: ${reason}`,
+    );
+  }
+
+  if (!isRecord(parsed) || typeof parsed.name !== "string" || parsed.name.length === 0) {
+    throw new Error(
+      `Expected custom_theme.syntax_theme (${themePath}) to be a Shiki theme with a non-empty "name".`,
+    );
+  }
+
+  return parsed as CustomSyntaxThemeData;
+}
+
 /** Read the optional config-defined custom theme palette from one TOML object level. */
-function readCustomTheme(source: Record<string, unknown>): CustomThemeConfig | undefined {
+function readCustomTheme(
+  source: Record<string, unknown>,
+  configPath?: string,
+): CustomThemeConfig | undefined {
   const customThemeSource = source.custom_theme;
   if (!isRecord(customThemeSource)) {
     return undefined;
@@ -179,6 +224,12 @@ function readCustomTheme(source: Record<string, unknown>): CustomThemeConfig | u
   const label = normalizeString(customThemeSource.label);
   if (label !== undefined) {
     customTheme.label = label;
+  }
+
+  const syntaxThemePath = normalizeString(customThemeSource.syntax_theme);
+  if (syntaxThemePath !== undefined) {
+    customTheme.syntaxThemePath = syntaxThemePath;
+    customTheme.syntaxThemeData = readCustomSyntaxTheme(customThemeSource.syntax_theme, configPath);
   }
 
   for (const key of CUSTOM_THEME_COLOR_KEYS) {
@@ -215,6 +266,8 @@ function mergeCustomTheme(
     ...overrides,
     base: overrides.base ?? base.base ?? "github-dark-default",
     label: overrides.label ?? base.label,
+    syntaxThemePath: overrides.syntaxThemePath ?? base.syntaxThemePath,
+    syntaxThemeData: overrides.syntaxThemeData ?? base.syntaxThemeData,
     syntax:
       base.syntax || overrides.syntax
         ? {
@@ -333,13 +386,19 @@ export function resolveConfiguredCliInput(
   if (userConfigPath) {
     const userConfig = readTomlRecord(userConfigPath);
     resolvedOptions = mergeOptions(resolvedOptions, resolveConfigLayer(userConfig, input));
-    resolvedCustomTheme = mergeCustomTheme(resolvedCustomTheme, readCustomTheme(userConfig));
+    resolvedCustomTheme = mergeCustomTheme(
+      resolvedCustomTheme,
+      readCustomTheme(userConfig, userConfigPath),
+    );
   }
 
   if (repoConfigPath) {
     const repoConfig = readTomlRecord(repoConfigPath);
     resolvedOptions = mergeOptions(resolvedOptions, resolveConfigLayer(repoConfig, input));
-    resolvedCustomTheme = mergeCustomTheme(resolvedCustomTheme, readCustomTheme(repoConfig));
+    resolvedCustomTheme = mergeCustomTheme(
+      resolvedCustomTheme,
+      readCustomTheme(repoConfig, repoConfigPath),
+    );
   }
 
   resolvedOptions = mergeOptions(resolvedOptions, input.options);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -110,9 +110,23 @@ export interface CustomSyntaxColorsConfig {
   punctuation?: string;
 }
 
+/**
+ * A full VS Code / Shiki theme JSON loaded from disk and registered with the
+ * highlighter for source-accurate syntax coloring. Only `name` is required; the
+ * remaining TextMate fields are passed through to Shiki untouched.
+ */
+export interface CustomSyntaxThemeData {
+  name: string;
+  [key: string]: unknown;
+}
+
 export interface CustomThemeConfig {
   base?: string;
   label?: string;
+  /** Path (from config) to a Shiki theme JSON used for syntax highlighting. */
+  syntaxThemePath?: string;
+  /** The loaded + validated Shiki theme JSON referenced by `syntaxThemePath`. */
+  syntaxThemeData?: CustomSyntaxThemeData;
   background?: string;
   panel?: string;
   panelAlt?: string;

--- a/src/ui/diff/pierre.test.ts
+++ b/src/ui/diff/pierre.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseDiffFromFile } from "@pierre/diffs";
+import { disposeHighlighter, parseDiffFromFile } from "@pierre/diffs";
 import type { DiffFile } from "../../core/types";
 import {
   buildSplitRows,
@@ -665,6 +665,59 @@ describe("Pierre diff rows", () => {
       expect(spans.find((span) => span.text.includes("compute"))?.fg).toBe("#223344");
       expect(spans.find((span) => span.text.includes('"hello"'))?.fg).toBe("#334455");
     }
+  });
+
+  test("registers custom syntax themes under a collision-safe internal name", async () => {
+    const metadata = parseDiffFromFile(
+      { name: "syntax.ts", contents: "const a = 1;\n", cacheKey: "collision-before" },
+      {
+        name: "syntax.ts",
+        contents: "export const a = 2;\n",
+        cacheKey: "collision-after",
+      },
+      { context: 3 },
+      true,
+    );
+    const file: DiffFile = {
+      id: "custom-syntax-collision",
+      path: "syntax.ts",
+      patch: "",
+      language: "typescript",
+      stats: { additions: 1, deletions: 1 },
+      metadata,
+      agent: null,
+    };
+
+    await disposeHighlighter();
+    await loadHighlightedDiff(file, resolveTheme("dracula", null));
+
+    const theme = resolveTheme("custom", null, {
+      base: "github-dark-default",
+      syntaxThemeData: {
+        name: "dracula",
+        type: "dark",
+        colors: {
+          "editor.background": "#000000",
+          "editor.foreground": "#ffffff",
+        },
+        tokenColors: [
+          {
+            scope: ["keyword", "storage", "storage.type"],
+            settings: { foreground: "#ff00ff" },
+          },
+        ],
+      },
+    });
+    const highlighted = await loadHighlightedDiff(file, theme);
+    const spans = buildStackRows(file, highlighted, theme)
+      .filter(
+        (row): row is Extract<DiffRow, { type: "stack-line" }> =>
+          row.type === "stack-line" && row.cell.kind === "addition",
+      )
+      .flatMap((row) => row.cell.spans);
+
+    expect(theme.syntaxTheme).toBe("hunk-custom-syntax:dracula");
+    expect(spans.find((span) => span.text.includes("export"))?.fg?.toLowerCase()).toBe("#ff00ff");
   });
 
   test("uses Shiki's bundled Catppuccin theme for Catppuccin syntax", async () => {

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -2,6 +2,7 @@ import {
   cleanLastNewline,
   getHighlighterOptions,
   getSharedHighlighter,
+  registerCustomTheme,
   renderDiffWithHighlighter,
   renderFileWithHighlighter,
   type FileContents,
@@ -571,8 +572,33 @@ export function trailingCollapsedLines(metadata: FileDiffMetadata) {
   return Math.max(additionRemaining, 0);
 }
 
+// Custom Shiki themes are registered once with Pierre's global theme registry. Track which
+// names we've registered so repeated highlight passes don't re-register (Pierre warns on dupes).
+const registeredCustomSyntaxThemes = new Set<string>();
+
+/** Register a config-provided Shiki theme JSON with Pierre before it's referenced by name. */
+function ensureCustomSyntaxThemeRegistered(theme: HighlightThemeInput) {
+  if (typeof theme === "string") {
+    return;
+  }
+
+  const data = theme.syntaxThemeData;
+  if (!data || registeredCustomSyntaxThemes.has(data.name)) {
+    return;
+  }
+
+  registeredCustomSyntaxThemes.add(data.name);
+  // Pierre resolves themes by name against its custom registry first, then Shiki's bundled
+  // themes. The registry stores async loaders, so hand it one resolving to the loaded JSON.
+  type CustomThemeLoader = Parameters<typeof registerCustomTheme>[1];
+  const loader: CustomThemeLoader = () =>
+    Promise.resolve(data as unknown as Awaited<ReturnType<CustomThemeLoader>>);
+  registerCustomTheme(data.name, loader);
+}
+
 /** Prepare syntax highlighting for one language/theme pair using Pierre's shared highlighter. */
 async function prepareHighlighter(language: string | undefined, theme: HighlightThemeInput) {
+  ensureCustomSyntaxThemeRegistered(theme);
   const resolvedLanguage = language ?? "text";
   const syntaxTheme = highlighterThemeName(theme);
   const cacheKey = `${syntaxTheme}:${resolvedLanguage}`;

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -573,12 +573,9 @@ export function trailingCollapsedLines(metadata: FileDiffMetadata) {
 }
 
 // Custom Shiki themes are registered once with Pierre's global theme registry. Track which
-// names we've registered so repeated highlight passes don't re-register (Pierre warns on dupes).
-// ponytail: dedup is by theme name only. Pierre's registry is itself keyed by name and rejects
-// re-registration, so swapping a theme's JSON under the same name within one process would keep
-// serving the original tokens. There is no in-process JSON-reload path today (config is read once
-// at startup; the theme picker only cycles already-built themes), so this is a non-issue in
-// practice. If live theme-file reload is ever added, register under a content-derived name.
+// internal ids we've registered so repeated highlight passes don't re-register (Pierre warns on
+// dupes). Hunk uses a namespaced id instead of the JSON's own `name` so user themes can share names
+// with Shiki's bundled themes without hitting Pierre's resolved-theme cache for the built-in.
 const registeredCustomSyntaxThemes = new Set<string>();
 
 /** Register a config-provided Shiki theme JSON with Pierre before it's referenced by name. */
@@ -588,17 +585,21 @@ function ensureCustomSyntaxThemeRegistered(theme: HighlightThemeInput) {
   }
 
   const data = theme.syntaxThemeData;
-  if (!data || registeredCustomSyntaxThemes.has(data.name)) {
+  const themeName = highlighterThemeName(theme);
+  if (!data || registeredCustomSyntaxThemes.has(themeName)) {
     return;
   }
 
-  registeredCustomSyntaxThemes.add(data.name);
-  // Pierre resolves themes by name against its custom registry first, then Shiki's bundled
-  // themes. The registry stores async loaders, so hand it one resolving to the loaded JSON.
+  registeredCustomSyntaxThemes.add(themeName);
+  // Pierre requires the loader result's `name` to match the requested theme key, so clone the JSON
+  // with Hunk's internal registration id while keeping the original data untouched for callers.
   type CustomThemeLoader = Parameters<typeof registerCustomTheme>[1];
   const loader: CustomThemeLoader = () =>
-    Promise.resolve(data as unknown as Awaited<ReturnType<CustomThemeLoader>>);
-  registerCustomTheme(data.name, loader);
+    Promise.resolve({
+      ...data,
+      name: themeName,
+    } as unknown as Awaited<ReturnType<CustomThemeLoader>>);
+  registerCustomTheme(themeName, loader);
 }
 
 /** Prepare syntax highlighting for one language/theme pair using Pierre's shared highlighter. */

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -574,6 +574,11 @@ export function trailingCollapsedLines(metadata: FileDiffMetadata) {
 
 // Custom Shiki themes are registered once with Pierre's global theme registry. Track which
 // names we've registered so repeated highlight passes don't re-register (Pierre warns on dupes).
+// ponytail: dedup is by theme name only. Pierre's registry is itself keyed by name and rejects
+// re-registration, so swapping a theme's JSON under the same name within one process would keep
+// serving the original tokens. There is no in-process JSON-reload path today (config is read once
+// at startup; the theme picker only cycles already-built themes), so this is a non-issue in
+// practice. If live theme-file reload is ever added, register under a content-derived name.
 const registeredCustomSyntaxThemes = new Set<string>();
 
 /** Register a config-provided Shiki theme JSON with Pierre before it's referenced by name. */

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -257,7 +257,7 @@ describe("themes", () => {
       syntax: { keyword: "#ff00ff" },
     });
 
-    expect(custom.syntaxTheme).toBe("Shades of Purple");
+    expect(custom.syntaxTheme).toBe("hunk-custom-syntax:Shades of Purple");
     expect(custom.syntaxThemeData).toEqual(syntaxThemeData);
     // The 9-token palette is still kept for collision normalization against diff backgrounds.
     expect(custom.syntaxColors.keyword).toBe("#ff00ff");

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -247,6 +247,22 @@ describe("themes", () => {
     expect(custom.syntaxColors.keyword).toBe("#ff00ff");
   });
 
+  test("a full syntax theme JSON drives highlighting by name", () => {
+    const syntaxThemeData = { name: "Shades of Purple", type: "dark" as const, tokenColors: [] };
+    const custom = resolveTheme("custom", null, {
+      base: "catppuccin-mocha",
+      label: "My Theme",
+      syntaxThemeData,
+      // A 9-token block is present too, but the full theme JSON should take precedence.
+      syntax: { keyword: "#ff00ff" },
+    });
+
+    expect(custom.syntaxTheme).toBe("Shades of Purple");
+    expect(custom.syntaxThemeData).toEqual(syntaxThemeData);
+    // The 9-token palette is still kept for collision normalization against diff backgrounds.
+    expect(custom.syntaxColors.keyword).toBe("#ff00ff");
+  });
+
   test("withTransparentBackground only swaps painted background fields", () => {
     const theme = resolveTheme("github-dark-default", null);
     const transparent = withTransparentBackground(theme);

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -1,5 +1,5 @@
 import type { ThemeMode } from "@opentui/core";
-import type { CustomThemeConfig } from "../core/types";
+import type { CustomSyntaxThemeData, CustomThemeConfig } from "../core/types";
 import { blendHex, contrastRatio, relativeLuminance } from "./lib/color";
 import {
   BUNDLED_SHIKI_THEME_IDS,
@@ -250,6 +250,13 @@ function fallbackTheme(themeMode?: ThemeMode | null) {
   return builtInThemeById(fallbackId) ?? THEMES[0]!;
 }
 
+const CUSTOM_SYNTAX_THEME_PREFIX = "hunk-custom-syntax:";
+
+/** Return the collision-safe internal id used when registering a config-provided Shiki theme. */
+function customSyntaxThemeId(themeData: CustomSyntaxThemeData) {
+  return `${CUSTOM_SYNTAX_THEME_PREFIX}${themeData.name}`;
+}
+
 /** Build one config-defined custom theme by inheriting from a Shiki-backed base palette. */
 function buildCustomTheme(customTheme: CustomThemeConfig) {
   const baseTheme = builtInThemeById(customTheme.base) ?? fallbackTheme();
@@ -294,7 +301,7 @@ function buildCustomTheme(customTheme: CustomThemeConfig) {
     // Otherwise explicit 9-token overrides use Hunk's semantic remap path (so they actually
     // affect highlighted code), and a bare custom palette inherits the base theme's syntax.
     syntaxTheme: customTheme.syntaxThemeData
-      ? customTheme.syntaxThemeData.name
+      ? customSyntaxThemeId(customTheme.syntaxThemeData)
       : customTheme.syntax
         ? undefined
         : baseTheme.syntaxTheme,

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -290,9 +290,15 @@ function buildCustomTheme(customTheme: CustomThemeConfig) {
     noteBackground: customTheme.noteBackground ?? baseTheme.noteBackground,
     noteTitleBackground: customTheme.noteTitleBackground ?? baseTheme.noteTitleBackground,
     noteTitleText: customTheme.noteTitleText ?? baseTheme.noteTitleText,
-    // Explicit syntax color overrides should use Hunk's semantic remap path rather than the
-    // inherited Shiki theme, otherwise the overrides would never affect highlighted code.
-    syntaxTheme: customTheme.syntax ? undefined : baseTheme.syntaxTheme,
+    // A full Shiki theme JSON wins: highlight from its own tokens for source-accurate color.
+    // Otherwise explicit 9-token overrides use Hunk's semantic remap path (so they actually
+    // affect highlighted code), and a bare custom palette inherits the base theme's syntax.
+    syntaxTheme: customTheme.syntaxThemeData
+      ? customTheme.syntaxThemeData.name
+      : customTheme.syntax
+        ? undefined
+        : baseTheme.syntaxTheme,
+    syntaxThemeData: customTheme.syntaxThemeData,
   };
 
   return withLazySyntaxStyle(themeBase, {

--- a/src/ui/themes/types.ts
+++ b/src/ui/themes/types.ts
@@ -1,4 +1,5 @@
 import type { SyntaxStyle } from "@opentui/core";
+import type { CustomSyntaxThemeData } from "../../core/types";
 
 export interface AppTheme {
   id: string;
@@ -39,6 +40,8 @@ export interface AppTheme {
   noteTitleText: string;
   /** Optional Shiki/Pierre theme name for source-accurate code highlighting. */
   syntaxTheme?: string;
+  /** Optional full Shiki theme JSON registered with the highlighter under `syntaxTheme`. */
+  syntaxThemeData?: CustomSyntaxThemeData;
   syntaxColors: SyntaxColors;
   syntaxStyle: SyntaxStyle;
 }


### PR DESCRIPTION
## Summary

Custom themes can now point at a full VS Code / Shiki theme JSON for syntax highlighting, instead of being limited to the nine semantic `[custom_theme.syntax]` tokens.

Previously, defining `[custom_theme.syntax]` dropped the Shiki theme entirely and fell back to recoloring Pierre's default theme at a few collision points. The result was that a real VS Code theme could never be reproduced fully — only roughly approximated.

With this users should be able to take their VSCode themes and reproduce them 100% in Hunk.

## What this adds

A new `custom_theme.syntax_theme` key — a path to a VS Code / Shiki theme JSON, absolute or relative to the config file that declares it:

```toml
[custom_theme]
base = "catppuccin-mocha"
syntax_theme = "shades-of-purple.json"
```

- The file is loaded and validated at config time (clear errors for a missing file, invalid JSON, or a theme without a `name`), so a bad path fails fast rather than silently dropping highlighting.
- The theme is registered with Pierre's highlighter and used as the active syntax theme, so code is colored exactly as that theme would render it in the editor.
- The nine `[custom_theme.syntax]` tokens, when present, stay as the collision-normalization palette so syntax hues never visually merge with diff add/remove backgrounds.

Because Hunk renders through Pierre/Shiki, which consumes VS Code theme JSON natively, this works for any VS Code theme, not just one.

## Testing

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun test src/core/config.test.ts src/ui/themes.test.ts src/ui/diff`
- Real render smoke test against a full Shades of Purple theme JSON: the output contains the theme's own token colors (e.g. `#FF9D00`, `#FAD000`, `#FF628C`, `#9EFFFF`) that exist only in the full JSON, confirming the theme drives highlighting rather than the nine-token approximation.