### PR TITLE
feat(ui): add borderless chrome mode

### DIFF
--- a/.changeset/borderless-chrome.md
+++ b/.changeset/borderless-chrome.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add a borderless chrome mode that replaces drawn borders and separators with filled background bands derived from the active theme. Each theme gains a derived surface elevation ladder so file headers, the unchanged-lines band, popups, and comment boxes stay visually distinct without lines. Toggle it from the View menu, the `Shift+B` keybinding, the `borderless` config key, or the `--borderless` flag.

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -75,6 +75,7 @@ function buildCommonOptions(
     wrapLines: resolveBooleanFlag(argv, "--wrap", "--no-wrap"),
     hunkHeaders: resolveBooleanFlag(argv, "--hunk-headers", "--no-hunk-headers"),
     agentNotes: resolveBooleanFlag(argv, "--agent-notes", "--no-agent-notes"),
+    borderless: resolveBooleanFlag(argv, "--borderless", "--no-borderless"),
     transparentBackground: resolveBooleanFlag(argv, "--transparent-bg", "--no-transparent-bg"),
   };
 }
@@ -94,6 +95,8 @@ function applyCommonOptions(command: Command) {
     .option("--no-hunk-headers", "hide hunk metadata rows")
     .option("--agent-notes", "show agent notes by default")
     .option("--no-agent-notes", "hide agent notes by default")
+    .option("--borderless", "use filled background bands instead of chrome borders")
+    .option("--no-borderless", "use drawn borders for chrome")
     .option("--transparent-bg", "let terminal background show through Hunk surfaces")
     .option("--no-transparent-bg", "paint Hunk surfaces with the active theme");
 }
