### PR TITLE
feat(review): keyboard comment-line cursor for line-specific notes

### DIFF
--- a/src/core/liveComments.test.ts
+++ b/src/core/liveComments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createTestDiffFile, lines } from "../../test/helpers/diff-helpers";
 import {
   buildLiveComment,
+  commentTargetsForHunk,
   findDiffFileByPath,
   findHunkIndexForLine,
   firstCommentTargetForHunk,
@@ -59,6 +60,32 @@ describe("live comment helpers", () => {
       side: "new",
       line: 22,
     });
+  });
+
+  test("enumerates every changed line as an ordered comment target list", () => {
+    const targets = commentTargetsForHunk({
+      additionStart: 20,
+      additionLines: 2,
+      deletionStart: 20,
+      deletionLines: 1,
+      hunkContent: [
+        { type: "context", lines: 2 },
+        { type: "change", deletions: 1, additions: 2 },
+        { type: "context", lines: 1 },
+        { type: "change", deletions: 0, additions: 1 },
+      ],
+    } as Parameters<typeof commentTargetsForHunk>[0]);
+
+    // Context (2 lines) advances both sides to line 22. The change block yields its
+    // deletion first (old 22) then both additions (new 22, 23), leaving old at 23 and
+    // new at 24. One more context line advances to old 24 / new 25, then a lone
+    // addition lands on new 25.
+    expect(targets).toEqual([
+      { side: "old", line: 22 },
+      { side: "new", line: 22 },
+      { side: "new", line: 23 },
+      { side: "new", line: 25 },
+    ]);
   });
 
   test("resolves hunk-wide comment targets to one stable line", () => {

--- a/src/core/liveComments.ts
+++ b/src/core/liveComments.ts
@@ -113,6 +113,39 @@ export function firstCommentTargetForHunk(hunk: Hunk): Omit<ResolvedCommentTarge
   };
 }
 
