### PR TITLE
feat(ui): add PR-style changeset overview with title and description

### DIFF
--- a/.changeset/pr-style-changeset-description.md
+++ b/.changeset/pr-style-changeset-description.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add a PR-style title and rich-markdown description to changeset reviews. Agents can set top-level `title` and `description` fields in the `--agent-context` sidecar; Hunk shows them in a toggleable Overview overlay (`o`) that auto-opens once when present.

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "bun": "^1.3.10",
         "commander": "^14.0.3",
         "diff": "^8.0.3",
+        "marked": "^18.0.5",
         "shell-quote": "1.8.4",
         "string-width": "^8.2.1",
         "zod": "^4.3.6",
@@ -440,7 +441,7 @@
 
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
-    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
@@ -665,6 +666,8 @@
     "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@opentui/core/diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "@opentui/core/marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 

--- a/docs/agent-workflows.md
+++ b/docs/agent-workflows.md
@@ -130,7 +130,7 @@ For normal worktree use, prefer `--repo /path/to/worktree`. Reach for `--session
 
 ## Alternative workflow: load agent comments from a file
 
-Use `--agent-context` when you already have agent-written rationale or notes in a JSON sidecar file and want to render them beside the diff.
+Use `--agent-context` when you already have agent-written rationale or notes in a JSON file and want to render them beside the diff.
 
 ```bash
 hunk diff --agent-context notes.json
@@ -138,6 +138,43 @@ hunk patch change.patch --agent-context notes.json
 ```
 
 For a compact real example, see [`examples/3-agent-review-demo/agent-context.json`](../examples/3-agent-review-demo/agent-context.json).
+
+### agent-context JSON format
+
+The `--agent-context` file has the following top-level fields:
+
+| Field         | Type     | Description                                                                                                                                      |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `version`     | `number` | Schema version. Use `1`.                                                                                                                         |
+| `title`       | `string` | Optional. A one-line PR-style changeset title shown in the Overview overlay header.                                                              |
+| `description` | `string` | Optional. A markdown body for the Overview overlay (headings, lists, bold/italic, inline `code`, fenced code blocks, blockquotes, rules, links). |
+| `summary`     | `string` | Optional. Legacy plain-text changeset summary. Used as the Overview body when `description` is absent (`description ?? summary`).                |
+| `files`       | `array`  | Per-file annotations. Each entry has `path`, optional `summary`, and an `annotations` array of hunk-level notes.                                 |
+
+When the agent sets a `title` or `description`, the Overview overlay auto-opens once when the session starts. A file with only a legacy `summary` does not auto-open, but its summary is still shown as the overview body when you open the overlay yourself. Press `o` to toggle the overlay or `Esc` to close it. The overlay is also accessible from the Agent menu.
+
+A minimal file with the new fields looks like:
+
+```json
+{
+  "version": 1,
+  "title": "feat(search): ranked command-palette matching",
+  "description": "## Overview\n\nThis changeset introduces a ranked scoring model.\n\n- `normalize.ts` — shared query normalization\n- `search.ts` — score-based sorting\n\nPrefix and exact matches now outrank loose substring hits.",
+  "files": [
+    {
+      "path": "src/search.ts",
+      "annotations": [
+        {
+          "newRange": [15, 35],
+          "summary": "Scores and sorts results instead of returning the first substring list.",
+          "rationale": "Ensures the most obvious intent appears at the top of the palette.",
+          "author": "sonnet"
+        }
+      ]
+    }
+  ]
+}
+```
 
 ## Practical defaults
 

--- a/examples/3-agent-review-demo/README.md
+++ b/examples/3-agent-review-demo/README.md
@@ -11,6 +11,9 @@ hunk patch examples/3-agent-review-demo/change.patch \
 
 ## What to look for
 
+- the PR-style overview that opens first (`o` to toggle): a changeset title and a
+  rendered-markdown description explaining the change as a whole
 - query normalization extracted into its own helper
 - ranking logic that prefers strong matches over loose substring hits
-- inline notes beside the changed hunks, not in a separate panel or PR description
+- inline notes beside the changed hunks themselves, kept close to the code they
+  explain rather than collapsed into the overview

--- a/examples/3-agent-review-demo/agent-context.json
+++ b/examples/3-agent-review-demo/agent-context.json
@@ -1,5 +1,7 @@
 {
   "version": 1,
+  "title": "feat(search): ranked command-palette matching with query normalization",
+  "description": "## Overview\n\nThis changeset improves the command-palette search experience by introducing a shared normalization step and a ranked scoring model.\n\n### What changed\n\n- `normalize.ts` adds a single `normalizeQuery` helper that strips extra whitespace, lowercases the input, and expands dashed shortcut terms (e.g. `short-cuts` → `shortcuts`) before any matching happens.\n- `search.ts` now scores each candidate and sorts by score so that prefix and exact keyword matches outrank weaker substring hits. The scoring tiers are `4` (exact), `3` (prefix), `2` (keyword), `1` (substring), with zero-score items filtered out.\n- `index.ts` caps the preview at the top three results — once ranking is reliable, flooding the UI with weaker matches adds noise rather than value.\n\n### Why it matters\n\nBefore this change the palette returned the first loose substring list, making every match look equally good. A user typing `\"git\"` would see unrelated commands ranked alongside `git commit`. The new scorer consistently surfaces the most obvious intent at the top.",
   "summary": "Improves command-palette matching by normalizing query text and ranking stronger matches ahead of loose substring hits.",
   "files": [
     {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "bun": "^1.3.10",
     "commander": "^14.0.3",
     "diff": "^8.0.3",
+    "marked": "^18.0.5",
     "shell-quote": "1.8.4",
     "string-width": "^8.2.1",
     "zod": "^4.3.6"
@@ -127,7 +128,7 @@
     "react": "^19.2.4"
   },
   "simple-git-hooks": {
-    "pre-commit": "bunx lint-staged"
+    "pre-commit": "bunx --bun lint-staged"
   },
   "engines": {
     "node": ">=18"

--- a/src/core/agent.test.ts
+++ b/src/core/agent.test.ts
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, it, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { findAgentFileContext, loadAgentContext } from "./agent";
+import { agentOverviewFields, findAgentFileContext, loadAgentContext } from "./agent";
 
 const tempDirs: string[] = [];
 
@@ -13,6 +13,30 @@ afterEach(() => {
       rmSync(dir, { recursive: true, force: true });
     }
   }
+});
+
+it("agentOverviewFields exposes title, description, and summary independently", () => {
+  expect(
+    agentOverviewFields({ version: 1, title: "T", description: "D", summary: "S", files: [] }),
+  ).toEqual({ agentTitle: "T", agentSummary: "S", agentDescription: "D" });
+});
+
+it("agentOverviewFields keeps a legacy summary without promoting it to description", () => {
+  // The summary stays available for the overview body fallback, but it must not
+  // become the description — otherwise a summary-only sidecar would auto-open.
+  expect(agentOverviewFields({ version: 1, summary: "S", files: [] })).toEqual({
+    agentTitle: undefined,
+    agentSummary: "S",
+    agentDescription: undefined,
+  });
+});
+
+it("agentOverviewFields handles a null context", () => {
+  expect(agentOverviewFields(null)).toEqual({
+    agentTitle: undefined,
+    agentSummary: undefined,
+    agentDescription: undefined,
+  });
 });
 
 describe("agent context", () => {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -106,8 +106,30 @@ export async function loadAgentContext(
 
   return {
     version: typeof parsed.version === "number" ? parsed.version : 1,
+    title: typeof parsed.title === "string" ? parsed.title : undefined,
     summary: typeof parsed.summary === "string" ? parsed.summary : undefined,
+    description: typeof parsed.description === "string" ? parsed.description : undefined,
     files,
+  };
+}
+
+/**
+ * Resolve the changeset-level overview fields. These carry only what the agent
+ * set explicitly: `agentTitle`/`agentDescription` reflect the new PR-style
+ * fields, and `agentSummary` keeps the legacy summary. The overview body falls
+ * back to the summary at render time (`description ?? summary`); keeping the
+ * fallback out of here means auto-open can key off the explicit fields alone
+ * and a legacy summary-only sidecar does not pop the overlay on load.
+ */
+export function agentOverviewFields(agentContext: AgentContext | null): {
+  agentTitle?: string;
+  agentSummary?: string;
+  agentDescription?: string;
+} {
+  return {
+    agentTitle: agentContext?.title,
+    agentSummary: agentContext?.summary,
+    agentDescription: agentContext?.description,
   };
 }
 

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -213,6 +213,46 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.changeset.files[0]?.agent?.annotations).toHaveLength(1);
   });
 
