### PR TITLE
fix: confirm before quitting when unsaved review work would be lost

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -49,6 +49,9 @@ const LazyHelpDialog = lazy(async () => ({
 const LazyMenuDropdown = lazy(async () => ({
   default: (await import("./components/chrome/MenuDropdown")).MenuDropdown,
 }));
+const LazyQuitConfirmDialog = lazy(async () => ({
+  default: (await import("./components/chrome/QuitConfirmDialog")).QuitConfirmDialog,
+}));
 const LazyThemeSelectorDialog = lazy(async () => ({
   default: (await import("./components/chrome/ThemeSelectorDialog")).ThemeSelectorDialog,
 }));
@@ -146,6 +149,7 @@ export function App({
   const [forceSidebarOpen, setForceSidebarOpen] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showAgentSkill, setShowAgentSkill] = useState(false);
+  const [quitConfirmOpen, setQuitConfirmOpen] = useState(false);
   const [focusArea, setFocusArea] = useState<FocusArea>("files");
   const [activeAddNoteTarget, setActiveAddNoteTarget] = useState<ActiveAddNoteTarget | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(34);
@@ -182,6 +186,8 @@ export function App({
     [activeTheme.id, themeOptions],
   );
   const review = useReviewController({ files: bootstrap.changeset.files });
+  const hasReviewWorkToLose =
+    review.reviewNoteCount > 0 || review.liveCommentCount > 0 || review.draftNote !== null;
   const filteredFiles = review.visibleFiles;
   const selectedFile = review.selectedFile;
   const selectedHunkIndex = review.selectedHunkIndex;
@@ -646,8 +652,24 @@ export function App({
 
   /** Leave the app through the shared shutdown path. */
   const requestQuit = useCallback(() => {
+    if (hasReviewWorkToLose) {
+      setQuitConfirmOpen(true);
+      return;
+    }
+
+    onQuit();
+  }, [hasReviewWorkToLose, onQuit]);
+
+  /** Confirm quitting after the user acknowledges review notes will be discarded. */
+  const confirmQuit = useCallback(() => {
+    setQuitConfirmOpen(false);
     onQuit();
   }, [onQuit]);
+
+  /** Keep the current review open after an accidental quit shortcut. */
+  const cancelQuit = useCallback(() => {
+    setQuitConfirmOpen(false);
+  }, []);
 
   /** Close the modal keyboard help overlay. */
   const closeHelp = useCallback(() => {
@@ -824,7 +846,9 @@ export function App({
     closeAgentSkill,
     closeHelp,
     closeMenu,
+    confirmQuit,
     acceptThemeSelector,
+    cancelQuit,
     cancelDraftNote,
     closeThemeSelector,
     focusArea,
@@ -837,6 +861,7 @@ export function App({
     openMenu,
     openThemeSelector,
     pagerMode,
+    quitConfirmOpen,
     requestQuit,
     scrollCodeHorizontally,
     saveDraftNote,
@@ -1125,6 +1150,18 @@ export function App({
             onClose={closeThemeSelector}
             onPickItem={pickThemeSelectorItem}
             onScroll={moveThemeSelector}
+          />
+        </Suspense>
+      ) : null}
+
+      {quitConfirmOpen ? (
+        <Suspense fallback={null}>
+          <LazyQuitConfirmDialog
+            terminalHeight={terminal.height}
+            terminalWidth={terminal.width}
+            theme={baseTheme}
+            onCancel={cancelQuit}
+            onConfirm={confirmQuit}
           />
         </Suspense>
       ) : null}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -187,7 +187,7 @@ export function App({
   );
   const review = useReviewController({ files: bootstrap.changeset.files });
   const hasReviewWorkToLose =
-    review.reviewNoteCount > 0 || review.liveCommentCount > 0 || review.draftNote !== null;
+    review.userNoteCount > 0 || review.liveCommentCount > 0 || review.draftNote !== null;
   const filteredFiles = review.visibleFiles;
   const selectedFile = review.selectedFile;
   const selectedHunkIndex = review.selectedHunkIndex;

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -148,6 +148,28 @@ function createBootstrap(initialMode: LayoutMode = "split", pager = false): AppB
   });
 }
 
+function createNoReviewBootstrap(initialMode: LayoutMode = "split", pager = false): AppBootstrap {
+  return createTestVcsAppBootstrap({
+    changesetId: "changeset:app-no-review-work",
+    files: [
+      createTestDiffFile(
+        "alpha",
+        "alpha.ts",
+        "export const alpha = 1;\n",
+        "export const alpha = 2;\nexport const add = true;\n",
+      ),
+      createTestDiffFile(
+        "beta",
+        "beta.ts",
+        "export const beta = 1;\n",
+        "export const betaValue = 1;\n",
+      ),
+    ],
+    initialMode,
+    pager,
+  });
+}
+
 function createSingleFileBootstrap(): AppBootstrap {
   return createTestVcsAppBootstrap({
     changesetId: "changeset:app-single-file",
@@ -3356,10 +3378,10 @@ describe("App interactions", () => {
     }
   });
 
-  test("quit shortcuts route through the provided onQuit handler in regular and pager modes", async () => {
+  test("quit shortcuts route through the provided onQuit handler without review notes", async () => {
     const regularQuit = mock(() => undefined);
     const regularSetup = await testRender(
-      <AppHost bootstrap={createBootstrap()} onQuit={regularQuit} />,
+      <AppHost bootstrap={createNoReviewBootstrap()} onQuit={regularQuit} />,
       { width: 220, height: 24 },
     );
 
@@ -3379,7 +3401,7 @@ describe("App interactions", () => {
 
     const pagerQuit = mock(() => undefined);
     const pagerSetup = await testRender(
-      <AppHost bootstrap={createBootstrap("auto", true)} onQuit={pagerQuit} />,
+      <AppHost bootstrap={createNoReviewBootstrap("auto", true)} onQuit={pagerQuit} />,
       { width: 180, height: 20 },
     );
 
@@ -3394,6 +3416,175 @@ describe("App interactions", () => {
     } finally {
       await act(async () => {
         pagerSetup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit confirmation protects saved review notes until confirmed", async () => {
+    const onQuit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createNoReviewBootstrap()} onQuit={onQuit} />,
+      { width: 220, height: 24, useKittyKeyboard: null },
+    );
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("Keep this note.");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.pressKeys(["\u001b[115;5u"]);
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Quit review?"));
+
+      expect(onQuit).toHaveBeenCalledTimes(0);
+      expect(frame).toContain("comments or notes");
+
+      await act(async () => {
+        await setup.mockInput.typeText("t");
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame).toContain("Quit review?");
+      expect(frame).not.toContain("Theme selector");
+
+      await act(async () => {
+        await setup.mockInput.typeText("n");
+      });
+      frame = await waitForFrame(setup, (nextFrame) => !nextFrame.includes("Quit review?"));
+
+      expect(frame).not.toContain("Quit review?");
+      expect(onQuit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await waitForFrame(setup, (nextFrame) => nextFrame.includes("Quit review?"));
+
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flush(setup);
+
+      expect(onQuit).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit confirmation protects live comments until confirmed", async () => {
+    const onQuit = mock(() => undefined);
+    const { dispatchCommand, hostClient } = createMockHostClient();
+    const setup = await testRender(
+      <AppHost bootstrap={createNoReviewBootstrap()} hostClient={hostClient} onQuit={onQuit} />,
+      { width: 220, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await dispatchCommand({
+          type: "command",
+          requestId: "quit-comment-1",
+          command: "comment",
+          input: {
+            sessionId: "session-1",
+            filePath: "alpha.ts",
+            side: "new",
+            line: 1,
+            summary: "Do not lose this live comment.",
+            reveal: true,
+          },
+        });
+      });
+
+      await waitForFrame(setup, (frame) => frame.includes("Do not lose this live comment."));
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      const frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Quit review?"));
+
+      expect(frame).toContain("Quit review?");
+      expect(onQuit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await flush(setup);
+
+      expect(onQuit).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit confirmation protects draft notes and treats Escape as gated quit when closed", async () => {
+    const onQuit = mock(() => undefined);
+    const setup = await testRender(
+      <AppHost bootstrap={createNoReviewBootstrap()} onQuit={onQuit} />,
+      { width: 220, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("c");
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockMouse.click(6, 4);
+      });
+      await flush(setup);
+
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Quit review?"));
+
+      expect(frame).toContain("Quit review?");
+      expect(onQuit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.pressEscape();
+      });
+      frame = await waitForFrame(setup, (nextFrame) => !nextFrame.includes("Quit review?"));
+
+      expect(frame).not.toContain("Quit review?");
+      expect(frame).toContain("Draft note");
+      expect(onQuit).toHaveBeenCalledTimes(0);
+
+      await act(async () => {
+        await setup.mockInput.pressEscape();
+      });
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Quit review?"));
+
+      expect(frame).toContain("Quit review?");
+      expect(onQuit).toHaveBeenCalledTimes(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
       });
     }
   });

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -170,6 +170,21 @@ function createNoReviewBootstrap(initialMode: LayoutMode = "split", pager = fals
   });
 }
 
+function createAgentSidecarOnlyBootstrap(): AppBootstrap {
+  return createTestVcsAppBootstrap({
+    changesetId: "changeset:app-agent-sidecar-only",
+    files: [
+      createTestDiffFile(
+        "alpha",
+        "alpha.ts",
+        "export const alpha = 1;\n",
+        "export const alpha = 2;\nexport const add = true;\n",
+        true,
+      ),
+    ],
+  });
+}
+
 function createSingleFileBootstrap(): AppBootstrap {
   return createTestVcsAppBootstrap({
     changesetId: "changeset:app-single-file",
@@ -3420,7 +3435,31 @@ describe("App interactions", () => {
     }
   });
 
-  test("quit confirmation protects saved review notes until confirmed", async () => {
+  test("quit shortcut ignores persisted agent sidecar annotations", async () => {
+    const qQuit = mock(() => undefined);
+    const qSetup = await testRender(
+      <AppHost bootstrap={createAgentSidecarOnlyBootstrap()} onQuit={qQuit} />,
+      { width: 220, height: 24 },
+    );
+
+    try {
+      await flush(qSetup);
+
+      await act(async () => {
+        await qSetup.mockInput.typeText("q");
+      });
+      await flush(qSetup);
+
+      expect(qQuit).toHaveBeenCalledTimes(1);
+      expect(qSetup.captureCharFrame()).not.toContain("Quit review?");
+    } finally {
+      await act(async () => {
+        qSetup.renderer.destroy();
+      });
+    }
+  });
+
+  test("quit confirmation protects saved user notes until confirmed", async () => {
     const onQuit = mock(() => undefined);
     const setup = await testRender(
       <AppHost bootstrap={createNoReviewBootstrap()} onQuit={onQuit} />,

--- a/src/ui/components/chrome/QuitConfirmDialog.tsx
+++ b/src/ui/components/chrome/QuitConfirmDialog.tsx
@@ -1,0 +1,74 @@
+import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
+import { fitText, padText } from "../../lib/text";
+import type { AppTheme } from "../../themes";
+import { ModalFrame } from "./ModalFrame";
+
+/** Confirm before leaving a review that has comments or notes in memory. */
+export function QuitConfirmDialog({
+  terminalHeight,
+  terminalWidth,
+  theme,
+  onCancel,
+  onConfirm,
+}: {
+  terminalHeight: number;
+  terminalWidth: number;
+  theme: AppTheme;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const width = Math.min(68, Math.max(48, terminalWidth - 8));
+  const bodyWidth = Math.max(1, width - 4);
+  const modalHeight = Math.min(10, Math.max(8, terminalHeight - 2));
+  const stayLabel = " Stay ";
+  const quitLabel = " Quit ";
+
+  return (
+    <ModalFrame
+      height={modalHeight}
+      terminalHeight={terminalHeight}
+      terminalWidth={terminalWidth}
+      theme={theme}
+      title="Quit review?"
+      width={width}
+      onClose={onCancel}
+    >
+      <box style={{ width: "100%", height: "100%", flexDirection: "column" }}>
+        <box style={{ width: "100%", height: 1 }}>
+          <text fg={theme.text}>
+            {fitText("This review has comments or notes that will be lost.", bodyWidth)}
+          </text>
+        </box>
+        <box style={{ width: "100%", height: 1 }}>
+          <text fg={theme.muted}>
+            {fitText("Press Enter or y to quit, Esc or n to stay.", bodyWidth)}
+          </text>
+        </box>
+        <box style={{ width: "100%", height: 1 }} />
+        <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
+          <box
+            style={{ backgroundColor: theme.panelAlt }}
+            onMouseUp={(event: TuiMouseEvent) => {
+              event.stopPropagation();
+              onCancel();
+            }}
+          >
+            <text fg={theme.text}>{stayLabel}</text>
+          </box>
+          <text fg={theme.muted}>
+            {padText("", Math.max(1, bodyWidth - stayLabel.length - quitLabel.length - 1))}
+          </text>
+          <box
+            style={{ backgroundColor: theme.accentMuted }}
+            onMouseUp={(event: TuiMouseEvent) => {
+              event.stopPropagation();
+              onConfirm();
+            }}
+          >
+            <text fg={theme.text}>{quitLabel}</text>
+          </box>
+        </box>
+      </box>
+    </ModalFrame>
+  );
+}

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -57,7 +57,9 @@ export interface UseAppKeyboardShortcutsOptions {
   closeAgentSkill: () => void;
   closeHelp: () => void;
   closeMenu: () => void;
+  confirmQuit: () => void;
   acceptThemeSelector: () => void;
+  cancelQuit: () => void;
   cancelDraftNote: () => void;
   closeThemeSelector: () => void;
   focusArea: FocusArea;
@@ -70,6 +72,7 @@ export interface UseAppKeyboardShortcutsOptions {
   openMenu: (menuId: MenuId) => void;
   openThemeSelector: () => void;
   pagerMode: boolean;
+  quitConfirmOpen: boolean;
   requestQuit: () => void;
   scrollCodeHorizontally: (delta: number) => void;
   scrollDiff: (delta: number, unit: ScrollUnit) => void;
@@ -101,7 +104,9 @@ export function useAppKeyboardShortcuts({
   closeAgentSkill,
   closeHelp,
   closeMenu,
+  confirmQuit,
   acceptThemeSelector,
+  cancelQuit,
   cancelDraftNote,
   closeThemeSelector,
   focusArea,
@@ -114,6 +119,7 @@ export function useAppKeyboardShortcuts({
   openMenu,
   openThemeSelector,
   pagerMode,
+  quitConfirmOpen,
   requestQuit,
   scrollCodeHorizontally,
   saveDraftNote,
@@ -139,6 +145,7 @@ export function useAppKeyboardShortcuts({
   const activeMenuIdRef = useRef(activeMenuId);
   const focusAreaRef = useRef(focusArea);
   const pagerModeRef = useRef(pagerMode);
+  const quitConfirmOpenRef = useRef(quitConfirmOpen);
   const showAgentSkillRef = useRef(showAgentSkill);
   const showHelpRef = useRef(showHelp);
   const themeSelectorOpenRef = useRef(themeSelectorOpen);
@@ -146,6 +153,7 @@ export function useAppKeyboardShortcuts({
   activeMenuIdRef.current = activeMenuId;
   focusAreaRef.current = focusArea;
   pagerModeRef.current = pagerMode;
+  quitConfirmOpenRef.current = quitConfirmOpen;
   showAgentSkillRef.current = showAgentSkill;
   showHelpRef.current = showHelp;
   themeSelectorOpenRef.current = themeSelectorOpen;
@@ -283,6 +291,26 @@ export function useAppKeyboardShortcuts({
     }
 
     return false;
+  };
+
+  const handleQuitConfirmShortcut = (key: KeyEvent) => {
+    if (!quitConfirmOpenRef.current) {
+      return false;
+    }
+
+    consumeKey(key);
+
+    if (key.name === "return" || key.name === "enter" || key.name === "y") {
+      confirmQuit();
+      return true;
+    }
+
+    if (isEscapeKey(key) || key.name === "n") {
+      cancelQuit();
+      return true;
+    }
+
+    return true;
   };
 
   const handleThemeSelectorShortcut = (key: KeyEvent) => {
@@ -581,6 +609,10 @@ export function useAppKeyboardShortcuts({
   };
 
   useKeyboard((key: KeyEvent) => {
+    if (handleQuitConfirmShortcut(key)) {
+      return;
+    }
+
     if (handleMenuToggleShortcut(key)) {
       return;
     }

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -135,6 +135,7 @@ export interface ReviewController {
   liveCommentsByFileId: Record<string, LiveComment[]>;
   reviewNoteCount: number;
   reviewNoteSummaries: SessionReviewNoteSummary[];
+  userNoteCount: number;
   userNotesByFileId: Record<string, UserReviewNote[]>;
   moveToAnnotatedFile: (delta: number) => void;
   moveToAnnotatedHunk: (delta: number) => void;
@@ -908,6 +909,12 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     [liveCommentsByFileId],
   );
 
+  /** Count only human-authored notes created during this in-memory review session. */
+  const userNoteCount = useMemo(
+    () => Object.values(userNotesByFileId).reduce((sum, notes) => sum + notes.length, 0),
+    [userNotesByFileId],
+  );
+
   /** Format current inline notes for daemon snapshots without exposing UI-only objects. */
   const reviewNoteSummaries = useMemo<SessionReviewNoteSummary[]>(() => {
     const noteSummaries: SessionReviewNoteSummary[] = [];
@@ -996,6 +1003,7 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     liveCommentsByFileId,
     reviewNoteCount,
     reviewNoteSummaries,
+    userNoteCount,
     userNotesByFileId,
     scrollToNote,
     selectedFile,


### PR DESCRIPTION
## Summary

Pressing `q`/Esc to quit now asks for confirmation when you have unsaved review work (draft notes, user notes, or live comments), so you no longer lose in-progress review input by accidentally quitting. Quitting with nothing unsaved still exits immediately.

## Why this matters

Issue #499 reports losing review work by quitting without warning. This adds a quit-confirmation dialog gated on whether there is actually unsaved, in-memory review work to lose. Crucially, it ignores persisted/static agent sidecar annotations (`file.agent.annotations`): those reload on the next launch and are not lost on quit, so an agent-context review no longer shows a spurious "notes will be lost" prompt when the user has not authored anything.

## Changes

- `QuitConfirmDialog` component + `useAppKeyboardShortcuts` wiring for `q`/Esc.
- The quit gate counts only draft notes, user notes, and live comments — not static agent annotations — so it prompts exactly when unsaved work exists.

## Testing

`bun test AppHost.interactions.test.tsx` passes (65 tests) and `bun run typecheck` is clean. New coverage asserts: quitting with only agent sidecar annotations does not prompt, while a draft/user note/live comment does prompt, and confirming/cancelling behaves correctly.

Fixes #499
