### PR TITLE
Recommend installation from the main homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm i -g hunkdiff
 Or with Homebrew:
 
 ```bash
-brew install modem-dev/tap/hunk
+brew install hunk
 ```
 
 Requirements:


### PR DESCRIPTION
It is now available there, is more up to date than the custom tap, and doesn't need to be trusted with homebrew's new trust system.