### PR TITLE
fix(session): refresh daemons for STML payloads

### DIFF
--- a/.changeset/refresh-stml-session-daemon.md
+++ b/.changeset/refresh-stml-session-daemon.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Restart stale session daemons during upgrades so rich STML comments reach live Hunk reviews.

--- a/src/session-broker/brokerServer.test.ts
+++ b/src/session-broker/brokerServer.test.ts
@@ -291,7 +291,7 @@ describe("Hunk session daemon server", () => {
       expect(capabilities.status).toBe(200);
       await expect(capabilities.json()).resolves.toMatchObject({
         version: 1,
-        daemonVersion: 4,
+        daemonVersion: 5,
         actions: [
           "list",
           "get",

--- a/src/session/capabilities.test.ts
+++ b/src/session/capabilities.test.ts
@@ -83,6 +83,21 @@ describe("readHunkSessionDaemonCapabilities", () => {
     await expect(readHunkSessionDaemonCapabilities(config)).resolves.toBeNull();
   });
 
+  test("rejects version 4 daemons that drop STML fields from comment payloads", async () => {
+    const { config } = await listen((_request: IncomingMessage, response: ServerResponse) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          version: HUNK_SESSION_API_VERSION,
+          daemonVersion: 4,
+          actions: ["comment-add", "comment-apply"],
+        }),
+      );
+    });
+
+    await expect(readHunkSessionDaemonCapabilities(config)).resolves.toBeNull();
+  });
+
   test("accepts capabilities only when both API and daemon compatibility versions match", async () => {
     const { config } = await listen((_request: IncomingMessage, response: ServerResponse) => {
       response.writeHead(200, { "content-type": "application/json" });

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -29,9 +29,10 @@ export const HUNK_SESSION_API_VERSION = 1;
 
 /**
  * Version daemon/session compatibility separately from the HTTP action surface so newer Hunk
- * builds can refresh an older daemon even when it still exposes the same API endpoints.
+ * builds can refresh an older daemon even when it still exposes the same API endpoints. Bump this
+ * when daemon-forwarded payloads change, even if the supported action names stay stable.
  */
-export const HUNK_SESSION_DAEMON_VERSION = 4;
+export const HUNK_SESSION_DAEMON_VERSION = 5;
 
 export type SessionDaemonAction =
   | "list"


### PR DESCRIPTION
## Summary

- Bump the Hunk session daemon compatibility version from 4 to 5 so current builds replace daemons that predate STML comment payload forwarding.
- Document that compatibility must advance when forwarded payload shapes change, even if action names remain stable.
- Add regression coverage proving version 4 daemons are rejected and a patch Changeset.

## Why

A long-lived version 4 daemon can advertise every current session action while silently dropping the newer `markup` field from `comment-add` and `comment-apply`. Current source then receives only the plain-text summary, so STML notes unexpectedly render as fallback text. Treating version 4 as incompatible makes normal Hunk startup restart that stale daemon automatically.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun test src/session/capabilities.test.ts src/session-broker/brokerServer.test.ts src/session-broker/brokerClient.test.ts` (25 passed)
- `bun test ./src ./packages ./scripts ./test/cli ./test/session` (1,182 passed, 5 skipped)

*This PR description was generated by Pi using OpenAI GPT-5.3 Codex*
