### PR TITLE
feat: highlight .mts and .cts files as TypeScript

### DIFF
--- a/.changeset/mts-cts-typescript-highlighting.md
+++ b/.changeset/mts-cts-typescript-highlighting.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Highlight `.mts` and `.cts` files as TypeScript instead of plain text.

--- a/src/core/diffFile.test.ts
+++ b/src/core/diffFile.test.ts
@@ -36,6 +36,14 @@ describe("buildDiffFile", () => {
     expect(file.stats).toEqual({ additions: 2, deletions: 1 });
   });
 
+  test("derives TypeScript language for module and commonjs TypeScript files", () => {
+    const mtsFile = buildDiffFile(metadataFor("a\n", "b\n", "foo.mts"), "PATCH", 0, "src", null);
+    const ctsFile = buildDiffFile(metadataFor("a\n", "b\n", "foo.cts"), "PATCH", 1, "src", null);
+
+    expect(mtsFile.language).toBe("typescript");
+    expect(ctsFile.language).toBe("typescript");
+  });
+
   test("infers binary status from the patch when not given explicitly", () => {
     const binary = buildDiffFile(metadata, "Binary files a/x and b/x differ\n", 0, "src", null);
     expect(binary.isBinary).toBe(true);

--- a/src/core/diffFile.ts
+++ b/src/core/diffFile.ts
@@ -1,7 +1,7 @@
-import { type FileDiffMetadata } from "@pierre/diffs";
+import { getFiletypeFromFileName, type FileDiffMetadata } from "@pierre/diffs";
 import { findAgentFileContext } from "./agent";
 import { patchLooksBinary } from "./binary";
-import { getLanguageForFileName } from "./fileLanguage";
+import "./fileLanguage";
 import { normalizeDiffMetadataPaths, normalizeDiffPath } from "./diffPaths";
 import type { FileSourceFetcher } from "./fileSource";
 import type { AgentContext, DiffFile, DiffLineMoveKinds } from "./types";
@@ -77,7 +77,7 @@ export function buildDiffFile(
     path,
     previousPath: resolvedPreviousPath,
     patch,
-    language: getLanguageForFileName(path) ?? undefined,
+    language: getFiletypeFromFileName(path) ?? undefined,
     stats: stats ?? countDiffStats(normalizedMetadata),
     metadata: normalizedMetadata,
     lineMoveKinds,

--- a/src/core/diffFile.ts
+++ b/src/core/diffFile.ts
@@ -1,7 +1,7 @@
-import { getFiletypeFromFileName, type FileDiffMetadata } from "@pierre/diffs";
+import { type FileDiffMetadata } from "@pierre/diffs";
 import { findAgentFileContext } from "./agent";
 import { patchLooksBinary } from "./binary";
-import "./fileLanguage";
+import { getFiletypeFromFileName } from "./fileLanguage";
 import { normalizeDiffMetadataPaths, normalizeDiffPath } from "./diffPaths";
 import type { FileSourceFetcher } from "./fileSource";
 import type { AgentContext, DiffFile, DiffLineMoveKinds } from "./types";

--- a/src/core/diffFile.ts
+++ b/src/core/diffFile.ts
@@ -1,6 +1,7 @@
-import { getFiletypeFromFileName, type FileDiffMetadata } from "@pierre/diffs";
+import { type FileDiffMetadata } from "@pierre/diffs";
 import { findAgentFileContext } from "./agent";
 import { patchLooksBinary } from "./binary";
+import { getLanguageForFileName } from "./fileLanguage";
 import { normalizeDiffMetadataPaths, normalizeDiffPath } from "./diffPaths";
 import type { FileSourceFetcher } from "./fileSource";
 import type { AgentContext, DiffFile, DiffLineMoveKinds } from "./types";
@@ -76,7 +77,7 @@ export function buildDiffFile(
     path,
     previousPath: resolvedPreviousPath,
     patch,
-    language: getFiletypeFromFileName(path) ?? undefined,
+    language: getLanguageForFileName(path) ?? undefined,
     stats: stats ?? countDiffStats(normalizedMetadata),
     metadata: normalizedMetadata,
     lineMoveKinds,

--- a/src/core/fileLanguage.test.ts
+++ b/src/core/fileLanguage.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { getLanguageForFileName } from "./fileLanguage";
+
+describe("getLanguageForFileName", () => {
+  test("maps TypeScript module/commonjs extensions to typescript", () => {
+    expect(getLanguageForFileName("foo.mts")).toBe("typescript");
+    expect(getLanguageForFileName("foo.cts")).toBe("typescript");
+    expect(getLanguageForFileName("src/nested/foo.mts")).toBe("typescript");
+  });
+
+  test("preserves Pierre's built-in extension detection", () => {
+    expect(getLanguageForFileName("foo.ts")).toBe("typescript");
+    expect(getLanguageForFileName("foo.tsx")).toBe("tsx");
+    expect(getLanguageForFileName("foo.mjs")).toBe("javascript");
+    expect(getLanguageForFileName("foo.cjs")).toBe("javascript");
+  });
+});

--- a/src/core/fileLanguage.test.ts
+++ b/src/core/fileLanguage.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getFiletypeFromFileName } from "@pierre/diffs";
-import "./fileLanguage";
+import { getFiletypeFromFileName } from "./fileLanguage";
 
 describe("custom file language registration", () => {
   test("maps TypeScript module/commonjs extensions to typescript", () => {

--- a/src/core/fileLanguage.test.ts
+++ b/src/core/fileLanguage.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { getLanguageForFileName } from "./fileLanguage";
+import { getFiletypeFromFileName } from "@pierre/diffs";
+import "./fileLanguage";
 
-describe("getLanguageForFileName", () => {
+describe("custom file language registration", () => {
   test("maps TypeScript module/commonjs extensions to typescript", () => {
-    expect(getLanguageForFileName("foo.mts")).toBe("typescript");
-    expect(getLanguageForFileName("foo.cts")).toBe("typescript");
-    expect(getLanguageForFileName("src/nested/foo.mts")).toBe("typescript");
+    expect(getFiletypeFromFileName("foo.mts")).toBe("typescript");
+    expect(getFiletypeFromFileName("foo.cts")).toBe("typescript");
+    expect(getFiletypeFromFileName("src/nested/foo.mts")).toBe("typescript");
   });
 
   test("preserves Pierre's built-in extension detection", () => {
-    expect(getLanguageForFileName("foo.ts")).toBe("typescript");
-    expect(getLanguageForFileName("foo.tsx")).toBe("tsx");
-    expect(getLanguageForFileName("foo.mjs")).toBe("javascript");
-    expect(getLanguageForFileName("foo.cjs")).toBe("javascript");
+    expect(getFiletypeFromFileName("foo.ts")).toBe("typescript");
+    expect(getFiletypeFromFileName("foo.tsx")).toBe("tsx");
+    expect(getFiletypeFromFileName("foo.mjs")).toBe("javascript");
+    expect(getFiletypeFromFileName("foo.cjs")).toBe("javascript");
   });
 });

--- a/src/core/fileLanguage.ts
+++ b/src/core/fileLanguage.ts
@@ -19,24 +19,14 @@ const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
   cts: "typescript",
 };
 
-let registered = false;
-
-/** Register Hunk's extra extension mappings with Pierre exactly once. */
-function ensureCustomExtensionsRegistered(): void {
-  if (registered) return;
-  registered = true;
-  for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
-    setCustomExtension(extension, language);
-  }
+for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
+  setCustomExtension(extension, language);
 }
-
-ensureCustomExtensionsRegistered();
 
 /**
  * Resolve the highlight language for a file path, applying Hunk's custom
  * extension mappings on top of Pierre's built-in detection.
  */
 export function getLanguageForFileName(fileName: string): SupportedLanguages {
-  ensureCustomExtensionsRegistered();
   return getFiletypeFromFileName(fileName);
 }

--- a/src/core/fileLanguage.ts
+++ b/src/core/fileLanguage.ts
@@ -1,0 +1,42 @@
+import {
+  getFiletypeFromFileName,
+  setCustomExtension,
+  type SupportedLanguages,
+} from "@pierre/diffs";
+
+/**
+ * File extensions Pierre's built-in map does not cover but that Hunk wants to
+ * highlight as an existing language.
+ *
+ * Pierre maps `mjs`/`cjs` to JavaScript but omits the TypeScript equivalents
+ * `mts`/`cts`, so they fall back to plain text. Registering them as custom
+ * extensions teaches both our own language detection and Pierre's renderer
+ * (including its highlight workers, which receive the custom-extension map) to
+ * treat them as TypeScript.
+ */
+const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
+  mts: "typescript",
+  cts: "typescript",
+};
+
+let registered = false;
+
+/** Register Hunk's extra extension mappings with Pierre exactly once. */
+function ensureCustomExtensionsRegistered(): void {
+  if (registered) return;
+  registered = true;
+  for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
+    setCustomExtension(extension, language);
+  }
+}
+
+ensureCustomExtensionsRegistered();
+
+/**
+ * Resolve the highlight language for a file path, applying Hunk's custom
+ * extension mappings on top of Pierre's built-in detection.
+ */
+export function getLanguageForFileName(fileName: string): SupportedLanguages {
+  ensureCustomExtensionsRegistered();
+  return getFiletypeFromFileName(fileName);
+}

--- a/src/core/fileLanguage.ts
+++ b/src/core/fileLanguage.ts
@@ -4,16 +4,7 @@ import {
   type SupportedLanguages,
 } from "@pierre/diffs";
 
-/**
- * File extensions Pierre's built-in map does not cover but that Hunk wants to
- * highlight as an existing language.
- *
- * Pierre maps `mjs`/`cjs` to JavaScript but omits the TypeScript equivalents
- * `mts`/`cts`, so they fall back to plain text. Registering them as custom
- * extensions teaches both our own language detection and Pierre's renderer
- * (including its highlight workers, which receive the custom-extension map) to
- * treat them as TypeScript.
- */
+// Pierre omits these TypeScript extensions, so register them before lookups or rendering.
 const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
   mts: "typescript",
   cts: "typescript",
@@ -23,10 +14,7 @@ for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
   setCustomExtension(extension, language);
 }
 
-/**
- * Resolve the highlight language for a file path, applying Hunk's custom
- * extension mappings on top of Pierre's built-in detection.
- */
+/** Return the syntax highlight language for a file path or name. */
 export function getLanguageForFileName(fileName: string): SupportedLanguages {
   return getFiletypeFromFileName(fileName);
 }

--- a/src/core/fileLanguage.ts
+++ b/src/core/fileLanguage.ts
@@ -1,4 +1,8 @@
-import { setCustomExtension, type SupportedLanguages } from "@pierre/diffs";
+import {
+  getFiletypeFromFileName,
+  setCustomExtension,
+  type SupportedLanguages,
+} from "@pierre/diffs";
 
 // Pierre omits these TypeScript extensions, so register them before lookups or rendering.
 const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
@@ -9,3 +13,5 @@ const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
 for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
   setCustomExtension(extension, language);
 }
+
+export { getFiletypeFromFileName };

--- a/src/core/fileLanguage.ts
+++ b/src/core/fileLanguage.ts
@@ -1,8 +1,4 @@
-import {
-  getFiletypeFromFileName,
-  setCustomExtension,
-  type SupportedLanguages,
-} from "@pierre/diffs";
+import { setCustomExtension, type SupportedLanguages } from "@pierre/diffs";
 
 // Pierre omits these TypeScript extensions, so register them before lookups or rendering.
 const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
@@ -12,9 +8,4 @@ const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
 
 for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
   setCustomExtension(extension, language);
-}
-
-/** Return the syntax highlight language for a file path or name. */
-export function getLanguageForFileName(fileName: string): SupportedLanguages {
-  return getFiletypeFromFileName(fileName);
 }


### PR DESCRIPTION
[Node has native support for TypeScript](https://nodejs.org/learn/typescript/run-natively), but it treats `.ts` files differently based on if your package.json type is ESM/CJS.

To get consistent behavior they use `.cts` or `.mts` so the script is treated as CJS/ESM even if it does not line up with the package type.

pierre (and hunk) don't support these extensions by default for syntax highlighting:
<img width="270" height="205" alt="image" src="https://github.com/user-attachments/assets/2872eb68-b927-460b-9548-3d4a1348628c" />

with the custom extensions we get the expected syntax highlighting:
<img width="260" height="222" alt="image" src="https://github.com/user-attachments/assets/09639839-da61-4713-bb65-2c21e99e7bcc" />

There's also [a PR to pierre](https://github.com/pierrecomputer/pierre/pull/893) for adding `mts` and `cts` to their file type map so this will hopefully not be needed in the long term.