### PR TITLE
test(pty): isolate integration tests from ambient user config

### DIFF
--- a/.changeset/isolate-pty-config.md
+++ b/.changeset/isolate-pty-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Isolate PTY integration tests from the developer's ambient Hunk user config/state so snapshots assert against built-in defaults. No user-visible change.

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -195,6 +195,14 @@ export function createPtyHarness() {
     return dir;
   }
 
+  // Isolate every launch from the developer's ambient user config/state so PTY snapshots assert
+  // against built-in defaults instead of whatever ~/.config/hunk/config.toml happens to set.
+  let isolatedConfigHome: string | undefined;
+  function configHome() {
+    isolatedConfigHome ??= makeTempDir("hunk-tuistory-config-");
+    return isolatedConfigHome;
+  }
+
   function cleanup() {
     while (tempDirs.length > 0) {
       const dir = tempDirs.pop();
@@ -631,6 +639,7 @@ export function createPtyHarness() {
       rows: options.rows ?? 24,
       env: {
         ...process.env,
+        XDG_CONFIG_HOME: configHome(),
         HUNK_MCP_DISABLE: "1",
         HUNK_DISABLE_UPDATE_NOTICE: "1",
         ...options.env,
@@ -656,6 +665,7 @@ export function createPtyHarness() {
       rows: options.rows ?? 24,
       env: {
         ...process.env,
+        XDG_CONFIG_HOME: configHome(),
         HUNK_MCP_DISABLE: "1",
         HUNK_DISABLE_UPDATE_NOTICE: "1",
         ...options.env,


### PR DESCRIPTION
## What's Changed

PTY integration launches passed `env: process.env` straight through to the spawned terminal, so tests silently inherited whatever Hunk user config the developer had on disk.

A local `~/.config/hunk/config.toml` with `wrap_lines = true` deterministically failed 7 layout assertions (`real PTY sessions can toggle wrapped lines`, the arrow-key horizontal-scroll tests, etc.) because the diff rendered wrapped when the tests assumed the built-in unwrapped default. CI passed only because it has no user config — exactly the kind of "works on CI, fails locally" inconsistency that makes the suite feel flaky.

## Fix

Point every PTY launch (`launchHunk`, `launchShellCommand`, and the file-backed-stdin path) at a fresh empty `XDG_CONFIG_HOME` owned by the harness. Hunk resolves user config/state from that dir first, so snapshots now assert against built-in defaults regardless of the developer's environment. The temp dir is tracked and cleaned up like the other fixtures.

## Verification

- Full `bun test ./test/pty`: **50 pass / 0 fail** (was 43 pass / 7 fail locally before the change).
- `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)