### PR TITLE
chore(release): prepare 0.17.6

### DIFF
--- a/.changeset/recover-release-assets.md
+++ b/.changeset/recover-release-assets.md
@@ -1,5 +1,0 @@
----
-"hunkdiff": patch
----
-
-Republish the 0.17.5 application changes as 0.17.6 so the GitHub release includes downloadable binaries for every supported platform. Application behavior is unchanged from 0.17.5.

--- a/.changeset/recover-release-assets.md
+++ b/.changeset/recover-release-assets.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Republish the 0.17.5 application changes as 0.17.6 so the GitHub release includes downloadable binaries for every supported platform. Application behavior is unchanged from 0.17.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.6
+
+### Patch Changes
+
+- 736b1d7: Republish the 0.17.5 application changes as 0.17.6 so the GitHub release includes downloadable binaries for every supported platform. Application behavior is unchanged from 0.17.5.
+
 ## 0.17.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hunkdiff",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Desktop-inspired terminal diff viewer for understanding agent-authored changesets.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Summary

- Prepare `hunkdiff` 0.17.6 as a packaging-only recovery of 0.17.5.
- Preserve the exact application behavior and backports already shipped to npm as 0.17.5.
- Consume a patch changeset documenting that 0.17.6 will restore downloadable GitHub release binaries.
- Keep GitHub release creation in the tag workflow, after benchmark, build, staging, and npm publication complete.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run ./scripts/check-release-version.ts v0.17.6`
- `git diff --check origin/0.17.x...HEAD`

*This PR description was generated by Pi using OpenAI GPT-5.3*