@@ -157,6 +160,7 @@ function renderCliHelp() {
     "  --wrap / --no-wrap                      wrap or truncate long diff lines",
     "  --hunk-headers / --no-hunk-headers      show or hide hunk metadata rows",
     "  --agent-notes / --no-agent-notes        show or hide agent notes by default",
+    "  --borderless / --no-borderless          fill chrome with background bands or draw borders",
     "  --transparent-bg / --no-transparent-bg  let terminal background show through Hunk surfaces",
     "  --theme <theme>                         named theme override",
     "",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -72,6 +72,7 @@ const DEFAULT_VIEW_PREFERENCES: PersistedViewPreferences = {
   showHunkHeaders: true,
   showAgentNotes: false,
   copyDecorations: false,
+  borderless: false,
 };
 
 interface ConfigResolutionOptions {
@@ -238,6 +239,7 @@ function readConfigPreferences(source: Record<string, unknown>): CommonOptions {
     hunkHeaders: normalizeBoolean(source.hunk_headers),
     agentNotes: normalizeBoolean(source.agent_notes),
     copyDecorations: normalizeBoolean(source.copy_decorations),
+    borderless: normalizeBoolean(source.borderless),
     transparentBackground:
       normalizeBoolean(source.transparentBackground) ??
       normalizeBoolean(source.transparent_background),
@@ -261,6 +263,7 @@ function mergeOptions(base: CommonOptions, overrides: CommonOptions): CommonOpti
     hunkHeaders: overrides.hunkHeaders ?? base.hunkHeaders,
     agentNotes: overrides.agentNotes ?? base.agentNotes,
     copyDecorations: overrides.copyDecorations ?? base.copyDecorations,
+    borderless: overrides.borderless ?? base.borderless,
     transparentBackground: overrides.transparentBackground ?? base.transparentBackground,
     colorMoved: overrides.colorMoved ?? base.colorMoved,
   };
@@ -327,6 +330,7 @@ export function resolveConfiguredCliInput(
     hunkHeaders: DEFAULT_VIEW_PREFERENCES.showHunkHeaders,
     agentNotes: DEFAULT_VIEW_PREFERENCES.showAgentNotes,
     copyDecorations: DEFAULT_VIEW_PREFERENCES.copyDecorations,
+    borderless: DEFAULT_VIEW_PREFERENCES.borderless,
     transparentBackground: false,
   };
 
@@ -357,6 +361,7 @@ export function resolveConfiguredCliInput(
     hunkHeaders: resolvedOptions.hunkHeaders ?? DEFAULT_VIEW_PREFERENCES.showHunkHeaders,
     agentNotes: resolvedOptions.agentNotes ?? DEFAULT_VIEW_PREFERENCES.showAgentNotes,
     copyDecorations: resolvedOptions.copyDecorations ?? DEFAULT_VIEW_PREFERENCES.copyDecorations,
+    borderless: resolvedOptions.borderless ?? DEFAULT_VIEW_PREFERENCES.borderless,
     transparentBackground: resolvedOptions.transparentBackground ?? false,
     colorMoved: resolvedOptions.colorMoved,
   };

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -460,5 +460,6 @@ export async function loadAppBootstrap(
     initialShowHunkHeaders: input.options.hunkHeaders ?? true,
     initialShowAgentNotes: input.options.agentNotes ?? false,
     initialCopyDecorations: input.options.copyDecorations ?? false,
+    initialBorderless: input.options.borderless ?? false,
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -92,6 +92,7 @@ export interface CommonOptions {
   hunkHeaders?: boolean;
   agentNotes?: boolean;
   copyDecorations?: boolean;
+  borderless?: boolean;
   transparentBackground?: boolean;
   colorMoved?: boolean;
 }
@@ -157,6 +158,7 @@ export interface PersistedViewPreferences {
   showHunkHeaders: boolean;
   showAgentNotes: boolean;
   copyDecorations: boolean;
+  borderless: boolean;
 }
 
 export interface HelpCommandInput {
@@ -366,4 +368,5 @@ export interface AppBootstrap {
   initialShowHunkHeaders?: boolean;
   initialShowAgentNotes?: boolean;
   initialCopyDecorations?: boolean;
+  initialBorderless?: boolean;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -29,6 +29,7 @@ import { openSelectedFileInEditor } from "./lib/openInEditor";
 import { resolveResponsiveLayout } from "./lib/responsive";
 import { resizeSidebarWidth } from "./lib/sidebar";
 import { availableThemes, resolveTheme, withTransparentBackground } from "./themes";
+import type { ChromeMode } from "./themes";
 
 type FocusArea = "files" | "filter" | "note";
 type ActiveAddNoteTarget = ActiveAddNoteAffordance & { fileId: string };
@@ -68,6 +69,7 @@ function withCurrentViewOptions(
     showHunkHeaders: boolean;
     showLineNumbers: boolean;
     wrapLines: boolean;
+    borderless: boolean;
   },
 ): CliInput {
   return {
@@ -80,6 +82,7 @@ function withCurrentViewOptions(
       hunkHeaders: view.showHunkHeaders,
       lineNumbers: view.showLineNumbers,
       wrapLines: view.wrapLines,
+      borderless: view.borderless,
     },
   };
 }
@@ -134,6 +137,7 @@ export function App({
   const [copyDecorations, setCopyDecorations] = useState(bootstrap.initialCopyDecorations ?? false);
   const [codeHorizontalOffset, setCodeHorizontalOffset] = useState(0);
   const [showHunkHeaders, setShowHunkHeaders] = useState(bootstrap.initialShowHunkHeaders ?? true);
+  const [borderless, setBorderless] = useState(bootstrap.initialBorderless ?? false);
   const [themeSelectorState, setThemeSelectorState] = useState<ThemeSelectorState>({
     open: false,
     selectedIndex: 0,
@@ -156,10 +160,18 @@ export function App({
     [bootstrap.customTheme],
   );
   const effectiveThemeId = themeSelectorState.previewThemeId ?? themeId;
-  const baseTheme = useMemo(
-    () => resolveTheme(effectiveThemeId, detectedThemeMode ?? null, bootstrap.customTheme),
-    [effectiveThemeId, detectedThemeMode, bootstrap.customTheme],
-  );
+  const baseTheme = useMemo(() => {
+    const resolved = resolveTheme(
+      effectiveThemeId,
+      detectedThemeMode ?? null,
+      bootstrap.customTheme,
+    );
+    const chrome: ChromeMode = borderless ? "borderless" : "bordered";
+    // Carry the chrome mode on the base theme so overlays (menus/dialogs), which
+    // use baseTheme for a solid background, render borderless too. Only clone when
+    // the mode differs so the lazy syntax-style getter stays untouched when bordered.
+    return resolved.chrome === chrome ? resolved : { ...resolved, chrome };
+  }, [effectiveThemeId, detectedThemeMode, bootstrap.customTheme, borderless]);
   const activeTheme = useMemo(
     () =>
       bootstrap.input.options.transparentBackground
@@ -238,7 +250,9 @@ export function App({
     showAgentNotes,
   });
 
-  const bodyPadding = pagerMode ? 0 : BODY_PADDING;
+  // Borderless chrome fills the width edge-to-edge; the legacy body gutter would otherwise expose
+  // the root (code) background as a 1-column band down each side, reading as a stray vertical bar.
+  const bodyPadding = pagerMode || borderless ? 0 : BODY_PADDING;
   const bodyWidth = Math.max(0, terminal.width - bodyPadding);
   const responsiveLayout = resolveResponsiveLayout(layoutMode, terminal.width);
   const canForceShowSidebar = bodyWidth >= SIDEBAR_MIN_WIDTH + DIVIDER_WIDTH + DIFF_MIN_WIDTH;
@@ -504,6 +518,11 @@ export function App({
     setShowHunkHeaders((current) => !current);
   };
 
+  /** Switch chrome between drawn borders and filled background bands. */
+  const toggleBorderless = () => {
+    setBorderless((current) => !current);
+  };
+
   const canRefreshCurrentInput = canReloadInput(bootstrap.input);
   const watchEnabled = Boolean(bootstrap.input.options.watch && canRefreshCurrentInput);
 
@@ -520,6 +539,7 @@ export function App({
       showHunkHeaders,
       showLineNumbers,
       wrapLines,
+      borderless,
     });
 
     await onReloadSession(nextInput, {
@@ -542,6 +562,7 @@ export function App({
     showLineNumbers,
     themeId,
     wrapLines,
+    borderless,
   ]);
 
   const triggerRefreshCurrentInput = useCallback(() => {
@@ -744,6 +765,8 @@ export function App({
         showHunkHeaders,
         showLineNumbers,
         renderSidebar,
+        borderless,
+        toggleBorderless,
         toggleCopyDecorations,
         toggleAgentNotes,
         toggleFocusArea,
@@ -775,6 +798,8 @@ export function App({
       showHunkHeaders,
       showLineNumbers,
       renderSidebar,
+      borderless,
+      toggleBorderless,
       toggleAgentNotes,
       toggleFocusArea,
       toggleHelp,
@@ -834,6 +859,7 @@ export function App({
     switchMenu,
     themeSelectorOpen: themeSelectorState.open,
     toggleAgentNotes,
+    toggleBorderless,
     toggleFocusArea,
     toggleGapForSelectedHunk: review.toggleSelectedHunkGap,
     toggleHelp,

--- a/src/ui/components/chrome/AgentSkillDialog.tsx
+++ b/src/ui/components/chrome/AgentSkillDialog.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import { chromeSurfaceBg } from "./chromeSurface";
 import { ModalFrame } from "./ModalFrame";
 
 export const AGENT_SKILL_COMMAND = "hunk skill path";
@@ -61,8 +62,10 @@ export function AgentSkillDialog({
             style={{
               width: cardWidth,
               height: promptRows.length + 2,
-              border: true,
-              borderColor: theme.border,
+              // Inner prompt box: a bordered inset, or a filled note band when borderless.
+              ...(theme.chrome === "borderless"
+                ? { backgroundColor: chromeSurfaceBg(theme, "note") }
+                : { border: true, borderColor: theme.border }),
               flexDirection: "column",
               paddingLeft: 1,
               paddingRight: 1,

--- a/src/ui/components/chrome/ChromeSeparator.tsx
+++ b/src/ui/components/chrome/ChromeSeparator.tsx
@@ -1,0 +1,27 @@
+import { fitText } from "../../lib/text";
+import type { AppTheme } from "../../themes";
+
+/**
+ * Horizontal boundary between stacked sections (e.g. file blocks). Draws a rule
+ * glyph in bordered mode; renders nothing in borderless mode, where the adjacent
+ * section-header band carries the separation instead.
+ */
+export function ChromeSeparator({ theme, width }: { theme: AppTheme; width: number }) {
+  if (theme.chrome === "borderless") {
+    return null;
+  }
+
+  return (
+    <box
+      style={{
+        width: "100%",
+        height: 1,
+        paddingLeft: 1,
+        paddingRight: 1,
+        backgroundColor: theme.panel,
+      }}
+    >
+      <text fg={theme.border}>{fitText("─".repeat(width), width)}</text>
+    </box>
+  );
+}

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -48,6 +48,7 @@ export function HelpDialog({
         ["a", "toggle AI notes"],
         ["z", "toggle unchanged context"],
         ["l / w / m", "lines / wrap / metadata"],
+        ["B", "toggle borderless chrome"],
         ["e", "open file in $EDITOR"],
       ],
     },

--- a/src/ui/components/chrome/MenuBar.tsx
+++ b/src/ui/components/chrome/MenuBar.tsx
@@ -1,5 +1,6 @@
 import type { AppTheme } from "../../themes";
 import { fitText } from "../../lib/text";
+import { topChromeBg } from "./chromeSurface";
 import type { MenuId, MenuSpec } from "./menu";
 
 /** Render the top menu bar and the current changeset title. */
@@ -20,11 +21,12 @@ export function MenuBar({
   onHoverMenu: (menuId: MenuId) => void;
   onToggleMenu: (menuId: MenuId) => void;
 }) {
+  const chromeBg = topChromeBg(theme);
   return (
     <box
       style={{
         height: 1,
-        backgroundColor: theme.panelAlt,
+        backgroundColor: chromeBg,
         flexDirection: "row",
         alignItems: "center",
         paddingLeft: 1,
@@ -39,7 +41,7 @@ export function MenuBar({
             style={{
               width: menu.width,
               height: 1,
-              backgroundColor: active ? theme.accentMuted : theme.panelAlt,
+              backgroundColor: active ? theme.accentMuted : chromeBg,
             }}
             onMouseUp={() => onToggleMenu(menu.id)}
             onMouseOver={() => onHoverMenu(menu.id)}

--- a/src/ui/components/chrome/MenuDropdown.tsx
+++ b/src/ui/components/chrome/MenuDropdown.tsx
@@ -1,5 +1,7 @@
 import type { AppTheme } from "../../themes";
+import { blendHex } from "../../lib/color";
 import { padText } from "../../lib/text";
+import { chromeSurfaceBg, overlaySurfaceStyle } from "./chromeSurface";
 import type { MenuEntry, MenuId, MenuSpec } from "./menu";
 
 /** Render one actionable menu line with an optional keyboard hint. */
@@ -56,6 +58,14 @@ export function MenuDropdown({
 }) {
   const clampedWidth = Math.min(activeMenuWidth, Math.max(22, terminalWidth - 2));
   const clampedLeft = Math.max(1, Math.min(activeMenuSpec.left, terminalWidth - clampedWidth - 1));
+  const borderless = theme.chrome === "borderless";
+  // Bordered menus add 2 rows for the top/bottom rule; borderless ones have no border, so the
+  // box must hug its entries or it trails empty band rows.
+  const dropdownHeight = activeMenuEntries.length + (borderless ? 0 : 2);
+  // A faint rule keeps separators legible against the filled band without reintroducing chrome.
+  const separatorFg = borderless
+    ? blendHex(theme.muted, chromeSurfaceBg(theme, "overlay"), 0.5)
+    : theme.border;
 
   return (
     <box
@@ -64,11 +74,9 @@ export function MenuDropdown({
         top: 1,
         left: clampedLeft,
         width: clampedWidth,
-        height: activeMenuEntries.length + 2,
+        height: dropdownHeight,
         zIndex: 40,
-        border: true,
-        borderColor: theme.border,
-        backgroundColor: theme.panel,
+        ...overlaySurfaceStyle(theme, theme.border),
         flexDirection: "column",
       }}
     >
@@ -76,9 +84,15 @@ export function MenuDropdown({
         entry.kind === "separator" ? (
           <box
             key={`${activeMenuId}:separator:${index}`}
-            style={{ height: 1, paddingLeft: 1, paddingRight: 1 }}
+            style={{
+              height: 1,
+              paddingLeft: 1,
+              paddingRight: 1,
+              backgroundColor: chromeSurfaceBg(theme, "overlay"),
+            }}
           >
-            <text fg={theme.border}>{padText("-".repeat(clampedWidth - 4), clampedWidth - 2)}</text>
+            {/* Both modes rule off groups; borderless uses a fainter line so it stays subtle. */}
+            <text fg={separatorFg}>{padText("-".repeat(clampedWidth - 4), clampedWidth - 2)}</text>
           </box>
         ) : (
           <box
@@ -88,7 +102,10 @@ export function MenuDropdown({
               paddingLeft: 1,
               paddingRight: 1,
               flexDirection: "row",
-              backgroundColor: activeMenuItemIndex === index ? theme.accentMuted : theme.panel,
+              backgroundColor:
+                activeMenuItemIndex === index
+                  ? chromeSurfaceBg(theme, "selection")
+                  : chromeSurfaceBg(theme, "overlay"),
             }}
             onMouseOver={() => onHoverItem(index)}
             onMouseUp={() => onSelectItem(entry)}

--- a/src/ui/components/chrome/ModalFrame.tsx
+++ b/src/ui/components/chrome/ModalFrame.tsx
@@ -2,6 +2,7 @@ import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
 import type { ReactNode } from "react";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import { overlaySurfaceStyle } from "./chromeSurface";
 
 /** Render a centered framed modal container that other dialogs can reuse. */
 export function ModalFrame({
@@ -53,9 +54,7 @@ export function ModalFrame({
           width: clampedWidth,
           height: clampedHeight,
           zIndex: 60,
-          border: true,
-          borderColor: theme.accent,
-          backgroundColor: theme.panel,
+          ...overlaySurfaceStyle(theme, theme.accent),
           flexDirection: "column",
         }}
         onMouseScroll={(event: TuiMouseEvent) => {

--- a/src/ui/components/chrome/StatusBar.tsx
+++ b/src/ui/components/chrome/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { isEscapeKey } from "../../lib/keyboard";
 import type { AppTheme } from "../../themes";
+import { topChromeBg } from "./chromeSurface";
 
 /** Render the active file filter input or current filter summary. */
 export function StatusBar({
@@ -25,7 +26,7 @@ export function StatusBar({
     <box
       style={{
         height: 1,
-        backgroundColor: theme.panelAlt,
+        backgroundColor: topChromeBg(theme),
         paddingLeft: 1,
         paddingRight: 1,
         alignItems: "center",

--- a/src/ui/components/chrome/chromeSurface.ts
+++ b/src/ui/components/chrome/chromeSurface.ts
@@ -1,0 +1,71 @@
+import type { AppTheme, ChromeSurfaces } from "../../themes";
+
+/** A named level on the theme's elevation ladder. */
+export type SurfaceLevel = keyof ChromeSurfaces;
+
+/**
+ * Bordered-mode background for each surface level, i.e. the pre-borderless look.
+ * Keeping it here is what lets every component ask for a level by name and get
+ * the right value for the active {@link AppTheme.chrome} mode without branching.
+ */
+function borderedSurfaceBg(theme: AppTheme, level: SurfaceLevel): string {
+  switch (level) {
+    case "code":
+      return theme.background;
+    case "contextBand":
+      return theme.panelAlt;
+    case "sectionHeader":
+    case "sidebar":
+    case "overlay":
+      return theme.panel;
+    case "note":
+      return theme.noteBackground;
+    case "noteTitle":
+      return theme.noteTitleBackground;
+    case "selection":
+      return theme.accentMuted;
+    case "selectionPrimary":
+      return theme.accent;
+  }
+}
+
+/**
+ * Resolve the background for a chrome surface, honoring the active chrome mode:
+ * the derived elevation band in borderless mode, the legacy panel color otherwise.
+ * Single decision point so border-vs-band logic never scatters across components.
+ */
+export function chromeSurfaceBg(theme: AppTheme, level: SurfaceLevel): string {
+  return theme.chrome === "borderless" ? theme.surfaces[level] : borderedSurfaceBg(theme, level);
+}
+
+/**
+ * Background for the top/bottom chrome bars (menu bar, status bar) — the VS Code
+ * title/status-bar color (`panelAlt`) in both modes, distinct from the panel-colored
+ * file-section headers. Borderless mode only drops the rule under it.
+ */
+export function topChromeBg(theme: AppTheme): string {
+  return theme.panelAlt;
+}
+
+/** Box style fragment for a floating overlay (popup, menu, or dialog). */
+export interface OverlaySurfaceStyle {
+  border: boolean;
+  borderColor?: string;
+  backgroundColor: string;
+}
+
+/**
+ * Style a floating overlay: a filled elevated band with no border in borderless
+ * mode, or the legacy bordered panel otherwise. The bordered border color varies
+ * per surface (dialogs use accent, menus use the neutral border), so callers pass
+ * the color their bordered look used.
+ */
+export function overlaySurfaceStyle(
+  theme: AppTheme,
+  borderedBorderColor: string,
+): OverlaySurfaceStyle {
+  if (theme.chrome === "borderless") {
+    return { border: false, backgroundColor: theme.surfaces.overlay };
+  }
+  return { border: true, borderColor: borderedBorderColor, backgroundColor: theme.panel };
+}

--- a/src/ui/components/panes/AgentCard.tsx
+++ b/src/ui/components/panes/AgentCard.tsx
@@ -1,6 +1,7 @@
 import { buildAgentPopoverContent } from "../../lib/agentPopover";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import { overlaySurfaceStyle } from "../chrome/chromeSurface";
 
 /** Render one framed floating agent note popover. */
 export function AgentCard({
@@ -40,9 +41,7 @@ export function AgentCard({
       style={{
         width,
         height: popover.height,
-        border: true,
-        borderColor: theme.accent,
-        backgroundColor: theme.panel,
+        ...overlaySurfaceStyle(theme, theme.accent),
         paddingLeft: 1,
         paddingRight: 1,
         paddingTop: 0,

--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -190,6 +190,20 @@ export function AgentInlineNote({
     };
   }, [draft]);
 
+  // In borderless chrome the note keeps its box-drawing rows for geometry, but the
+  // glyphs are painted in the band color so no lines show — a filled note band.
+  const borderless = theme.chrome === "borderless";
+  const surfaceBg = borderless ? theme.surfaces.note : theme.panel;
+  const borderFg = borderless ? surfaceBg : theme.noteBorder;
+  // Borderless chrome layers the card: a slightly higher title band over the body, and
+  // filled primary/secondary action buttons, so the box structure reads without any border.
+  // The title-row border glyphs hide against the title band (not the body) in this mode.
+  const titleBg = borderless ? theme.surfaces.noteTitle : theme.panel;
+  const titleBorderFg = borderless ? titleBg : theme.noteBorder;
+  const saveBg = borderless ? theme.accent : surfaceBg;
+  const saveFg = borderless ? theme.background : theme.noteTitleText;
+  const cancelBg = borderless ? theme.surfaces.noteTitle : surfaceBg;
+  const cancelFg = theme.noteTitleText;
   const closeText = onClose ? "[x]" : "";
   const titleText = `${inlineNoteTitle(annotation, noteIndex, noteCount)} - ${annotationRangeLabel(annotation, file)}`;
   const splitWidths = splitColumnWidths(width);
@@ -285,23 +299,23 @@ export function AgentInlineNote({
       Array.from({ length: rowCount }, (_, rowIndex) => (
         <box
           key={`${keyPrefix}:${rowIndex}`}
-          style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}
+          style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}
         >
-          <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+          <box style={{ width: boxLeft, height: 1, backgroundColor: surfaceBg }}>
             <text>{" ".repeat(boxLeft)}</text>
           </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               │
             </text>
           </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
-          <box style={{ width: draftContentWidth, height: 1, backgroundColor: theme.panel }}>
-            <text bg={theme.panel}>{" ".repeat(draftContentWidth)}</text>
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }} />
+          <box style={{ width: draftContentWidth, height: 1, backgroundColor: surfaceBg }}>
+            <text bg={surfaceBg}>{" ".repeat(draftContentWidth)}</text>
           </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }} />
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               │
             </text>
           </box>
@@ -309,22 +323,20 @@ export function AgentInlineNote({
       ));
 
     return (
-      <box style={{ width: "100%", flexDirection: "column", backgroundColor: theme.panel }}>
-        <box
-          style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}
-        >
-          <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+      <box style={{ width: "100%", flexDirection: "column", backgroundColor: surfaceBg }}>
+        <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}>
+          <box style={{ width: boxLeft, height: 1, backgroundColor: surfaceBg }}>
             <text>{" ".repeat(boxLeft)}</text>
           </box>
-          <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
+          <box style={{ width: boxWidth, height: 1, backgroundColor: titleBg }}>
             <text>
-              <span fg={theme.noteBorder} bg={theme.panel}>
+              <span fg={titleBorderFg} bg={titleBg}>
                 ╭─
               </span>
-              <span fg={theme.noteTitleText} bg={theme.panel}>
+              <span fg={theme.noteTitleText} bg={titleBg}>
                 {draftTitleText}
               </span>
-              <span fg={theme.noteBorder} bg={theme.panel}>
+              <span fg={titleBorderFg} bg={titleBg}>
                 {draftTopBorderSuffix}
               </span>
             </text>
@@ -338,31 +350,25 @@ export function AgentInlineNote({
             width: "100%",
             height: draftTextareaRows,
             flexDirection: "row",
-            backgroundColor: theme.panel,
+            backgroundColor: surfaceBg,
           }}
         >
-          <box
-            style={{ width: boxLeft, height: draftTextareaRows, backgroundColor: theme.panel }}
-          />
+          <box style={{ width: boxLeft, height: draftTextareaRows, backgroundColor: surfaceBg }} />
           <box
             style={{
               width: 1,
               height: draftTextareaRows,
               flexDirection: "column",
-              backgroundColor: theme.panel,
+              backgroundColor: surfaceBg,
             }}
           >
             {Array.from({ length: draftTextareaRows }, (_, rowIndex) => (
-              <text
-                key={`draft-textarea-left-border:${rowIndex}`}
-                fg={theme.noteBorder}
-                bg={theme.panel}
-              >
+              <text key={`draft-textarea-left-border:${rowIndex}`} fg={borderFg} bg={surfaceBg}>
                 │
               </text>
             ))}
           </box>
-          <box style={{ width: 1, height: draftTextareaRows, backgroundColor: theme.panel }} />
+          <box style={{ width: 1, height: draftTextareaRows, backgroundColor: surfaceBg }} />
           <textarea
             ref={textareaRef}
             width={draftContentWidth}
@@ -370,9 +376,9 @@ export function AgentInlineNote({
             initialValue={draft.body}
             placeholder="Write a note…"
             focused={draft.focused}
-            backgroundColor={theme.panel}
+            backgroundColor={surfaceBg}
             textColor={theme.text}
-            focusedBackgroundColor={theme.panel}
+            focusedBackgroundColor={surfaceBg}
             focusedTextColor={theme.text}
             keyBindings={[{ name: "j", ctrl: true, action: "newline" }]}
             onContentChange={() => {
@@ -410,21 +416,17 @@ export function AgentInlineNote({
               }
             }}
           />
-          <box style={{ width: 1, height: draftTextareaRows, backgroundColor: theme.panel }} />
+          <box style={{ width: 1, height: draftTextareaRows, backgroundColor: surfaceBg }} />
           <box
             style={{
               width: 1,
               height: draftTextareaRows,
               flexDirection: "column",
-              backgroundColor: theme.panel,
+              backgroundColor: surfaceBg,
             }}
           >
             {Array.from({ length: draftTextareaRows }, (_, rowIndex) => (
-              <text
-                key={`draft-textarea-right-border:${rowIndex}`}
-                fg={theme.noteBorder}
-                bg={theme.panel}
-              >
+              <text key={`draft-textarea-right-border:${rowIndex}`} fg={borderFg} bg={surfaceBg}>
                 │
               </text>
             ))}
@@ -433,60 +435,54 @@ export function AgentInlineNote({
 
         {renderDraftBodyPaddingRows("draft-body-bottom-padding", draftBottomPaddingRows)}
 
-        <box
-          style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}
-        >
-          <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+        <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}>
+          <box style={{ width: boxLeft, height: 1, backgroundColor: surfaceBg }}>
             <text>{" ".repeat(boxLeft)}</text>
           </box>
-          <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: boxWidth, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               {draftActionBorder}
             </text>
           </box>
         </box>
 
-        <box
-          style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}
-        >
-          <box style={{ width: footerButtonLeft, height: 1, backgroundColor: theme.panel }}>
+        <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}>
+          <box style={{ width: footerButtonLeft, height: 1, backgroundColor: surfaceBg }}>
             <text>{" ".repeat(footerButtonLeft)}</text>
           </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               │
             </text>
           </box>
           <box onMouseUp={draft.onSave} style={{ width: saveInnerWidth, height: 1 }}>
-            <text fg={theme.noteTitleText} bg={theme.panel}>
+            <text fg={saveFg} bg={saveBg}>
               {padText(" Save (^S) ", saveInnerWidth)}
             </text>
           </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               │
             </text>
           </box>
           <box onMouseUp={draft.onCancel} style={{ width: cancelInnerWidth, height: 1 }}>
-            <text fg={theme.noteTitleText} bg={theme.panel}>
+            <text fg={cancelFg} bg={cancelBg}>
               {padText(" Cancel (Esc) ", cancelInnerWidth)}
             </text>
           </box>
-          <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               │
             </text>
           </box>
         </box>
 
-        <box
-          style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}
-        >
-          <box style={{ width: footerButtonLeft, height: 1, backgroundColor: theme.panel }}>
+        <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}>
+          <box style={{ width: footerButtonLeft, height: 1, backgroundColor: surfaceBg }}>
             <text>{" ".repeat(footerButtonLeft)}</text>
           </box>
-          <box style={{ width: footerButtonWidth, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+          <box style={{ width: footerButtonWidth, height: 1, backgroundColor: surfaceBg }}>
+            <text fg={borderFg} bg={surfaceBg}>
               {draftButtonBottom}
             </text>
           </box>
@@ -498,25 +494,25 @@ export function AgentInlineNote({
   const renderSavedBodyRow = (key: string, text: string, kind: AgentInlineNoteLine["kind"]) => (
     <box
       key={key}
-      style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}
+      style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}
     >
-      <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+      <box style={{ width: boxLeft, height: 1, backgroundColor: surfaceBg }}>
         <text>{" ".repeat(boxLeft)}</text>
       </box>
-      <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-        <text fg={theme.noteBorder} bg={theme.panel}>
+      <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+        <text fg={borderFg} bg={surfaceBg}>
           │
         </text>
       </box>
-      <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
-      <box style={{ width: contentWidth, height: 1, backgroundColor: theme.panel }}>
-        <text fg={kind === "summary" ? theme.text : theme.muted} bg={theme.panel}>
+      <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }} />
+      <box style={{ width: contentWidth, height: 1, backgroundColor: surfaceBg }}>
+        <text fg={kind === "summary" ? theme.text : theme.muted} bg={surfaceBg}>
           {padText(text, contentWidth)}
         </text>
       </box>
-      <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
-      <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-        <text fg={theme.noteBorder} bg={theme.panel}>
+      <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }} />
+      <box style={{ width: 1, height: 1, backgroundColor: surfaceBg }}>
+        <text fg={borderFg} bg={surfaceBg}>
           │
         </text>
       </box>
@@ -524,41 +520,41 @@ export function AgentInlineNote({
   );
 
   return (
-    <box style={{ width: "100%", flexDirection: "column", backgroundColor: theme.panel }}>
-      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
-        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+    <box style={{ width: "100%", flexDirection: "column", backgroundColor: surfaceBg }}>
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: surfaceBg }}>
           <text>{" ".repeat(boxLeft)}</text>
         </box>
-        <box style={{ width: savedTopPrefixWidth, height: 1, backgroundColor: theme.panel }}>
+        <box style={{ width: savedTopPrefixWidth, height: 1, backgroundColor: titleBg }}>
           <text>
-            <span fg={theme.noteBorder} bg={theme.panel}>
+            <span fg={titleBorderFg} bg={titleBg}>
               ╭─
             </span>
-            <span fg={theme.noteTitleText} bg={theme.panel}>
+            <span fg={theme.noteTitleText} bg={titleBg}>
               {savedTitleText}
             </span>
-            <span fg={theme.noteBorder} bg={theme.panel}>
+            <span fg={titleBorderFg} bg={titleBg}>
               {"─".repeat(savedTopBorderSuffixWidth)}
             </span>
           </text>
         </box>
         {closeText ? (
-          <box style={{ width: closeGapWidth, height: 1, backgroundColor: theme.panel }}>
-            <text bg={theme.panel}>{" ".repeat(closeGapWidth)}</text>
+          <box style={{ width: closeGapWidth, height: 1, backgroundColor: titleBg }}>
+            <text bg={titleBg}>{" ".repeat(closeGapWidth)}</text>
           </box>
         ) : null}
         {closeText ? (
           <box
             onMouseUp={onClose}
-            style={{ width: closeWidth, height: 1, backgroundColor: theme.panel }}
+            style={{ width: closeWidth, height: 1, backgroundColor: titleBg }}
           >
-            <text fg={theme.noteTitleText} bg={theme.panel}>
+            <text fg={theme.noteTitleText} bg={titleBg}>
               {closeText}
             </text>
           </box>
         ) : null}
-        <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.panel}>
+        <box style={{ width: 1, height: 1, backgroundColor: titleBg }}>
+          <text fg={titleBorderFg} bg={titleBg}>
             ╮
           </text>
         </box>
@@ -570,12 +566,12 @@ export function AgentInlineNote({
         renderSavedBodyRow(`${line.kind}:${index}`, line.text, line.kind),
       )}
 
-      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: theme.panel }}>
-        <box style={{ width: boxLeft, height: 1, backgroundColor: theme.panel }}>
+      <box style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: surfaceBg }}>
+        <box style={{ width: boxLeft, height: 1, backgroundColor: surfaceBg }}>
           <text>{" ".repeat(boxLeft)}</text>
         </box>
-        <box style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.panel}>
+        <box style={{ width: boxWidth, height: 1, backgroundColor: surfaceBg }}>
+          <text fg={borderFg} bg={surfaceBg}>
             {bottomBorder}
           </text>
         </box>

--- a/src/ui/components/panes/DiffFileHeaderRow.tsx
+++ b/src/ui/components/panes/DiffFileHeaderRow.tsx
@@ -2,6 +2,7 @@ import type { DiffFile } from "../../../core/types";
 import { fileLabelParts } from "../../lib/files";
 import { fitText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import { chromeSurfaceBg } from "../chrome/chromeSurface";
 
 interface DiffFileHeaderRowProps {
   file: DiffFile;
@@ -33,7 +34,7 @@ export function DiffFileHeaderRow({
         justifyContent: "space-between",
         paddingLeft: 1,
         paddingRight: 1,
-        backgroundColor: theme.panel,
+        backgroundColor: chromeSurfaceBg(theme, "sectionHeader"),
       }}
       onMouseUp={onSelect}
     >

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1724,14 +1724,21 @@ export function DiffPane({
     }
   }, [scrollRef]);
 
+  // Borderless chrome paints the diff stream on the editor canvas (code surface) so the structural
+  // pane background matches the context rows; bordered mode keeps the legacy panel background framed
+  // by its borders.
+  const paneBg = theme.chrome === "borderless" ? theme.surfaces.code : theme.panel;
+
   return (
     <box
       style={{
         width,
-        border: pagerMode ? [] : ["top"],
+        // Borderless chrome drops the rule + gap under the menu bar; the menu-bar
+        // band and first file-header band carry the separation instead.
+        border: pagerMode || theme.chrome === "borderless" ? [] : ["top"],
         borderColor: theme.border,
-        backgroundColor: theme.panel,
-        paddingY: pagerMode ? 0 : 1,
+        backgroundColor: paneBg,
+        paddingY: pagerMode || theme.chrome === "borderless" ? 0 : 1,
         paddingX: 0,
         flexDirection: "column",
       }}
@@ -1772,10 +1779,10 @@ export function DiffPane({
               onMouseScroll={handleMouseScroll}
               onMouseUp={endCopySelection}
               scrollAcceleration={mouseWheelScrollAcceleration}
-              rootOptions={{ backgroundColor: theme.panel }}
-              wrapperOptions={{ backgroundColor: theme.panel }}
-              viewportOptions={{ backgroundColor: theme.panel }}
-              contentOptions={{ backgroundColor: theme.panel }}
+              rootOptions={{ backgroundColor: paneBg }}
+              wrapperOptions={{ backgroundColor: paneBg }}
+              viewportOptions={{ backgroundColor: paneBg }}
+              contentOptions={{ backgroundColor: paneBg }}
               verticalScrollbarOptions={{ visible: false }}
               horizontalScrollbarOptions={{ visible: false }}
             >
@@ -1790,7 +1797,7 @@ export function DiffPane({
                     return (
                       <box
                         key={item.key}
-                        style={{ width: "100%", height: item.height, backgroundColor: theme.panel }}
+                        style={{ width: "100%", height: item.height, backgroundColor: paneBg }}
                       />
                     );
                   }

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -7,8 +7,8 @@ import type { DiffSectionGeometry } from "../../diff/diffSectionGeometry";
 import type { VisibleAgentNote } from "../../lib/agentAnnotations";
 import type { CopySelectedRowRange } from "./copySelection";
 import { diffSectionId } from "../../lib/ids";
-import { fitText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import { ChromeSeparator } from "../chrome/ChromeSeparator";
 import { DiffFileHeaderRow } from "./DiffFileHeaderRow";
 
 interface DiffSectionProps {
@@ -85,23 +85,11 @@ function DiffSectionComponent({
       style={{
         width: "100%",
         flexDirection: "column",
-        backgroundColor: theme.panel,
+        backgroundColor: theme.chrome === "borderless" ? theme.surfaces.code : theme.panel,
         overflow: "visible",
       }}
     >
-      {showSeparator ? (
-        <box
-          style={{
-            width: "100%",
-            height: 1,
-            paddingLeft: 1,
-            paddingRight: 1,
-            backgroundColor: theme.panel,
-          }}
-        >
-          <text fg={theme.border}>{fitText("─".repeat(separatorWidth), separatorWidth)}</text>
-        </box>
-      ) : null}
+      {showSeparator ? <ChromeSeparator theme={theme} width={separatorWidth} /> : null}
 
       {showHeader ? (
         <DiffFileHeaderRow

--- a/src/ui/components/panes/FileListItem.tsx
+++ b/src/ui/components/panes/FileListItem.tsx
@@ -3,6 +3,7 @@ import { fileRowId } from "../../lib/ids";
 import { sidebarEntryStats, type FileGroupEntry, type FileListEntry } from "../../lib/files";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import { chromeSurfaceBg } from "../chrome/chromeSurface";
 
 /** Get icon and color for file state using standard git status codes. */
 function getFileStateIcon(entry: FileListEntry, theme: AppTheme): { icon: string; color: string } {
@@ -43,7 +44,7 @@ export function FileGroupHeader({
         width: "100%",
         height: 1,
         paddingLeft,
-        backgroundColor: theme.panel,
+        backgroundColor: chromeSurfaceBg(theme, "sidebar"),
       }}
     >
       <text fg={theme.muted}>{fitText(entry.label, Math.max(1, textWidth))}</text>
@@ -69,7 +70,9 @@ export const FileListItem = memo(function FileListItem({
   theme: AppTheme;
   onSelectFile: (fileId: string) => void;
 }) {
-  const rowBackground = selected ? theme.panelAlt : theme.panel;
+  const rowBackground = selected
+    ? chromeSurfaceBg(theme, "contextBand")
+    : chromeSurfaceBg(theme, "sidebar");
   const stats = sidebarEntryStats(entry);
   const { icon, color } = getFileStateIcon(entry, theme);
   const iconWidth = icon ? 2 : 0; // icon + space

--- a/src/ui/components/panes/PaneDivider.tsx
+++ b/src/ui/components/panes/PaneDivider.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
 import type { AppTheme } from "../../themes";
+import { chromeSurfaceBg } from "../chrome/chromeSurface";
 
 /** Render the visible divider plus a wider invisible drag target. */
 export function PaneDivider({
@@ -21,28 +22,43 @@ export function PaneDivider({
   onMouseDragEnd: (event: TuiMouseEvent) => void;
   onMouseUp: (event: TuiMouseEvent) => void;
 }) {
+  // Borderless chrome hides the divider line at rest and reveals an accent rule
+  // only while resizing, so the grab handle stays discoverable when dragging.
+  const borderless = theme.chrome === "borderless";
+  const revealLine = !borderless || isResizing;
+
   return (
     <>
       <box
         style={{
           width: 1,
-          border: ["top", "left"],
-          borderColor: isResizing ? theme.accent : theme.border,
-          backgroundColor: isResizing ? theme.accentMuted : theme.panel,
+          // Explicitly clear the border at rest in borderless mode; an omitted
+          // border key still renders the line from customBorderChars below.
+          border: revealLine ? ["top", "left"] : [],
+          ...(revealLine ? { borderColor: isResizing ? theme.accent : theme.border } : {}),
+          backgroundColor: isResizing
+            ? theme.accentMuted
+            : borderless
+              ? chromeSurfaceBg(theme, "sidebar")
+              : theme.panel,
         }}
-        customBorderChars={{
-          topLeft: "┬",
-          topRight: "┬",
-          bottomLeft: "┴",
-          bottomRight: "┴",
-          horizontal: "─",
-          vertical: "│",
-          topT: "┬",
-          bottomT: "┴",
-          leftT: "├",
-          rightT: "┤",
-          cross: "┼",
-        }}
+        {...(revealLine
+          ? {
+              customBorderChars: {
+                topLeft: "┬",
+                topRight: "┬",
+                bottomLeft: "┴",
+                bottomRight: "┴",
+                horizontal: "─",
+                vertical: "│",
+                topT: "┬",
+                bottomT: "┴",
+                leftT: "├",
+                rightT: "┤",
+                cross: "┼",
+              },
+            }
+          : {})}
       />
 
       <box

--- a/src/ui/components/panes/SidebarPane.tsx
+++ b/src/ui/components/panes/SidebarPane.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState, type RefObject } from "react";
 import { sidebarEntryStatsWidth, type SidebarEntry } from "../../lib/files";
 import { buildSidebarRenderWindow } from "../../lib/sidebarRenderWindow";
 import type { AppTheme } from "../../themes";
+import { chromeSurfaceBg } from "../chrome/chromeSurface";
 import { FileGroupHeader, FileListItem } from "./FileListItem";
 
 /** Render the file navigation sidebar. */
@@ -92,13 +93,14 @@ export function SidebarPane({
     };
   }, [entries.length, scrollRef]);
 
+  const sidebarBg = chromeSurfaceBg(theme, "sidebar");
   return (
     <box
       style={{
         width,
-        border: ["top"],
-        borderColor: theme.border,
-        backgroundColor: theme.panel,
+        // Borderless chrome separates the sidebar by its own band, not a top rule.
+        ...(theme.chrome === "borderless" ? {} : { border: ["top"], borderColor: theme.border }),
+        backgroundColor: sidebarBg,
         paddingY: 1,
         paddingX: 0,
         flexDirection: "column",
@@ -111,10 +113,10 @@ export function SidebarPane({
         focused={false}
         scrollY={true}
         viewportCulling={true}
-        rootOptions={{ backgroundColor: theme.panel }}
-        wrapperOptions={{ backgroundColor: theme.panel }}
-        viewportOptions={{ backgroundColor: theme.panel }}
-        contentOptions={{ backgroundColor: theme.panel }}
+        rootOptions={{ backgroundColor: sidebarBg }}
+        wrapperOptions={{ backgroundColor: sidebarBg }}
+        viewportOptions={{ backgroundColor: sidebarBg }}
+        contentOptions={{ backgroundColor: sidebarBg }}
         verticalScrollbarOptions={{ visible: false }}
         horizontalScrollbarOptions={{ visible: false }}
       >
@@ -124,7 +126,7 @@ export function SidebarPane({
               return (
                 <box
                   key={item.key}
-                  style={{ width: "100%", height: item.height, backgroundColor: theme.panel }}
+                  style={{ width: "100%", height: item.height, backgroundColor: sidebarBg }}
                 />
               );
             }

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2322,13 +2322,13 @@ describe("UI components", () => {
     const frame = await captureFrame(
       <HelpDialog
         canRefresh={true}
-        terminalHeight={39}
+        terminalHeight={40}
         terminalWidth={76}
         theme={theme}
         onClose={() => {}}
       />,
       76,
-      39,
+      40,
     );
 
     const expectedRows = [
@@ -2355,6 +2355,7 @@ describe("UI components", () => {
       "a               toggle AI notes",
       "z               toggle unchanged context",
       "l / w / m       lines / wrap / metadata",
+      "B               toggle borderless chrome",
       "e               open file in $EDITOR",
       "Review",
       "/               focus file filter",

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -7,6 +7,7 @@ import {
   resolveStackCellGeometry,
 } from "./codeColumns";
 import { gapKey } from "./expandCollapsedRows";
+import { chromeSurfaceBg } from "../components/chrome/chromeSurface";
 import type { DiffRow, RenderSpan, SplitLineCell, StackLineCell } from "./pierre";
 import {
   diffRailMarker,
@@ -1156,6 +1157,9 @@ function renderHeaderRow(
       : null,
   ].filter((badge): badge is { key: string; text: string; onClick: () => void } => Boolean(badge));
   const badgeWidth = badges.reduce((total, badge) => total + badge.text.length + 1, 0);
+  // Collapsed-gap and hunk-header rows are in-file context affordances; keep them
+  // on the quiet contextBand so they stay distinct from section-header bands.
+  const bandBg = chromeSurfaceBg(theme, "contextBand");
   const collapsedExpandable = row.type === "collapsed" && Boolean(onToggleGap);
   const labelText =
     row.type === "collapsed" ? collapsedRowLabel(row.text, collapsedExpandable) : row.text;
@@ -1173,7 +1177,7 @@ function renderHeaderRow(
         style={{
           width,
           height: 1,
-          backgroundColor: theme.panelAlt,
+          backgroundColor: bandBg,
         }}
         onMouseMove={() => onHoverRow?.(row.key)}
         onMouseOver={() => onHoverRow?.(row.key)}
@@ -1182,14 +1186,11 @@ function renderHeaderRow(
         <text>
           <span
             fg={selected ? neutralRailColor(theme) : dimRailColor(neutralRailColor(theme), theme)}
-            bg={theme.panelAlt}
+            bg={bandBg}
           >
             {marker()}
           </span>
-          <span
-            fg={row.type === "collapsed" ? theme.muted : theme.badgeNeutral}
-            bg={theme.panelAlt}
-          >
+          <span fg={row.type === "collapsed" ? theme.muted : theme.badgeNeutral} bg={bandBg}>
             {label}
           </span>
         </text>
@@ -1205,7 +1206,7 @@ function renderHeaderRow(
         width,
         height: 1,
         flexDirection: "row",
-        backgroundColor: theme.panelAlt,
+        backgroundColor: bandBg,
       }}
       onMouseMove={() => onHoverRow?.(row.key)}
       onMouseOver={() => onHoverRow?.(row.key)}
@@ -1217,14 +1218,11 @@ function renderHeaderRow(
         <text>
           <span
             fg={selected ? neutralRailColor(theme) : dimRailColor(neutralRailColor(theme), theme)}
-            bg={theme.panelAlt}
+            bg={bandBg}
           >
             {marker()}
           </span>
-          <span
-            fg={row.type === "collapsed" ? theme.muted : theme.badgeNeutral}
-            bg={theme.panelAlt}
-          >
+          <span fg={row.type === "collapsed" ? theme.muted : theme.badgeNeutral} bg={bandBg}>
             {label}
           </span>
         </text>

--- a/src/ui/diff/rowStyle.ts
+++ b/src/ui/diff/rowStyle.ts
@@ -101,7 +101,10 @@ export function splitCellPalette(
 
   return {
     gutterBg: theme.lineNumberBg,
-    contentBg: theme.contextBg,
+    // Borderless chrome paints context code on the editor canvas (contextContentBg) so the diff
+    // body reads as the editor, matching the pane background; bordered mode keeps the legacy
+    // contextBg. For bundled themes the two are identical, so this only affects custom palettes.
+    contentBg: theme.chrome === "borderless" ? theme.contextContentBg : theme.contextBg,
     signColor: theme.muted,
     numberColor: theme.lineNumberFg,
   };
@@ -133,7 +136,10 @@ export function stackCellPalette(
 
   return {
     gutterBg: theme.lineNumberBg,
-    contentBg: theme.contextBg,
+    // Borderless chrome paints context code on the editor canvas (contextContentBg) so the diff
+    // body reads as the editor, matching the pane background; bordered mode keeps the legacy
+    // contextBg. For bundled themes the two are identical, so this only affects custom palettes.
+    contentBg: theme.chrome === "borderless" ? theme.contextContentBg : theme.contextBg,
     signColor: theme.muted,
     numberColor: theme.lineNumberFg,
   };

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -42,6 +42,14 @@ function isUppercaseGKey(key: KeyEvent) {
   );
 }
 
+/** Detect Shift-B without stealing the lowercase page-up binding. */
+function isUppercaseBKey(key: KeyEvent) {
+  return (
+    (key.sequence === "B" && !key.option && !key.ctrl && !key.meta) ||
+    (key.name === "b" && key.shift && !key.option && !key.ctrl && !key.meta)
+  );
+}
+
 export interface UseAppKeyboardShortcutsOptions {
   activeMenuId: MenuId | null;
   activateCurrentMenuItem: () => void;
@@ -72,6 +80,7 @@ export interface UseAppKeyboardShortcutsOptions {
   startUserNote: () => void;
   switchMenu: (delta: number) => void;
   toggleAgentNotes: () => void;
+  toggleBorderless: () => void;
   toggleFocusArea: () => void;
   toggleGapForSelectedHunk: () => void;
   toggleHelp: () => void;
@@ -115,6 +124,7 @@ export function useAppKeyboardShortcuts({
   startUserNote,
   switchMenu,
   toggleAgentNotes,
+  toggleBorderless,
   toggleFocusArea,
   toggleGapForSelectedHunk,
   toggleHelp,
@@ -522,6 +532,11 @@ export function useAppKeyboardShortcuts({
 
     if (key.name === "m" || key.sequence === "m") {
       runAndCloseMenu(toggleHunkHeaders);
+      return;
+    }
+
+    if (isUppercaseBKey(key)) {
+      runAndCloseMenu(toggleBorderless);
       return;
     }
 

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -18,6 +18,8 @@ export interface BuildAppMenusOptions {
   showHunkHeaders: boolean;
   showLineNumbers: boolean;
   renderSidebar: boolean;
+  borderless: boolean;
+  toggleBorderless: () => void;
   toggleCopyDecorations: () => void;
   toggleAgentNotes: () => void;
   toggleFocusArea: () => void;
@@ -49,6 +51,8 @@ export function buildAppMenus({
   showHunkHeaders,
   showLineNumbers,
   renderSidebar,
+  borderless,
+  toggleBorderless,
   toggleCopyDecorations,
   toggleAgentNotes,
   toggleFocusArea,
@@ -168,6 +172,13 @@ export function buildAppMenus({
         hint: "m",
         checked: showHunkHeaders,
         action: toggleHunkHeaders,
+      },
+      {
+        kind: "item",
+        label: "Borderless chrome",
+        hint: "B",
+        checked: borderless,
+        action: toggleBorderless,
       },
       {
         kind: "item",

--- a/src/ui/lib/keyboard.test.ts
+++ b/src/ui/lib/keyboard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import { isPageUpKey } from "./keyboard";
+
+const key = (over: Partial<KeyEvent>): KeyEvent =>
+  ({ name: "", sequence: "", ...over }) as KeyEvent;
+
+describe("isPageUpKey", () => {
+  test("unmodified b scrolls a page up", () => {
+    expect(isPageUpKey(key({ name: "b", sequence: "b" }))).toBe(true);
+    expect(isPageUpKey(key({ name: "pageup" }))).toBe(true);
+  });
+
+  test("Shift+B is not page up, leaving it free for the borderless toggle", () => {
+    expect(isPageUpKey(key({ name: "b", sequence: "B", shift: true }))).toBe(false);
+  });
+});

--- a/src/ui/lib/keyboard.ts
+++ b/src/ui/lib/keyboard.ts
@@ -56,7 +56,11 @@ export function isPageDownKey(key: KeyEvent) {
 
 /** Match any key alias that should scroll backward by a full viewport. */
 export function isPageUpKey(key: KeyEvent) {
-  return key.name === "pageup" || key.name === "b" || key.sequence === "b";
+  // The less-style `b` alias is unmodified only, so Shift+B stays free for the borderless toggle.
+  if (key.name === "pageup") {
+    return true;
+  }
+  return (key.name === "b" || key.sequence === "b") && !key.shift;
 }
 
 /** Match any key alias that should scroll forward by a single diff row. */

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -146,6 +146,8 @@ describe("ui helpers", () => {
       showHunkHeaders: false,
       showLineNumbers: true,
       renderSidebar: false,
+      borderless: false,
+      toggleBorderless: () => {},
       toggleCopyDecorations: () => {},
       toggleAgentNotes: () => {},
       toggleFocusArea: () => {},

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -13,7 +13,7 @@ import {
 import { withLazySyntaxStyle } from "./themes/syntax";
 import type { AppTheme, SyntaxColors, ThemeBase } from "./themes/types";
 
-export type { AppTheme, SyntaxColors, ThemeBase } from "./themes/types";
+export type { AppTheme, ChromeMode, ChromeSurfaces, SyntaxColors, ThemeBase } from "./themes/types";
 
 export const TRANSPARENT_BACKGROUND = "transparent";
 export const DEFAULT_DARK_THEME_ID = "github-dark-default";
@@ -369,6 +369,16 @@ export function withTransparentBackground(theme: AppTheme): AppTheme {
     selectedHunk: TRANSPARENT_BACKGROUND,
     noteBackground: TRANSPARENT_BACKGROUND,
     noteTitleBackground: TRANSPARENT_BACKGROUND,
+    surfaces: {
+      ...theme.surfaces,
+      code: TRANSPARENT_BACKGROUND,
+      contextBand: TRANSPARENT_BACKGROUND,
+      sectionHeader: TRANSPARENT_BACKGROUND,
+      sidebar: TRANSPARENT_BACKGROUND,
+      overlay: TRANSPARENT_BACKGROUND,
+      note: TRANSPARENT_BACKGROUND,
+      noteTitle: TRANSPARENT_BACKGROUND,
+    },
   };
 }
 
@@ -386,5 +396,12 @@ export function withTransparentSurfaces(theme: AppTheme): AppTheme {
     contextBg: TRANSPARENT_BACKGROUND,
     contextContentBg: TRANSPARENT_BACKGROUND,
     lineNumberBg: TRANSPARENT_BACKGROUND,
+    surfaces: {
+      ...theme.surfaces,
+      code: TRANSPARENT_BACKGROUND,
+      contextBand: TRANSPARENT_BACKGROUND,
+      sectionHeader: TRANSPARENT_BACKGROUND,
+      sidebar: TRANSPARENT_BACKGROUND,
+    },
   };
 }

--- a/src/ui/themes/surfaces.test.ts
+++ b/src/ui/themes/surfaces.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { hexColorDistance } from "../lib/color";
+import { THEMES } from "../themes";
+import type { ChromeSurfaces } from "./types";
+
+/**
+ * Pairs of surface levels that can appear directly adjacent in the UI and must
+ * therefore stay visually distinct in borderless chrome (where no line separates
+ * them). The numbers are minimum RGB distances; bands are deliberately subtle, so
+ * the threshold only guards against two levels collapsing into the same shade.
+ */
+const ADJACENT_PAIRS: Array<[keyof ChromeSurfaces, keyof ChromeSurfaces]> = [
+  ["code", "contextBand"], // gap/unchanged band sits in the code flow
+  ["code", "sectionHeader"], // file header sits in the code flow
+  ["contextBand", "sectionHeader"], // a gap band can sit right under a header
+  ["code", "sidebar"], // sidebar adjoins the code pane
+  ["code", "overlay"], // a popup floats over code
+  ["sectionHeader", "overlay"], // a popup can float over a header
+];
+
+const MIN_DISTANCE = 6;
+
+describe("chrome surface ladder", () => {
+  for (const theme of THEMES) {
+    test(`${theme.id} keeps adjacent surfaces distinct`, () => {
+      for (const [a, b] of ADJACENT_PAIRS) {
+        const distance = hexColorDistance(theme.surfaces[a], theme.surfaces[b]);
+        expect(
+          distance,
+          `${theme.id}: surfaces.${a} and surfaces.${b} are too close (${distance.toFixed(1)})`,
+        ).toBeGreaterThanOrEqual(MIN_DISTANCE);
+      }
+    });
+  }
+});

--- a/src/ui/themes/surfaces.ts
+++ b/src/ui/themes/surfaces.ts
@@ -1,0 +1,37 @@
+import { blendHex } from "../lib/color";
+import type { ChromeSurfaces, ThemeBase } from "./types";
+
+/**
+ * Map a theme's existing semantic palette onto the {@link ChromeSurfaces} ladder,
+ * the way a VS Code theme assigns workbench colors: the editor background for
+ * code, the panel color for the sidebar and file-section headers (like the active
+ * tab), the dimmer panelAlt for the title/status bars, the gap band, and floating
+ * widgets, and the note colors for comment boxes. Using the theme's own tokens
+ * (rather than synthetic blends) means each theme keeps its intended chrome
+ * direction — lighter-than-editor for github-dark, darker for Shades of Purple —
+ * and authored custom themes look native. Adjacent-level distinctness is covered
+ * by `surfaces.test.ts`.
+ *
+ * Note surfaces are the exception: a theme's `noteBackground` is usually just the
+ * panel color (fine when a drawn border frames the box), but borderless chrome has
+ * no border, so a panel-colored note would dissolve into the stream. We lift the
+ * note body and — a touch more — its title band toward the foreground so the filled
+ * comment card reads as a distinct, layered surface without any border.
+ */
+export function deriveSurfaces(theme: ThemeBase): ChromeSurfaces {
+  return {
+    // Three visibly distinct regions: the editor canvas (code), the file-header / gap
+    // bands one step off it (panel), and the sidebar recessed furthest (panelAlt). Header
+    // must differ from code, contextBand, and overlay, so panel is its only fit; the sidebar
+    // then takes panelAlt so the file tree, the headers, and the canvas never share a shade.
+    code: theme.background,
+    sidebar: theme.panelAlt,
+    sectionHeader: theme.panel,
+    contextBand: theme.panelAlt,
+    overlay: theme.panelAlt,
+    note: blendHex(theme.text, theme.noteBackground, 0.08),
+    noteTitle: blendHex(theme.text, theme.noteTitleBackground, 0.16),
+    selection: theme.accentMuted,
+    selectionPrimary: theme.accent,
+  };
+}

--- a/src/ui/themes/syntax.ts
+++ b/src/ui/themes/syntax.ts
@@ -1,4 +1,5 @@
 import { RGBA, SyntaxStyle } from "@opentui/core";
+import { deriveSurfaces } from "./surfaces";
 import type { AppTheme, SyntaxColors, ThemeBase } from "./types";
 
 /** Build the syntax palette OpenTUI should use for in-terminal code rendering. */
@@ -27,6 +28,9 @@ export function withLazySyntaxStyle(theme: ThemeBase, syntaxColors: SyntaxColors
 
   return {
     ...theme,
+    // Default to bordered chrome; the app overrides this from the user toggle.
+    chrome: "bordered",
+    surfaces: deriveSurfaces(theme),
     syntaxColors,
     get syntaxStyle() {
       syntaxStyle ??= createSyntaxStyle(syntaxColors);

--- a/src/ui/themes/types.ts
+++ b/src/ui/themes/types.ts
@@ -1,9 +1,43 @@
 import type { SyntaxStyle } from "@opentui/core";
 
+/** Whether chrome boundaries are drawn as lines/boxes or as filled background bands. */
+export type ChromeMode = "bordered" | "borderless";
+
+/**
+ * Ordered elevation ladder of background surfaces, low -> high. Adjacent levels
+ * are derived to stay visually distinct so borderless chrome reads as layered
+ * bands instead of one flat field. Every theme carries the full ladder; the
+ * active {@link ChromeMode} decides whether primitives draw a border or fill a band.
+ */
+export interface ChromeSurfaces {
+  /** Editor body / code area (base). */
+  code: string;
+  /** Quiet context affordances inside a file, e.g. the unchanged-lines/gap toggle. */
+  contextBand: string;
+  /** File-section headers and the top menu bar. */
+  sectionHeader: string;
+  /** File-tree sidebar panel. */
+  sidebar: string;
+  /** Floating overlays: popups, menus, dialogs. */
+  overlay: string;
+  /** Agent comment body. */
+  note: string;
+  /** Agent comment title band. */
+  noteTitle: string;
+  /** Hovered/selected row inside menus and lists. */
+  selection: string;
+  /** Primary/active selection (accent), e.g. the active theme row or a Save action. */
+  selectionPrimary: string;
+}
+
 export interface AppTheme {
   id: string;
   label: string;
   appearance: "light" | "dark";
+  /** How chrome boundaries render. Defaults to "bordered"; set per the user toggle. */
+  chrome: ChromeMode;
+  /** Derived elevation ladder used by borderless chrome primitives. */
+  surfaces: ChromeSurfaces;
   background: string;
   panel: string;
   panelAlt: string;
@@ -57,4 +91,4 @@ export type SyntaxColors = {
   punctuation: string;
 };
 
-export type ThemeBase = Omit<AppTheme, "syntaxColors" | "syntaxStyle">;
+export type ThemeBase = Omit<AppTheme, "syntaxColors" | "syntaxStyle" | "chrome" | "surfaces">;


### PR DESCRIPTION
## What

Adds an opt-in "borderless" chrome mode that replaces drawn borders and
separators with filled background bands derived from the active theme. The diff
still reads as distinct regions — file headers, the unchanged-lines band,
sidebar, popups, and comment boxes — but through layered surfaces instead of
lines, for a cleaner, modern look.

Bordered chrome remains the default; nothing changes unless you opt in.

## How to toggle

- `--borderless` / `--no-borderless` CLI flags
- `borderless` config key
- **View → Borderless chrome** menu entry
- `Shift+B` keybinding (listed in the `?` help)

## Demo

https://github.com/user-attachments/assets/ad291a36-e4d4-481d-873c-bd8aa844555c

## How it works

Each theme gains a derived **surface elevation ladder** (`ChromeSurfaces`)
mapped from its existing semantic palette (editor / panel / titlebar tokens), so
authored themes look native and adjacent levels stay visually distinct. A small
set of primitives centralizes the border-vs-band decision so the choice never
scatters across components:

- `chromeSurfaceBg(theme, level)` — resolve a surface background by ladder level
- `overlaySurfaceStyle(theme)` — bordered box vs filled band for popups/dialogs
- `railGlyph(theme)` / `ChromeSeparator` — diff rails and separators

Touched chrome: menu bar, status bar, file-section headers, sidebar, diff rails,
menus/dialogs/popups, agent comment cards, and the pane divider (which still
reveals a rule while dragging to resize).

## Tests

- Cross-theme guardrail asserting adjacent surface levels stay distinguishable
  on every bundled theme
- Keybinding guard (`Shift+B` stays out of the page-up alias)
- Updated menu/help dialog coverage
