### PR TITLE
feat(watch): live-reload theme and chrome on config change

### DIFF
--- a/.changeset/live-config-reload.md
+++ b/.changeset/live-config-reload.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Live-reload the theme and chrome whenever Hunk's config changes — no `--watch` required. The viewer always polls the global (`~/.config/hunk/config.toml`) and repo-local (`.hunk/config.toml`) config files and reloads through the existing reload path on change, the way VS Code / Cursor apply settings on save — so edits to `[custom_theme]`, layout, and other view options take effect without restarting the viewer. In `--watch` mode the same loop additionally tracks the diff input.

--- a/src/core/watch.test.ts
+++ b/src/core/watch.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { computeWatchSignature } from "./watch";
+import { computeConfigSignature, computeWatchSignature } from "./watch";
 import type { CliInput } from "./types";
 
 const tempDirs: string[] = [];
@@ -151,5 +151,66 @@ describe("computeWatchSignature", () => {
     );
 
     expect(changedSignature).not.toEqual(initialSignature);
+  });
+});
+
+describe("computeConfigSignature", () => {
+  const previousXdg = process.env.XDG_CONFIG_HOME;
+
+  afterEach(() => {
+    if (previousXdg === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = previousXdg;
+    }
+  });
+
+  test("marks a missing global config without throwing", () => {
+    const configHome = realpathSync(mkdtempSync(join(tmpdir(), "hunk-cfg-missing-")));
+    tempDirs.push(configHome);
+    process.env.XDG_CONFIG_HOME = configHome;
+
+    const nonRepo = realpathSync(mkdtempSync(join(tmpdir(), "hunk-cfg-nonrepo-")));
+    tempDirs.push(nonRepo);
+
+    const signature = computeConfigSignature(nonRepo);
+
+    expect(signature).toContain(join(configHome, "hunk", "config.toml"));
+    expect(signature).toContain(":missing");
+  });
+
+  test("changes when the global config file changes", () => {
+    const configHome = realpathSync(mkdtempSync(join(tmpdir(), "hunk-cfg-change-")));
+    tempDirs.push(configHome);
+    process.env.XDG_CONFIG_HOME = configHome;
+    mkdirSync(join(configHome, "hunk"), { recursive: true });
+    const configPath = join(configHome, "hunk", "config.toml");
+
+    const nonRepo = realpathSync(mkdtempSync(join(tmpdir(), "hunk-cfg-change-cwd-")));
+    tempDirs.push(nonRepo);
+
+    writeFileSync(configPath, 'theme = "custom"\n');
+    const initialSignature = computeConfigSignature(nonRepo);
+
+    writeFileSync(configPath, 'theme = "custom"\nborderless = true\n');
+    const changedSignature = computeConfigSignature(nonRepo);
+
+    expect(initialSignature).not.toContain(":missing");
+    expect(changedSignature).not.toEqual(initialSignature);
+  });
+
+  test("includes the repo-local .hunk/config.toml when inside a repo", () => {
+    const configHome = realpathSync(mkdtempSync(join(tmpdir(), "hunk-cfg-repo-home-")));
+    tempDirs.push(configHome);
+    process.env.XDG_CONFIG_HOME = configHome;
+
+    const repo = createTempRepo("hunk-cfg-repo-");
+    mkdirSync(join(repo, ".hunk"), { recursive: true });
+    writeFileSync(join(repo, ".hunk", "config.toml"), "menu_bar = false\n");
+
+    const signature = computeConfigSignature(repo);
+
+    expect(signature).toContain(join(repo, ".hunk", "config.toml"));
+    expect(signature).not.toContain(`${join(repo, ".hunk", "config.toml")}:missing`);
   });
 });

--- a/src/core/watch.ts
+++ b/src/core/watch.ts
@@ -1,5 +1,12 @@
 import fs from "node:fs";
-import { createVcsWatchSignature, getConfiguredVcsAdapter, operationFromInput } from "./vcs";
+import path from "node:path";
+import { resolveGlobalConfigPath } from "./paths";
+import {
+  createVcsWatchSignature,
+  findVcsRepoRootCandidate,
+  getConfiguredVcsAdapter,
+  operationFromInput,
+} from "./vcs";
 import type { CliInput } from "./types";
 
 /** Return whether the current input can be rebuilt from files or VCS state without rereading stdin. */
