### PR TITLE
fix: quit only on q shortcut

### DIFF
--- a/.changeset/quit-with-q-only.md
+++ b/.changeset/quit-with-q-only.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Stop treating Escape as a global quit shortcut; use `q` to quit while preserving Escape for dialogs and focused controls.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Or with Homebrew:
 ```bash
 brew install hunk
 ```
+
 > [!NOTE]
 > If you previously installed hunk via `modem-dev/tap`, be sure to uninstall it first with `brew uninstall modem-dev/tap/hunk`.
 

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -3356,7 +3356,7 @@ describe("App interactions", () => {
     }
   });
 
-  test("quit shortcuts route through the provided onQuit handler in regular and pager modes", async () => {
+  test("q routes through the provided onQuit handler in regular and pager modes", async () => {
     const regularQuit = mock(() => undefined);
     const regularSetup = await testRender(
       <AppHost bootstrap={createBootstrap()} onQuit={regularQuit} />,
@@ -3391,6 +3391,48 @@ describe("App interactions", () => {
       await flush(pagerSetup);
 
       expect(pagerQuit).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => {
+        pagerSetup.renderer.destroy();
+      });
+    }
+  });
+
+  test("Escape does not quit in regular or pager modes", async () => {
+    const regularQuit = mock(() => undefined);
+    const regularSetup = await testRender(
+      <AppHost bootstrap={createBootstrap()} onQuit={regularQuit} />,
+      { width: 220, height: 24 },
+    );
+
+    try {
+      await flush(regularSetup);
+      await act(async () => {
+        await regularSetup.mockInput.pressEscape();
+      });
+      await flush(regularSetup);
+
+      expect(regularQuit).toHaveBeenCalledTimes(0);
+    } finally {
+      await act(async () => {
+        regularSetup.renderer.destroy();
+      });
+    }
+
+    const pagerQuit = mock(() => undefined);
+    const pagerSetup = await testRender(
+      <AppHost bootstrap={createBootstrap("auto", true)} onQuit={pagerQuit} />,
+      { width: 180, height: 20 },
+    );
+
+    try {
+      await flush(pagerSetup);
+      await act(async () => {
+        await pagerSetup.mockInput.pressEscape();
+      });
+      await flush(pagerSetup);
+
+      expect(pagerQuit).toHaveBeenCalledTimes(0);
     } finally {
       await act(async () => {
         pagerSetup.renderer.destroy();

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -202,7 +202,7 @@ export function useAppKeyboardShortcuts({
       return;
     }
 
-    if (key.name === "q" || isEscapeKey(key)) {
+    if (key.name === "q") {
       requestQuit();
       return;
     }
@@ -412,11 +412,6 @@ export function useAppKeyboardShortcuts({
     if (key.name === "?" || key.sequence === "?") {
       toggleHelp();
       closeMenu();
-      return;
-    }
-
-    if (isEscapeKey(key)) {
-      requestQuit();
       return;
     }
 


### PR DESCRIPTION
## Summary

- Stop treating Escape as a global quit shortcut in regular and pager modes
- Keep q as the quit shortcut while preserving Escape for dialogs and focused controls
- Add regression coverage for Escape not quitting

## Tests

- bun run typecheck
- bun run lint
- bun test src/ui/AppHost.interactions.test.tsx -t "q routes|Escape does not quit"

*This PR description was generated by Pi using OpenAI GPT-5*