### PR TITLE
fix: unblock CI (README formatting, note-geometry scroll clamp, test config isolation)

### DIFF
--- a/.changeset/mounted-note-geometry.md
+++ b/.changeset/mounted-note-geometry.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix a transient bottom-edge scroll clamp: mounted diff sections now always render their agent-note rows, so the review stream's painted height matches its measured layout height and over-scrolling at the bottom can no longer snap short by the height of an offscreen note.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Or with Homebrew:
 ```bash
 brew install hunk
 ```
+
 > [!NOTE]
 > If you previously installed hunk via `modem-dev/tap`, be sure to uninstall it first with `brew uninstall modem-dev/tap/hunk`.
 

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -676,42 +676,6 @@ export function DiffPane({
       wrapLines,
     ],
   );
-  const baseEstimatedBodyHeights = useMemo(
-    () => baseSectionGeometry.map((metrics) => metrics.bodyHeight),
-    [baseSectionGeometry],
-  );
-  const baseFileSectionLayouts = useMemo(
-    () => buildFileSectionLayouts(files, baseEstimatedBodyHeights, sectionHeaderHeights),
-    [baseEstimatedBodyHeights, files, sectionHeaderHeights],
-  );
-
-  const visibleViewportFileIds = useMemo(() => {
-    const overscanTerminalRows = Math.max(8, rapidScrollOverscanRows);
-    const minVisibleY = Math.max(0, scrollViewport.top - overscanTerminalRows);
-    const maxVisibleY = scrollViewport.top + scrollViewport.height + overscanTerminalRows;
-    return collectIntersectingFileSectionIds(baseFileSectionLayouts, minVisibleY, maxVisibleY);
-  }, [baseFileSectionLayouts, rapidScrollOverscanRows, scrollViewport.height, scrollViewport.top]);
-
-  const visibleAgentNotesByFile = useMemo(() => {
-    const next = new Map<string, VisibleAgentNote[]>();
-
-    const fileIdsToMeasure = new Set(visibleViewportFileIds);
-    // Always measure the selected file with its real note rows so hunk navigation can compute
-    // accurate bounds even before the file scrolls into the visible viewport.
-    if (selectedFileId) {
-      fileIdsToMeasure.add(selectedFileId);
-    }
-
-    for (const fileId of fileIdsToMeasure) {
-      const visibleNotes = allAgentNotesByFile.get(fileId);
-      if (visibleNotes && visibleNotes.length > 0) {
-        next.set(fileId, visibleNotes);
-      }
-    }
-
-    return next;
-  }, [allAgentNotesByFile, selectedFileId, showAgentNotes, visibleViewportFileIds]);
-
   // Measure with the *full* set of agent notes per file, not just the visible-viewport set.
   // The visible set is correct for rendering (skip painting cards on off-screen files), but
   // using it here makes total content height fluctuate with scroll position: as a file with
@@ -1207,6 +1171,32 @@ export function DiffPane({
   );
   const fileRenderItems = fileRenderWindow?.items ?? fullFileRenderItems;
   const mountedFileIndices = fileRenderWindow?.mountedFileIndices ?? null;
+  // Render note rows for exactly the mounted sections (all sections when windowing is off).
+  // Section layouts and spacer heights are measured with the full note set, so a mounted section
+  // that skipped its notes would paint shorter than its layout height and transiently shrink the
+  // scrollbox content height, clamping bottom-edge scrolls. A viewport-proximity set cannot be
+  // the source of truth here: it decays with rapid-scroll state on a timer, while the mounted
+  // window extends beyond it via file overscan and prefetch.
+  const visibleAgentNotesByFile = useMemo(() => {
+    const next = new Map<string, VisibleAgentNote[]>();
+
+    const mountedFileIds = mountedFileIndices
+      ? mountedFileIndices.map((index) => files[index]?.id)
+      : files.map((file) => file.id);
+
+    for (const fileId of mountedFileIds) {
+      if (!fileId) {
+        continue;
+      }
+
+      const visibleNotes = allAgentNotesByFile.get(fileId);
+      if (visibleNotes && visibleNotes.length > 0) {
+        next.set(fileId, visibleNotes);
+      }
+    }
+
+    return next;
+  }, [allAgentNotesByFile, files, mountedFileIndices]);
   // Previous snapshot used to keep VisibleBodyBounds object identity stable across scroll
   // commits; DiffSection's memo comparator checks `visibleBodyBounds` by reference, so handing
   // back the prior object when top/height are numerically unchanged lets mounted sections skip

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -11,6 +11,7 @@ import {
   lines,
 } from "../../../test/helpers/diff-helpers";
 import { hexColorDistance } from "../lib/color";
+import { RAPID_SCROLL_OVERSCAN_IDLE_MS } from "../lib/adaptiveScrollOverscan";
 import { resolveTheme } from "../themes";
 import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts, buildInStreamFileHeaderHeights } from "../lib/fileSectionLayout";