+/**
+ * Enumerate every changed (added/deleted) line in a hunk as an ordered comment
+ * target list, top-to-bottom. Deletions precede additions within each change
+ * block (stack-view order). Context lines are skipped because comments anchor on
+ * changed lines. Used to drive the keyboard comment-line cursor so a reviewer can
+ * pick a specific line to annotate without the mouse.
+ */
+export function commentTargetsForHunk(hunk: Hunk): Array<Omit<ResolvedCommentTarget, "hunkIndex">> {
+  const targets: Array<Omit<ResolvedCommentTarget, "hunkIndex">> = [];
+  let deletionLineNumber = hunk.deletionStart;
+  let additionLineNumber = hunk.additionStart;
+
+  for (const content of hunk.hunkContent) {
+    if (content.type === "context") {
+      deletionLineNumber += content.lines;
+      additionLineNumber += content.lines;
+      continue;
+    }
+
+    for (let offset = 0; offset < content.deletions; offset += 1) {
+      targets.push({ side: "old", line: deletionLineNumber + offset });
+    }
+    for (let offset = 0; offset < content.additions; offset += 1) {
+      targets.push({ side: "new", line: additionLineNumber + offset });
+    }
+
+    deletionLineNumber += content.deletions;
+    additionLineNumber += content.additions;
+  }
+
+  return targets;
+}
+
 /** Resolve either a hunk-wide or line-specific target against one visible diff file. */
 export function resolveCommentTarget(
   file: DiffFile,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -832,6 +832,7 @@ export function App({
     moveToAnnotatedHunk,
     moveToFile,
     moveToHunk: review.moveToHunk,
+    moveCommentLineCursor: review.moveCommentLineCursor,
     moveMenuItem,
     moveThemeSelector,
     openMenu,
@@ -1017,6 +1018,7 @@ export function App({
           scrollRef={diffScrollRef}
           selectedFileId={selectedFile?.id}
           selectedHunkIndex={selectedHunkIndex}
+          activeCommentLineTarget={review.activeCommentLineTarget}
           scrollToNote={review.scrollToNote}
           draftNote={review.draftNote}
           draftNoteFocused={focusArea === "note"}

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -26,6 +26,7 @@ export function HelpDialog({
         ["Shift+Space", "page up (alt)"],
         ["d / u", "half page down / up"],
         ["[ / ]", "previous / next hunk"],
+        ["J / K", "next / prev changed line (comment cursor)"],
         [", / .", "previous / next file"],
         ["{ / }", "previous / next comment"],
         ["← / →", "scroll code left / right (Shift = faster)"],
@@ -55,7 +56,7 @@ export function HelpDialog({
       title: "Review",
       items: [
         ["/", "focus file filter"],
-        ["c", "create review note"],
+        ["c", "create review note (cursor line or hunk)"],
         ["Tab", "toggle files/filter focus"],
         ["F10", "open menus"],
         [canRefresh ? "r / q" : "q", canRefresh ? "reload / quit" : "quit"],

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -21,7 +21,7 @@ import type {
 } from "../../../core/types";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
-import type { DraftReviewNote } from "../../hooks/useReviewController";
+import type { ActiveCommentLineTarget, DraftReviewNote } from "../../hooks/useReviewController";
 import {
   alwaysShowReviewNote,
   reviewNoteSource,
@@ -183,6 +183,7 @@ export function DiffPane({
   scrollRef,
   selectedFileId,
   selectedHunkIndex,
+  activeCommentLineTarget = null,
   scrollToNote = false,
   draftNote = null,
   draftNoteFocused = false,
@@ -230,6 +231,7 @@ export function DiffPane({
   scrollRef: RefObject<ScrollBoxRenderable | null>;
   selectedFileId?: string;
   selectedHunkIndex: number;
+  activeCommentLineTarget?: ActiveCommentLineTarget | null;
   scrollToNote?: boolean;
   draftNote?: DraftReviewNote | null;
   draftNoteFocused?: boolean;
@@ -1806,6 +1808,9 @@ export function DiffPane({
                       headerStatsWidth={headerStatsWidth}
                       layout={layout}
                       selectedHunkIndex={file.id === selectedFileId ? selectedHunkIndex : -1}
+                      activeCommentLineTarget={
+                        file.id === selectedFileId ? activeCommentLineTarget : null
+                      }
                       copySelectedRowRanges={copySelectedRowKeysByFile.get(file.id)}
                       copySelectedSide={copySelectionSide}
                       shouldLoadHighlight={highlightPrefetchFileIds.has(file.id)}

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../../core/types";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import { PierreDiffView, type ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
+import type { ActiveCommentLineTarget } from "../../hooks/useReviewController";
 import type { VisibleBodyBounds } from "../../diff/rowWindowing";
 import type { DiffSectionGeometry } from "../../diff/diffSectionGeometry";
 import type { VisibleAgentNote } from "../../lib/agentAnnotations";
@@ -19,6 +20,7 @@ interface DiffSectionProps {
   headerStatsWidth: number;
   layout: Exclude<LayoutMode, "auto">;
   selectedHunkIndex: number;
+  activeCommentLineTarget?: ActiveCommentLineTarget | null;
   copySelectedRowRanges?: Map<string, CopySelectedRowRange>;
   copySelectedSide?: "left" | "right";
   shouldLoadHighlight: boolean;
@@ -53,6 +55,7 @@ function DiffSectionComponent({
   headerStatsWidth,
   layout,
   selectedHunkIndex,
+  activeCommentLineTarget = null,
   copySelectedRowRanges,
   copySelectedSide,
   shouldLoadHighlight,
@@ -134,6 +137,7 @@ function DiffSectionComponent({
         onStartUserNoteAtHunk={onStartUserNoteAtHunk}
         onToggleGap={onToggleGap}
         selectedHunkIndex={selectedHunkIndex}
+        activeCommentLineTarget={activeCommentLineTarget}
         sectionGeometry={sectionGeometry}
         shouldLoadHighlight={shouldLoadHighlight}
         // The parent review stream owns scrolling across files.
@@ -157,6 +161,7 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
     previous.headerStatsWidth === next.headerStatsWidth &&
     previous.layout === next.layout &&
     previous.selectedHunkIndex === next.selectedHunkIndex &&
+    previous.activeCommentLineTarget === next.activeCommentLineTarget &&
     previous.copySelectedRowRanges === next.copySelectedRowRanges &&
     previous.copySelectedSide === next.copySelectedSide &&
     previous.shouldLoadHighlight === next.shouldLoadHighlight &&

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2339,7 +2339,7 @@ describe("UI components", () => {
     const frame = await captureFrame(
       <HelpDialog
         canRefresh={true}
-        terminalHeight={39}
+        terminalHeight={40}
         terminalWidth={76}
         theme={theme}
         onClose={() => {}}
@@ -2358,6 +2358,7 @@ describe("UI components", () => {
       "Shift+Space     page up (alt)",
       "d / u           half page down / up",
       "[ / ]           previous / next hunk",
+      "J / K           next / prev changed line",
       ", / .           previous / next file",
       "{ / }           previous / next comment",
       "← / →           scroll code left / right (Shift = faster)",

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,6 +1,7 @@
 import { useRenderer } from "@opentui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
+import type { ActiveCommentLineTarget } from "../hooks/useReviewController";
 import { AgentInlineNote } from "../components/panes/AgentInlineNote";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
@@ -79,6 +80,7 @@ export function PierreDiffView({
   hoverClearSignal = 0,
   width,
   selectedHunkIndex,
+  activeCommentLineTarget = null,
   sectionGeometry,
   shouldLoadHighlight = true,
   scrollable = true,
@@ -104,6 +106,7 @@ export function PierreDiffView({
   hoverClearSignal?: number;
   width: number;
   selectedHunkIndex: number;
+  activeCommentLineTarget?: ActiveCommentLineTarget | null;
   sectionGeometry?: DiffSectionGeometry;
   shouldLoadHighlight?: boolean;
   scrollable?: boolean;
@@ -255,6 +258,26 @@ export function PierreDiffView({
     return next;
   }, [plannedRows]);
 
+  // Resolve the diff row that the keyboard comment-line cursor is pointing at so it can show
+  // the same add-note affordance the mouse hover uses, but persistently. Matching is by
+  // hunk/side/line; in split view an "old"-side target may share a row whose affordance reports
+  // the "new" side, so the badge can be absent there even though `c` still targets the line.
+  const commentCursorRowKey = useMemo(() => {
+    if (!activeCommentLineTarget) {
+      return null;
+    }
+    for (const [rowKey, affordance] of addNoteAffordanceByRowKey) {
+      if (
+        affordance.hunkIndex === activeCommentLineTarget.hunkIndex &&
+        affordance.target?.side === activeCommentLineTarget.side &&
+        affordance.target?.line === activeCommentLineTarget.line
+      ) {
+        return rowKey;
+      }
+    }
+    return null;
+  }, [activeCommentLineTarget, addNoteAffordanceByRowKey]);
+
   /** One shared hover handler for every diff row; DiffRowView passes the hovered row's key. */
   const handleHoverRow = useCallback(
     (rowKey: string) => {
@@ -383,7 +406,8 @@ export function PierreDiffView({
               noteGuideSide={plannedRow.noteGuideSide}
               showAddNoteBadge={
                 startUserNoteAtHunkHandler !== undefined &&
-                hoveredRowKey === plannedRow.row.key &&
+                (hoveredRowKey === plannedRow.row.key ||
+                  commentCursorRowKey === plannedRow.row.key) &&
                 addNoteAffordanceByRowKey.has(plannedRow.row.key)
               }
               onHoverRow={handleHoverRow}

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -4,6 +4,8 @@ import { useRef } from "react";
 import type { LayoutMode } from "../../core/types";
 import type { MenuId } from "../components/chrome/menu";
 import {
+  isCommentLineDownKey,
+  isCommentLineUpKey,
   isCreateReviewNoteKey,
   isEscapeKey,
   isHalfPageDownKey,
@@ -63,6 +65,7 @@ export interface UseAppKeyboardShortcutsOptions {
   focusArea: FocusArea;
   focusFilter: () => void;
   moveToAnnotatedHunk: (delta: number) => void;
+  moveCommentLineCursor: (delta: number) => void;
   moveToFile: (delta: number) => void;
   moveToHunk: (delta: number) => void;
   moveMenuItem: (delta: number) => void;
@@ -107,6 +110,7 @@ export function useAppKeyboardShortcuts({
   focusArea,
   focusFilter,
   moveToAnnotatedHunk,
+  moveCommentLineCursor,
   moveToFile,
   moveToHunk,
   moveMenuItem,
@@ -427,6 +431,18 @@ export function useAppKeyboardShortcuts({
 
     if (isCreateReviewNoteKey(key)) {
       runAndCloseMenu(startUserNote);
+      return;
+    }
+
+    // Shift+J / Shift+K move a comment-line cursor over changed lines so `c` can
+    // target a specific line. Checked before the plain j/k row-scroll handlers.
+    if (isCommentLineDownKey(key)) {
+      runAndCloseMenu(() => moveCommentLineCursor(1));
+      return;
+    }
+
+    if (isCommentLineUpKey(key)) {
+      runAndCloseMenu(() => moveCommentLineCursor(-1));
       return;
     }
 

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -1082,4 +1082,63 @@ describe("useReviewController", () => {
       });
     }
   });
+
+  test("keyboard comment-line cursor targets changed lines and rolls across hunks", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      // A fresh cursor lands on the first changed line of the selected hunk (deletion side).
+      await act(async () => {
+        expectValue(controllerRef.current).moveCommentLineCursor(1);
+      });
+      expect(expectValue(controllerRef.current).activeCommentLineTarget).toEqual({
+        hunkIndex: 0,
+        side: "old",
+        line: 1,
+      });
+
+      // A note started with no explicit target adopts the cursor line, overriding the
+      // whole-hunk anchor (which would otherwise prefer the addition side).
+      let draftSide: string | undefined;
+      let draftLine: number | undefined;
+      await act(async () => {
+        const draft = expectValue(controllerRef.current).startUserNote();
+        draftSide = draft?.side;
+        draftLine = draft?.line;
+      });
+      expect(draftSide).toBe("old");
+      expect(draftLine).toBe(1);
+
+      // Advancing steps onto the addition of the same changed line.
+      await act(async () => {
+        expectValue(controllerRef.current).moveCommentLineCursor(1);
+      });
+      expect(expectValue(controllerRef.current).activeCommentLineTarget).toEqual({
+        hunkIndex: 0,
+        side: "new",
+        line: 1,
+      });
+
+      // Past the end of hunk 0 the cursor rolls into hunk 1 and drags the selection with it.
+      await act(async () => {
+        expectValue(controllerRef.current).moveCommentLineCursor(1);
+      });
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+      expect(expectValue(controllerRef.current).activeCommentLineTarget).toEqual({
+        hunkIndex: 1,
+        side: "old",
+        line: 12,
+      });
+
+      // Clearing drops the cursor so notes fall back to the whole-hunk anchor.
+      await act(async () => {
+        expectValue(controllerRef.current).clearCommentLineCursor();
+      });
+      expect(expectValue(controllerRef.current).activeCommentLineTarget).toBeNull();
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
 });

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -17,6 +17,7 @@ import {
 } from "react";
 import {
   buildLiveComment,
+  commentTargetsForHunk,
   findDiffFileByPath,
   firstCommentTargetForHunk,
   resolveCommentTarget,
@@ -125,6 +126,11 @@ export interface ReviewSelectionOptions {
   scrollToNote?: boolean;
 }
 
+/** A keyboard-selected comment line within the currently selected hunk. */
+export interface ActiveCommentLineTarget extends UserNoteLineTarget {
+  hunkIndex: number;
+}
+
 export interface ReviewController {
   allFiles: DiffFile[];
   expandedGapsByFileId: Record<string, ReadonlySet<string>>;
@@ -140,6 +146,9 @@ export interface ReviewController {
   moveToAnnotatedHunk: (delta: number) => void;
   moveToFile: (delta: number) => void;
   moveToHunk: (delta: number) => void;
+  moveCommentLineCursor: (delta: number) => void;
+  clearCommentLineCursor: () => void;
+  activeCommentLineTarget: ActiveCommentLineTarget | null;
   scrollToNote: boolean;
   selectedFile: DiffFile | undefined;
   selectedFileId: string;
@@ -188,6 +197,11 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
   const [filter, setFilter] = useState("");
   const [selectedFileId, setSelectedFileId] = useState(files[0]?.id ?? "");
   const [selectedHunkIndex, setSelectedHunkIndex] = useState(0);
+  const [commentLineCursor, setCommentLineCursor] = useState<{
+    fileId: string;
+    hunkIndex: number;
+    index: number;
+  } | null>(null);
   const [selectedFileTopAlignRequestId, setSelectedFileTopAlignRequestId] = useState(0);
   const [selectedHunkRevealRequestId, setSelectedHunkRevealRequestId] = useState(0);
   const [scrollToNote, setScrollToNote] = useState(false);
@@ -361,6 +375,102 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     },
     [hunkCursors, selectHunk, selectedFile?.id, selectedHunkIndex],
   );
+
+  /**
+   * Move a keyboard comment-line cursor over the changed lines of the selected
+   * file so a reviewer can target a specific line for a note without the mouse.
+   * Rolls into adjacent hunks (same file) and clamps at the file edges.
+   */
+  const moveCommentLineCursor = useCallback(
+    (delta: number) => {
+      const file = selectedFile;
+      if (!file || delta === 0) {
+        return;
+      }
+      const hunks = file.metadata.hunks;
+      const targetsAt = (hunkPosition: number) => {
+        const hunk = hunks[hunkPosition];
+        return hunk ? commentTargetsForHunk(hunk) : [];
+      };
+
+      const cursorMatchesSelection =
+        commentLineCursor?.fileId === file.id &&
+        commentLineCursor?.hunkIndex === selectedHunkIndex;
+
+      // Fresh cursor (none yet, or selection moved elsewhere via [ ] / navigation):
+      // land on the first or last changed line of the selected hunk without leaving it.
+      if (!cursorMatchesSelection) {
+        const targets = targetsAt(selectedHunkIndex);
+        if (targets.length === 0) {
+          return;
+        }
+        setCommentLineCursor({
+          fileId: file.id,
+          hunkIndex: selectedHunkIndex,
+          index: delta > 0 ? 0 : targets.length - 1,
+        });
+        return;
+      }
+
+      const step = delta > 0 ? 1 : -1;
+      let hunkIndex = commentLineCursor.hunkIndex;
+      let index = commentLineCursor.index + delta;
+
+      while (true) {
+        const targets = targetsAt(hunkIndex);
+        if (index >= 0 && index < targets.length) {
+          break;
+        }
+
+        const nextHunkIndex = hunkIndex + step;
+        if (nextHunkIndex < 0 || nextHunkIndex >= hunks.length) {
+          // No further hunk: clamp to the nearest edge of the current hunk.
+          if (targets.length === 0) {
+            return;
+          }
+          index = step > 0 ? targets.length - 1 : 0;
+          break;
+        }
+
+        hunkIndex = nextHunkIndex;
+        const nextTargets = targetsAt(hunkIndex);
+        // Skip hunks without changed lines; keep scanning in the same direction.
+        index =
+          nextTargets.length === 0 ? (step > 0 ? 0 : -1) : step > 0 ? 0 : nextTargets.length - 1;
+      }
+
+      if (hunkIndex !== selectedHunkIndex) {
+        selectHunk(file.id, hunkIndex);
+      }
+      setCommentLineCursor({ fileId: file.id, hunkIndex, index });
+    },
+    [commentLineCursor, selectHunk, selectedFile, selectedHunkIndex],
+  );
+
+  /** Drop the keyboard comment-line cursor (comments fall back to whole-hunk targeting). */
+  const clearCommentLineCursor = useCallback(() => {
+    setCommentLineCursor(null);
+  }, []);
+
+  /** The concrete line the comment-line cursor points at, when it is on the selected hunk. */
+  const activeCommentLineTarget = useMemo<ActiveCommentLineTarget | null>(() => {
+    if (
+      !commentLineCursor ||
+      commentLineCursor.fileId !== selectedFileId ||
+      commentLineCursor.hunkIndex !== selectedHunkIndex
+    ) {
+      return null;
+    }
+    const hunk = selectedFile?.metadata.hunks[commentLineCursor.hunkIndex];
+    if (!hunk) {
+      return null;
+    }
+    const target = commentTargetsForHunk(hunk)[commentLineCursor.index];
+    if (!target) {
+      return null;
+    }
+    return { hunkIndex: commentLineCursor.hunkIndex, side: target.side, line: target.line };
+  }, [commentLineCursor, selectedFile, selectedFileId, selectedHunkIndex]);
 
   /** Move through only hunks that currently have agent notes or live comments. */
   const moveToAnnotatedHunk = useCallback(
@@ -809,7 +919,14 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
         return null;
       }
 
-      const target = requestedTarget ?? firstCommentTargetForHunk(hunk);
+      // Prefer an explicit target, then the keyboard comment-line cursor when it is
+      // pointed at this hunk, then fall back to the stable whole-hunk anchor.
+      const cursorTarget =
+        commentLineCursor?.fileId === file.id && commentLineCursor?.hunkIndex === hunkIndex
+          ? commentTargetsForHunk(hunk)[commentLineCursor.index]
+          : undefined;
+      const target = requestedTarget ?? cursorTarget ?? firstCommentTargetForHunk(hunk);
+      const usedExplicitTarget = Boolean(requestedTarget ?? cursorTarget);
       const draft: DraftReviewNote = {
         id: `draft:${file.id}:${hunkIndex}:${Date.now()}`,
         fileId: file.id,
@@ -825,11 +942,11 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
       selectHunk(
         file.id,
         hunkIndex,
-        requestedTarget ? { preserveViewport: true } : { scrollToNote: true },
+        usedExplicitTarget ? { preserveViewport: true } : { scrollToNote: true },
       );
       return draft;
     },
-    [allFiles, selectHunk, selectedFile?.id, selectedHunkIndex],
+    [allFiles, commentLineCursor, selectHunk, selectedFile?.id, selectedHunkIndex],
   );
 
   /** Update the body of the active draft note. */
@@ -1018,6 +1135,9 @@ export function useReviewController({ files }: { files: DiffFile[] }): ReviewCon
     moveToAnnotatedHunk,
     moveToFile,
     moveToHunk,
+    moveCommentLineCursor,
+    clearCommentLineCursor,
+    activeCommentLineTarget,
     navigateToLocation,
     removeLiveComment,
     removeUserNote,

--- a/src/ui/lib/keyboard.ts
+++ b/src/ui/lib/keyboard.ts
@@ -69,6 +69,26 @@ export function isStepUpKey(key: KeyEvent) {
   return key.name === "up" || key.name === "k" || key.sequence === "k";
 }
 
+/** Match Shift+J: advance the comment-line cursor to the next changed line. */
+export function isCommentLineDownKey(key: KeyEvent) {
+  return (
+    (key.sequence === "J" || (key.name === "j" && key.shift)) &&
+    !key.ctrl &&
+    !key.meta &&
+    !key.option
+  );
+}
+
+/** Match Shift+K: move the comment-line cursor to the previous changed line. */
+export function isCommentLineUpKey(key: KeyEvent) {
+  return (
+    (key.sequence === "K" || (key.name === "k" && key.shift)) &&
+    !key.ctrl &&
+    !key.meta &&
+    !key.option
+  );
+}
+
 /** Match any key alias that should scroll forward by half a viewport. */
 export function isHalfPageDownKey(key: KeyEvent) {
   return key.name === "d" || key.sequence === "d";


### PR DESCRIPTION
## What

Adds a keyboard-driven **comment-line cursor** so reviewers can target a specific changed line for an inline note without reaching for the mouse. Today `c` always anchors a note at the first line of the selected hunk, and only a mouse click can pick an arbitrary line.

## How it works

- `Shift+J` / `Shift+K` move a comment-line cursor over the changed lines of the selected file, rolling into adjacent hunks and clamping at file edges.
- The cursor line shows the existing "+ note" affordance badge (persistently, unlike hover).
- `c` anchors the note at the cursor line, falling back to the whole-hunk anchor when the cursor is inactive — so existing behaviour is unchanged for anyone who doesn't use it.

## Implementation

- `core/liveComments.ts`: `commentTargetsForHunk()` enumerates a hunk's changed lines in visual order.
- `useReviewController.ts`: cursor state, `moveCommentLineCursor` / `clearCommentLineCursor`, and a derived `activeCommentLineTarget`; `startUserNote` adopts the cursor line.
- `keyboard.ts` + `useAppKeyboardShortcuts.ts`: `Shift+J` / `Shift+K` matchers, handled before the plain `j` / `k` row-scroll bindings.
- `PierreDiffView` / `DiffSection` / `DiffPane`: thread `activeCommentLineTarget` through so the badge pins the cursor line.
- `HelpDialog.tsx`: documents the new binding.

## Tests

- Unit test for `commentTargetsForHunk`.
- Controller test covering cursor movement, cross-hunk rolling, and note targeting.

`bun run typecheck`, `bun run lint`, and `bun test ./src` all pass (aside from two pre-existing `src/core/vcs/git.test.ts` failures unrelated to this change — they assert plain-text git diff output but the local environment emits ANSI colour).
