### PR TITLE
refactor(flake): port flake to flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,6 +42,26 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs-lib"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "import-tree": {
       "locked": {
         "lastModified": 1763762820,
@@ -91,7 +111,11 @@
     "root": {
       "inputs": {
         "bun2nix": "bun2nix",
-        "nixpkgs": "nixpkgs"
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,17 @@
   description = "Dev Flake for Modem-dev's Hunk";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    bun2nix.url = "github:nix-community/bun2nix";
-    bun2nix.inputs.nixpkgs.follows = "nixpkgs";
+    nixpkgs-lib.follows = "nixpkgs";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs-lib";
+    };
+    bun2nix = {
+      url = "github:nix-community/bun2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
+
   nixConfig = {
     extra-substituters = [
       "https://nix-community.cachix.org"
@@ -13,69 +21,66 @@
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
   };
-  outputs = {
-    self,
-    nixpkgs,
-    bun2nix,
-    ...
-  }: let
-    lib = nixpkgs.lib;
-    supportedSystems = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
-    forAllSystems = lib.genAttrs supportedSystems;
-    perSystem = forAllSystems (
-      system: let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
-        hunk = pkgs.callPackage ./nix/package.nix {
-          bun2nix = bun2nix.packages.${system}.default;
-        };
-        updateBunLock = pkgs.writeShellScriptBin "hunk-update-bun-lock" ''
-          set -euo pipefail
-          ${bun2nix.packages.${system}.default}/bin/bun2nix -o nix/bun.lock.nix -c ../ "$@"
-          if [ -s nix/bun.lock.nix ] && [ "$(${pkgs.coreutils}/bin/tail -c 1 nix/bun.lock.nix)" != "" ]; then
-            printf '\n' >> nix/bun.lock.nix
-          fi
-        '';
-      in {
-        packages = {
-          inherit hunk;
-          default = hunk;
-        };
-        apps = {
-          default = {
-            type = "app";
-            program = "${hunk}/bin/hunk";
-            meta.description = "Run Hunk";
-          };
-          update-bun-lock = {
-            type = "app";
-            program = "${updateBunLock}/bin/hunk-update-bun-lock";
-            meta.description = "Regenerate nix/bun.lock.nix with the flake-pinned bun2nix";
-          };
-        };
-        devShells = {
-          default = pkgs.callPackage ./nix/devShell.nix {};
-        };
-      }
-    );
-    systemOutput = name: lib.mapAttrs (_: value: value.${name}) perSystem;
-  in {
-    packages = systemOutput "packages";
-    apps = systemOutput "apps";
-    devShells = systemOutput "devShells";
 
-    homeManagerModules = {
-      hunk = import ./nix/home-manager.nix;
-      default = {pkgs, ...}: {
-        imports = [self.homeManagerModules.hunk];
-        programs.hunk.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  outputs =
+    { flake-parts, bun2nix, ... }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      perSystem =
+        { system, pkgs, ... }:
+        let
+          hunk = pkgs.callPackage ./nix/package.nix {
+            bun2nix = bun2nix.packages.${system}.default;
+          };
+
+          updateBunLock = pkgs.writeShellScriptBin "hunk-update-bun-lock" ''
+            set -euo pipefail
+            ${bun2nix.packages.${system}.default}/bin/bun2nix -o nix/bun.lock.nix -c ../ "$@"
+            if [ -s nix/bun.lock.nix ] && [ "$(${pkgs.coreutils}/bin/tail -c 1 nix/bun.lock.nix)" != "" ]; then
+              printf '\n' >> nix/bun.lock.nix
+            fi
+          '';
+        in
+        {
+          packages = {
+            inherit hunk;
+            default = hunk;
+          };
+
+          apps = {
+            default = {
+              type = "app";
+              program = "${hunk}/bin/hunk";
+              meta.description = "Run Hunk";
+            };
+
+            update-bun-lock = {
+              type = "app";
+              program = "${updateBunLock}/bin/hunk-update-bun-lock";
+              meta.description = "Regenerate nix/bun.lock.nix with the flake-pinned bun2nix";
+            };
+          };
+
+          devShells = {
+            default = pkgs.callPackage ./nix/devShell.nix { };
+          };
+        };
+
+      flake = {
+        homeManagerModules = {
+          hunk = import ./nix/home-manager.nix;
+          default = { pkgs, lib, ... }: {
+            imports = [ inputs.self.homeManagerModules.hunk ];
+            programs.hunk.package =
+              lib.mkDefault
+                inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          };
+        };
       };
     };
-  };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,49 +3,54 @@
   bun2nix,
   lib,
   ...
-}: let
+}:
+let
   packageJson = lib.importJSON ../package.json;
 in
-  bun2nix.mkDerivation {
-    pname = "hunkdiff";
-    version = packageJson.version;
+bun2nix.mkDerivation {
+  pname = "hunkdiff";
+  version = packageJson.version;
 
-    src = ../.;
+  src = ../.;
 
-    bunDeps = bun2nix.fetchBunDeps {
-      bunNix = ./bun.lock.nix;
-    };
+  bunDeps = bun2nix.fetchBunDeps {
+    bunNix = ./bun.lock.nix;
+  };
 
-    buildPhase = ''
-      runHook preBuild
-      mkdir -p .bun-tmp .bun-install
-      BUN_TMPDIR=$PWD/.bun-tmp \
-      BUN_INSTALL=$PWD/.bun-install \
-      ${bun}/bin/bun build --compile \
-        --no-compile-autoload-bunfig \
-        "./src/main.tsx" \
-        --outfile "hunk-bin"
-      runHook postBuild
-    '';
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p .bun-tmp .bun-install
+    BUN_TMPDIR=$PWD/.bun-tmp \
+    BUN_INSTALL=$PWD/.bun-install \
+    ${bun}/bin/bun build --compile \
+      --no-compile-autoload-bunfig \
+      "./src/main.tsx" \
+      --outfile "hunk-bin"
+    runHook postBuild
+  '';
 
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      cp -p ./hunk-bin $out/bin/hunk
-      cp -r ./skills $out/
-      runHook postInstall
-    '';
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp -p ./hunk-bin $out/bin/hunk
+    cp -r ./skills $out/
+    runHook postInstall
+  '';
 
-    # See https://nix-community.github.io/bun2nix/building-packages/hook.html#arguments for options
-    dontFixup = true;
-    dontStrip = true;
-    dontRunLifecycleScripts = true;
+  # See https://nix-community.github.io/bun2nix/building-packages/hook.html#arguments for options
+  dontFixup = true;
+  dontStrip = true;
+  dontRunLifecycleScripts = true;
 
-    meta = with lib; {
-      description = "Terminal diff viewer for agentic changesets";
-      homepage = "https://github.com/modem-dev/hunk";
-      license = licenses.mit;
-      mainProgram = "hunk";
-      platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-    };
-  }
+  meta = with lib; {
+    description = "Terminal diff viewer for agentic changesets";
+    homepage = "https://github.com/modem-dev/hunk";
+    license = licenses.mit;
+    mainProgram = "hunk";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
TLDR: migrate to flake-parts to fix evaluation breakage from NixOS 26.11 dropping x86_64-darwin

Replaces the custom `forAllSystems` loop with `flake-parts` to restore lazy evaluation semantics and ensure 1:1 behavioral parity. The old manual plumbing forced evaluation across all declared systems simultaneously, causing the removal of `x86_64-darwin` in NixOS 26.11 to completely break evaluation on Linux and other systems.