### PR TITLE
docs(skill): keep diff tours within one viewport

### DIFF
--- a/.changeset/guide-viewport-tours.md
+++ b/.changeset/guide-viewport-tours.md
@@ -1,0 +1,4 @@
+---
+---
+
+Teach the bundled review skill to keep guided diff-tour stops within one viewport and focus exact slices inside large hunks without removing user-authored notes.

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -72,6 +72,8 @@ hunk session navigate --repo . --prev-comment
 
 - `--hunk <n>` is 1-based
 - `--new-line` / `--old-line` are 1-based line numbers on that diff side
+- `--new-line` / `--old-line` select the containing hunk; they do not guarantee scrolling to that exact line inside a large hunk
+- To focus an exact slice inside one large hunk, add an inline agent note at the target line. If earlier temporary agent notes in that hunk would become the first note, remove only those completed agent notes, preserve user-authored notes, then use `--next-comment` to scroll to the remaining target note.
 - Use either `--next-comment` or `--prev-comment`, not both
 
 ### Reload
@@ -143,6 +145,8 @@ Typical flow:
 Guidelines:
 
 - Work in the order that tells the clearest story, not necessarily file order
+- Keep each narrated tour step within one terminal viewport when practical. Split the narration for a large hunk into semantic slices of roughly 20-40 lines instead of explaining the whole hunk at once. Use the inline-note focus technique above when safe; otherwise give the exact line range and ask the user to scroll.
+- After narrating one tour step, pause for the user to continue unless they explicitly ask for a continuous walkthrough.
 - Navigate before commenting so the user sees the code you're discussing
 - Use `comment apply` for agent-generated batches and `comment add` for one-off notes
 - Use `--focus` sparingly when the note itself should actively steer the review


### PR DESCRIPTION
## Summary

- clarify that line-based session navigation selects the containing hunk rather than guaranteeing an exact intra-hunk scroll
- document a safe inline-note workflow for focusing exact slices while preserving user-authored notes
- keep narrated diff-tour stops within one viewport and pause between stops by default

## Validation

- `quick_validate.py skills/hunk-review`
- `bun run format:check`
- exercised the inline-note focus workflow in a live Hunk 0.17 session

## Changeset

- empty changeset because this is maintenance-only agent guidance
