### PR TITLE
fix(pager): extend row backgrounds to host edge

### DIFF
--- a/.changeset/fill-static-pager-rows.md
+++ b/.changeset/fill-static-pager-rows.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Extend static pager diff-row backgrounds to the edge of host panels such as Lazygit.

--- a/src/ui/staticDiffPager.test.ts
+++ b/src/ui/staticDiffPager.test.ts
@@ -5,9 +5,9 @@ function stripAnsi(text: string) {
   return text.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
 }
 
-/** Remove Hunk's intentional SGR color codes while leaving unsafe controls visible. */
-function stripColorSgr(text: string) {
-  return text.replace(/\x1b\[[0-9;]*m/g, "");
+/** Remove Hunk's intentional color and line-fill codes while leaving unsafe controls visible. */
+function stripIntentionalAnsi(text: string) {
+  return text.replace(/\x1b(?:\[[0-9;]*m|\[K)/g, "");
 }
 
 const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
@@ -95,6 +95,18 @@ describe("static diff pager", () => {
     expect(plain).toContain("▌  1 +  const value = 2;");
   });
 
+  test("extends stacked row backgrounds to the host panel edge", async () => {
+    const patchText =
+      "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-short\n+also short\n";
+
+    const output = await renderStaticDiffPager(patchText);
+    const changedLines = output.split("\n").filter((line) => stripAnsi(line).includes("short"));
+    const backgroundFill = /\x1b\[48;2;\d+;\d+;\d+m\x1b\[K\x1b\[0m$/;
+
+    expect(changedLines).toHaveLength(2);
+    expect(changedLines.every((line) => backgroundFill.test(line))).toBe(true);
+  });
+
   test("uses configured custom themes in static pager output", async () => {
     const patchText =
       "diff --git a/a.ts b/a.ts\n--- a/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n-const value = 1;\n+const value = 2;\n";
@@ -180,7 +192,7 @@ describe("static diff pager", () => {
       "",
     ].join("\n");
 
-    const output = stripColorSgr(
+    const output = stripIntentionalAnsi(
       await renderStaticDiffPager(text, {}, { stderr: { write: () => true } }),
     );
 
@@ -199,7 +211,7 @@ describe("static diff pager", () => {
       "",
     ].join("\n");
 
-    const output = stripColorSgr(await renderStaticDiffPager(patchText));
+    const output = stripIntentionalAnsi(await renderStaticDiffPager(patchText));
 
     expect(output).toContain("evil");
     expect(output).toContain("@@ -1 +1 @@");
@@ -217,7 +229,7 @@ describe("static diff pager", () => {
       "",
     ].join("\n");
 
-    const output = stripColorSgr(await renderStaticDiffPager(patchText));
+    const output = stripIntentionalAnsi(await renderStaticDiffPager(patchText));
 
     expectNoUnsafeTerminalControls(output);
   });

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -68,6 +68,12 @@ function colorText(text: string, fg?: string, bg?: string) {
   return prefix ? `${prefix}${safeText}${RESET}` : safeText;
 }
 
+/** Extend one row background to the host panel edge without assuming the panel width. */
+function fillRemainingLine(bg: string) {
+  const background = ansiColor("bg", bg);
+  return background ? `${background}\x1b[K${RESET}` : "";
+}
+
 /** Serialize highlighted code spans into ANSI text, preserving a row background when present. */
 function serializeSpans(spans: RenderSpan[], rowBg: string) {
   return spans.map((span) => colorText(span.text, span.fg, span.bg ?? rowBg)).join("");
@@ -157,7 +163,7 @@ function renderStaticStackRow(
     staticStackGutterText(cell, lineNumberWidth, options.lineNumbers !== false),
     palette.numberColor,
     palette.gutterBg,
-  )}${serializeSpans(cell.spans, palette.contentBg)}`;
+  )}${serializeSpans(cell.spans, palette.contentBg)}${fillRemainingLine(palette.contentBg)}`;
 }
 
 function renderStaticSplitCell(


### PR DESCRIPTION
## Summary

- Extend static stacked diff-row backgrounds to the host panel edge with ANSI Erase in Line while the semantic row background is active.
- Let hosts such as LazyGit determine the actual line boundary instead of padding to a guessed width.
- Add regression coverage for added and removed rows plus a patch Changeset.

Closes #562.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun test src/ui/staticDiffPager.test.ts` (12 passed)
- `bun test ./src ./packages ./scripts ./test/cli ./test/session` (1,182 passed, 5 skipped)
- `bun run test:tty-smoke` (9 passed)
- Manual side-by-side verification in LazyGit 0.62.1 against `origin/main`
- `bun run test:integration` (54 passed, 1 unrelated watch-mode failure reproduced on `origin/main`)

*This PR description was generated by Pi using OpenAI GPT-5.3 Codex*