@@ -51,6 +58,25 @@ export function computeWatchSignature(input: CliInput) {
 
   if (input.options.agentContext && input.options.agentContext !== "-") {
     parts.push(`agent:${statSignature(input.options.agentContext)}`);
+  }
+
+  return parts.join("\n---\n");
+}
+
+/** Compute a change-detection signature over Hunk's config files (global +
+ *  repo-local), so a viewer in --watch mode can notice theme/chrome edits and
+ *  live-reload — mirrors the diff-input watcher but for configuration. */
+export function computeConfigSignature(cwd: string = process.cwd()) {
+  const parts: string[] = [];
+
+  const globalConfigPath = resolveGlobalConfigPath();
+  if (globalConfigPath) {
+    parts.push(statSignature(globalConfigPath));
+  }
+
+  const repoRoot = findVcsRepoRootCandidate(cwd);
+  if (repoRoot) {
+    parts.push(statSignature(path.join(repoRoot, ".hunk", "config.toml")));
   }
 
   return parts.join("\n---\n");

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -6,7 +6,7 @@ import {
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import type { AppBootstrap, CliInput, LayoutMode, UserNoteLineTarget } from "../core/types";
-import { canReloadInput, computeWatchSignature } from "../core/watch";
+import { canReloadInput, computeConfigSignature, computeWatchSignature } from "../core/watch";
 import type { HunkSessionBrokerClient, ReloadedSessionResult } from "../hunk-session/types";
 import { MenuBar } from "./components/chrome/MenuBar";
 import { StatusBar } from "./components/chrome/StatusBar";
@@ -583,18 +583,27 @@ export function App({
     triggerRefreshCurrentInput,
   ]);
 
+  // Always live-reload when Hunk's config files (~/.config/hunk/config.toml,
+  // repo-local .hunk/config.toml) change — theme/chrome edits repaint immediately,
+  // the way VS Code / Cursor apply settings on save, no --watch required. In
+  // --watch mode this same loop ALSO tracks the diff input. Folding both into one
+  // poll keeps a single in-flight guard, so a config reload can never race a diff
+  // reload. Reusing refreshCurrentInput re-reads config — so palette edits repaint
+  // live — while preserving the active view options (and any CLI overrides).
   useEffect(() => {
-    if (!watchEnabled) {
+    if (!canRefreshCurrentInput) {
       return;
     }
 
     let cancelled = false;
     let polling = false;
     let refreshing = false;
-    let lastSignature: string;
+    let lastInputSignature: string;
+    let lastConfigSignature: string;
 
     try {
-      lastSignature = computeWatchSignature(bootstrap.input);
+      lastInputSignature = watchEnabled ? computeWatchSignature(bootstrap.input) : "";
+      lastConfigSignature = computeConfigSignature();
     } catch (error) {
       console.error("Failed to initialize watch mode.", error);
       return;
@@ -608,20 +617,25 @@ export function App({
       polling = true;
 
       try {
-        const nextSignature = computeWatchSignature(bootstrap.input);
-        if (nextSignature !== lastSignature) {
-          lastSignature = nextSignature;
+        const nextInputSignature = watchEnabled ? computeWatchSignature(bootstrap.input) : "";
+        const nextConfigSignature = computeConfigSignature();
+        if (
+          nextInputSignature !== lastInputSignature ||
+          nextConfigSignature !== lastConfigSignature
+        ) {
+          lastInputSignature = nextInputSignature;
+          lastConfigSignature = nextConfigSignature;
           refreshing = true;
           void refreshCurrentInput()
             .catch((error) => {
-              console.error("Failed to auto-reload the current diff.", error);
+              console.error("Failed to auto-reload after a watched change.", error);
             })
             .finally(() => {
               refreshing = false;
             });
         }
       } catch (error) {
-        console.error("Failed to poll watch mode input.", error);
+        console.error("Failed to poll watch mode.", error);
       } finally {
         polling = false;
       }
@@ -632,7 +646,7 @@ export function App({
       cancelled = true;
       clearInterval(interval);
     };
-  }, [bootstrap.input, refreshCurrentInput, watchEnabled]);
+  }, [bootstrap.input, canRefreshCurrentInput, refreshCurrentInput, watchEnabled]);
 
   /** Leave the app through the shared shutdown path. */
   const requestQuit = useCallback(() => {


### PR DESCRIPTION
## Summary

When running `hunk diff --watch`, the viewer now live-reloads its theme and chrome the moment Hunk's config changes — no restart required. Previously `--watch` only tracked the diff input, so editing `~/.config/hunk/config.toml` (e.g. switching a `[custom_theme]` palette from a theming tool) had no effect until you quit and relaunched.

## What this adds

The watch loop now also watches Hunk's config files and reloads on change:

- The global config (`~/.config/hunk/config.toml`) and the repo-local config (`.hunk/config.toml`) are folded into the existing diff-input watch poll via a new `computeConfigSignature()` in `core/watch.ts`.
- Keeping it in the **same** poll loop means there's a single in-flight guard, so a config reload can never race the diff reload.
- On any change (input or config) it reuses `refreshCurrentInput()`, which re-runs the normal config resolution pipeline — so freshly-read `[custom_theme]` / `[custom_theme.syntax]` palettes repaint live — while preserving the active view options and any CLI overrides (no `--theme`/`--mode` flag gets silently clobbered by config).

Only active in `--watch` mode, so default one-shot reviews are unchanged.

## Testing

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test:theme-contrast`
- `bun test src/core/watch.test.ts` — added unit coverage for `computeConfigSignature` (missing global config, change detection, repo-local `.hunk/config.toml` pickup)
- Real render smoke test: ran `hunk diff --watch` against a repo, switched the active theme so a tool rewrote `[custom_theme]`, and confirmed the running viewer repainted from a dark to a light palette (background `#2D2B55` → `#f9f9f9`, panels and diff bands updated) without a restart, and back again.