### PR TITLE
fix(ui): restore threaded rendering on macOS

### DIFF
--- a/.changeset/faster-first-diff-frame.md
+++ b/.changeset/faster-first-diff-frame.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Restore OpenTUI's platform-default renderer threading to improve interactive startup on macOS.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -100,6 +100,7 @@ async function main() {
   >(createSessionRegistration(bootstrap), createInitialSessionSnapshot(bootstrap));
   hostClient.start();
 
+  // Keep OpenTUI's platform-safe threading default (enabled on macOS, disabled on Linux).
   const renderer = await createCliRenderer({
     stdin: controllingTerminal?.stdin,
     stdout: process.stdout,
@@ -107,7 +108,6 @@ async function main() {
       hasControllingTerminal: Boolean(controllingTerminal),
     }),
     screenMode: "alternate-screen",
-    useThread: false,
     exitOnCtrlC: false,
     openConsoleOnError: true,
     onDestroy: () => controllingTerminal?.close(),


### PR DESCRIPTION
## Summary

- stop forcing OpenTUI's renderer thread off on every platform
- restore OpenTUI's default: threaded rendering on macOS, with OpenTUI continuing to disable it on Linux
- keep this change isolated from the older Unicode-width work so the Kitty result has a clear A/B cause

## Why

Hunk enters the alternate screen before React builds and emits the first complete review frame. That makes the issue's long blank-screen interval consistent with first-frame renderer work blocking the main thread rather than Git loading.

OpenTUI 0.4.3 defaults `useThread` to `true`, then explicitly turns it off on Linux. Hunk currently passes `useThread: false`, overriding the optimized macOS default. Removing that override delegates the platform choice back to OpenTUI and should move macOS renderer output off the main thread again.

This PR deliberately does not change code-column measurement or claim to explain the older v0.14 regression. It addresses the clear v0.17-era macOS threading regression independently so it can be tested in the reporter's Kitty environment.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test:integration`
- `bun run test:tty-smoke`

Linux is unchanged because OpenTUI disables threaded rendering there. Final validation therefore requires comparing this branch against v0.17.0 in Kitty on macOS.

Refs #534

*This PR description was generated by Pi using OpenAI GPT-5.4*
