### PR TITLE
Authenticate session daemon restarts

### DIFF
--- a/.changeset/quiet-daemons-guard.md
+++ b/.changeset/quiet-daemons-guard.md
@@ -2,4 +2,4 @@
 "hunkdiff": patch
 ---
 
-Authenticate the local session daemon before reusing or restarting it so a foreign process on the configured port is reported as a conflict instead of being signaled.
+Authenticate the local session daemon before reusing or restarting it so a foreign process on the configured port is reported as a conflict instead of being signaled. Older pre-authentication daemons now require closing older Hunk windows before retrying.

--- a/.changeset/quiet-daemons-guard.md
+++ b/.changeset/quiet-daemons-guard.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Authenticate the local session daemon before reusing or restarting it so a foreign process on the configured port is reported as a conflict instead of being signaled.

--- a/src/hunk-session/cli.test.ts
+++ b/src/hunk-session/cli.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createTestListedSession,
   createTestSelectedSessionContext,
@@ -16,6 +19,11 @@ import {
   HUNK_SESSION_DAEMON_VERSION,
 } from "../session/protocol";
 import {
+  buildSessionBrokerRuntimeMetadata,
+  resolveSessionBrokerRuntimePaths,
+  writeSessionBrokerRuntimeMetadata,
+} from "../session-broker/brokerLauncher";
+import {
   createHttpHunkSessionCliClient,
   formatClearCommentsOutput,
   formatCommentApplyOutput,
@@ -32,13 +40,52 @@ import {
 
 const selector = { sessionId: "session-1" } satisfies SessionSelectorInput;
 const originalFetch = globalThis.fetch;
+const originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+const runtimeDirs: string[] = [];
+const testNonce = "test-session-cli-nonce";
+
+function createRuntimeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "hunk-session-cli-test-"));
+  runtimeDirs.push(dir);
+  process.env.XDG_RUNTIME_DIR = dir;
+  return dir;
+}
+
+function writeMetadata(port = 47657, nonce = testNonce) {
+  writeSessionBrokerRuntimeMetadata(
+    resolveSessionBrokerRuntimePaths({
+      host: "127.0.0.1",
+      port,
+    }),
+    buildSessionBrokerRuntimeMetadata({
+      config: {
+        host: "127.0.0.1",
+        port,
+      },
+      nonce,
+    }),
+  );
+}
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  if (originalRuntimeDir === undefined) {
+    delete process.env.XDG_RUNTIME_DIR;
+  } else {
+    process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+  }
+  while (runtimeDirs.length > 0) {
+    const dir = runtimeDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
 });
 
 describe("HTTP Hunk session CLI client", () => {
   test("maps CLI methods onto the daemon session API envelope", async () => {
+    createRuntimeDir();
+    writeMetadata();
     const requests: unknown[] = [];
     const session = createTestListedSession();
     const context = createTestSelectedSessionContext();
@@ -100,6 +147,7 @@ describe("HTTP Hunk session CLI client", () => {
         return Response.json({
           version: HUNK_SESSION_API_VERSION,
           daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+          nonce: testNonce,
           actions: Object.keys(responses),
         });
       }

--- a/src/session-broker/brokerClient.test.ts
+++ b/src/session-broker/brokerClient.test.ts
@@ -1,10 +1,18 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createTestSessionRegistration,
   createTestSessionReviewFile,
   createTestSessionSnapshot,
 } from "../../test/helpers/session-daemon-fixtures";
+import {
+  buildSessionBrokerRuntimeMetadata,
+  resolveSessionBrokerRuntimePaths,
+  writeSessionBrokerRuntimeMetadata,
+} from "./brokerLauncher";
 import { HUNK_SESSION_API_VERSION, HUNK_SESSION_DAEMON_VERSION } from "../session/protocol";
 import { SessionBrokerClient } from "./brokerClient";
 
@@ -12,7 +20,10 @@ const originalHost = process.env.HUNK_MCP_HOST;
 const originalPort = process.env.HUNK_MCP_PORT;
 const originalDisable = process.env.HUNK_MCP_DISABLE;
 const originalUnsafeRemote = process.env.HUNK_MCP_UNSAFE_ALLOW_REMOTE;
+const originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
 const originalConsoleError = console.error;
+const runtimeDirs: string[] = [];
+const testNonce = "test-session-broker-client-nonce";
 
 function createRegistration() {
   return createTestSessionRegistration({
@@ -47,6 +58,24 @@ async function waitUntil(label: string, fn: () => boolean, timeoutMs = 5_000, in
   throw new Error(`Timed out waiting for ${label}.`);
 }
 
+function createRuntimeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "hunk-session-broker-client-test-"));
+  runtimeDirs.push(dir);
+  process.env.XDG_RUNTIME_DIR = dir;
+  return dir;
+}
+
+function writeMetadata(
+  config: { host: string; port: number; httpOrigin: string; wsOrigin: string },
+  nonce = testNonce,
+  pid = process.pid,
+) {
+  writeSessionBrokerRuntimeMetadata(
+    resolveSessionBrokerRuntimePaths(config),
+    buildSessionBrokerRuntimeMetadata({ config, nonce, pid }),
+  );
+}
+
 afterEach(() => {
   if (originalHost === undefined) {
     delete process.env.HUNK_MCP_HOST;
@@ -70,6 +99,19 @@ afterEach(() => {
     delete process.env.HUNK_MCP_UNSAFE_ALLOW_REMOTE;
   } else {
     process.env.HUNK_MCP_UNSAFE_ALLOW_REMOTE = originalUnsafeRemote;
+  }
+
+  if (originalRuntimeDir === undefined) {
+    delete process.env.XDG_RUNTIME_DIR;
+  } else {
+    process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+  }
+
+  while (runtimeDirs.length > 0) {
+    const dir = runtimeDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   }
 
   console.error = originalConsoleError;
@@ -131,6 +173,149 @@ describe("Hunk session daemon client", () => {
     }
   });
 
+  test("restartIncompatibleDaemon refuses to signal an unauthenticated health listener", async () => {
+    createRuntimeDir();
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ ok: true, pid: 54321, sessions: 0, pendingCommands: 0 }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const config = {
+      host: "127.0.0.1",
+      port,
+      httpOrigin: `http://127.0.0.1:${port}`,
+      wsOrigin: `ws://127.0.0.1:${port}`,
+    };
+
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    const originalKill = process.kill;
+    const killCalls: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      killCalls.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      await expect((client as any).restartIncompatibleDaemon(config)).rejects.toThrow(
+        /occupied by a non-Hunk process/,
+      );
+      expect(killCalls.filter((call) => call.signal !== 0)).toEqual([]);
+    } finally {
+      process.kill = originalKill;
+      client.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("restartIncompatibleDaemon refuses to signal when runtime metadata and health disagree on pid", async () => {
+    createRuntimeDir();
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          pid: 54321,
+          nonce: testNonce,
+          sessions: 0,
+          pendingCommands: 0,
+        }),
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const config = {
+      host: "127.0.0.1",
+      port,
+      httpOrigin: `http://127.0.0.1:${port}`,
+      wsOrigin: `ws://127.0.0.1:${port}`,
+    };
+    writeMetadata(config, testNonce, 12345);
+
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    const originalKill = process.kill;
+    const killCalls: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      killCalls.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      await expect((client as any).restartIncompatibleDaemon(config)).rejects.toThrow(
+        /occupied by a non-Hunk process/,
+      );
+      expect(killCalls.filter((call) => call.signal !== 0)).toEqual([]);
+    } finally {
+      process.kill = originalKill;
+      client.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("restartIncompatibleDaemon still signals a matching authenticated daemon", async () => {
+    createRuntimeDir();
+    const daemonPid = 54321;
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          pid: daemonPid,
+          nonce: testNonce,
+          sessions: 0,
+          pendingCommands: 0,
+        }),
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const config = {
+      host: "127.0.0.1",
+      port,
+      httpOrigin: `http://127.0.0.1:${port}`,
+      wsOrigin: `ws://127.0.0.1:${port}`,
+    };
+    writeMetadata(config, testNonce, daemonPid);
+
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    const originalKill = process.kill;
+    const killCalls: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      killCalls.push({ pid, signal });
+      if (signal === "SIGTERM") {
+        void new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      await expect((client as any).restartIncompatibleDaemon(config)).resolves.toBeUndefined();
+      expect(killCalls.filter((call) => call.signal !== 0)).toEqual([
+        { pid: daemonPid, signal: "SIGTERM" },
+      ]);
+    } finally {
+      process.kill = originalKill;
+      client.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   test("logs one actionable warning when a refreshed daemon rejects an older Hunk window", async () => {
     const listener = createServer((_request, response) => {
       response.writeHead(200, { "content-type": "application/json" });
@@ -152,13 +337,20 @@ describe("Hunk session daemon client", () => {
       fetch(request, bunServer) {
         const url = new URL(request.url);
         if (url.pathname === "/health") {
-          return Response.json({ ok: true, pid: process.pid, sessions: 0, pendingCommands: 0 });
+          return Response.json({
+            ok: true,
+            pid: process.pid,
+            nonce: testNonce,
+            sessions: 0,
+            pendingCommands: 0,
+          });
         }
 
         if (url.pathname === "/session-api/capabilities") {
           return Response.json({
             version: HUNK_SESSION_API_VERSION,
             daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+            nonce: testNonce,
             actions: ["list"],
           });
         }

--- a/src/session-broker/brokerClient.test.ts
+++ b/src/session-broker/brokerClient.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -213,6 +213,71 @@ describe("Hunk session daemon client", () => {
     }
   });
 
+  test("restartIncompatibleDaemon refuses to signal a pre-authentication Hunk daemon", async () => {
+    createRuntimeDir();
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          pid: 54321,
+          sessions: 0,
+          pendingCommands: 0,
+          sessionApi: "http://127.0.0.1/session-api",
+          sessionCapabilities: "http://127.0.0.1/session-api/capabilities",
+          sessionSocket: "ws://127.0.0.1/session",
+        }),
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const config = {
+      host: "127.0.0.1",
+      port,
+      httpOrigin: `http://127.0.0.1:${port}`,
+      wsOrigin: `ws://127.0.0.1:${port}`,
+    };
+    const paths = resolveSessionBrokerRuntimePaths(config);
+    mkdirSync(paths.runtimeDir, { recursive: true });
+    writeFileSync(
+      paths.metadataPath,
+      JSON.stringify({
+        pid: 54321,
+        host: config.host,
+        port: config.port,
+        command: process.execPath,
+        args: ["daemon", "serve"],
+        launchedAt: new Date().toISOString(),
+        launchedByPid: process.ppid,
+        launchCwd: process.cwd(),
+      }),
+    );
+
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    const originalKill = process.kill;
+    const killCalls: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      killCalls.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      await expect((client as any).restartIncompatibleDaemon(config)).rejects.toThrow(
+        /older Hunk session daemon/,
+      );
+      expect(killCalls.filter((call) => call.signal !== 0)).toEqual([]);
+    } finally {
+      process.kill = originalKill;
+      client.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   test("restartIncompatibleDaemon refuses to signal when runtime metadata and health disagree on pid", async () => {
     createRuntimeDir();
     const server = createServer((_request, response) => {
@@ -254,6 +319,60 @@ describe("Hunk session daemon client", () => {
       await expect((client as any).restartIncompatibleDaemon(config)).rejects.toThrow(
         /occupied by a non-Hunk process/,
       );
+      expect(killCalls.filter((call) => call.signal !== 0)).toEqual([]);
+    } finally {
+      process.kill = originalKill;
+      client.stop();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("restartIncompatibleDaemon retries instead of signaling when the daemon identity changed", async () => {
+    createRuntimeDir();
+    const daemonPid = 67890;
+    const daemonNonce = "fresh-session-broker-client-nonce";
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          ok: true,
+          pid: daemonPid,
+          nonce: daemonNonce,
+          sessions: 0,
+          pendingCommands: 0,
+        }),
+      );
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    const config = {
+      host: "127.0.0.1",
+      port,
+      httpOrigin: `http://127.0.0.1:${port}`,
+      wsOrigin: `ws://127.0.0.1:${port}`,
+    };
+    writeMetadata(config, daemonNonce, daemonPid);
+
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    const originalKill = process.kill;
+    const killCalls: Array<{ pid: number; signal?: string | number }> = [];
+    process.kill = ((pid: number, signal?: string | number) => {
+      killCalls.push({ pid, signal });
+      return true;
+    }) as typeof process.kill;
+
+    try {
+      await expect(
+        (client as any).restartIncompatibleDaemon(config, {
+          pid: 12345,
+          nonce: "stale-session-broker-client-nonce",
+        }),
+      ).resolves.toBe("identity-changed");
       expect(killCalls.filter((call) => call.signal !== 0)).toEqual([]);
     } finally {
       process.kill = originalKill;

--- a/src/session-broker/brokerClient.ts
+++ b/src/session-broker/brokerClient.ts
@@ -17,11 +17,14 @@ import {
 import {
   ensureSessionBrokerAvailable,
   inspectSessionBrokerPort,
+  isSameSessionBrokerDaemonIdentity,
   nonHunkProcessPortConflictError,
+  type SessionBrokerDaemonIdentity,
+  unauthenticatedHunkDaemonPortConflictError,
   waitForSessionBrokerShutdown,
 } from "./brokerLauncher";
 import {
-  readHunkSessionDaemonCapabilities,
+  readHunkSessionDaemonCapabilitiesForIdentity,
   reportHunkDaemonUpgradeRestart,
 } from "../session/capabilities";
 
@@ -118,38 +121,89 @@ export class SessionBrokerClient<
   }
 
   private async ensureDaemonAvailable(config: ResolvedSessionBrokerConfig) {
-    await ensureSessionBrokerAvailable({
-      config,
-      timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
-    });
-
-    const capabilities = await readHunkSessionDaemonCapabilities(config);
-    if (!capabilities) {
-      await this.restartIncompatibleDaemon(config);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
       await ensureSessionBrokerAvailable({
         config,
         timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
       });
 
-      if (!(await readHunkSessionDaemonCapabilities(config))) {
-        throw new Error(
-          "The running session broker daemon is incompatible with this build. " +
-            "Restart the app so it can launch a fresh daemon from the current source tree.",
+      const portState = await inspectSessionBrokerPort({ config });
+      if (portState.kind === "foreign") {
+        throw nonHunkProcessPortConflictError(config);
+      }
+
+      if (portState.kind === "legacy") {
+        throw unauthenticatedHunkDaemonPortConflictError(config);
+      }
+
+      if (portState.kind !== "daemon") {
+        continue;
+      }
+
+      const capabilities = await readHunkSessionDaemonCapabilitiesForIdentity(
+        config,
+        portState.health,
+      );
+      if (capabilities) {
+        this.lastConnectionWarning = null;
+        return;
+      }
+
+      const restartResult = await this.restartIncompatibleDaemon(config, portState.health);
+      if (restartResult === "identity-changed") {
+        continue;
+      }
+
+      await ensureSessionBrokerAvailable({
+        config,
+        timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
+      });
+
+      const refreshedState = await inspectSessionBrokerPort({ config });
+      if (refreshedState.kind === "daemon") {
+        const refreshedCapabilities = await readHunkSessionDaemonCapabilitiesForIdentity(
+          config,
+          refreshedState.health,
         );
+        if (refreshedCapabilities) {
+          this.lastConnectionWarning = null;
+          return;
+        }
       }
     }
 
-    this.lastConnectionWarning = null;
+    throw new Error(
+      "The running session broker daemon is incompatible with this build. " +
+        "Restart the app so it can launch a fresh daemon from the current source tree.",
+    );
   }
 
-  private async restartIncompatibleDaemon(config: ResolvedSessionBrokerConfig) {
-    reportHunkDaemonUpgradeRestart();
+  private async restartIncompatibleDaemon(
+    config: ResolvedSessionBrokerConfig,
+    expectedIdentity?: SessionBrokerDaemonIdentity,
+  ) {
     const portState = await inspectSessionBrokerPort({ config });
     if (portState.kind === "foreign") {
       throw nonHunkProcessPortConflictError(config);
     }
 
+    if (portState.kind === "legacy") {
+      throw unauthenticatedHunkDaemonPortConflictError(config);
+    }
+
+    if (portState.kind === "starting") {
+      return "identity-changed" as const;
+    }
+
     const health = portState.kind === "daemon" ? portState.health : null;
+    if (
+      health &&
+      expectedIdentity &&
+      !isSameSessionBrokerDaemonIdentity(health, expectedIdentity)
+    ) {
+      return "identity-changed" as const;
+    }
+
     const pid = health?.pid;
     if (pid === process.pid) {
       throw new Error(
@@ -164,6 +218,7 @@ export class SessionBrokerClient<
       return;
     }
 
+    reportHunkDaemonUpgradeRestart();
     try {
       process.kill(pid, "SIGTERM");
     } catch (error) {
@@ -175,6 +230,7 @@ export class SessionBrokerClient<
     const shutDown = await waitForSessionBrokerShutdown({
       config,
       timeoutMs: DAEMON_STARTUP_TIMEOUT_MS,
+      identity: health,
     });
     if (!shutDown) {
       throw new Error(

--- a/src/session-broker/brokerClient.ts
+++ b/src/session-broker/brokerClient.ts
@@ -16,7 +16,8 @@ import {
 } from "./brokerConfig";
 import {
   ensureSessionBrokerAvailable,
-  readSessionBrokerHealth,
+  inspectSessionBrokerPort,
+  nonHunkProcessPortConflictError,
   waitForSessionBrokerShutdown,
 } from "./brokerLauncher";
 import {
@@ -143,7 +144,12 @@ export class SessionBrokerClient<
 
   private async restartIncompatibleDaemon(config: ResolvedSessionBrokerConfig) {
     reportHunkDaemonUpgradeRestart();
-    const health = await readSessionBrokerHealth(config);
+    const portState = await inspectSessionBrokerPort({ config });
+    if (portState.kind === "foreign") {
+      throw nonHunkProcessPortConflictError(config);
+    }
+
+    const health = portState.kind === "daemon" ? portState.health : null;
     const pid = health?.pid;
     if (pid === process.pid) {
       throw new Error(

--- a/src/session-broker/brokerLauncher.test.ts
+++ b/src/session-broker/brokerLauncher.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { ChildProcess } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  buildSessionBrokerRuntimeMetadata,
   ensureSessionBrokerAvailable,
+  inspectSessionBrokerPort,
   isLoopbackPortReachable,
+  readSessionBrokerRuntimeMetadata,
   resolveDaemonLaunchCommand,
   resolveSessionBrokerRuntimePaths,
+  writeSessionBrokerRuntimeMetadata,
 } from "./brokerLauncher";
 
 const tempDirs: string[] = [];
@@ -143,16 +147,10 @@ describe("session daemon launcher", () => {
 
     const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
     expect(existsSync(paths.lockPath)).toBe(false);
-    expect(JSON.parse(readFileSync(paths.metadataPath, "utf8"))).toMatchObject({
-      pid: process.pid,
-      host: "127.0.0.1",
-      port: 47657,
-      command: "/usr/bin/bun",
-      args: ["src/main.tsx", "daemon", "serve"],
-    });
+    expect(existsSync(paths.metadataPath)).toBe(false);
   });
 
-  test("recovers a stale launch lock from a dead launcher and overwrites stale metadata", async () => {
+  test("recovers a stale launch lock from a dead launcher and removes stale metadata", async () => {
     const runtimeDir = createRuntimeDir();
     const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
     const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
@@ -178,9 +176,10 @@ describe("session daemon launcher", () => {
           pid: 999999,
           host: testConfig.host,
           port: testConfig.port,
+          nonce: "stale-nonce",
           command: "/usr/bin/bun",
           args: ["src/main.tsx", "daemon", "serve"],
-          launchedAt: new Date(0).toISOString(),
+          startedAt: new Date(0).toISOString(),
           launchedByPid: 999999,
           launchCwd: "/stale",
         },
@@ -211,10 +210,102 @@ describe("session daemon launcher", () => {
 
     expect(launchCount).toBe(1);
     expect(existsSync(paths.lockPath)).toBe(false);
-    expect(JSON.parse(readFileSync(paths.metadataPath, "utf8"))).toMatchObject({
-      pid: 54321,
-      launchedByPid: process.pid,
-      launchCwd: "/repo",
+    expect(existsSync(paths.metadataPath)).toBe(false);
+  });
+
+  test("reads runtime metadata only when it matches the configured port", () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
+    const metadata = buildSessionBrokerRuntimeMetadata({
+      config: testConfig,
+      nonce: "runtime-nonce",
+      pid: process.pid,
     });
+    writeSessionBrokerRuntimeMetadata(paths, metadata);
+
+    expect(readSessionBrokerRuntimeMetadata(testConfig, env)).toMatchObject({
+      pid: process.pid,
+      nonce: "runtime-nonce",
+    });
+    expect(
+      readSessionBrokerRuntimeMetadata(
+        {
+          host: testConfig.host,
+          port: testConfig.port + 1,
+        },
+        env,
+      ),
+    ).toBeNull();
+  });
+
+  test("classifies an unauthenticated health response as foreign", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const listener = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => Response.json({ ok: true, pid: 54321 }),
+    });
+    const config = {
+      host: "127.0.0.1",
+      port: listener.port!,
+      httpOrigin: `http://127.0.0.1:${listener.port}`,
+      wsOrigin: `ws://127.0.0.1:${listener.port}`,
+    };
+
+    try {
+      await expect(inspectSessionBrokerPort({ config, env })).resolves.toEqual({ kind: "foreign" });
+    } finally {
+      listener.stop(true);
+    }
+  });
+
+  test("classifies matching health and runtime metadata as the active daemon", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const nonce = "verified-runtime-nonce";
+    const listener = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        Response.json({
+          ok: true,
+          pid: process.pid,
+          nonce,
+          sessions: 0,
+          pendingCommands: 0,
+        }),
+    });
+    const config = {
+      host: "127.0.0.1",
+      port: listener.port!,
+      httpOrigin: `http://127.0.0.1:${listener.port}`,
+      wsOrigin: `ws://127.0.0.1:${listener.port}`,
+    };
+    writeSessionBrokerRuntimeMetadata(
+      resolveSessionBrokerRuntimePaths(config, env),
+      buildSessionBrokerRuntimeMetadata({
+        config,
+        nonce,
+        pid: process.pid,
+      }),
+    );
+
+    try {
+      await expect(inspectSessionBrokerPort({ config, env })).resolves.toMatchObject({
+        kind: "daemon",
+        health: {
+          pid: process.pid,
+          nonce,
+        },
+        metadata: {
+          pid: process.pid,
+          nonce,
+        },
+      });
+    } finally {
+      listener.stop(true);
+    }
   });
 });

--- a/src/session-broker/brokerLauncher.test.ts
+++ b/src/session-broker/brokerLauncher.test.ts
@@ -261,6 +261,155 @@ describe("session daemon launcher", () => {
     }
   });
 
+  test("classifies a pre-authentication Hunk daemon as legacy", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const listener = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        Response.json({
+          ok: true,
+          pid: process.pid,
+          sessions: 0,
+          pendingCommands: 0,
+          sessionApi: "http://127.0.0.1/session-api",
+          sessionCapabilities: "http://127.0.0.1/session-api/capabilities",
+          sessionSocket: "ws://127.0.0.1/session",
+        }),
+    });
+    const config = {
+      host: "127.0.0.1",
+      port: listener.port!,
+      httpOrigin: `http://127.0.0.1:${listener.port}`,
+      wsOrigin: `ws://127.0.0.1:${listener.port}`,
+    };
+    const paths = resolveSessionBrokerRuntimePaths(config, env);
+    mkdirSync(paths.runtimeDir, { recursive: true });
+    writeFileSync(
+      paths.metadataPath,
+      JSON.stringify({
+        pid: process.pid,
+        host: config.host,
+        port: config.port,
+        command: process.execPath,
+        args: ["daemon", "serve"],
+        launchedAt: new Date().toISOString(),
+        launchedByPid: process.ppid,
+        launchCwd: process.cwd(),
+      }),
+    );
+
+    try {
+      await expect(inspectSessionBrokerPort({ config, env })).resolves.toEqual({ kind: "legacy" });
+    } finally {
+      listener.stop(true);
+    }
+  });
+
+  test("does not launch a replacement over a pre-authentication Hunk daemon", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const listener = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        Response.json({
+          ok: true,
+          pid: process.pid,
+          sessions: 0,
+          pendingCommands: 0,
+          sessionApi: "http://127.0.0.1/session-api",
+          sessionCapabilities: "http://127.0.0.1/session-api/capabilities",
+          sessionSocket: "ws://127.0.0.1/session",
+        }),
+    });
+    const config = {
+      host: "127.0.0.1",
+      port: listener.port!,
+      httpOrigin: `http://127.0.0.1:${listener.port}`,
+      wsOrigin: `ws://127.0.0.1:${listener.port}`,
+    };
+    const paths = resolveSessionBrokerRuntimePaths(config, env);
+    mkdirSync(paths.runtimeDir, { recursive: true });
+    writeFileSync(
+      paths.metadataPath,
+      JSON.stringify({
+        pid: process.pid,
+        host: config.host,
+        port: config.port,
+        command: process.execPath,
+        args: ["daemon", "serve"],
+        launchedAt: new Date().toISOString(),
+        launchedByPid: process.ppid,
+        launchCwd: process.cwd(),
+      }),
+    );
+    let launchAttempts = 0;
+
+    try {
+      await expect(
+        ensureSessionBrokerAvailable({
+          config,
+          env,
+          timeoutMs: 50,
+          intervalMs: 10,
+          launchDaemon: () => {
+            launchAttempts += 1;
+            return { pid: process.pid } as ChildProcess;
+          },
+        }),
+      ).rejects.toThrow(/older Hunk session daemon/);
+      expect(launchAttempts).toBe(0);
+    } finally {
+      listener.stop(true);
+    }
+  });
+
+  test("classifies authenticated health without metadata as starting while launch lock is live", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const nonce = "starting-runtime-nonce";
+    const listener = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        Response.json({
+          ok: true,
+          pid: process.pid,
+          nonce,
+          sessions: 0,
+          pendingCommands: 0,
+        }),
+    });
+    const config = {
+      host: "127.0.0.1",
+      port: listener.port!,
+      httpOrigin: `http://127.0.0.1:${listener.port}`,
+      wsOrigin: `ws://127.0.0.1:${listener.port}`,
+    };
+    const paths = resolveSessionBrokerRuntimePaths(config, env);
+    mkdirSync(paths.runtimeDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      paths.lockPath,
+      JSON.stringify({
+        ownerPid: process.pid,
+        host: config.host,
+        port: config.port,
+        acquiredAt: new Date().toISOString(),
+      }),
+      { mode: 0o600 },
+    );
+
+    try {
+      await expect(inspectSessionBrokerPort({ config, env })).resolves.toEqual({
+        kind: "starting",
+      });
+    } finally {
+      listener.stop(true);
+    }
+  });
+
   test("classifies matching health and runtime metadata as the active daemon", async () => {
     const runtimeDir = createRuntimeDir();
     const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };

--- a/src/session-broker/brokerLauncher.ts
+++ b/src/session-broker/brokerLauncher.ts
@@ -29,13 +29,14 @@ interface SessionBrokerLaunchLockFile {
   acquiredAt: string;
 }
 
-interface SessionBrokerLaunchMetadata {
+export interface SessionBrokerRuntimeMetadata {
   pid: number;
   host: string;
   port: number;
+  nonce: string;
   command: string;
   args: string[];
-  launchedAt: string;
+  startedAt: string;
   launchedByPid: number;
   launchCwd: string;
 }
@@ -43,6 +44,33 @@ interface SessionBrokerLaunchMetadata {
 interface SessionBrokerLaunchLock {
   release: () => void;
 }
+
+export interface SessionBrokerHealth {
+  ok: boolean;
+  pid: number;
+  nonce: string;
+  sessions?: number;
+  pendingCommands?: number;
+  startedAt?: string;
+  uptimeMs?: number;
+  sessionApi?: string;
+  sessionCapabilities?: string;
+  sessionSocket?: string;
+  staleSessionTtlMs?: number;
+}
+
+export type SessionBrokerPortState =
+  | {
+      kind: "daemon";
+      health: SessionBrokerHealth;
+      metadata: SessionBrokerRuntimeMetadata;
+    }
+  | {
+      kind: "foreign";
+    }
+  | {
+      kind: "none";
+    };
 
 export interface EnsureSessionBrokerAvailableOptions {
   config?: ResolvedSessionBrokerConfig;
@@ -91,6 +119,14 @@ function resolveRuntimeBaseDir(env: NodeJS.ProcessEnv = process.env) {
   return env.XDG_RUNTIME_DIR?.trim() || tmpdir();
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
 function isRunningPid(pid: number) {
   if (!Number.isInteger(pid) || pid <= 0) {
     return false;
@@ -120,9 +156,62 @@ function removeFileIfPresent(path: string) {
   }
 }
 
+function isValidSessionBrokerRuntimeMetadata(
+  value: unknown,
+): value is SessionBrokerRuntimeMetadata {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const metadata = value as Record<string, unknown>;
+  return (
+    Number.isInteger(metadata.pid) &&
+    (metadata.pid as number) > 0 &&
+    isNonEmptyString(metadata.host) &&
+    Number.isInteger(metadata.port) &&
+    (metadata.port as number) > 0 &&
+    isNonEmptyString(metadata.nonce) &&
+    isNonEmptyString(metadata.command) &&
+    isStringArray(metadata.args) &&
+    isNonEmptyString(metadata.startedAt) &&
+    Number.isInteger(metadata.launchedByPid) &&
+    (metadata.launchedByPid as number) >= 0 &&
+    isNonEmptyString(metadata.launchCwd)
+  );
+}
+
+function isValidSessionBrokerHealth(value: unknown): value is SessionBrokerHealth {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const health = value as Record<string, unknown>;
+  return (
+    health.ok === true &&
+    Number.isInteger(health.pid) &&
+    (health.pid as number) > 0 &&
+    isNonEmptyString(health.nonce)
+  );
+}
+
+function readSessionBrokerRuntimeMetadataFile(path: string) {
+  const metadata = readJsonFile<unknown>(path);
+  return isValidSessionBrokerRuntimeMetadata(metadata) ? metadata : null;
+}
+
 function cleanStaleDaemonMetadata(paths: SessionBrokerRuntimePaths) {
-  const metadata = readJsonFile<SessionBrokerLaunchMetadata>(paths.metadataPath);
+  const rawMetadata = readJsonFile<{ pid?: unknown }>(paths.metadataPath);
+  const pid = typeof rawMetadata?.pid === "number" ? rawMetadata.pid : null;
+  if (pid === null) {
+    return;
+  }
+
+  const metadata = readSessionBrokerRuntimeMetadataFile(paths.metadataPath);
   if (!metadata) {
+    if (!isRunningPid(pid)) {
+      removeFileIfPresent(paths.metadataPath);
+    }
+
     return;
   }
 
@@ -141,7 +230,7 @@ function tryAcquireDaemonLaunchLock({
   staleAfterMs: number;
 }): SessionBrokerLaunchLock | null {
   const paths = resolveSessionBrokerRuntimePaths(config, env);
-  mkdirSync(paths.runtimeDir, { recursive: true });
+  mkdirSync(paths.runtimeDir, { recursive: true, mode: 0o700 });
 
   const payload: SessionBrokerLaunchLockFile = {
     ownerPid: process.pid,
@@ -199,19 +288,73 @@ function tryAcquireDaemonLaunchLock({
   return null;
 }
 
-function writeDaemonLaunchMetadata(
+export function buildSessionBrokerRuntimeMetadata({
+  config = resolveSessionBrokerConfig(),
+  nonce,
+  cwd = process.cwd(),
+  argv = process.argv,
+  execPath = process.execPath,
+  pid = process.pid,
+  launchedByPid = process.ppid,
+}: {
+  config?: Pick<ResolvedSessionBrokerConfig, "host" | "port">;
+  nonce: string;
+  cwd?: string;
+  argv?: string[];
+  execPath?: string;
+  pid?: number;
+  launchedByPid?: number;
+}): SessionBrokerRuntimeMetadata {
+  return {
+    pid,
+    host: config.host,
+    port: config.port,
+    nonce,
+    command: execPath,
+    args: argv.slice(1),
+    startedAt: new Date().toISOString(),
+    launchedByPid,
+    launchCwd: cwd,
+  };
+}
+
+export function writeSessionBrokerRuntimeMetadata(
   paths: SessionBrokerRuntimePaths,
-  metadata: SessionBrokerLaunchMetadata,
+  metadata: SessionBrokerRuntimeMetadata,
 ) {
+  mkdirSync(paths.runtimeDir, { recursive: true, mode: 0o700 });
   writeFileSync(paths.metadataPath, JSON.stringify(metadata, null, 2), {
     encoding: "utf8",
     mode: 0o600,
   });
 }
 
+export function removeSessionBrokerRuntimeMetadata(
+  paths: SessionBrokerRuntimePaths,
+  ownedBy?: Pick<SessionBrokerRuntimeMetadata, "pid" | "nonce">,
+) {
+  if (ownedBy) {
+    const current = readSessionBrokerRuntimeMetadataFile(paths.metadataPath);
+    if (!current || current.pid !== ownedBy.pid || current.nonce !== ownedBy.nonce) {
+      return;
+    }
+  }
+
+  removeFileIfPresent(paths.metadataPath);
+}
+
 function daemonPortConflictError(config: Pick<ResolvedSessionBrokerConfig, "host" | "port">) {
   return new Error(
     `Session broker port ${config.host}:${config.port} is already in use by another process. ` +
+      `Stop the conflicting process or set HUNK_MCP_PORT to a different loopback port.`,
+  );
+}
+
+export function nonHunkProcessPortConflictError(
+  config: Pick<ResolvedSessionBrokerConfig, "host" | "port">,
+) {
+  return new Error(
+    `The configured Hunk session daemon port ${config.host}:${config.port} is occupied by a non-Hunk process. ` +
       `Stop the conflicting process or set HUNK_MCP_PORT to a different loopback port.`,
   );
 }
@@ -304,24 +447,26 @@ export function resolveSessionBrokerRuntimePaths(
   };
 }
 
-export interface SessionBrokerHealth {
-  ok: boolean;
-  pid?: number;
-  sessions?: number;
-  pendingCommands?: number;
-  startedAt?: string;
-  uptimeMs?: number;
-  sessionApi?: string;
-  sessionCapabilities?: string;
-  sessionSocket?: string;
-  staleSessionTtlMs?: number;
+export function readSessionBrokerRuntimeMetadata(
+  config: Pick<ResolvedSessionBrokerConfig, "host" | "port"> = resolveSessionBrokerConfig(),
+  env: NodeJS.ProcessEnv = process.env,
+) {
+  const paths = resolveSessionBrokerRuntimePaths(config, env);
+  cleanStaleDaemonMetadata(paths);
+  const metadata = readSessionBrokerRuntimeMetadataFile(paths.metadataPath);
+  if (!metadata) {
+    return null;
+  }
+
+  return metadata.host === config.host && metadata.port === config.port ? metadata : null;
 }
 
-/** Read the daemon's health payload when one is reachable on the configured loopback port. */
-export async function readSessionBrokerHealth(
-  config: ResolvedSessionBrokerConfig = resolveSessionBrokerConfig(),
-  timeoutMs = 500,
-) {
+const INVALID_SESSION_BROKER_HEALTH = Symbol("invalid-session-broker-health");
+
+async function fetchSessionBrokerHealthPayload(
+  config: ResolvedSessionBrokerConfig,
+  timeoutMs: number,
+): Promise<typeof INVALID_SESSION_BROKER_HEALTH | unknown | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   timeout.unref?.();
@@ -334,12 +479,55 @@ export async function readSessionBrokerHealth(
       return null;
     }
 
-    return (await response.json()) as SessionBrokerHealth;
+    try {
+      return await response.json();
+    } catch {
+      return INVALID_SESSION_BROKER_HEALTH;
+    }
   } catch {
     return null;
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function inspectSessionBrokerPort({
+  config = resolveSessionBrokerConfig(),
+  timeoutMs = 500,
+  env = process.env,
+}: {
+  config?: ResolvedSessionBrokerConfig;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+} = {}): Promise<SessionBrokerPortState> {
+  const payload = await fetchSessionBrokerHealthPayload(config, timeoutMs);
+  if (payload === null) {
+    return { kind: "none" };
+  }
+
+  if (payload === INVALID_SESSION_BROKER_HEALTH || !isValidSessionBrokerHealth(payload)) {
+    return { kind: "foreign" };
+  }
+
+  const metadata = readSessionBrokerRuntimeMetadata(config, env);
+  if (!metadata || metadata.pid !== payload.pid || metadata.nonce !== payload.nonce) {
+    return { kind: "foreign" };
+  }
+
+  return {
+    kind: "daemon",
+    health: payload,
+    metadata,
+  };
+}
+
+/** Read the daemon's health payload when one is reachable on the configured loopback port. */
+export async function readSessionBrokerHealth(
+  config: ResolvedSessionBrokerConfig = resolveSessionBrokerConfig(),
+  timeoutMs = 500,
+) {
+  const portState = await inspectSessionBrokerPort({ config, timeoutMs });
+  return portState.kind === "daemon" ? portState.health : null;
 }
 
 /** Check whether the loopback session broker already answers health probes. */
@@ -483,18 +671,7 @@ export async function ensureSessionBrokerAvailable({
           return;
         }
 
-        const launchCommand = resolveDaemonLaunchCommand(argv, execPath);
-        const child = launchDaemon({ cwd, env, argv, execPath });
-        writeDaemonLaunchMetadata(paths, {
-          pid: child.pid ?? 0,
-          host: config.host,
-          port: config.port,
-          command: launchCommand.command,
-          args: launchCommand.args,
-          launchedAt: new Date().toISOString(),
-          launchedByPid: process.pid,
-          launchCwd: cwd,
-        });
+        launchDaemon({ cwd, env, argv, execPath });
 
         const ready = await waitForDaemonHealthWithCheck({
           config,
@@ -526,6 +703,15 @@ export async function ensureSessionBrokerAvailable({
     }
 
     cleanStaleDaemonMetadata(paths);
+  }
+
+  const portState = await inspectSessionBrokerPort({ config, timeoutMs: intervalMs, env });
+  if (portState.kind === "daemon") {
+    return;
+  }
+
+  if (portState.kind === "foreign") {
+    throw nonHunkProcessPortConflictError(config);
   }
 
   if (await isPortReachable(config)) {

--- a/src/session-broker/brokerLauncher.ts
+++ b/src/session-broker/brokerLauncher.ts
@@ -59,11 +59,22 @@ export interface SessionBrokerHealth {
   staleSessionTtlMs?: number;
 }
 
+export interface SessionBrokerDaemonIdentity {
+  pid: number;
+  nonce: string;
+}
+
 export type SessionBrokerPortState =
   | {
       kind: "daemon";
       health: SessionBrokerHealth;
       metadata: SessionBrokerRuntimeMetadata;
+    }
+  | {
+      kind: "legacy";
+    }
+  | {
+      kind: "starting";
     }
   | {
       kind: "foreign";
@@ -194,9 +205,44 @@ function isValidSessionBrokerHealth(value: unknown): value is SessionBrokerHealt
   );
 }
 
+function isLikelyLegacySessionBrokerHealth(value: unknown) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const health = value as Record<string, unknown>;
+  return (
+    health.ok === true &&
+    Number.isInteger(health.pid) &&
+    (health.pid as number) > 0 &&
+    !isNonEmptyString(health.nonce) &&
+    (isNonEmptyString(health.sessionApi) ||
+      isNonEmptyString(health.sessionCapabilities) ||
+      isNonEmptyString(health.sessionSocket))
+  );
+}
+
 function readSessionBrokerRuntimeMetadataFile(path: string) {
   const metadata = readJsonFile<unknown>(path);
   return isValidSessionBrokerRuntimeMetadata(metadata) ? metadata : null;
+}
+
+function hasLiveDaemonLaunchLock(
+  paths: SessionBrokerRuntimePaths,
+  config: Pick<ResolvedSessionBrokerConfig, "host" | "port">,
+) {
+  const lock = readJsonFile<SessionBrokerLaunchLockFile>(paths.lockPath);
+  if (
+    !lock ||
+    lock.host !== config.host ||
+    lock.port !== config.port ||
+    !Number.isInteger(lock.ownerPid) ||
+    lock.ownerPid <= 0
+  ) {
+    return false;
+  }
+
+  return isRunningPid(lock.ownerPid);
 }
 
 function cleanStaleDaemonMetadata(paths: SessionBrokerRuntimePaths) {
@@ -359,6 +405,22 @@ export function nonHunkProcessPortConflictError(
   );
 }
 
+export function unauthenticatedHunkDaemonPortConflictError(
+  config: Pick<ResolvedSessionBrokerConfig, "host" | "port">,
+) {
+  return new Error(
+    `An older Hunk session daemon is using ${config.host}:${config.port} and cannot be authenticated by this build. ` +
+      `Close older Hunk windows, then retry.`,
+  );
+}
+
+export function isSameSessionBrokerDaemonIdentity(
+  left: SessionBrokerDaemonIdentity,
+  right: SessionBrokerDaemonIdentity,
+) {
+  return left.pid === right.pid && left.nonce === right.nonce;
+}
+
 function daemonStartupTimeoutError(
   config: Pick<ResolvedSessionBrokerConfig, "host" | "port">,
   timeoutMessage?: string,
@@ -505,12 +567,21 @@ export async function inspectSessionBrokerPort({
     return { kind: "none" };
   }
 
+  if (payload !== INVALID_SESSION_BROKER_HEALTH && isLikelyLegacySessionBrokerHealth(payload)) {
+    return { kind: "legacy" };
+  }
+
   if (payload === INVALID_SESSION_BROKER_HEALTH || !isValidSessionBrokerHealth(payload)) {
     return { kind: "foreign" };
   }
 
+  const paths = resolveSessionBrokerRuntimePaths(config, env);
   const metadata = readSessionBrokerRuntimeMetadata(config, env);
-  if (!metadata || metadata.pid !== payload.pid || metadata.nonce !== payload.nonce) {
+  if (!metadata) {
+    return hasLiveDaemonLaunchLock(paths, config) ? { kind: "starting" } : { kind: "foreign" };
+  }
+
+  if (metadata.pid !== payload.pid || metadata.nonce !== payload.nonce) {
     return { kind: "foreign" };
   }
 
@@ -573,14 +644,42 @@ export async function waitForSessionBrokerShutdown({
   config = resolveSessionBrokerConfig(),
   timeoutMs = 3_000,
   intervalMs = 100,
+  identity,
 }: {
   config?: ResolvedSessionBrokerConfig;
   timeoutMs?: number;
   intervalMs?: number;
+  identity?: SessionBrokerDaemonIdentity;
 } = {}) {
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
+    if (identity && !isRunningPid(identity.pid)) {
+      return true;
+    }
+
+    if (identity) {
+      const portState = await inspectSessionBrokerPort({ config, timeoutMs: intervalMs });
+      if (
+        portState.kind === "daemon" &&
+        isSameSessionBrokerDaemonIdentity(portState.health, identity)
+      ) {
+        await Bun.sleep(intervalMs);
+        continue;
+      }
+
+      if (!(await isLoopbackPortReachable(config, intervalMs))) {
+        return true;
+      }
+
+      if (portState.kind === "daemon") {
+        return true;
+      }
+
+      await Bun.sleep(intervalMs);
+      continue;
+    }
+
     if (!(await isSessionBrokerHealthy(config))) {
       return true;
     }
@@ -655,6 +754,19 @@ export async function ensureSessionBrokerAvailable({
     return;
   }
 
+  const initialPortState = await inspectSessionBrokerPort({ config, timeoutMs: intervalMs, env });
+  if (initialPortState.kind === "daemon") {
+    return;
+  }
+
+  if (initialPortState.kind === "legacy") {
+    throw unauthenticatedHunkDaemonPortConflictError(config);
+  }
+
+  if (initialPortState.kind === "foreign") {
+    throw nonHunkProcessPortConflictError(config);
+  }
+
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
@@ -708,6 +820,14 @@ export async function ensureSessionBrokerAvailable({
   const portState = await inspectSessionBrokerPort({ config, timeoutMs: intervalMs, env });
   if (portState.kind === "daemon") {
     return;
+  }
+
+  if (portState.kind === "starting") {
+    throw daemonStartupTimeoutError(config, timeoutMessage);
+  }
+
+  if (portState.kind === "legacy") {
+    throw unauthenticatedHunkDaemonPortConflictError(config);
   }
 
   if (portState.kind === "foreign") {

--- a/src/session-broker/brokerServer.test.ts
+++ b/src/session-broker/brokerServer.test.ts
@@ -1,21 +1,27 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
 import { connect, createServer } from "node:net";
-import { platform } from "node:os";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createTestSessionRegistration,
   createTestSessionSnapshot,
 } from "../../test/helpers/session-daemon-fixtures";
 import { SessionBrokerState } from "@hunk/session-broker-core";
+import { readSessionBrokerRuntimeMetadata } from "./brokerLauncher";
 import { serveSessionBrokerDaemon } from "./brokerServer";
 
 const originalHost = process.env.HUNK_MCP_HOST;
 const originalPort = process.env.HUNK_MCP_PORT;
 const originalUnsafeRemote = process.env.HUNK_MCP_UNSAFE_ALLOW_REMOTE;
+const originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+const runtimeDirs: string[] = [];
 
 interface HealthResponse {
   ok: boolean;
   pid: number;
+  nonce: string;
   sessions: number;
   pendingCommands: number;
   paths?: Record<string, string>;
@@ -89,6 +95,13 @@ async function waitForSessionCount(port: number, count: number) {
     const health = await readHealth(port);
     return health?.sessions === count ? health : null;
   });
+}
+
+function createRuntimeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "hunk-session-broker-server-test-"));
+  runtimeDirs.push(dir);
+  process.env.XDG_RUNTIME_DIR = dir;
+  return dir;
 }
 
 async function openSessionSocket(port: number) {
@@ -224,6 +237,19 @@ afterEach(() => {
   } else {
     process.env.HUNK_MCP_UNSAFE_ALLOW_REMOTE = originalUnsafeRemote;
   }
+
+  if (originalRuntimeDir === undefined) {
+    delete process.env.XDG_RUNTIME_DIR;
+  } else {
+    process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+  }
+
+  while (runtimeDirs.length > 0) {
+    const dir = runtimeDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
 });
 
 describe("Hunk session daemon server", () => {
@@ -255,6 +281,7 @@ describe("Hunk session daemon server", () => {
   });
 
   test("exposes only Hunk session endpoints and rejects the old MCP tool endpoint", async () => {
+    createRuntimeDir();
     const port = await reserveLoopbackPort();
     process.env.HUNK_MCP_HOST = "127.0.0.1";
     process.env.HUNK_MCP_PORT = String(port);
@@ -274,6 +301,7 @@ describe("Hunk session daemon server", () => {
         sessionCapabilities: `http://127.0.0.1:${port}/session-api/capabilities`,
         sessionSocket: `ws://127.0.0.1:${port}/session`,
       });
+      expect(healthPayload.nonce).toBeString();
 
       const genericCapabilities = await fetch(`http://127.0.0.1:${port}/broker/capabilities`);
       expect(genericCapabilities.status).toBe(404);
@@ -291,7 +319,8 @@ describe("Hunk session daemon server", () => {
       expect(capabilities.status).toBe(200);
       await expect(capabilities.json()).resolves.toMatchObject({
         version: 1,
-        daemonVersion: 4,
+        daemonVersion: 5,
+        nonce: healthPayload.nonce,
         actions: [
           "list",
           "get",
@@ -318,9 +347,38 @@ describe("Hunk session daemon server", () => {
       await expect(legacyMcp.json()).resolves.toMatchObject({
         error: "This app no longer exposes agent-facing MCP tools. Use the session CLI instead.",
       });
+
+      expect(readSessionBrokerRuntimeMetadata()).toMatchObject({
+        pid: process.pid,
+        port,
+        nonce: healthPayload.nonce,
+      });
     } finally {
       server.stop(true);
     }
+  });
+
+  test("writes runtime metadata while serving and removes it on shutdown", async () => {
+    createRuntimeDir();
+    const port = await reserveLoopbackPort();
+    process.env.HUNK_MCP_HOST = "127.0.0.1";
+    process.env.HUNK_MCP_PORT = String(port);
+
+    const server = serveSessionBrokerDaemon();
+
+    try {
+      const health = await waitForHealth(port);
+      expect(readSessionBrokerRuntimeMetadata()).toMatchObject({
+        pid: process.pid,
+        port,
+        nonce: health.nonce,
+      });
+    } finally {
+      server.stop(true);
+    }
+
+    await waitForShutdown(port);
+    expect(readSessionBrokerRuntimeMetadata()).toBeNull();
   });
 
   test("rejects HTTP requests with non-loopback or wrong-port Host headers", async () => {

--- a/src/session-broker/brokerServer.ts
+++ b/src/session-broker/brokerServer.ts
@@ -3,6 +3,7 @@ import {
   serveSessionBrokerDaemon as serveSessionBrokerDaemonWithBun,
   type RunningSessionBrokerDaemon as RunningBunSessionBrokerDaemon,
 } from "@hunk/session-broker-bun";
+import { randomBytes } from "node:crypto";
 import {
   LEGACY_MCP_PATH,
   SESSION_BROKER_SOCKET_PATH,
@@ -40,6 +41,12 @@ import {
   type SessionDaemonRequest,
   type SessionDaemonResponse,
 } from "../session/protocol";
+import {
+  buildSessionBrokerRuntimeMetadata,
+  removeSessionBrokerRuntimeMetadata,
+  resolveSessionBrokerRuntimePaths,
+  writeSessionBrokerRuntimeMetadata,
+} from "./brokerLauncher";
 
 const DEFAULT_STALE_SESSION_TTL_MS = 45_000;
 const DEFAULT_STALE_SESSION_SWEEP_INTERVAL_MS = 15_000;
@@ -91,10 +98,11 @@ export function formatDaemonServeError(error: unknown, host: string, port: numbe
   return new Error(`Failed to start the session broker daemon on ${host}:${port}: ${message}`);
 }
 
-function sessionCapabilities(): SessionDaemonCapabilities {
+function sessionCapabilities(nonce: string): SessionDaemonCapabilities {
   return {
     version: HUNK_SESSION_API_VERSION,
     daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+    nonce,
     actions: SUPPORTED_SESSION_ACTIONS,
   };
 }
@@ -419,6 +427,12 @@ export function serveSessionBrokerDaemon(
 ): RunningSessionBrokerDaemon {
   const config = resolveSessionBrokerConfig();
   const allowRemote = allowsUnsafeRemoteSessionBroker();
+  const daemonNonce = randomBytes(16).toString("hex");
+  const runtimePaths = resolveSessionBrokerRuntimePaths(config);
+  const runtimeMetadata = buildSessionBrokerRuntimeMetadata({
+    config,
+    nonce: daemonNonce,
+  });
   const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
   const staleSessionTtlMs = options.staleSessionTtlMs ?? DEFAULT_STALE_SESSION_TTL_MS;
   const staleSessionSweepIntervalMs =
@@ -427,9 +441,8 @@ export function serveSessionBrokerDaemon(
   const daemon = createSessionBrokerDaemon({
     broker: createHunkBrokerController(state),
     capabilities: {
-      version: HUNK_SESSION_DAEMON_VERSION,
+      ...sessionCapabilities(daemonNonce),
       name: "hunk-session-broker",
-      actions: SUPPORTED_SESSION_ACTIONS,
     },
     idleTimeoutMs,
     staleSessionTtlMs,
@@ -462,6 +475,7 @@ export function serveSessionBrokerDaemon(
         // CLI clients and debugging workflows still expect to discover from one place.
         return Response.json({
           ...daemon.getHealth(),
+          nonce: daemonNonce,
           sessionApi: `${config.httpOrigin}${HUNK_SESSION_API_PATH}`,
           sessionCapabilities: `${config.httpOrigin}${HUNK_SESSION_CAPABILITIES_PATH}`,
           sessionSocket: `${config.wsOrigin}${SESSION_BROKER_SOCKET_PATH}`,
@@ -469,7 +483,7 @@ export function serveSessionBrokerDaemon(
       }
 
       if (url.pathname === HUNK_SESSION_CAPABILITIES_PATH) {
-        return Response.json(sessionCapabilities());
+        return Response.json(sessionCapabilities(daemonNonce));
       }
 
       // Keep the richer Hunk session API here rather than in the shared package so commands like
@@ -491,6 +505,14 @@ export function serveSessionBrokerDaemon(
     },
   });
 
+  try {
+    writeSessionBrokerRuntimeMetadata(runtimePaths, runtimeMetadata);
+  } catch (error) {
+    server.stop(true);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to write session broker runtime metadata: ${message}`);
+  }
+
   const shutdown = () => {
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
@@ -500,6 +522,7 @@ export function serveSessionBrokerDaemon(
   process.once("SIGINT", shutdown);
   process.once("SIGTERM", shutdown);
   void server.stopped.finally(() => {
+    removeSessionBrokerRuntimeMetadata(runtimePaths, runtimeMetadata);
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
   });

--- a/src/session/capabilities.test.ts
+++ b/src/session/capabilities.test.ts
@@ -1,10 +1,21 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildSessionBrokerRuntimeMetadata,
+  resolveSessionBrokerRuntimePaths,
+  writeSessionBrokerRuntimeMetadata,
+} from "../session-broker/brokerLauncher";
 import { readHunkSessionDaemonCapabilities } from "./capabilities";
 import { HUNK_SESSION_API_VERSION, HUNK_SESSION_DAEMON_VERSION } from "./protocol";
 
 const servers = new Set<ReturnType<typeof createServer>>();
 const originalFetch = globalThis.fetch;
+const originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+const runtimeDirs: string[] = [];
+const testNonce = "test-session-daemon-nonce";
 
 async function listen(
   handler: (request: IncomingMessage, response: ServerResponse<IncomingMessage>) => void,
@@ -30,8 +41,41 @@ async function listen(
   };
 }
 
+function createRuntimeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "hunk-session-capabilities-test-"));
+  runtimeDirs.push(dir);
+  process.env.XDG_RUNTIME_DIR = dir;
+  return dir;
+}
+
+function writeMetadata(
+  config: {
+    host: string;
+    port: number;
+    httpOrigin: string;
+    wsOrigin: string;
+  },
+  nonce = testNonce,
+) {
+  writeSessionBrokerRuntimeMetadata(
+    resolveSessionBrokerRuntimePaths(config),
+    buildSessionBrokerRuntimeMetadata({ config, nonce }),
+  );
+}
+
 afterEach(async () => {
   globalThis.fetch = originalFetch;
+  if (originalRuntimeDir === undefined) {
+    delete process.env.XDG_RUNTIME_DIR;
+  } else {
+    process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+  }
+  while (runtimeDirs.length > 0) {
+    const dir = runtimeDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
   await Promise.all(
     [...servers].map(
       (server) =>
@@ -51,6 +95,13 @@ describe("readHunkSessionDaemonCapabilities", () => {
         signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
       });
     }) as typeof fetch;
+    createRuntimeDir();
+    writeMetadata({
+      host: "127.0.0.1",
+      port: 47657,
+      httpOrigin: "http://127.0.0.1:47657",
+      wsOrigin: "ws://127.0.0.1:47657",
+    });
 
     await expect(
       readHunkSessionDaemonCapabilities(
@@ -70,6 +121,8 @@ describe("readHunkSessionDaemonCapabilities", () => {
       response.writeHead(500, { "content-type": "application/json" });
       response.end(JSON.stringify({ error: "boom" }));
     });
+    createRuntimeDir();
+    writeMetadata(config);
 
     await expect(readHunkSessionDaemonCapabilities(config)).resolves.toBeNull();
   });
@@ -79,25 +132,49 @@ describe("readHunkSessionDaemonCapabilities", () => {
       response.writeHead(200, { "content-type": "application/json" });
       response.end(JSON.stringify({ version: HUNK_SESSION_API_VERSION, actions: ["list"] }));
     });
+    createRuntimeDir();
+    writeMetadata(config);
 
     await expect(readHunkSessionDaemonCapabilities(config)).resolves.toBeNull();
   });
 
-  test("accepts capabilities only when both API and daemon compatibility versions match", async () => {
+  test("returns null when the daemon nonce does not match runtime metadata", async () => {
     const { config } = await listen((_request: IncomingMessage, response: ServerResponse) => {
       response.writeHead(200, { "content-type": "application/json" });
       response.end(
         JSON.stringify({
           version: HUNK_SESSION_API_VERSION,
           daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+          nonce: "wrong-nonce",
           actions: ["list", "get"],
         }),
       );
     });
+    createRuntimeDir();
+    writeMetadata(config);
+
+    await expect(readHunkSessionDaemonCapabilities(config)).resolves.toBeNull();
+  });
+
+  test("accepts capabilities only when the versions and daemon nonce match", async () => {
+    const { config } = await listen((_request: IncomingMessage, response: ServerResponse) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          version: HUNK_SESSION_API_VERSION,
+          daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+          nonce: testNonce,
+          actions: ["list", "get"],
+        }),
+      );
+    });
+    createRuntimeDir();
+    writeMetadata(config);
 
     await expect(readHunkSessionDaemonCapabilities(config)).resolves.toEqual({
       version: HUNK_SESSION_API_VERSION,
       daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+      nonce: testNonce,
       actions: ["list", "get"],
     });
   });

--- a/src/session/capabilities.ts
+++ b/src/session/capabilities.ts
@@ -2,7 +2,10 @@ import {
   resolveSessionBrokerConfig,
   type ResolvedSessionBrokerConfig,
 } from "../session-broker/brokerConfig";
-import { readSessionBrokerRuntimeMetadata } from "../session-broker/brokerLauncher";
+import {
+  readSessionBrokerRuntimeMetadata,
+  type SessionBrokerDaemonIdentity,
+} from "../session-broker/brokerLauncher";
 import {
   HUNK_SESSION_API_VERSION,
   HUNK_SESSION_CAPABILITIES_PATH,
@@ -19,19 +22,11 @@ export function reportHunkDaemonUpgradeRestart(log: (message: string) => void = 
   log(HUNK_DAEMON_UPGRADE_RESTART_NOTICE);
 }
 
-/**
- * Read the live daemon's advertised compatibility, returning null when the daemon is too old for
- * this Hunk build even if it still answers the same HTTP action list.
- */
-export async function readHunkSessionDaemonCapabilities(
-  config: ResolvedSessionBrokerConfig = resolveSessionBrokerConfig(),
+export async function readHunkSessionDaemonCapabilitiesForIdentity(
+  config: ResolvedSessionBrokerConfig,
+  identity: SessionBrokerDaemonIdentity,
   timeoutMs = HUNK_SESSION_DAEMON_HTTP_TIMEOUT_MS,
 ): Promise<SessionDaemonCapabilities | null> {
-  const metadata = readSessionBrokerRuntimeMetadata(config);
-  if (!metadata) {
-    return null;
-  }
-
   return requestSessionDaemonHttp({
     config,
     path: HUNK_SESSION_CAPABILITIES_PATH,
@@ -59,7 +54,7 @@ export async function readHunkSessionDaemonCapabilities(
         (capabilities as { version?: unknown }).version !== HUNK_SESSION_API_VERSION ||
         (capabilities as { daemonVersion?: unknown }).daemonVersion !==
           HUNK_SESSION_DAEMON_VERSION ||
-        (capabilities as { nonce?: unknown }).nonce !== metadata.nonce ||
+        (capabilities as { nonce?: unknown }).nonce !== identity.nonce ||
         !Array.isArray((capabilities as { actions?: unknown }).actions)
       ) {
         return null;
@@ -68,4 +63,20 @@ export async function readHunkSessionDaemonCapabilities(
       return capabilities as SessionDaemonCapabilities;
     },
   });
+}
+
+/**
+ * Read the live daemon's advertised compatibility, returning null when the daemon is too old for
+ * this Hunk build even if it still answers the same HTTP action list.
+ */
+export async function readHunkSessionDaemonCapabilities(
+  config: ResolvedSessionBrokerConfig = resolveSessionBrokerConfig(),
+  timeoutMs = HUNK_SESSION_DAEMON_HTTP_TIMEOUT_MS,
+): Promise<SessionDaemonCapabilities | null> {
+  const metadata = readSessionBrokerRuntimeMetadata(config);
+  if (!metadata) {
+    return null;
+  }
+
+  return readHunkSessionDaemonCapabilitiesForIdentity(config, metadata, timeoutMs);
 }

--- a/src/session/capabilities.ts
+++ b/src/session/capabilities.ts
@@ -2,6 +2,7 @@ import {
   resolveSessionBrokerConfig,
   type ResolvedSessionBrokerConfig,
 } from "../session-broker/brokerConfig";
+import { readSessionBrokerRuntimeMetadata } from "../session-broker/brokerLauncher";
 import {
   HUNK_SESSION_API_VERSION,
   HUNK_SESSION_CAPABILITIES_PATH,
@@ -26,6 +27,11 @@ export async function readHunkSessionDaemonCapabilities(
   config: ResolvedSessionBrokerConfig = resolveSessionBrokerConfig(),
   timeoutMs = HUNK_SESSION_DAEMON_HTTP_TIMEOUT_MS,
 ): Promise<SessionDaemonCapabilities | null> {
+  const metadata = readSessionBrokerRuntimeMetadata(config);
+  if (!metadata) {
+    return null;
+  }
+
   return requestSessionDaemonHttp({
     config,
     path: HUNK_SESSION_CAPABILITIES_PATH,
@@ -53,6 +59,7 @@ export async function readHunkSessionDaemonCapabilities(
         (capabilities as { version?: unknown }).version !== HUNK_SESSION_API_VERSION ||
         (capabilities as { daemonVersion?: unknown }).daemonVersion !==
           HUNK_SESSION_DAEMON_VERSION ||
+        (capabilities as { nonce?: unknown }).nonce !== metadata.nonce ||
         !Array.isArray((capabilities as { actions?: unknown }).actions)
       ) {
         return null;

--- a/src/session/commands.daemon.test.ts
+++ b/src/session/commands.daemon.test.ts
@@ -10,6 +10,8 @@ import {
 } from "./commands";
 import { HUNK_SESSION_API_VERSION, HUNK_SESSION_DAEMON_VERSION } from "./protocol";
 
+const testNonce = "test-session-command-daemon-nonce";
+
 // These tests exercise the REAL resolveDaemonAvailability path (which the hook-based suite in
 // commands.test.ts deliberately bypasses) by pointing the broker config at a known-free loopback
 // port via HUNK_MCP_PORT. No daemon is listening there, so the health and reachability probes
@@ -92,6 +94,32 @@ describe("resolveDaemonAvailability with a foreign process on the port", () => {
       server.stop(true);
     }
   });
+
+  probeTest("rejects an unauthenticated health response as a non-Hunk process", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url);
+        if (url.pathname === "/health") {
+          return Response.json({ ok: true, pid: process.pid });
+        }
+
+        return new Response("nope", { status: 404 });
+      },
+    });
+    process.env.HUNK_MCP_PORT = String(server.port);
+    try {
+      await expect(
+        runSessionCommand({
+          kind: "session",
+          action: "list",
+          output: "json",
+        } satisfies SessionCommandInput),
+      ).rejects.toThrow(/occupied by a non-Hunk process/);
+    } finally {
+      server.stop(true);
+    }
+  });
 });
 
 describe("text output formatting", () => {
@@ -101,6 +129,7 @@ describe("text output formatting", () => {
       getCapabilities: async () => ({
         version: HUNK_SESSION_API_VERSION,
         daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+        nonce: testNonce,
         actions: [
           "list",
           "get",

--- a/src/session/commands.daemon.test.ts
+++ b/src/session/commands.daemon.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createServer } from "node:net";
-import { platform } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
 import type { SessionCommandInput } from "../core/types";
 import { createTestListedSession } from "../../test/helpers/session-daemon-fixtures";
+import {
+  buildSessionBrokerRuntimeMetadata,
+  resolveSessionBrokerRuntimePaths,
+  writeSessionBrokerRuntimeMetadata,
+} from "../session-broker/brokerLauncher";
 import {
   runSessionCommand,
   setSessionCommandTestHooks,
@@ -17,6 +24,8 @@ const testNonce = "test-session-command-daemon-nonce";
 // port via HUNK_MCP_PORT. No daemon is listening there, so the health and reachability probes
 // resolve naturally — no module mocking, so nothing leaks into sibling suites.
 const originalPort = process.env.HUNK_MCP_PORT;
+const originalRuntimeDir = process.env.XDG_RUNTIME_DIR;
+const runtimeDirs: string[] = [];
 
 // These cases drive the real availability probe against a loopback port with no daemon. Bun's
 // Windows networking does not reliably surface a connection refusal for a closed loopback port
@@ -37,6 +46,13 @@ async function reserveFreePort() {
   return port;
 }
 
+function createRuntimeDir() {
+  const dir = mkdtempSync(join(tmpdir(), "hunk-session-command-daemon-test-"));
+  runtimeDirs.push(dir);
+  process.env.XDG_RUNTIME_DIR = dir;
+  return dir;
+}
+
 beforeEach(() => {
   setSessionCommandTestHooks(null);
 });
@@ -47,6 +63,19 @@ afterEach(() => {
     delete process.env.HUNK_MCP_PORT;
   } else {
     process.env.HUNK_MCP_PORT = originalPort;
+  }
+
+  if (originalRuntimeDir === undefined) {
+    delete process.env.XDG_RUNTIME_DIR;
+  } else {
+    process.env.XDG_RUNTIME_DIR = originalRuntimeDir;
+  }
+
+  while (runtimeDirs.length > 0) {
+    const dir = runtimeDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
   }
 });
 
@@ -116,6 +145,72 @@ describe("resolveDaemonAvailability with a foreign process on the port", () => {
           output: "json",
         } satisfies SessionCommandInput),
       ).rejects.toThrow(/occupied by a non-Hunk process/);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe("resolveDaemonAvailability with a daemon that appears between probes", () => {
+  probeTest("returns sessions instead of reporting a port conflict", async () => {
+    createRuntimeDir();
+    let healthRequests = 0;
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url);
+        if (url.pathname === "/health") {
+          healthRequests += 1;
+          if (healthRequests === 1) {
+            return new Response("not ready", { status: 404 });
+          }
+
+          return Response.json({
+            ok: true,
+            pid: process.pid,
+            nonce: testNonce,
+            sessions: 1,
+            pendingCommands: 0,
+          });
+        }
+
+        return new Response("nope", { status: 404 });
+      },
+    });
+    process.env.HUNK_MCP_PORT = String(server.port);
+    const config = {
+      host: "127.0.0.1",
+      port: server.port!,
+      httpOrigin: `http://127.0.0.1:${server.port}`,
+      wsOrigin: `ws://127.0.0.1:${server.port}`,
+    };
+    writeSessionBrokerRuntimeMetadata(
+      resolveSessionBrokerRuntimePaths(config),
+      buildSessionBrokerRuntimeMetadata({ config, nonce: testNonce, pid: process.pid }),
+    );
+    setSessionCommandTestHooks({
+      createClient: () =>
+        ({
+          getCapabilities: async () => ({
+            version: HUNK_SESSION_API_VERSION,
+            daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+            nonce: testNonce,
+            actions: ["list"],
+          }),
+          listSessions: async () => [createTestListedSession({ sessionId: "session-1" })],
+        }) as HunkDaemonCliClient,
+    });
+
+    try {
+      const output = await runSessionCommand({
+        kind: "session",
+        action: "list",
+        output: "json",
+      } satisfies SessionCommandInput);
+
+      expect(JSON.parse(output).sessions).toHaveLength(1);
+      expect(healthRequests).toBeGreaterThanOrEqual(2);
     } finally {
       server.stop(true);
     }

--- a/src/session/commands.test.ts
+++ b/src/session/commands.test.ts
@@ -13,7 +13,6 @@ import {
   setSessionCommandTestHooks,
   type HunkDaemonCliClient,
 } from "./commands";
-import { HUNK_DAEMON_UPGRADE_RESTART_NOTICE } from "./capabilities";
 import { HUNK_SESSION_API_VERSION, HUNK_SESSION_DAEMON_VERSION } from "./protocol";
 
 const testNonce = "test-session-command-nonce";
@@ -200,7 +199,7 @@ describe("session command compatibility checks", () => {
         },
       ]);
       expect(createdClients).toEqual(["stale-capabilities", "fresh-context"]);
-      expect(notices).toContain(HUNK_DAEMON_UPGRADE_RESTART_NOTICE);
+      expect(notices).toEqual([]);
     } finally {
       console.error = originalConsoleError;
     }
@@ -271,7 +270,7 @@ describe("session command compatibility checks", () => {
         },
       ]);
       expect(createdClients).toEqual(["stale-capabilities", "fresh-list"]);
-      expect(notices).toContain(HUNK_DAEMON_UPGRADE_RESTART_NOTICE);
+      expect(notices).toEqual([]);
     } finally {
       console.error = originalConsoleError;
     }
@@ -357,7 +356,7 @@ describe("session command compatibility checks", () => {
         },
       ]);
       expect(createdClients).toEqual(["stale-capabilities", "fresh-comment-add"]);
-      expect(notices).toContain(HUNK_DAEMON_UPGRADE_RESTART_NOTICE);
+      expect(notices).toEqual([]);
     } finally {
       console.error = originalConsoleError;
     }

--- a/src/session/commands.test.ts
+++ b/src/session/commands.test.ts
@@ -16,6 +16,8 @@ import {
 import { HUNK_DAEMON_UPGRADE_RESTART_NOTICE } from "./capabilities";
 import { HUNK_SESSION_API_VERSION, HUNK_SESSION_DAEMON_VERSION } from "./protocol";
 
+const testNonce = "test-session-command-nonce";
+
 function createTestListedSession(sessionId: string) {
   return buildTestListedSession({
     files: [createTestSessionFileSummary({ additions: 1, deletions: 0, path: "README.md" })],
@@ -59,6 +61,7 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
     getCapabilities: async () => ({
       version: HUNK_SESSION_API_VERSION,
       daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+      nonce: testNonce,
       actions: [
         "list",
         "get",
@@ -219,6 +222,7 @@ describe("session command compatibility checks", () => {
           return {
             version: HUNK_SESSION_API_VERSION - 1,
             daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+            nonce: testNonce,
             actions: ["list"],
           };
         },
@@ -857,6 +861,7 @@ describe("session command compatibility checks", () => {
           getCapabilities: async () => ({
             version: HUNK_SESSION_API_VERSION,
             daemonVersion: HUNK_SESSION_DAEMON_VERSION,
+            nonce: testNonce,
             actions: [
               "list",
               "get",

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -6,9 +6,10 @@ import type {
 import type { SessionLiveCommentSummary, SessionReviewNoteSummary } from "../hunk-session/types";
 import {
   ensureSessionBrokerAvailable,
+  inspectSessionBrokerPort,
   isSessionBrokerHealthy,
   isLoopbackPortReachable,
-  readSessionBrokerHealth,
+  nonHunkProcessPortConflictError,
   waitForSessionBrokerShutdown,
 } from "../session-broker/brokerLauncher";
 import { resolveSessionBrokerConfig } from "../session-broker/brokerConfig";
@@ -93,7 +94,12 @@ async function restartDaemonForMissingAction(
   action: SessionDaemonAction,
   selector?: SessionSelectorInput,
 ) {
-  const health = await readSessionBrokerHealth();
+  const portState = await inspectSessionBrokerPort();
+  if (portState.kind === "foreign") {
+    throw nonHunkProcessPortConflictError(resolveSessionBrokerConfig());
+  }
+
+  const health = portState.kind === "daemon" ? portState.health : null;
   const pid = health?.pid;
   const hadSessions = (health?.sessions ?? 0) > 0;
   if (!pid || pid === process.pid) {
@@ -149,6 +155,11 @@ async function resolveDaemonAvailability(action: SessionCommandInput["action"]) 
   const healthy = await isSessionBrokerHealthy(config);
   if (healthy) {
     return true;
+  }
+
+  const portState = await inspectSessionBrokerPort({ config });
+  if (portState.kind === "foreign") {
+    throw nonHunkProcessPortConflictError(config);
   }
 
   const portReachable = await isLoopbackPortReachable(config);

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -10,6 +10,7 @@ import {
   isSessionBrokerHealthy,
   isLoopbackPortReachable,
   nonHunkProcessPortConflictError,
+  unauthenticatedHunkDaemonPortConflictError,
   waitForSessionBrokerShutdown,
 } from "../session-broker/brokerLauncher";
 import { resolveSessionBrokerConfig } from "../session-broker/brokerConfig";
@@ -99,6 +100,16 @@ async function restartDaemonForMissingAction(
     throw nonHunkProcessPortConflictError(resolveSessionBrokerConfig());
   }
 
+  if (portState.kind === "legacy") {
+    throw unauthenticatedHunkDaemonPortConflictError(resolveSessionBrokerConfig());
+  }
+
+  if (portState.kind === "starting") {
+    throw new Error(
+      "The Hunk session daemon is still starting. Wait a moment for it to finish publishing runtime metadata, then retry.",
+    );
+  }
+
   const health = portState.kind === "daemon" ? portState.health : null;
   const pid = health?.pid;
   const hadSessions = (health?.sessions ?? 0) > 0;
@@ -109,9 +120,10 @@ async function restartDaemonForMissingAction(
     );
   }
 
+  reportHunkDaemonUpgradeRestart();
   process.kill(pid, "SIGTERM");
 
-  const shutDown = await waitForSessionBrokerShutdown();
+  const shutDown = await waitForSessionBrokerShutdown({ identity: health });
   if (!shutDown) {
     throw new Error(
       `Stopped waiting for the old Hunk session daemon to exit after it was found missing ${action}.`,
@@ -145,7 +157,6 @@ async function ensureRequiredAction(action: SessionDaemonAction, selector?: Sess
     return;
   }
 
-  reportHunkDaemonUpgradeRestart();
   await (sessionCommandTestHooks?.restartDaemonForMissingAction?.(action, selector) ??
     restartDaemonForMissingAction(action, selector));
 }
@@ -158,6 +169,22 @@ async function resolveDaemonAvailability(action: SessionCommandInput["action"]) 
   }
 
   const portState = await inspectSessionBrokerPort({ config });
+  if (portState.kind === "daemon") {
+    return true;
+  }
+
+  if (portState.kind === "legacy") {
+    throw unauthenticatedHunkDaemonPortConflictError(config);
+  }
+
+  if (portState.kind === "starting") {
+    await ensureSessionBrokerAvailable({
+      config,
+      timeoutMs: 3_000,
+    });
+    return true;
+  }
+
   if (portState.kind === "foreign") {
     throw nonHunkProcessPortConflictError(config);
   }

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -31,7 +31,7 @@ export const HUNK_SESSION_API_VERSION = 1;
  * Version daemon/session compatibility separately from the HTTP action surface so newer Hunk
  * builds can refresh an older daemon even when it still exposes the same API endpoints.
  */
-export const HUNK_SESSION_DAEMON_VERSION = 4;
+export const HUNK_SESSION_DAEMON_VERSION = 5;
 
 export type SessionDaemonAction =
   | "list"
@@ -49,6 +49,7 @@ export type SessionDaemonAction =
 export interface SessionDaemonCapabilities {
   version: number;
   daemonVersion: number;
+  nonce: string;
   actions: SessionDaemonAction[];
 }
 


### PR DESCRIPTION
## Summary

- add a per-daemon nonce to runtime metadata, `/health`, and `/session-api/capabilities`
- authenticate the daemon by correlating health/capabilities responses with daemon-owned runtime metadata before reusing or restarting it
- refuse to signal unauthenticated listeners, PID mismatches, stale identity reads, and older pre-authentication Hunk daemons
- keep restart decisions bound to the exact `{pid, nonce}` that was found incompatible, so a fresh compatible daemon cannot be killed by a stale check
- handle daemon startup/concurrent probe races without reporting a false non-Hunk port conflict

## Behavior

This intentionally keeps the strict option for older pre-authentication daemons: if an older Hunk window is still running on the configured port, the new build asks the user to close older Hunk windows and retry instead of attempting an unauthenticated v4 restart.

Foreign listeners still produce the non-Hunk port conflict message. Authenticated stale daemons can still be restarted, but only when the daemon identity matches the one that failed compatibility checks.

## Tests

- `bun run typecheck`
- `bun test ./src ./packages ./scripts ./test/cli ./test/session` (`1024 pass`, `13 skip`, `0 fail`)
- `bun run lint`
- `./node_modules/.bin/oxfmt --check .changeset/quiet-daemons-guard.md src/hunk-session/cli.test.ts src/session-broker/brokerClient.test.ts src/session-broker/brokerClient.ts src/session-broker/brokerLauncher.test.ts src/session-broker/brokerLauncher.ts src/session-broker/brokerServer.test.ts src/session-broker/brokerServer.ts src/session/capabilities.test.ts src/session/capabilities.ts src/session/commands.daemon.test.ts src/session/commands.test.ts src/session/commands.ts src/session/protocol.ts`
- `./node_modules/.bin/oxfmt --check .changeset/quiet-daemons-guard.md src/session-broker/brokerClient.ts src/session-broker/brokerClient.test.ts src/session-broker/brokerLauncher.ts src/session-broker/brokerLauncher.test.ts src/session/capabilities.ts src/session/commands.ts src/session/commands.test.ts src/session/commands.daemon.test.ts`