### PR TITLE
fix(session-broker): detect Windows bunfs paths when auto-launching the daemon

### DIFF
--- a/.changeset/windows-bunfs-daemon-argv.md
+++ b/.changeset/windows-bunfs-daemon-argv.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix session daemon auto-launch on Windows: the compiled binary's virtual `B:\~BUN\...` entrypoint was mistaken for a script path and passed to the relaunched daemon as a bogus argument, so `hunk session` commands never found a live session.

--- a/src/session-broker/brokerLauncher.test.ts
+++ b/src/session-broker/brokerLauncher.test.ts
@@ -71,6 +71,27 @@ describe("session daemon launcher", () => {
     });
   });
 
+  test("uses execPath for Windows Bun-compiled binaries mounted on the virtual B: drive", () => {
+    // On Windows, Bun single-file executables report the bundle as B:\~BUN\root\<name>.exe;
+    // treating it as a script entrypoint would pass the virtual path to the relaunched
+    // binary as a bogus argument (#502). Both separators appear depending on the shell.
+    const realBinary =
+      "C:\\Users\\dev\\AppData\\Roaming\\npm\\node_modules\\hunkdiff\\node_modules\\hunkdiff-windows-x64\\bin\\hunk.exe";
+
+    expect(
+      resolveDaemonLaunchCommand(["bun", "B:/~BUN/root/hunk.exe", "diff"], realBinary),
+    ).toEqual({
+      command: realBinary,
+      args: ["daemon", "serve"],
+    });
+    expect(
+      resolveDaemonLaunchCommand(["bun", "B:\\~BUN\\root\\hunk.exe", "diff"], realBinary),
+    ).toEqual({
+      command: realBinary,
+      args: ["daemon", "serve"],
+    });
+  });
+
   test("detects whether some process is already listening on the daemon port", async () => {
     const listener = Bun.serve({
       hostname: "127.0.0.1",

--- a/src/session-broker/brokerLauncher.ts
+++ b/src/session-broker/brokerLauncher.ts
@@ -69,6 +69,19 @@ export interface EnsureSessionBrokerAvailableOptions {
 
 /** Detect Bun's virtual filesystem prefix used inside compiled single-file executables. */
 const BUNFS_PREFIX = "/$bunfs/";
+/** Bun's Windows equivalent mounts the compiled bundle on a virtual B: drive. */
+const BUNFS_WINDOWS_PREFIX = "b:/~bun/";
+
+/** True when argv[1] is a Bun single-file-executable virtual path on any platform. */
+function isBunfsEntrypoint(entrypoint: string) {
+  if (entrypoint.startsWith(BUNFS_PREFIX)) {
+    return true;
+  }
+
+  // Windows reports the virtual path with either separator depending on the shell, so
+  // normalize before comparing (e.g. "B:\\~BUN\\root\\hunk.exe" or "B:/~BUN/root/hunk.exe").
+  return entrypoint.replaceAll("\\", "/").toLowerCase().startsWith(BUNFS_WINDOWS_PREFIX);
+}
 
 function safeRuntimeToken(value: string) {
   return value.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "") || "default";
@@ -246,10 +259,13 @@ export function resolveDaemonLaunchCommand(
   const entrypoint = argv[1];
 
   // Bun-compiled single-file executables report argv as
-  //   ["bun", "/$bunfs/root/<name>", ...userArgs]
+  //   ["bun", "/$bunfs/root/<name>", ...userArgs]         (Unix)
+  //   ["bun", "B:/~BUN/root/<name>.exe", ...userArgs]     (Windows)
   // with execPath pointing to the real binary on disk.
-  // Detect the virtual $bunfs path and use execPath directly.
-  if (entrypoint && entrypoint.startsWith(BUNFS_PREFIX)) {
+  // Detect the virtual path and use execPath directly; letting the Windows form fall through
+  // to the script-entrypoint branch would relaunch the binary with the virtual path as a bogus
+  // first argument and the daemon would never start (#502).
+  if (entrypoint && isBunfsEntrypoint(entrypoint)) {
     return {
       command: execPath,
       args: ["daemon", "serve"],


### PR DESCRIPTION
Fixes #502.

## What

On Windows, Bun-compiled single-file executables report `argv[1]` as a virtual path on Bun's `B:` drive (`B:\~BUN\root\hunk.exe` — the reporter's log shows the forward-slash form). `resolveDaemonLaunchCommand` only recognized the Unix virtual prefix (`/$bunfs/`), so the Windows path fell through to the script-entrypoint branch (it contains path separators) and the auto-launched daemon became `hunk.exe B:/~BUN/root/hunk.exe daemon serve` — the compiled binary received the virtual path as a bogus first argument, the daemon never started, and `hunk session list` found no sessions unless `hunk daemon serve` was started manually.

## How

Recognize the Windows bunfs prefix (`b:/~bun/`, case-insensitive, either separator) alongside `/$bunfs/` in a small `isBunfsEntrypoint` helper, so compiled binaries relaunch via `execPath` with clean `daemon serve` args on every platform.

## Testing

- New unit test covering both separator forms; verified it fails against the previous implementation and passes with the fix.
- `bun run typecheck`, full `bun test` (1084 pass), format, lint.
- Not verified on real Windows hardware — the repro in #502 maps exactly onto the argv shapes covered by the unit test, but a confirmation from the reporter after release would be good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)