@@ -1411,6 +1412,22 @@ describe("UI components", () => {
 
       await settleDiffPane(setup);
       expect(scrollRef.current?.scrollTop ?? 0).toBe(bottomScrollTop);
+
+      await act(async () => {
+        scrollRef.current?.scrollTo(bottomScrollTop + 1);
+      });
+      await settleDiffPane(setup);
+
+      expect(scrollRef.current?.scrollTop ?? 0).toBe(bottomScrollTop);
+
+      // Regression: once rapid-scroll overscan decays back to zero, a noted file above the
+      // viewport stays mounted only through file overscan. Its section must still render note
+      // rows, or the content height shrinks and this over-scroll clamps below the real bottom.
+      await act(async () => {
+        await Bun.sleep(RAPID_SCROLL_OVERSCAN_IDLE_MS + 50);
+        await setup.renderOnce();
+      });
+      await settleDiffPane(setup);
 
       await act(async () => {
         scrollRef.current?.scrollTo(bottomScrollTop + 1);

--- a/test/helpers/config-home.ts
+++ b/test/helpers/config-home.ts
@@ -1,0 +1,12 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Create an empty XDG_CONFIG_HOME for spawned hunk processes so integration tests assert
+ * against built-in defaults instead of the developer's ambient ~/.config/hunk/config.toml.
+ * hunk resolves XDG_CONFIG_HOME ahead of platform defaults, so this isolates every OS.
+ */
+export function createTestConfigHome(prefix = "hunk-test-config-") {
+  return mkdtempSync(join(tmpdir(), prefix));
+}

--- a/test/session/broker-e2e.test.ts
+++ b/test/session/broker-e2e.test.ts
@@ -3,9 +3,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTestConfigHome } from "../helpers/config-home";
 
 const repoRoot = process.cwd();
 const sourceEntrypoint = join(repoRoot, "src/main.tsx");
+// Spawned hunk processes must assert built-in defaults, not the developer's ambient user config.
+const testConfigHome = createTestConfigHome();
 const tempDirs: string[] = [];
 const ttyToolsAvailable =
   Bun.spawnSync(["bash", "-lc", "command -v script >/dev/null && command -v timeout >/dev/null"], {
@@ -124,6 +127,7 @@ function spawnHunkSession(
     stderr: "pipe",
     env: {
       ...process.env,
+      XDG_CONFIG_HOME: testConfigHome,
       TERM: "xterm-256color",
       COLUMNS: "120",
       LINES: "24",
@@ -140,6 +144,7 @@ function runSessionCli(args: string[], port: number) {
     stderr: "pipe",
     env: {
       ...process.env,
+      XDG_CONFIG_HOME: testConfigHome,
       HUNK_MCP_PORT: `${port}`,
     },
   });

--- a/test/session/cli.test.ts
+++ b/test/session/cli.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTestConfigHome } from "../helpers/config-home";
 
 const repoRoot = process.cwd();
 const sourceEntrypoint = join(repoRoot, "src/main.tsx");
+// Spawned hunk processes must assert built-in defaults, not the developer's ambient user config.
+const testConfigHome = createTestConfigHome();
 const tempDirs: string[] = [];
 const ttyToolsAvailable =
   Bun.spawnSync(["bash", "-lc", "command -v script >/dev/null && command -v timeout >/dev/null"], {
@@ -102,6 +105,7 @@ function spawnHunkSession(
     stderr: "pipe",
     env: {
       ...process.env,
+      XDG_CONFIG_HOME: testConfigHome,
       HUNK_MCP_PORT: `${port}`,
     },
   });
@@ -115,6 +119,7 @@ function runSessionCli(args: string[], port: number, stdinText?: string) {
     stderr: "pipe",
     env: {
       ...process.env,
+      XDG_CONFIG_HOME: testConfigHome,
       HUNK_MCP_PORT: `${port}`,
     },
   });

--- a/test/session/daemon.test.ts
+++ b/test/session/daemon.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { Subprocess } from "bun";
 import { createServer } from "node:net";
+import { createTestConfigHome } from "../helpers/config-home";
 
 const repoRoot = process.cwd();
+// Spawned hunk processes must assert built-in defaults, not the developer's ambient user config.
+const testConfigHome = createTestConfigHome();
 const spawned: Subprocess[] = [];
 
 async function reserveLoopbackPort() {
@@ -77,6 +80,7 @@ describe("session daemon lifecycle", () => {
       stderr: "pipe",
       env: {
         ...process.env,
+        XDG_CONFIG_HOME: testConfigHome,
         HUNK_MCP_PORT: String(port),
       },
     });

--- a/test/smoke/tty.test.ts
+++ b/test/smoke/tty.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTestConfigHome } from "../helpers/config-home";
 
 const repoRoot = process.cwd();
 const sourceEntrypoint = join(repoRoot, "src/main.tsx");
+// Spawned hunk processes must assert built-in defaults, not the developer's ambient user config.
+const testConfigHome = createTestConfigHome();
 const tempDirs: string[] = [];
 const enableTtySmokeTests = process.env.HUNK_RUN_TTY_SMOKE === "1";
 if (enableTtySmokeTests) {
@@ -169,6 +172,7 @@ async function runTtySmoke(options: {
     stderr: "pipe",
     env: {
       ...process.env,
+      XDG_CONFIG_HOME: testConfigHome,
       TERM: "xterm-256color",
       HUNK_MCP_DISABLE: "1",
       HUNK_DISABLE_UPDATE_NOTICE: "1",
@@ -203,6 +207,7 @@ async function runStdinPagerSmoke(options?: {
     stderr: "pipe",
     env: {
       ...process.env,
+      XDG_CONFIG_HOME: testConfigHome,
       TERM: "xterm-256color",
       HUNK_MCP_DISABLE: "1",
       HUNK_DISABLE_UPDATE_NOTICE: "1",


### PR DESCRIPTION
## What

Three fixes that unblock CI and local test runs:

1. **README formatting** — the Homebrew note from #497/#498 was missing a blank line after the install code fence, so `oxfmt --check` has been failing on main and short-circuiting the Typecheck + Test steps on every PR since 2026-07-02.

2. **Flaky Windows test root-caused and fixed** — `DiffPane keeps bottom scroll stable when offscreen agent notes are windowed out` failed intermittently on Windows (#501, #505 runs) with `Expected: 48, Received: 40`. Not a Windows quirk: note rows rendered only for files near the viewport, a set that decays with rapid-scroll state on a 160ms timer, while file overscan and prefetch keep sections mounted beyond it. A mounted section that skipped its notes painted 8 rows shorter than its note-inclusive layout height, transiently shrinking the scrollbox content height so a bottom-edge over-scroll clamped short. Fix: render note rows for exactly the mounted set — the same set the spacer math assumes — and delete the now-dead viewport-proximity set and its base-layout chain. The regression test waits out the overscan decay window, which reproduced the CI failure deterministically on Linux too.

3. **Test isolation** — extends the #494 PTY-harness ambient-config isolation to `test/session/` and `test/smoke/`, which still inherited the developer's real `~/.config/hunk/config.toml` and failed locally whenever it changed defaults (`agent_notes`, `line_numbers`, `hunk_headers`). CI was unaffected.

## Testing

- `bun run typecheck`, `bun test` (full suite), `bun run test:integration` (51/51), `bun run test:tty-smoke` (9/9, now green with a customized user config present), `bun run format:check`, `bun run lint`.
- Regression test verified to fail without the DiffPane fix (identical `48 vs 40` failure as Windows CI) and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)