### PR TITLE
fix(ui): wrap agent note text by terminal cells

### DIFF
--- a/.changeset/wrap-agent-notes-by-cells.md
+++ b/.changeset/wrap-agent-notes-by-cells.md
@@ -1,0 +1,8 @@
+---
+"hunkdiff": patch
+---
+
+Wrap plain-text agent notes by terminal cells instead of UTF-16 code
+units, so CJK and emoji text wraps correctly instead of being truncated
+with silent content loss. Long unbroken words split on grapheme
+boundaries, so wide characters and surrogate pairs are never cut apart.

--- a/src/ui/lib/agentPopover.ts
+++ b/src/ui/lib/agentPopover.ts
@@ -1,11 +1,11 @@
 import { sanitizeTerminalLine } from "../../lib/terminalText";
-import { fitText } from "./text";
+import { fitText, measureTextWidth, sliceTextByWidth } from "./text";
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
-/** Wrap plain text to a fixed terminal width, breaking long tokens when needed. */
+/** Wrap plain text to a fixed terminal-cell width, breaking long tokens when needed. */
 export function wrapText(text: string, width: number) {
   if (width <= 0) {
     return [""];
@@ -19,31 +19,49 @@ export function wrapText(text: string, width: number) {
   const words = normalized.split(" ");
   const lines: string[] = [];
   let current = "";
+  let currentWidth = 0;
 
   const pushCurrent = () => {
     if (current.length > 0) {
       lines.push(current);
       current = "";
+      currentWidth = 0;
     }
   };
 
   for (const word of words) {
-    if (word.length > width) {
+    const wordWidth = measureTextWidth(word);
+
+    if (wordWidth > width) {
       pushCurrent();
-      for (let offset = 0; offset < word.length; offset += width) {
-        lines.push(word.slice(offset, offset + width));
+      let offset = 0;
+      while (offset < wordWidth) {
+        const chunk = sliceTextByWidth(word, offset, width);
+        if (chunk.width <= 0) {
+          // Width is narrower than one cluster; keep the remainder on one
+          // line (fitText clamps at render time) instead of dropping it.
+          const rest = sliceTextByWidth(word, offset, Number.MAX_SAFE_INTEGER);
+          if (rest.text.length > 0) {
+            lines.push(rest.text);
+          }
+          break;
+        }
+        lines.push(chunk.text);
+        offset += chunk.width;
       }
       continue;
     }
 
-    const next = current.length === 0 ? word : `${current} ${word}`;
-    if (next.length <= width) {
-      current = next;
+    const nextWidth = current.length === 0 ? wordWidth : currentWidth + 1 + wordWidth;
+    if (nextWidth <= width) {
+      current = current.length === 0 ? word : `${current} ${word}`;
+      currentWidth = nextWidth;
       continue;
     }
 
     pushCurrent();
     current = word;
+    currentWidth = wordWidth;
   }
 
   pushCurrent();

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -321,6 +321,38 @@ describe("ui helpers", () => {
     expect(wrapText("alpha beta gamma", 8)).toEqual(["alpha", "beta", "gamma"]);
     expect(wrapText("supercalifragilistic", 6)).toEqual(["superc", "alifra", "gilist", "ic"]);
 
+    // Wide text wraps by terminal cells, not UTF-16 code units, so CJK lines
+    // never overflow the box and get clipped by fitText/padText downstream.
+    expect(wrapText("こんにちは世界", 8)).toEqual(["こんにち", "は世界"]);
+    expect(wrapText("これは全角文字の長い注釈です", 10)).toEqual([
+      "これは全角",
+      "文字の長い",
+      "注釈です",
+    ]);
+    expect(wrapText("fix 説明が長い日本語のまま続く", 10)).toEqual([
+      "fix",
+      "説明が長い",
+      "日本語のま",
+      "ま続く",
+    ]);
+
+    // Emoji clusters (surrogate pairs) are never split into lone surrogates.
+    expect(wrapText("🎉🎉🎉", 4)).toEqual(["🎉🎉", "🎉"]);
+
+    // Odd width: a 2-cell character cannot straddle the boundary, so each
+    // line carries one character even though a cell stays unused.
+    expect(wrapText("日本語", 3)).toEqual(["日", "本", "語"]);
+
+    // Multiple ASCII words still pack into one line when they fit.
+    expect(wrapText("ab cd", 5)).toEqual(["ab cd"]);
+
+    // Width narrower than one cluster keeps the text for fitText to clamp
+    // at render time instead of silently dropping it.
+    expect(wrapText("日日", 1)).toEqual(["日日"]);
+
+    // ZWJ emoji clusters stay whole when hard-splitting.
+    expect(wrapText("🧑‍💻🧑‍💻", 2)).toEqual(["🧑‍💻", "🧑‍💻"]);
+
     const content = buildAgentPopoverContent({
       summary: "Guard missing socket path",
       rationale: "Prevents noisy reconnect errors during first launch.",


### PR DESCRIPTION
## Summary

Plain-text agent notes (inline cards, hover popovers, static pager
inline-note lines) wrap their text with `wrapText`, which measures with
`String#length` and splits with `String#slice` — UTF-16 code units. The
renderers then clamp each line by terminal cells (`fitText` / `padText`),
so for CJK text (1 code unit = 2 cells) the wrapped lines come out up to
2× the box width and the clamp truncates them, silently dropping text.
Code-unit splitting can also cut an emoji's surrogate pair in half
(renders as U+FFFD).

- measure words with `measureTextWidth` and track the current line's
  cell width alongside the string, so line-fit checks compare cells to
  cells
- hard-split over-wide words with `sliceTextByWidth`, which walks
  grapheme clusters — wide characters and emoji are never split
- when the width is narrower than a single cluster, keep the remainder
  on one line for the renderer's `fitText` to clamp instead of dropping
  it, and decide "line is empty" by string length so zero-width
  characters can't produce over-wide lines
- add regression tests: CJK wrapping, mixed EN/JA text, odd widths,
  degenerate width 1, surrogate-pair and ZWJ emoji

Closes #566

### Repro

With a 40-cell box and a 62-char / 124-cell Japanese summary:

| | wrapText output |
|---|---|
| Before | 2 lines of 40 code units = 80 cells each; the renderer clips both lines, silently dropping ~half the text |
| After | 4 lines of ≤ 40 cells; nothing dropped |

English output is unchanged — wrapping of ASCII input is byte-identical
before and after.

## Testing

All run in a clean Linux container (oven/bun + git), matching CI's
ubuntu-latest environment:

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun test src` — 1,140 tests, 0 fail
- `bun run test:tty-smoke` — 9 pass, identical to a baseline run without
  this change (the harness needs util-linux `script`, which macOS lacks)
