### PR TITLE
bugfix: Let draft notes own keys in pager mode

### DIFF
--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -570,11 +570,6 @@ export function useAppKeyboardShortcuts({
       return;
     }
 
-    if (pagerModeRef.current) {
-      handlePagerShortcut(key);
-      return;
-    }
-
     if (handleDialogShortcut(key)) {
       return;
     }
@@ -588,6 +583,11 @@ export function useAppKeyboardShortcuts({
     }
 
     if (handleFocusedInputShortcut(key)) {
+      return;
+    }
+
+    if (pagerModeRef.current) {
+      handlePagerShortcut(key);
       return;
     }
 

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -360,6 +360,49 @@ describe("PTY notes", () => {
     }
   });
 
+  test("draft note focus blocks pager shortcuts until cancelled", async () => {
+    const fixture = harness.createPagerPatchFixture();
+    const session = await harness.launchHunk({
+      args: ["patch", fixture.patchFile, "--pager"],
+      cols: 120,
+      rows: 20,
+    });
+
+    try {
+      const initial = await session.waitForText(/before_01/, { timeout: 15_000 });
+      const targetRow = lineIndexOf(initial, "before_01");
+      const sidebarRow = /\bM scroll\.ts\s+\+40 -40/;
+
+      expect(targetRow).toBeGreaterThan(0);
+      expect(initial).not.toMatch(sidebarRow);
+
+      await revealAddNoteNear(session, targetRow);
+      await session.click(/\[\+\]/);
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await session.type("sidebar-trigger text");
+      const whileFocused = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("Draft note") && text.includes("sidebar-trigger text"),
+        5_000,
+      );
+
+      expect(whileFocused).not.toMatch(sidebarRow);
+
+      await session.click(/Cancel \(Esc\)/);
+      await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
+      await session.press("s");
+      const afterCancel = await harness.waitForSnapshot(
+        session,
+        (text) => sidebarRow.test(text),
+        5_000,
+      );
+
+      expect(afterCancel).toMatch(sidebarRow);
+    } finally {
+      session.close();
+    }
+  });
+
   test("multiple add-note drafts can be saved on one hunk", async () => {
     const fixture = harness.createDeletionOnlyFilePair();
     const session = await harness.launchHunk({


### PR DESCRIPTION
When Hunk was launched as a pager from git diff, typing in a draft inline note could trigger shortcuts. As example - instead of inserting `s` into the note, Hunk toggled the sidebar because pager-mode global shortcuts were handled before the focused note input.

## Steps
Here is a video of this problem

https://github.com/user-attachments/assets/65cc5a8f-5042-4d4e-97ba-0a49d1661756

1. open hunk pager through `git diff`
2. Start an inline note
3. Try to write `test`

After typing `s` sidebar is opened, focus from the inline note is lost, and I can't type anymore into it.

## Solution
- Fixes pager-mode draft note input so typed characters are not intercepted as pager shortcuts.
- Moves focused-input keyboard handling before pager shortcut handling in `useAppKeyboardShortcuts`.
- Adds a PTY regression test covering a draft note opened in `patch --pager`, verifying `s` is inserted into the note instead of toggling the sidebar.