+  test("carries agent title and description onto the changeset", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-diff-"));
+    tempDirs.push(dir);
+
+    const left = join(dir, "before.ts");
+    const right = join(dir, "after.ts");
+    const agent = join(dir, "agent.json");
+
+    writeFileSync(left, "export const answer = 41;\n");
+    writeFileSync(right, "export const answer = 42;\nexport const bonus = true;\n");
+    writeFileSync(
+      agent,
+      JSON.stringify({
+        version: 1,
+        title: "PR title",
+        description: "# Body",
+        summary: "Agent added the bonus export.",
+        files: [
+          {
+            path: "after.ts",
+            annotations: [{ newRange: [2, 2], summary: "Introduces the bonus flag." }],
+          },
+        ],
+      }),
+    );
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "diff",
+      left,
+      right,
+      options: {
+        mode: "auto",
+        agentContext: agent,
+      },
+    });
+
+    expect(bootstrap.changeset.agentTitle).toBe("PR title");
+    expect(bootstrap.changeset.agentDescription).toBe("# Body");
+  });
+
   test("loads git changes and relative agent context from an explicit cwd override", async () => {
     const dir = createTempRepo("hunk-git-cwd-");
     const nested = join(dir, "nested");

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -6,7 +6,7 @@ import {
 } from "@pierre/diffs";
 import { createTwoFilesPatch } from "diff";
 import { resolve as resolvePath } from "node:path";
-import { findAgentFileContext, loadAgentContext } from "./agent";
+import { agentOverviewFields, findAgentFileContext, loadAgentContext } from "./agent";
 import { createSkippedBinaryMetadata, isProbablyBinaryFile } from "./binary";
 import { buildDiffFile, type BuildDiffFileOptions, type DiffFileSourceContext } from "./diffFile";
 import { createFileSourceFetcher, type FileSourceSpec } from "./fileSource";
@@ -224,7 +224,7 @@ function normalizePatchChangeset(
       sourceLabel,
       title,
       summary: normalizedPatchText.trim() || undefined,
-      agentSummary: agentContext?.summary,
+      ...agentOverviewFields(agentContext),
       files: [],
     };
   }
@@ -241,7 +241,7 @@ function normalizePatchChangeset(
         .map((entry) => entry.patchMetadata)
         .filter(Boolean)
         .join("\n\n") || undefined,
-    agentSummary: agentContext?.summary,
+    ...agentOverviewFields(agentContext),
     files: metadataFiles.map((metadata, index) =>
       buildDiffFile(
         metadata,
@@ -287,7 +287,7 @@ function buildBinaryFileDiffChangeset(
     id: `pair:${displayPath}`,
     sourceLabel: input.kind === "difftool" ? "git difftool" : "file compare",
     title,
-    agentSummary: agentContext?.summary,
+    ...agentOverviewFields(agentContext),
     files: [
       buildDiffFile(
         createSkippedBinaryMetadata(displayPath, resolveBinaryComparisonType(leftPath, rightPath)),
@@ -354,7 +354,7 @@ async function loadFileDiffChangeset(
     id: `pair:${displayPath}`,
     sourceLabel: input.kind === "difftool" ? "git difftool" : "file compare",
     title,
-    agentSummary: agentContext?.summary,
+    ...agentOverviewFields(agentContext),
     files: [
       buildDiffFile(metadata, patch, 0, displayPath, agentContext, {
         previousPath: basename(input.left),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -37,7 +37,9 @@ export interface AgentFileContext {
 
 export interface AgentContext {
   version: number;
+  title?: string;
   summary?: string;
+  description?: string;
   files: AgentFileContext[];
 }
 
@@ -75,7 +77,9 @@ export interface Changeset {
   sourceLabel: string;
   title: string;
   summary?: string;
+  agentTitle?: string;
   agentSummary?: string;
+  agentDescription?: string;
   files: DiffFile[];
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -46,6 +46,9 @@ const LazyAgentSkillDialog = lazy(async () => ({
 const LazyHelpDialog = lazy(async () => ({
   default: (await import("./components/chrome/HelpDialog")).HelpDialog,
 }));
+const LazyOverviewDialog = lazy(async () => ({
+  default: (await import("./components/chrome/OverviewDialog")).OverviewDialog,
+}));
 const LazyMenuDropdown = lazy(async () => ({
   default: (await import("./components/chrome/MenuDropdown")).MenuDropdown,
 }));
@@ -143,6 +146,7 @@ export function App({
   const [forceSidebarOpen, setForceSidebarOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showAgentSkill, setShowAgentSkill] = useState(false);
+  const [showOverview, setShowOverview] = useState(false);
   const [focusArea, setFocusArea] = useState<FocusArea>("files");
   const [activeAddNoteTarget, setActiveAddNoteTarget] = useState<ActiveAddNoteTarget | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(34);
@@ -671,6 +675,31 @@ export function App({
     setShowHelp((current) => !current);
   }, []);
 
+  /** Close the changeset overview overlay. */
+  const closeOverview = useCallback(() => {
+    setShowOverview(false);
+  }, []);
+
+  /** Toggle the changeset overview overlay. */
+  const toggleOverview = useCallback(() => {
+    setShowOverview((current) => !current);
+  }, []);
+
+  /**
+   * Auto-open the overview once on initial mount when the changeset has a title or description.
+   * The ref guard prevents reopening after the user dismisses it.
+   */
+  const autoOpenedOverviewRef = useRef(false);
+  useEffect(() => {
+    if (pagerMode || autoOpenedOverviewRef.current) {
+      return;
+    }
+    if (bootstrap.changeset.agentDescription || bootstrap.changeset.agentTitle) {
+      autoOpenedOverviewRef.current = true;
+      setShowOverview(true);
+    }
+  }, [pagerMode, bootstrap.changeset.agentDescription, bootstrap.changeset.agentTitle]);
+
   /** Focus the file list/sidebar navigation area. */
   const focusFiles = useCallback(() => {
     setFocusArea("files");
@@ -755,6 +784,8 @@ export function App({
         toggleSidebar,
         triggerEditSelectedFile,
         wrapLines,
+        showOverview,
+        toggleOverview,
       }),
     [
       canRefreshCurrentInput,
@@ -784,6 +815,8 @@ export function App({
       toggleSidebar,
       triggerEditSelectedFile,
       wrapLines,
+      showOverview,
+      toggleOverview,
     ],
   );
 
@@ -830,6 +863,7 @@ export function App({
     selectLayoutMode,
     showAgentSkill,
     showHelp,
+    showOverview,
     startUserNote: () => startUserNote(),
     switchMenu,
     themeSelectorOpen: themeSelectorState.open,
@@ -840,9 +874,11 @@ export function App({
     toggleHunkHeaders,
     toggleLineNumbers,
     toggleLineWrap,
+    toggleOverview,
     toggleSidebar,
     triggerEditSelectedFile,
     triggerRefreshCurrentInput,
+    closeOverview,
   });
 
   /** Start a mouse drag resize for the optional sidebar. */
@@ -1092,6 +1128,20 @@ export function App({
             terminalWidth={terminal.width}
             theme={baseTheme}
             onClose={closeHelp}
+          />
+        </Suspense>
+      ) : null}
+
+      {!pagerMode && showOverview ? (
+        <Suspense fallback={null}>
+          <LazyOverviewDialog
+            title={bootstrap.changeset.agentTitle}
+            description={bootstrap.changeset.agentDescription}
+            summary={bootstrap.changeset.agentSummary}
+            terminalHeight={terminal.height}
+            terminalWidth={terminal.width}
+            theme={baseTheme}
+            onClose={closeOverview}
           />
         </Suspense>
       ) : null}

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -56,6 +56,7 @@ export function HelpDialog({
       items: [
         ["/", "focus file filter"],
         ["c", "create review note"],
+        ["o", "changeset overview"],
         ["Tab", "toggle files/filter focus"],
         ["F10", "open menus"],
         [canRefresh ? "r / q" : "q", canRefresh ? "reload / quit" : "quit"],

--- a/src/ui/components/chrome/OverviewDialog.test.tsx
+++ b/src/ui/components/chrome/OverviewDialog.test.tsx
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act, type ReactNode } from "react";
+import { resolveTheme } from "../../themes";
+
+const { OverviewDialog } = await import("./OverviewDialog");
+
+async function captureFrame(node: ReactNode, width = 120, height = 24) {
+  const setup = await testRender(node, { width, height });
+
+  try {
+    await act(async () => {
+      await setup.renderOnce();
+    });
+
+    return setup.captureCharFrame();
+  } finally {
+    await act(async () => {
+      setup.renderer.destroy();
+    });
+  }
+}
+
+describe("OverviewDialog", () => {
+  const theme = resolveTheme("github-dark-default", null);
+  const baseProps = {
+    terminalHeight: 30,
+    terminalWidth: 100,
+    theme,
+    onClose: () => {},
+  };
+
+  test("renders the title and description body text", async () => {
+    const frame = await captureFrame(
+      <OverviewDialog {...baseProps} title="PR title" description={"# Heading\n\nbody text"} />,
+      100,
+      30,
+    );
+
+    expect(frame).toContain("Overview");
+    expect(frame).toContain("PR title");
+    expect(frame).toContain("Heading");
+    expect(frame).toContain("body text");
+  });
+
+  test("differentiates heading levels with markdown hash prefixes", async () => {
+    const frame = await captureFrame(
+      <OverviewDialog {...baseProps} description={"# Top\n\n### Deep"} />,
+      100,
+      30,
+    );
+
+    expect(frame).toContain("# Top");
+    expect(frame).toContain("### Deep");
+  });
+
+  test("renders body without a title, no crash", async () => {
+    const frame = await captureFrame(
+      <OverviewDialog {...baseProps} description={"# Heading\n\nbody text"} />,
+      100,
+      30,
+    );
+
+    expect(frame).toContain("Heading");
+    expect(frame).toContain("body text");
+  });
+
+  test("falls back to the legacy summary as the body when no description is given", async () => {
+    const frame = await captureFrame(
+      <OverviewDialog {...baseProps} title="PR title" summary="legacy summary body" />,
+      100,
+      30,
+    );
+
+    expect(frame).toContain("PR title");
+    expect(frame).toContain("legacy summary body");
+  });
+
+  test("prefers description over summary when both are present", async () => {
+    const frame = await captureFrame(
+      <OverviewDialog {...baseProps} description="chosen description" summary="ignored summary" />,
+      100,
+      30,
+    );
+
+    expect(frame).toContain("chosen description");
+    expect(frame).not.toContain("ignored summary");
+  });
+
+  test("wraps a long multi-span bullet without garbling its words", async () => {
+    // Regression: long list items full of inline `code`/**bold** spans used to
+    // overlap because every span was fit to the full width and laid side by side.
+    const description =
+      "- **Markdown engine** — `markdownRows.ts` turns markdown into themeable rows using the `marked` lexer, then blockquotes and links all render correctly.";
+    // Render surface and the dialog's terminalWidth must match, or the dialog is
+    // clipped and a right-edge word is cut off — which is not what this guards.
+    const frame = await captureFrame(
+      <OverviewDialog {...baseProps} terminalWidth={80} description={description} />,
+      80,
+      30,
+    );
+
+    // Each distinct word must survive intact (not merged/overlapped with another).
+    for (const word of [
+      "Markdown",
+      "engine",
+      "markdownRows.ts",
+      "themeable",
+      "marked",
+      "blockquotes",
+      "links",
+    ]) {
+      expect(frame).toContain(word);
+    }
+    // The bullet marker is present and the garbled merge from the bug is gone.
+    expect(frame).toContain("•");
+    expect(frame).not.toContain("themeablemarked");
+    // Spaces at span boundaries (plain text -> inline `code`) must be preserved.
+    expect(frame).toContain("using the marked");
+  });
+
+  test("renders empty state when neither title nor description provided, no crash", async () => {
+    const frame = await captureFrame(<OverviewDialog {...baseProps} />, 100, 30);
+
+    expect(frame).toContain("No description provided.");
+  });
+});

--- a/src/ui/components/chrome/OverviewDialog.tsx
+++ b/src/ui/components/chrome/OverviewDialog.tsx
@@ -1,0 +1,211 @@
+import { fitText } from "../../lib/text";
+import {
+  renderMarkdownRows,
+  wrapStyledSpans,
+  type MarkdownRow,
+  type MarkdownSpan,
+} from "../../markdown/markdownRows";
+import type { AppTheme } from "../../themes";
+import { ModalFrame } from "./ModalFrame";
+
+/**
+ * One painted line in the overview body. Prose rows expand into one or more
+ * `spans` lines (wrapped to the width after their prefix); structural rows map
+ * to `blank`/`rule`.
+ */
+type VisualLine =
+  | { kind: "blank" }
+  | { kind: "rule" }
+  | {
+      kind: "spans";
+      prefix: string;
+      prefixColor: string;
+      /** Overrides per-span color (used so all heading spans share one color). */
+      spanColor?: string;
+      spans: MarkdownSpan[];
+    };
+
+/** Pick a foreground color for an inline span from the theme. */
+function spanColor(span: MarkdownSpan, theme: AppTheme): string {
+  switch (span.kind) {
+    case "code":
+      return theme.accent;
+    case "link":
+      return theme.accent;
+    default:
+      return theme.text;
+  }
+}
+
+/** Left prefix for a block row (bullets, ordinals, quote bar, heading depth), indented by nesting level. */
+function rowPrefix(row: MarkdownRow): string {
+  const indent = "  ".repeat(Math.max(0, row.level ?? 0));
+  switch (row.kind) {
+    case "heading":
+      // Show the markdown hashes so heading depth (h1-h6) is visually distinct.
+      return `${"#".repeat(Math.min(6, Math.max(1, row.level ?? 1)))} `;
+    case "bullet":
+      return `${indent}• `;
+    case "ordered":
+      return `${indent}${row.ordinal ?? 1}. `;
+    case "quote":
+      return "│ ";
+    case "code":
+      return "  ";
+    default:
+      return "";
+  }
+}
+
+/**
+ * Expand one logical markdown row into the visual lines to paint, wrapping prose
+ * spans to the width left after the row's prefix. Code lines are truncated rather
+ * than word-wrapped; continuation lines keep the quote bar but otherwise indent.
+ */
+function toVisualLines(row: MarkdownRow, bodyWidth: number, theme: AppTheme): VisualLine[] {
+  if (row.kind === "blank") {
+    return [{ kind: "blank" }];
+  }
+  if (row.kind === "rule") {
+    return [{ kind: "rule" }];
+  }
+
+  const prefix = rowPrefix(row);
+  const available = Math.max(1, bodyWidth - prefix.length);
+
+  if (row.kind === "code") {
+    const text = row.spans.map((span) => span.text).join("");
+    return [
+      {
+        kind: "spans",
+        prefix,
+        prefixColor: theme.muted,
+        spanColor: theme.muted,
+        spans: [{ text: fitText(text, available), kind: "text" }],
+      },
+    ];
+  }
+
+  const isQuote = row.kind === "quote";
+  const prefixColor = isQuote ? theme.border : theme.muted;
+  // Headings paint every span in one accent color; other rows color per span kind.
+  const headingSpanColor = row.kind === "heading" ? theme.accent : undefined;
+  const continuationPrefix = isQuote ? prefix : " ".repeat(prefix.length);
+
+  return wrapStyledSpans(row.spans, available).map((spans, lineIndex) => ({
+    kind: "spans" as const,
+    prefix: lineIndex === 0 ? prefix : continuationPrefix,
+    prefixColor,
+    spanColor: headingSpanColor,
+    spans,
+  }));
+}
+
+/** Render the changeset overview (title + markdown description) as a modal overlay. */
+export function OverviewDialog({
+  title,
+  description,
+  summary,
+  terminalHeight,
+  terminalWidth,
+  theme,
+  onClose,
+}: {
+  title?: string;
+  description?: string;
+  summary?: string;
+  terminalHeight: number;
+  terminalWidth: number;
+  theme: AppTheme;
+  onClose: () => void;
+}) {
+  const width = Math.min(96, Math.max(60, terminalWidth - 8));
+  const bodyWidth = Math.max(1, width - 4);
+  // The overview prefers the agent's markdown description, falling back to the
+  // legacy plain-text summary when no description was provided.
+  const bodyMarkdown = description ?? summary;
+  const rows = bodyMarkdown ? renderMarkdownRows(bodyMarkdown, bodyWidth) : [];
+  const hasContent = Boolean(title) || rows.length > 0;
+
+  // Flatten logical rows into the visual lines we actually paint, wrapping prose
+  // spans to the width left after the row's prefix. Doing this up front lets the
+  // modal size itself to the real line count instead of one-line-per-row.
+  const visualLines = rows.flatMap((row) => toVisualLines(row, bodyWidth, theme));
+
+  // Title takes 2 rows (text + blank spacer); empty state takes 1; otherwise the
+  // visual line count.
+  const contentRowCount = (title ? 2 : 0) + (hasContent ? visualLines.length : 1);
+  // ModalFrame contributes border rows, title row, padding, and one blank spacer row.
+  const modalFrameChromeRowCount = 6;
+  const requiredHeight = contentRowCount + modalFrameChromeRowCount;
+  const modalHeight = Math.min(requiredHeight, Math.max(10, terminalHeight - 2));
+  const shouldScroll = modalHeight < requiredHeight;
+
+  const body = (
+    <box style={{ width: "100%", flexDirection: "column" }}>
+      {title ? (
+        <>
+          <box style={{ width: "100%", height: 1 }}>
+            <text fg={theme.accent}>{fitText(title, bodyWidth)}</text>
+          </box>
+          <box style={{ width: "100%", height: 1 }} />
+        </>
+      ) : null}
+      {!hasContent ? (
+        <box style={{ width: "100%", height: 1 }}>
+          <text fg={theme.muted}>{fitText("No description provided.", bodyWidth)}</text>
+        </box>
+      ) : null}
+      {visualLines.map((line, index) => {
+        if (line.kind === "blank") {
+          return <box key={`line:${index}`} style={{ width: "100%", height: 1 }} />;
+        }
+        if (line.kind === "rule") {
+          return (
+            <box key={`line:${index}`} style={{ width: "100%", height: 1 }}>
+              <text fg={theme.border}>{"─".repeat(bodyWidth)}</text>
+            </box>
+          );
+        }
+        // Render the whole line as one <text> with colored <span> children.
+        // A single text node preserves the spaces at span boundaries, which
+        // separate <text> nodes in a flex row would trim away.
+        return (
+          <box key={`line:${index}`} style={{ width: "100%", height: 1 }}>
+            <text>
+              {line.prefix ? <span fg={line.prefixColor}>{line.prefix}</span> : null}
+              {line.spans.map((span, spanIndex) => (
+                <span
+                  key={`span:${index}:${spanIndex}`}
+                  fg={line.spanColor ?? spanColor(span, theme)}
+                >
+                  {span.text}
+                </span>
+              ))}
+            </text>
+          </box>
+        );
+      })}
+    </box>
+  );
+
+  return (
+    <ModalFrame
+      height={modalHeight}
+      terminalHeight={terminalHeight}
+      terminalWidth={terminalWidth}
+      theme={theme}
+      title="Overview"
+      width={width}
+      onClose={onClose}
+    >
+      {shouldScroll ? (
+        <scrollbox focused={false} height="100%" scrollY={true} width="100%">
+          {body}
+        </scrollbox>
+      ) : (
+        body
+      )}
+    </ModalFrame>
+  );
+}

--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -3,7 +3,7 @@ import { flushSync } from "@opentui/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types";
 import { annotationRangeLabel, reviewNoteSource } from "../../lib/agentAnnotations";
-import { wrapText } from "../../lib/agentPopover";
+import { wrapText } from "../../lib/text";
 import { isEscapeKey, isSaveDraftNoteKey } from "../../lib/keyboard";
 import { sanitizeTerminalLine } from "../../../lib/terminalText";
 import { fitText, padText } from "../../lib/text";

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -23,7 +23,7 @@ import {
 } from "./rowStyle";
 import { type PlannedReviewRow } from "./reviewRenderPlan";
 import { inlineNoteTitle } from "../components/panes/AgentInlineNote";
-import { wrapText } from "../lib/agentPopover";
+import { wrapText } from "../lib/text";
 import { sanitizeTerminalLine, sanitizeTerminalSpans } from "../../lib/terminalText";
 import { measureTextWidth, padText as padTextByWidth, sliceTextByWidth } from "../lib/text";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -69,6 +69,9 @@ export interface UseAppKeyboardShortcutsOptions {
   selectLayoutMode: (mode: LayoutMode) => void;
   showAgentSkill: boolean;
   showHelp: boolean;
+  showOverview: boolean;
+  closeOverview: () => void;
+  toggleOverview: () => void;
   startUserNote: () => void;
   switchMenu: (delta: number) => void;
   toggleAgentNotes: () => void;
@@ -112,6 +115,9 @@ export function useAppKeyboardShortcuts({
   selectLayoutMode,
   showAgentSkill,
   showHelp,
+  showOverview,
+  closeOverview,
+  toggleOverview,
   startUserNote,
   switchMenu,
   toggleAgentNotes,
@@ -131,6 +137,7 @@ export function useAppKeyboardShortcuts({
   const pagerModeRef = useRef(pagerMode);
   const showAgentSkillRef = useRef(showAgentSkill);
   const showHelpRef = useRef(showHelp);
+  const showOverviewRef = useRef(showOverview);
   const themeSelectorOpenRef = useRef(themeSelectorOpen);
 
   activeMenuIdRef.current = activeMenuId;
@@ -138,6 +145,7 @@ export function useAppKeyboardShortcuts({
   pagerModeRef.current = pagerMode;
   showAgentSkillRef.current = showAgentSkill;
   showHelpRef.current = showHelp;
+  showOverviewRef.current = showOverview;
   themeSelectorOpenRef.current = themeSelectorOpen;
 
   const resolveJumpShortcut = (key: KeyEvent): JumpShortcut | null => {
@@ -269,6 +277,11 @@ export function useAppKeyboardShortcuts({
 
     if (showHelpRef.current) {
       closeHelp();
+      return true;
+    }
+
+    if (showOverviewRef.current) {
+      closeOverview();
       return true;
     }
 
@@ -532,6 +545,11 @@ export function useAppKeyboardShortcuts({
 
     if (key.name === "e" || key.sequence === "e") {
       runAndCloseMenu(triggerEditSelectedFile);
+      return;
+    }
+
+    if (key.name === "o" || key.sequence === "o") {
+      toggleOverview();
       return;
     }
 

--- a/src/ui/lib/agentPopover.ts
+++ b/src/ui/lib/agentPopover.ts
@@ -1,53 +1,8 @@
 import { sanitizeTerminalLine } from "../../lib/terminalText";
-import { fitText } from "./text";
+import { fitText, wrapText } from "./text";
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
-}
-
-/** Wrap plain text to a fixed terminal width, breaking long tokens when needed. */
-export function wrapText(text: string, width: number) {
-  if (width <= 0) {
-    return [""];
-  }
-
-  const normalized = sanitizeTerminalLine(text).trim().replace(/\s+/g, " ");
-  if (normalized.length === 0) {
-    return [""];
-  }
-
-  const words = normalized.split(" ");
-  const lines: string[] = [];
-  let current = "";
-
-  const pushCurrent = () => {
-    if (current.length > 0) {
-      lines.push(current);
-      current = "";
-    }
-  };
-
-  for (const word of words) {
-    if (word.length > width) {
-      pushCurrent();
-      for (let offset = 0; offset < word.length; offset += width) {
-        lines.push(word.slice(offset, offset + width));
-      }
-      continue;
-    }
-
-    const next = current.length === 0 ? word : `${current} ${word}`;
-    if (next.length <= width) {
-      current = next;
-      continue;
-    }
-
-    pushCurrent();
-    current = word;
-  }
-
-  pushCurrent();
-  return lines.length > 0 ? lines : [""];
 }
 
 /** Title shown above an agent note — author name if present, otherwise "AI note", with optional "i/n" suffix. */

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -22,7 +22,9 @@ export interface BuildAppMenusOptions {
   toggleAgentNotes: () => void;
   toggleFocusArea: () => void;
   openAgentSkill: () => void;
+  showOverview: boolean;
   toggleHelp: () => void;
+  toggleOverview: () => void;
   toggleHunkHeaders: () => void;
   toggleLineNumbers: () => void;
   toggleLineWrap: () => void;
@@ -53,7 +55,9 @@ export function buildAppMenus({
   toggleAgentNotes,
   toggleFocusArea,
   openAgentSkill,
+  showOverview,
   toggleHelp,
+  toggleOverview,
   toggleHunkHeaders,
   toggleLineNumbers,
   toggleLineWrap,
@@ -222,6 +226,13 @@ export function buildAppMenus({
         kind: "item",
         label: "Agent skill",
         action: openAgentSkill,
+      },
+      {
+        kind: "item",
+        label: "Overview",
+        hint: "o",
+        checked: showOverview,
+        action: toggleOverview,
       },
       { kind: "separator" },
       {

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -149,3 +149,48 @@ export function padText(text: string, width: number) {
   const trimmed = fitText(text, width);
   return `${trimmed}${" ".repeat(Math.max(0, width - measureTextWidth(trimmed)))}`;
 }
+
+/** Wrap plain text to a fixed terminal width, breaking long tokens when needed. */
+export function wrapText(text: string, width: number) {
+  if (width <= 0) {
+    return [""];
+  }
+
+  const normalized = sanitizeTerminalLine(text).trim().replace(/\s+/g, " ");
+  if (normalized.length === 0) {
+    return [""];
+  }
+
+  const words = normalized.split(" ");
+  const lines: string[] = [];
+  let current = "";
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      lines.push(current);
+      current = "";
+    }
+  };
+
+  for (const word of words) {
+    if (word.length > width) {
+      pushCurrent();
+      for (let offset = 0; offset < word.length; offset += width) {
+        lines.push(word.slice(offset, offset + width));
+      }
+      continue;
+    }
+
+    const next = current.length === 0 ? word : `${current} ${word}`;
+    if (next.length <= width) {
+      current = next;
+      continue;
+    }
+
+    pushCurrent();
+    current = word;
+  }
+
+  pushCurrent();
+  return lines.length > 0 ? lines : [""];
+}

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -9,7 +9,8 @@ import {
   nextMenuItemIndex,
   type MenuEntry,
 } from "../components/chrome/menu";
-import { buildAgentPopoverContent, resolveAgentPopoverPlacement, wrapText } from "./agentPopover";
+import { buildAgentPopoverContent, resolveAgentPopoverPlacement } from "./agentPopover";
+import { wrapText } from "./text";
 import { buildAppMenus } from "./appMenus";
 import {
   isCreateReviewNoteKey,
@@ -150,7 +151,9 @@ describe("ui helpers", () => {
       toggleAgentNotes: () => {},
       toggleFocusArea: () => {},
       openAgentSkill: () => {},
+      showOverview: false,
       toggleHelp: () => {},
+      toggleOverview: () => {},
       toggleHunkHeaders: () => {},
       toggleLineNumbers: () => {},
       toggleLineWrap: () => {},
@@ -192,7 +195,13 @@ describe("ui helpers", () => {
       menus.agent
         .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
         .map((entry) => entry.label),
-    ).toEqual(["Agent notes", "Agent skill", "Next annotated file", "Previous annotated file"]);
+    ).toEqual([
+      "Agent notes",
+      "Agent skill",
+      "Overview",
+      "Next annotated file",
+      "Previous annotated file",
+    ]);
   });
 
   test("keyboard alias helpers normalize the shared scroll shortcut keys", () => {

--- a/src/ui/markdown/markdownRows.test.ts
+++ b/src/ui/markdown/markdownRows.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { renderMarkdownRows, wrapStyledSpans } from "./markdownRows";
+
+describe("renderMarkdownRows", () => {
+  it("renders a heading with depth", () => {
+    const rows = renderMarkdownRows("# Title", 80);
+    expect(rows[0]?.kind).toBe("heading");
+    expect(rows[0]?.level).toBe(1);
+    expect(rows[0]?.spans.map((s) => s.text).join("")).toBe("Title");
+  });
+
+  it("renders inline emphasis and code spans", () => {
+    const rows = renderMarkdownRows("a **b** _c_ `d`", 80);
+    const para = rows.find((r) => r.kind === "paragraph");
+    const kinds = para?.spans.map((s) => `${s.kind}:${s.text}`);
+    expect(kinds).toEqual(["text:a ", "strong:b", "text: ", "em:c", "text: ", "code:d"]);
+  });
+
+  it("renders bullet list items with nesting level", () => {
+    const rows = renderMarkdownRows("- one\n- two\n  - nested", 80);
+    const bullets = rows.filter((r) => r.kind === "bullet");
+    expect(bullets).toHaveLength(3);
+    expect(bullets[2]?.level).toBe(1);
+    expect(bullets[0]?.spans.map((s) => s.text).join("")).toBe("one");
+  });
+
+  it("renders ordered list items with ordinals", () => {
+    const rows = renderMarkdownRows("1. first\n2. second", 80);
+    const ordered = rows.filter((r) => r.kind === "ordered");
+    expect(ordered.map((r) => r.ordinal)).toEqual([1, 2]);
+  });
+
+  it("renders blockquotes, rules, and links", () => {
+    const rows = renderMarkdownRows("> quoted\n\n---\n\n[text](https://x.dev)", 80);
+    expect(rows.some((r) => r.kind === "quote")).toBe(true);
+    expect(rows.some((r) => r.kind === "rule")).toBe(true);
+    const linkSpan = rows.flatMap((r) => r.spans).find((s) => s.kind === "link");
+    expect(linkSpan?.href).toBe("https://x.dev");
+  });
+
+  it("renders fenced code blocks as code rows carrying the language", () => {
+    const rows = renderMarkdownRows("```ts\nconst a = 1;\nconst b = 2;\n```", 80);
+    const code = rows.filter((r) => r.kind === "code");
+    expect(code).toHaveLength(2);
+    expect(code[0]?.language).toBe("ts");
+    expect(code[0]?.spans.map((s) => s.text).join("")).toBe("const a = 1;");
+  });
+
+  it("emits a single logical paragraph row (wrapping happens at render time)", () => {
+    const rows = renderMarkdownRows("aaa bbb ccc ddd", 7);
+    const paras = rows.filter((r) => r.kind === "paragraph");
+    expect(paras).toHaveLength(1);
+    expect(paras[0]?.spans.map((s) => s.text).join("")).toBe("aaa bbb ccc ddd");
+  });
+
+  it("falls back to a paragraph for unsupported tokens (e.g. tables)", () => {
+    const rows = renderMarkdownRows("| a | b |\n| - | - |\n| 1 | 2 |", 80);
+    // No throw; everything degrades to readable paragraph or blank rows.
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => ["paragraph", "blank"].includes(r.kind))).toBe(true);
+  });
+});
+
+describe("wrapStyledSpans", () => {
+  it("wraps to the given width without exceeding it", () => {
+    const lines = wrapStyledSpans([{ text: "aaa bbb ccc ddd", kind: "text" }], 7);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line.map((s) => s.text).join("").length).toBeLessThanOrEqual(7);
+    }
+  });
+
+  it("preserves inline span kinds across wrapped lines", () => {
+    // The leading bold word and a trailing code word must keep their kinds even
+    // though the content wraps to multiple lines.
+    const lines = wrapStyledSpans(
+      [
+        { text: "bold", kind: "strong" },
+        { text: " word word word word word word ", kind: "text" },
+        { text: "code", kind: "code" },
+      ],
+      10,
+    );
+    expect(lines.length).toBeGreaterThan(1);
+    const all = lines.flat();
+    expect(all.find((s) => s.text === "bold")?.kind).toBe("strong");
+    expect(all.find((s) => s.text === "code")?.kind).toBe("code");
+  });
+
+  it("hard-breaks a word longer than the width", () => {
+    const lines = wrapStyledSpans([{ text: "supercalifragilistic", kind: "text" }], 6);
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line.map((s) => s.text).join("").length).toBeLessThanOrEqual(6);
+    }
+    expect(
+      lines
+        .flat()
+        .map((s) => s.text)
+        .join(""),
+    ).toBe("supercalifragilistic");
+  });
+
+  it("returns a single empty line for empty input", () => {
+    expect(wrapStyledSpans([], 10)).toEqual([[{ text: "", kind: "text" }]]);
+  });
+});

--- a/src/ui/markdown/markdownRows.ts
+++ b/src/ui/markdown/markdownRows.ts
@@ -1,0 +1,233 @@
+import { marked, type Token, type Tokens } from "marked";
+import { measureTextWidth, wrapText } from "../lib/text";
+
+export type MarkdownSpanKind = "text" | "strong" | "em" | "code" | "link";
+export interface MarkdownSpan {
+  text: string;
+  kind: MarkdownSpanKind;
+  href?: string;
+}
+export type MarkdownRowKind =
+  | "heading"
+  | "paragraph"
+  | "bullet"
+  | "ordered"
+  | "quote"
+  | "rule"
+  | "code"
+  | "blank";
+export interface MarkdownRow {
+  kind: MarkdownRowKind;
+  level?: number;
+  ordinal?: number;
+  spans: MarkdownSpan[];
+  language?: string;
+}
+
+/** Flatten marked inline tokens into styled spans, recursing through emphasis/links. */
+function flattenInline(
+  tokens: Token[] | undefined,
+  kind: MarkdownSpanKind = "text",
+): MarkdownSpan[] {
+  if (!tokens) {
+    return [];
+  }
+  const spans: MarkdownSpan[] = [];
+  for (const token of tokens) {
+    switch (token.type) {
+      case "strong":
+        spans.push(...flattenInline((token as Tokens.Strong).tokens, "strong"));
+        break;
+      case "em":
+        spans.push(...flattenInline((token as Tokens.Em).tokens, "em"));
+        break;
+      case "codespan":
+        spans.push({ text: (token as Tokens.Codespan).text, kind: "code" });
+        break;
+      case "link": {
+        const link = token as Tokens.Link;
+        const inner = flattenInline(link.tokens, "link");
+        const text = inner.map((s) => s.text).join("") || link.href;
+        spans.push({ text, kind: "link", href: link.href });
+        break;
+      }
+      case "br":
+        spans.push({ text: " ", kind });
+        break;
+      default: {
+        const text = (token as Tokens.Text).text ?? "";
+        if (text) {
+          spans.push({ text, kind });
+        }
+      }
+    }
+  }
+  return spans;
+}
+
+/**
+ * Word-wrap a list of styled spans to a width, preserving each word's span kind
+ * (strong/em/code/link) across line breaks. Whitespace between words is collapsed
+ * to a single space and never starts a line; words longer than the width are
+ * hard-broken. Returns one entry per visual line; always at least one line.
+ */
+export function wrapStyledSpans(spans: MarkdownSpan[], width: number): MarkdownSpan[][] {
+  const max = Math.max(1, width);
+  const lines: MarkdownSpan[][] = [];
+  let line: MarkdownSpan[] = [];
+  let lineWidth = 0;
+
+  /** Push the current line (trimming a trailing space) and start a fresh one. */
+  const flush = () => {
+    const last = line.at(-1);
+    if (last) {
+      last.text = last.text.replace(/\s+$/, "");
+      if (last.text.length === 0) {
+        line.pop();
+      }
+    }
+    lines.push(line.length ? line : [{ text: "", kind: "text" }]);
+    line = [];
+    lineWidth = 0;
+  };
+
+  /** Append text to the current line, merging into the previous span when styling matches. */
+  const append = (text: string, span: MarkdownSpan) => {
+    const prev = line.at(-1);
+    if (prev && prev.kind === span.kind && prev.href === span.href) {
+      prev.text += text;
+    } else {
+      line.push(span.href ? { text, kind: span.kind, href: span.href } : { text, kind: span.kind });
+    }
+    lineWidth += measureTextWidth(text);
+  };
+
+  for (const span of spans) {
+    // Split into words while keeping the whitespace runs as their own parts.
+    for (const part of span.text.split(/(\s+)/)) {
+      if (!part) {
+        continue;
+      }
+      if (/^\s+$/.test(part)) {
+        // Collapse runs of whitespace to a single space; never start a line with one.
+        if (lineWidth > 0 && lineWidth < max) {
+          append(" ", span);
+        }
+        continue;
+      }
+      let word = part;
+      // Hard-break words that cannot fit on a line by themselves.
+      while (measureTextWidth(word) > max) {
+        if (lineWidth > 0) {
+          flush();
+        }
+        append(word.slice(0, max), span);
+        word = word.slice(max);
+        flush();
+      }
+      if (lineWidth > 0 && lineWidth + measureTextWidth(word) > max) {
+        flush();
+      }
+      append(word, span);
+    }
+  }
+  flush();
+  return lines;
+}
+
+/** Render block-level tokens into rows, tracking list nesting depth. */
+function renderTokens(tokens: Token[], width: number, depth: number): MarkdownRow[] {
+  const rows: MarkdownRow[] = [];
+  for (const token of tokens) {
+    switch (token.type) {
+      case "heading": {
+        const heading = token as Tokens.Heading;
+        rows.push({ kind: "heading", level: heading.depth, spans: flattenInline(heading.tokens) });
+        rows.push({ kind: "blank", spans: [] });
+        break;
+      }
+      case "paragraph": {
+        // Emit one logical row with the full styled spans; the renderer wraps
+        // to the available width (where the prefix/indent width is known).
+        const para = token as Tokens.Paragraph;
+        rows.push({ kind: "paragraph", spans: flattenInline(para.tokens) });
+        rows.push({ kind: "blank", spans: [] });
+        break;
+      }
+      case "list": {
+        const list = token as Tokens.List;
+        list.items.forEach((item, index) => {
+          const itemSpans = flattenInline(
+            item.tokens?.[0]?.type === "text" ? (item.tokens[0] as Tokens.Text).tokens : undefined,
+          );
+          rows.push({
+            kind: list.ordered ? "ordered" : "bullet",
+            level: depth,
+            ordinal: list.ordered ? Number(list.start || 1) + index : undefined,
+            spans: itemSpans.length ? itemSpans : [{ text: item.text, kind: "text" }],
+          });
+          // Recurse into nested block tokens (e.g. nested lists) at depth + 1.
+          const nested = (item.tokens ?? []).filter((t) => t.type === "list");
+          rows.push(...renderTokens(nested, width, depth + 1));
+        });
+        rows.push({ kind: "blank", spans: [] });
+        break;
+      }
+      case "blockquote": {
+        const quote = token as Tokens.Blockquote;
+        for (const inner of renderTokens(quote.tokens, Math.max(1, width - 2), depth)) {
+          rows.push(inner.kind === "blank" ? inner : { ...inner, kind: "quote" });
+        }
+        break;
+      }
+      case "code": {
+        const code = token as Tokens.Code;
+        for (const line of code.text.split("\n")) {
+          rows.push({
+            kind: "code",
+            language: code.lang || undefined,
+            spans: [{ text: line, kind: "text" }],
+          });
+        }
+        rows.push({ kind: "blank", spans: [] });
+        break;
+      }
+      case "hr":
+        rows.push({ kind: "rule", spans: [] });
+        break;
+      case "space":
+        rows.push({ kind: "blank", spans: [] });
+        break;
+      default: {
+        // Unsupported token (table, html, image, etc.): degrade to readable text.
+        const raw =
+          (token as { text?: string; raw?: string }).text ?? (token as { raw?: string }).raw ?? "";
+        for (const line of wrapText(raw.trim(), Math.max(1, width))) {
+          if (line) {
+            rows.push({ kind: "paragraph", spans: [{ text: line, kind: "text" }] });
+          }
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+/** Parse markdown into themeable rows. Tolerant: never throws on malformed input. */
+export function renderMarkdownRows(markdown: string, width: number): MarkdownRow[] {
+  let tokens: Token[];
+  try {
+    tokens = marked.lexer(markdown ?? "");
+  } catch {
+    return wrapText((markdown ?? "").trim(), Math.max(1, width)).map((line) => ({
+      kind: "paragraph" as const,
+      spans: [{ text: line, kind: "text" as const }],
+    }));
+  }
+  const rows = renderTokens(tokens, width, 0);
+  // Trim a trailing blank row for tidy modal sizing.
+  if (rows.at(-1)?.kind === "blank") {
+    rows.pop();
+  }
+  return rows;
+}

--- a/test/pty/overview-integration.test.ts
+++ b/test/pty/overview-integration.test.ts
@@ -1,0 +1,119 @@
+import { writeFileSync } from "node:fs";
+import { basename } from "node:path";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+
+/** Give PTY-backed startup and redraws enough headroom for slower CI machines. */
+setDefaultTimeout(30_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("PTY overview dialog", () => {
+  /**
+   * Build a file pair with an agent-context sidecar that has a top-level title
+   * and description so the auto-open behaviour can be exercised.
+   */
+  function createOverviewFilePair() {
+    const fixture = harness.createAgentFilePair();
+
+    // Write a richer sidecar that adds changeset-level title + description on top
+    // of the existing file annotations so both agent notes and the overview dialog
+    // can be tested in the same session.
+    writeFileSync(
+      fixture.agentContext,
+      JSON.stringify({
+        version: 1,
+        title: "PR title",
+        description: "# Summary\n\nHello overview",
+        files: [
+          {
+            path: basename(fixture.after),
+            annotations: [
+              {
+                newRange: [2, 2],
+                summary: "Adds bonus export.",
+                rationale: "Highlights the follow-up addition for review.",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    return fixture;
+  }
+
+  test("overview overlay auto-opens and can be toggled with o and Esc", async () => {
+    const fixture = createOverviewFilePair();
+    const session = await harness.launchHunk({
+      args: [
+        "diff",
+        fixture.before,
+        fixture.after,
+        "--mode",
+        "split",
+        "--agent-context",
+        fixture.agentContext,
+      ],
+      cols: 140,
+      rows: 24,
+    });
+
+    try {
+      // (1) Overview should auto-open because the sidecar has title + description.
+      const autoOpened = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("PR title") && text.includes("Hello overview"),
+        15_000,
+      );
+      expect(autoOpened).toContain("PR title");
+      expect(autoOpened).toContain("Hello overview");
+
+      // (2) Esc should close the overlay and reveal the diff stream.
+      await session.press("escape");
+      const afterEsc = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("Hello overview") && text.includes("after.ts"),
+        5_000,
+      );
+      expect(afterEsc).not.toContain("Hello overview");
+      expect(afterEsc).toContain("after.ts");
+
+      // (3) o should reopen the overlay.
+      await session.press("o");
+      const reopened = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("PR title"),
+        5_000,
+      );
+      expect(reopened).toContain("PR title");
+
+      // (4) Esc again should close it.
+      await session.press("escape");
+      const closedAgain = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("Hello overview"),
+        5_000,
+      );
+      expect(closedAgain).not.toContain("Hello overview");
+
+      // (5) o once more to reopen, then o again to toggle closed.
+      await session.press("o");
+      await harness.waitForSnapshot(session, (text) => text.includes("PR title"), 5_000);
+
+      await session.press("o");
+      const toggledClosed = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("Hello overview"),
+        5_000,
+      );
+      expect(toggledClosed).not.toContain("Hello overview");
+    } finally {
+      session.close();
+    }
+  });
+});


### PR DESCRIPTION
Agents can now set top-level `title` and `description` fields in the --agent-context JSON; Hunk displays them in a toggleable Overview overlay (`o`) that auto-opens once when a title or description is present.

Includes a pure markdown-to-rows renderer with heading level differentiation, wrapText moved to a shared text helper, and updated docs covering the agent-context JSON format.

The intended use case is that agent will conclude longer work session with updating the hunk session with the overview, explaining the whole changeset as people would do for PR-s