### PR TITLE
fix(config): read Windows user-profile config

### DIFF
--- a/.changeset/seven-pans-hunt.md
+++ b/.changeset/seven-pans-hunt.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix global config discovery on Windows when `HOME` is unavailable.

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -263,6 +263,29 @@ describe("config resolution", () => {
     expect(overridden.input.options.transparentBackground).toBe(false);
   });
 
+  test("loads global config from USERPROFILE when HOME is unavailable", () => {
+    const profile = createTempDir("hunk-config-profile-");
+    mkdirSync(join(profile, ".config", "hunk"), { recursive: true });
+    writeFileSync(
+      join(profile, ".config", "hunk", "config.toml"),
+      "transparent_background = true\n",
+    );
+
+    const configured = resolveConfiguredCliInput(
+      {
+        kind: "vcs",
+        staged: false,
+        options: {},
+      },
+      {
+        cwd: createTempDir("hunk-config-cwd-"),
+        env: { USERPROFILE: profile },
+      },
+    );
+
+    expect(configured.input.options.transparentBackground).toBe(true);
+  });
+
   test("defaults unspecified themes to github-dark-default, including piped pager-style patch input", () => {
     const home = createTempDir("hunk-config-home-");
     const cwd = createTempDir("hunk-config-cwd-");

--- a/src/core/paths.test.ts
+++ b/src/core/paths.test.ts
@@ -29,6 +29,17 @@ describe("paths", () => {
     expect(resolveHunkStatePath(env)).toBe(join("/tmp", "home", ".config", "hunk", "state.json"));
   });
 
+  test("falls back to USERPROFILE when HOME is unavailable", () => {
+    const env = { USERPROFILE: join("/tmp", "windows-profile") } as NodeJS.ProcessEnv;
+
+    expect(resolveGlobalConfigPath(env)).toBe(
+      join("/tmp", "windows-profile", ".config", "hunk", "config.toml"),
+    );
+    expect(resolveHunkStatePath(env)).toBe(
+      join("/tmp", "windows-profile", ".config", "hunk", "state.json"),
+    );
+  });
+
   test("locates the bundled Hunk review skill from source", () => {
     const resolvedPath = resolveBundledHunkReviewSkillPath([import.meta.dir]);
 

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -9,8 +9,9 @@ export function resolveUserConfigDir(env: NodeJS.ProcessEnv = process.env) {
     return env.XDG_CONFIG_HOME;
   }
 
-  if (env.HOME) {
-    return join(env.HOME, ".config");
+  const home = env.HOME || env.USERPROFILE;
+  if (home) {
+    return join(home, ".config");
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- fall back to `USERPROFILE` when `HOME` is unavailable, preserving Hunk’s documented `.config/hunk/config.toml` location on Windows
- cover both path resolution and config loading behavior
- add a patch changeset

Closes #522

## Testing
- `bun test src/core/paths.test.ts src/core/config.test.ts`
- `bun run typecheck`
- `bun test` *(timed out after 120 seconds; all reported tests passed before timeout)*

*This PR description was generated by Pi using GPT-5*