### PR TITLE
feat(skill): generate the hunk-review skill from a typed agent surface

### DIFF
--- a/.changeset/skill-from-typed-surface.md
+++ b/.changeset/skill-from-typed-surface.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Generate the hunk-review skill from the typed session command surface so agent docs cannot drift from the CLI. Fixes stale error quotes in the skill and documents previously missing flags (`--include-notes`, `--markup`, `--rationale`, `--author`) in session help and skill synopsis lines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ CLI input
 - If a local sidecar is present, its file order is intentional, but the visible note UI should stay hunk-note driven rather than showing generic file or changeset explainer cards.
 - `hunk diff` working-tree reviews include untracked files by default. Use `--exclude-untracked` if you explicitly want tracked changes only.
 - Agents review via `skills/hunk-review/SKILL.md` using `hunk session *` commands; do not run interactive TUI commands directly.
+- `skills/hunk-review/SKILL.md` is generated. Edit `src/hunk-review/skillDocument.ts`, `src/hunk-session/agentSurface.ts`, or `src/hunk-session/agentErrors.ts`, then run `bun run generate:skill`; never hand-edit the skill file.
 
 ## commands
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build:prebuilt:artifact": "bun run build:bin && bun run ./scripts/build-prebuilt-artifact.ts",
     "stage:prebuilt:release": "bun run build:npm && bun run ./scripts/stage-prebuilt-npm.ts --artifact-root ./dist/release/artifacts",
     "install:bin": "bun run ./scripts/install-bin.ts",
+    "generate:skill": "bun run ./scripts/generate-skill.ts",
     "typecheck": "tsc --noEmit",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",

--- a/scripts/generate-skill.ts
+++ b/scripts/generate-skill.ts
@@ -1,0 +1,11 @@
+import { join } from "node:path";
+import { renderHunkReviewSkill } from "../src/hunk-review/skillDocument";
+
+/**
+ * Regenerate `skills/hunk-review/SKILL.md` from the typed agent surface. The checked-in file is
+ * the published artifact; `src/hunk-review/skillDocument.test.ts` fails when it drifts from the
+ * renderer, so run this after changing session commands, agent errors, or the skill prose.
+ */
+const skillPath = join(import.meta.dir, "..", "skills", "hunk-review", "SKILL.md");
+await Bun.write(skillPath, renderHunkReviewSkill());
+console.log(`Wrote ${skillPath}`);

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -180,4 +180,5 @@ Guidelines:
 - **"Pass the replacement Hunk command after `--`"** -- include `--` before the nested `diff` / `show` command.
 - **"Pass --stdin to read batch comments from stdin JSON."** -- `comment apply` only reads its batch payload from stdin.
 - **"Specify exactly one navigation target"** -- pick one of `--hunk`, `--old-line`, or `--new-line`.
+- **"Specify exactly one comment target"** -- pass `comment add` one of `--old-line` or `--new-line`.
 - **"Specify either --next-comment or --prev-comment, not both."** -- choose one comment-navigation direction.

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -44,16 +44,22 @@ Use `--source` only for advanced reloads where the live session you want to cont
 
 ```bash
 hunk session list [--json]
-hunk session get (--repo . | <id>) [--json]
-hunk session context (--repo . | <id>) [--json]
-hunk session review (--repo . | <id>) [--json] [--include-patch]
+hunk session get (<session-id> | --repo <path>) [--json]
+hunk session context (<session-id> | --repo <path>) [--json]
+hunk session review (<session-id> | --repo <path>) [--include-patch] [--include-notes] [--json]
 ```
 
 - `get` shows the session `Path`, `Repo`, and `Source`, which helps when choosing between `--repo` and `--session-path`
 - `Repo` is what `--repo` matches; `Path` is what `--session-path` matches
 - `review --json` returns file and hunk structure by default; add `--include-patch` only when a caller truly needs raw unified diff text
+- `review --include-notes` also returns the live review notes alongside the file and hunk structure
 
 ### Navigate
+
+```bash
+hunk session navigate (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) [--json]
+hunk session navigate (<session-id> | --repo <path>) (--next-comment | --prev-comment) [--json]
+```
 
 Absolute navigation requires `--file` and exactly one of `--hunk`, `--new-line`, or `--old-line`:
 
@@ -79,6 +85,13 @@ hunk session navigate --repo . --prev-comment
 Swaps the live session's contents. Pass a Hunk review command after `--`:
 
 ```bash
+hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] [--json] -- diff [ref] [-- <pathspec...>]
+hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] [--json] -- show [ref] [-- <pathspec...>]
+```
+
+Examples:
+
+```bash
 hunk session reload --repo . -- diff
 hunk session reload --repo . -- diff main...feature -- src/ui
 hunk session reload --repo . -- show HEAD~1
@@ -96,11 +109,18 @@ hunk session reload --session-path /path/to/live-window --source /path/to/other-
 ### Comments
 
 ```bash
-hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording" [--rationale "..."] [--author "agent"] [--focus]
-printf '%s\n' '{"comments":[{"filePath":"README.md","newLine":103,"summary":"Tighten this wording"}]}' | hunk session comment apply --repo . --stdin [--focus]
-hunk session comment list --repo . [--file README.md] [--type live|all|ai|agent|user]
-hunk session comment rm --repo . <comment-id>
-hunk session comment clear --repo . --yes [--file README.md]
+hunk session comment add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --summary <text> [--rationale <text>] [--author <name>] [--markup <stml>] [--focus] [--json]
+hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus] [--json]
+hunk session comment list (<session-id> | --repo <path>) [--file <path>] [--type <live|all|ai|agent|user>] [--json]
+hunk session comment rm (<session-id> | --repo <path>) <comment-id> [--json]
+hunk session comment clear (<session-id> | --repo <path>) [--file <path>] [--include-user|--all] --yes [--json]
+```
+
+Examples:
+
+```bash
+hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording"
+printf '%s\n' '{"comments":[{"filePath":"README.md","newLine":103,"summary":"Tighten this wording"}]}' | hunk session comment apply --repo . --stdin
 ```
 
 - `comment list --type user` shows human-authored inline notes; without `--type`, `comment list` preserves the legacy live-agent-comment view
@@ -153,10 +173,10 @@ Guidelines:
 
 ## Common errors
 
-- **"No visible diff file matches ..."** -- the file is not in the loaded review. Check `context`, then `reload` if needed.
+- **"No diff file matches ..."** -- the file is not in the loaded review. Check `context`, then `reload` if needed.
 - **"No active Hunk sessions"** -- if Hunk is visibly running, localhost may be blocked by the agent sandbox; retry with network/sandbox escalation. Otherwise ask the user to open Hunk.
 - **"Multiple active sessions match"** -- pass `<session-id>` explicitly.
-- **"No active Hunk session matches session path ..."** -- for advanced split-path reloads, verify the live window `Path` via `hunk session get` or `list`, then use `--session-path`.
+- **"No active session matches session path ..."** -- for advanced split-path reloads, verify the live window `Path` via `hunk session get` or `list`, then use `--session-path`.
 - **"Pass the replacement Hunk command after `--`"** -- include `--` before the nested `diff` / `show` command.
 - **"Pass --stdin to read batch comments from stdin JSON."** -- `comment apply` only reads its batch payload from stdin.
 - **"Specify exactly one navigation target"** -- pick one of `--hunk`, `--old-line`, or `--new-line`.

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -95,8 +95,15 @@ function buildCommonOptions(
     agentContext: options.agentContext,
     pager: options.pager ? true : undefined,
     watch: options.watch ? true : undefined,
-    experimental: options.experimental || argv[2] === "--experimental" ? true : undefined,
-    excludeUntracked: resolveBooleanFlag(argv, "--exclude-untracked", "--no-exclude-untracked"),
+    experimental:
+      options.experimental || argv[2] === AUXILIARY_AGENT_OPTIONS.experimental.flag
+        ? true
+        : undefined,
+    excludeUntracked: resolveBooleanFlag(
+      argv,
+      AUXILIARY_AGENT_OPTIONS.excludeUntracked.flag,
+      `--no-${AUXILIARY_AGENT_OPTIONS.excludeUntracked.flag.slice(2)}`,
+    ),
     lineNumbers: resolveBooleanFlag(argv, "--line-numbers", "--no-line-numbers"),
     tabWidth: options.tabWidth,
     wrapLines: resolveBooleanFlag(argv, "--wrap", "--no-wrap"),
@@ -444,7 +451,7 @@ async function parseDiffCommand(tokens: string[], argv: string[]): Promise<Parse
     )
     .addOption(
       new Option(
-        "--no-exclude-untracked",
+        `--no-${AUXILIARY_AGENT_OPTIONS.excludeUntracked.flag.slice(2)}`,
         "include untracked files in working tree reviews",
       ).hideHelp(),
     )
@@ -1293,7 +1300,7 @@ async function parseStashCommand(tokens: string[], argv: string[]): Promise<Pars
 /** Parse CLI arguments into one normalized input shape for the app loader layer. */
 export async function parseCli(argv: string[]): Promise<ParsedCliInput> {
   const rawArgs = argv.slice(2);
-  const prefixedExperimental = rawArgs[0] === "--experimental";
+  const prefixedExperimental = rawArgs[0] === AUXILIARY_AGENT_OPTIONS.experimental.flag;
   const args = prefixedExperimental ? rawArgs.slice(1) : rawArgs;
   const [commandName, ...rest] = args;
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -15,6 +15,7 @@ import { resolveBundledHunkReviewSkillPath } from "./paths";
 import {
   type AgentCommandConstraint,
   type AgentCommandSpec,
+  AUXILIARY_AGENT_OPTIONS,
   type SessionCommandOptions,
   COMMENT_DIRECTION_CONSTRAINT,
   COMMENT_TARGET_CONSTRAINT,
@@ -110,9 +111,15 @@ function applyCommonOptions(command: Command) {
   return command
     .option("--mode <mode>", "layout mode: auto, split, stack", parseLayoutMode)
     .option("--theme <theme>", "named theme override")
-    .option("--agent-context <path>", "JSON sidecar with agent rationale")
+    .option(
+      AUXILIARY_AGENT_OPTIONS.agentContext.flag,
+      AUXILIARY_AGENT_OPTIONS.agentContext.description,
+    )
     .option("--pager", "use pager-style chrome and controls")
-    .option("--experimental", "enable experimental features (currently STML agent-note markup)")
+    .option(
+      AUXILIARY_AGENT_OPTIONS.experimental.flag,
+      AUXILIARY_AGENT_OPTIONS.experimental.description,
+    )
     .option("--line-numbers", "show line numbers")
     .option("--no-line-numbers", "hide line numbers")
     .option("-x, --tab-width <columns>", "tab stop width: 1-16", parseTabWidth)
@@ -431,7 +438,10 @@ async function parseDiffCommand(tokens: string[], argv: string[]): Promise<Parse
   )
     .option("--staged", "show staged changes instead of the working tree")
     .option("--cached", "alias for --staged")
-    .option("--exclude-untracked", "exclude untracked files from working tree reviews")
+    .option(
+      AUXILIARY_AGENT_OPTIONS.excludeUntracked.flag,
+      AUXILIARY_AGENT_OPTIONS.excludeUntracked.description,
+    )
     .addOption(
       new Option(
         "--no-exclude-untracked",
@@ -1114,7 +1124,11 @@ async function parseMarkupCommand(tokens: string[]): Promise<ParsedCliInput> {
     const command = new Command("markup render")
       .description("preview experimental STML markup as terminal text")
       .argument("[file]", "markup file path, or - for stdin", "-")
-      .option("--width <n>", "layout width in columns", parsePositiveInt)
+      .option(
+        AUXILIARY_AGENT_OPTIONS.markupWidth.flag,
+        AUXILIARY_AGENT_OPTIONS.markupWidth.description,
+        parsePositiveInt,
+      )
       .option("--color <mode>", "auto, always, or never", "auto")
       .option("--theme <id>", "hunk theme used to resolve colors")
       .option("--json", "emit structured JSON");

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -14,6 +14,7 @@ import type {
 import { resolveBundledHunkReviewSkillPath } from "./paths";
 import {
   type AgentCommandSpec,
+  type SessionCommandOptions,
   COMMENT_DIRECTION_FLAGS,
   COMMENT_TARGET_FLAGS,
   NAVIGATE_TARGET_FLAGS,
@@ -681,7 +682,7 @@ function sessionCommandHelpText(command: Command, spec: AgentCommandSpec): HelpC
 }
 
 /** Render usage lines for a list of session commands as one indented help block. */
-function sessionUsageLines(specs: AgentCommandSpec[]) {
+function sessionUsageLines(specs: readonly AgentCommandSpec[]) {
   return specs.flatMap((spec) => spec.synopsis.map((line) => `  ${line}`));
 }
 
@@ -705,9 +706,9 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
 
   if (subcommand === "list") {
     const command = buildSessionCommand(SESSION_AGENT_COMMANDS.list);
-    let parsedOptions: { json?: boolean } = {};
+    let parsedOptions: SessionCommandOptions<"list"> = {};
 
-    command.action((options: { json?: boolean }) => {
+    command.action((options: SessionCommandOptions<"list">) => {
       parsedOptions = options;
     });
 
@@ -728,22 +729,13 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     const command = buildSessionCommand(spec);
 
     let parsedSessionId: string | undefined;
-    let parsedOptions: {
-      repo?: string;
-      includePatch?: boolean;
-      includeNotes?: boolean;
-      json?: boolean;
-    } = {};
+    // Review's parsed shape is a strict superset of get/context, so it types the shared branch.
+    let parsedOptions: SessionCommandOptions<"review"> = {};
 
-    command.action(
-      (
-        sessionId: string | undefined,
-        options: { repo?: string; includePatch?: boolean; includeNotes?: boolean; json?: boolean },
-      ) => {
-        parsedSessionId = sessionId;
-        parsedOptions = options;
-      },
-    );
+    command.action((sessionId: string | undefined, options: SessionCommandOptions<"review">) => {
+      parsedSessionId = sessionId;
+      parsedOptions = options;
+    });
 
     if (rest.includes("--help") || rest.includes("-h")) {
       return sessionCommandHelpText(command, spec);
@@ -773,35 +765,12 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     const command = buildSessionCommand(SESSION_AGENT_COMMANDS.navigate);
 
     let parsedSessionId: string | undefined;
-    let parsedOptions: {
-      repo?: string;
-      file?: string;
-      hunk?: number;
-      oldLine?: number;
-      newLine?: number;
-      nextComment?: boolean;
-      prevComment?: boolean;
-      json?: boolean;
-    } = {};
+    let parsedOptions: SessionCommandOptions<"navigate"> = {};
 
-    command.action(
-      (
-        sessionId: string | undefined,
-        options: {
-          repo?: string;
-          file?: string;
-          hunk?: number;
-          oldLine?: number;
-          newLine?: number;
-          nextComment?: boolean;
-          prevComment?: boolean;
-          json?: boolean;
-        },
-      ) => {
-        parsedSessionId = sessionId;
-        parsedOptions = options;
-      },
-    );
+    command.action((sessionId: string | undefined, options: SessionCommandOptions<"navigate">) => {
+      parsedSessionId = sessionId;
+      parsedOptions = options;
+    });
 
     if (rest.includes("--help") || rest.includes("-h")) {
       return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS.navigate);
@@ -864,18 +833,12 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     const command = buildSessionCommand(SESSION_AGENT_COMMANDS.reload);
 
     let parsedSessionId: string | undefined;
-    let parsedOptions: { sessionPath?: string; repo?: string; source?: string; json?: boolean } =
-      {};
+    let parsedOptions: SessionCommandOptions<"reload"> = {};
 
-    command.action(
-      (
-        sessionId: string | undefined,
-        options: { sessionPath?: string; repo?: string; source?: string; json?: boolean },
-      ) => {
-        parsedSessionId = sessionId;
-        parsedOptions = options;
-      },
-    );
+    command.action((sessionId: string | undefined, options: SessionCommandOptions<"reload">) => {
+      parsedSessionId = sessionId;
+      parsedOptions = options;
+    });
 
     if (outerTokens.includes("--help") || outerTokens.includes("-h")) {
       return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS.reload);
@@ -922,38 +885,13 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-add"]);
 
       let parsedSessionId: string | undefined;
-      let parsedOptions: {
-        repo?: string;
-        file: string;
-        summary: string;
-        oldLine?: number;
-        newLine?: number;
-        rationale?: string;
-        markup?: string;
-        author?: string;
-        focus?: boolean;
-        json?: boolean;
-      } = {
+      let parsedOptions: SessionCommandOptions<"comment-add"> = {
         file: "",
         summary: "",
       };
 
       command.action(
-        (
-          sessionId: string | undefined,
-          options: {
-            repo?: string;
-            file: string;
-            summary: string;
-            oldLine?: number;
-            newLine?: number;
-            rationale?: string;
-            markup?: string;
-            author?: string;
-            focus?: boolean;
-            json?: boolean;
-          },
-        ) => {
+        (sessionId: string | undefined, options: SessionCommandOptions<"comment-add">) => {
           parsedSessionId = sessionId;
           parsedOptions = options;
         },
@@ -993,23 +931,10 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-apply"]);
 
       let parsedSessionId: string | undefined;
-      let parsedOptions: {
-        repo?: string;
-        stdin?: boolean;
-        focus?: boolean;
-        json?: boolean;
-      } = {};
+      let parsedOptions: SessionCommandOptions<"comment-apply"> = {};
 
       command.action(
-        (
-          sessionId: string | undefined,
-          options: {
-            repo?: string;
-            stdin?: boolean;
-            focus?: boolean;
-            json?: boolean;
-          },
-        ) => {
+        (sessionId: string | undefined, options: SessionCommandOptions<"comment-apply">) => {
           parsedSessionId = sessionId;
           parsedOptions = options;
         },
@@ -1042,13 +967,10 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-list"]);
 
       let parsedSessionId: string | undefined;
-      let parsedOptions: { repo?: string; file?: string; type?: string; json?: boolean } = {};
+      let parsedOptions: SessionCommandOptions<"comment-list"> = {};
 
       command.action(
-        (
-          sessionId: string | undefined,
-          options: { repo?: string; file?: string; type?: string; json?: boolean },
-        ) => {
+        (sessionId: string | undefined, options: SessionCommandOptions<"comment-list">) => {
           parsedSessionId = sessionId;
           parsedOptions = options;
         },
@@ -1084,9 +1006,9 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-rm"]);
 
       let parsedTargets: string[] = [];
-      let parsedOptions: { repo?: string; json?: boolean } = {};
+      let parsedOptions: SessionCommandOptions<"comment-rm"> = {};
 
-      command.action((targets: string[], options: { repo?: string; json?: boolean }) => {
+      command.action((targets: string[], options: SessionCommandOptions<"comment-rm">) => {
         parsedTargets = targets;
         parsedOptions = options;
       });
@@ -1122,27 +1044,10 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-clear"]);
 
       let parsedSessionId: string | undefined;
-      let parsedOptions: {
-        repo?: string;
-        file?: string;
-        includeUser?: boolean;
-        all?: boolean;
-        yes?: boolean;
-        json?: boolean;
-      } = {};
+      let parsedOptions: SessionCommandOptions<"comment-clear"> = {};
 
       command.action(
-        (
-          sessionId: string | undefined,
-          options: {
-            repo?: string;
-            file?: string;
-            includeUser?: boolean;
-            all?: boolean;
-            yes?: boolean;
-            json?: boolean;
-          },
-        ) => {
+        (sessionId: string | undefined, options: SessionCommandOptions<"comment-clear">) => {
           parsedSessionId = sessionId;
           parsedOptions = options;
         },

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -13,19 +13,20 @@ import type {
 } from "./types";
 import { resolveBundledHunkReviewSkillPath } from "./paths";
 import {
+  type AgentCommandConstraint,
   type AgentCommandSpec,
   type SessionCommandOptions,
-  COMMENT_DIRECTION_FLAGS,
-  COMMENT_TARGET_FLAGS,
-  NAVIGATE_TARGET_FLAGS,
+  COMMENT_DIRECTION_CONSTRAINT,
+  COMMENT_TARGET_CONSTRAINT,
+  NAVIGATE_TARGET_CONSTRAINT,
+  optionKeyFromFlag,
   SESSION_AGENT_COMMANDS,
   SESSION_AGENT_COMMAND_LIST,
   SESSION_COMMENT_COMMAND_LIST,
 } from "../hunk-session/agentSurface";
 import {
-  atMostOneFlagMessage,
   COMMENT_APPLY_STDIN_MESSAGE,
-  exactlyOneTargetMessage,
+  constraintViolationMessage,
   RELOAD_SEPARATOR_MESSAGE,
 } from "../hunk-session/agentErrors";
 import { detectVcs } from "./vcs";
@@ -681,6 +682,17 @@ function sessionCommandHelpText(command: Command, spec: AgentCommandSpec): HelpC
   return { kind: "help", text: `${sections.join("\n\n")}\n` };
 }
 
+/** Throw the shared catalog message when a declared flag-group constraint is violated. */
+function enforceConstraint(constraint: AgentCommandConstraint, options: Record<string, unknown>) {
+  const provided = constraint.flags.filter(
+    (flag) => options[optionKeyFromFlag(flag)] !== undefined,
+  ).length;
+  const violated = constraint.kind === "exactly-one" ? provided !== 1 : provided > 1;
+  if (violated) {
+    throw new Error(constraintViolationMessage(constraint));
+  }
+}
+
 /** Render usage lines for a list of session commands as one indented help block. */
 function sessionUsageLines(specs: readonly AgentCommandSpec[]) {
   return specs.flatMap((spec) => spec.synopsis.map((line) => `  ${line}`));
@@ -780,9 +792,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
 
     /** Relative comment navigation mode. */
     if (parsedOptions.nextComment || parsedOptions.prevComment) {
-      if (parsedOptions.nextComment && parsedOptions.prevComment) {
-        throw new Error(atMostOneFlagMessage(COMMENT_DIRECTION_FLAGS));
-      }
+      enforceConstraint(COMMENT_DIRECTION_CONSTRAINT, parsedOptions);
 
       return {
         kind: "session",
@@ -800,14 +810,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       );
     }
 
-    const selectors = [
-      parsedOptions.hunk !== undefined,
-      parsedOptions.oldLine !== undefined,
-      parsedOptions.newLine !== undefined,
-    ].filter(Boolean);
-    if (selectors.length !== 1) {
-      throw new Error(exactlyOneTargetMessage("navigation target", NAVIGATE_TARGET_FLAGS));
-    }
+    enforceConstraint(NAVIGATE_TARGET_CONSTRAINT, parsedOptions);
 
     return {
       kind: "session",
@@ -903,13 +906,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
 
       await parseStandaloneCommand(command, commentRest);
 
-      const selectors = [
-        parsedOptions.oldLine !== undefined,
-        parsedOptions.newLine !== undefined,
-      ].filter(Boolean);
-      if (selectors.length !== 1) {
-        throw new Error(exactlyOneTargetMessage("comment target", COMMENT_TARGET_FLAGS));
-      }
+      enforceConstraint(COMMENT_TARGET_CONSTRAINT, parsedOptions);
 
       return {
         kind: "session",

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -12,6 +12,21 @@ import type {
   SessionCommentApplyItemInput,
 } from "./types";
 import { resolveBundledHunkReviewSkillPath } from "./paths";
+import {
+  type AgentCommandSpec,
+  COMMENT_DIRECTION_FLAGS,
+  COMMENT_TARGET_FLAGS,
+  NAVIGATE_TARGET_FLAGS,
+  SESSION_AGENT_COMMANDS,
+  SESSION_AGENT_COMMAND_LIST,
+  SESSION_COMMENT_COMMAND_LIST,
+} from "../hunk-session/agentSurface";
+import {
+  atMostOneFlagMessage,
+  COMMENT_APPLY_STDIN_MESSAGE,
+  exactlyOneTargetMessage,
+  RELOAD_SEPARATOR_MESSAGE,
+} from "../hunk-session/agentErrors";
 import { detectVcs } from "./vcs";
 import { parseTabWidth } from "./tabWidth";
 import { resolveCliVersion } from "./version";
@@ -624,6 +639,52 @@ function requireReloadableCliInput(input: ParsedCliInput): CliInput {
   return input;
 }
 
+/** Build one Commander command from its declarative agent-surface spec. */
+function buildSessionCommand(spec: AgentCommandSpec) {
+  const command = new Command(spec.name).description(spec.summary);
+
+  for (const positional of spec.positionals) {
+    if (positional.description) {
+      command.argument(positional.token, positional.description);
+    } else {
+      command.argument(positional.token);
+    }
+  }
+
+  for (const option of spec.options) {
+    const register = option.required
+      ? command.requiredOption.bind(command)
+      : command.option.bind(command);
+    if (option.parse === "positiveInt") {
+      register(option.flag, option.description, parsePositiveInt);
+    } else {
+      register(option.flag, option.description);
+    }
+  }
+
+  return command;
+}
+
+/** Render `--help` output for one session command, appending spec examples and extras. */
+function sessionCommandHelpText(command: Command, spec: AgentCommandSpec): HelpCommandInput {
+  const sections = [command.helpInformation().trimEnd()];
+
+  if (spec.examples && spec.examples.length > 0) {
+    sections.push(["Examples:", ...spec.examples.map((example) => `  ${example}`)].join("\n"));
+  }
+
+  if (spec.helpExtra && spec.helpExtra.length > 0) {
+    sections.push(spec.helpExtra.join("\n"));
+  }
+
+  return { kind: "help", text: `${sections.join("\n\n")}\n` };
+}
+
+/** Render usage lines for a list of session commands as one indented help block. */
+function sessionUsageLines(specs: AgentCommandSpec[]) {
+  return specs.flatMap((spec) => spec.synopsis.map((line) => `  ${line}`));
+}
+
 /** Parse `hunk session ...` as live-session daemon-backed commands. */
 async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
   const [subcommand, ...rest] = tokens;
@@ -637,30 +698,13 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
           "Inspect and control live Hunk review sessions through the local daemon.",
           "",
           "Commands:",
-          "  hunk session list",
-          "  hunk session get <session-id>",
-          "  hunk session get --repo <path>",
-          "  hunk session context <session-id>",
-          "  hunk session context --repo <path>",
-          "  hunk session review <session-id> [--include-patch] [--include-notes]",
-          "  hunk session review --repo <path> [--include-patch] [--include-notes]",
-          "  hunk session navigate (<session-id> | --repo <path>) --file <path> (--hunk <n> | --old-line <n> | --new-line <n>)",
-          "  hunk session navigate (<session-id> | --repo <path>) (--next-comment | --prev-comment)",
-          "  hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] -- diff [ref] [-- <pathspec...>]",
-          "  hunk session reload (<session-id> | --repo <path> | --session-path <path>) [--source <path>] -- show [ref] [-- <pathspec...>]",
-          "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --summary <text> [--focus]",
-          "  hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
-          "  hunk session comment list (<session-id> | --repo <path>) [--type <live|all|ai|agent|user>]",
-          "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
-          "  hunk session comment clear (<session-id> | --repo <path>) [--include-user|--all] --yes",
+          ...sessionUsageLines(SESSION_AGENT_COMMAND_LIST),
         ].join("\n") + "\n",
     };
   }
 
   if (subcommand === "list") {
-    const command = new Command("session list")
-      .description("list live Hunk sessions")
-      .option("--json", "emit structured JSON");
+    const command = buildSessionCommand(SESSION_AGENT_COMMANDS.list);
     let parsedOptions: { json?: boolean } = {};
 
     command.action((options: { json?: boolean }) => {
@@ -668,7 +712,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     });
 
     if (rest.includes("--help") || rest.includes("-h")) {
-      return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+      return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS.list);
     }
 
     await parseStandaloneCommand(command, rest);
@@ -680,23 +724,8 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
   }
 
   if (subcommand === "get" || subcommand === "context" || subcommand === "review") {
-    const command = new Command(`session ${subcommand}`)
-      .description(
-        subcommand === "get"
-          ? "show one live Hunk session"
-          : subcommand === "context"
-            ? "show the selected file and hunk for one live Hunk session"
-            : "export the live review model for one Hunk session",
-      )
-      .argument("[sessionId]")
-      .option("--repo <path>", "target the live session whose repo root matches this path")
-      .option("--json", "emit structured JSON");
-
-    if (subcommand === "review") {
-      command
-        .option("--include-patch", "include raw unified diff text for each file in review output")
-        .option("--include-notes", "include live review notes in review output");
-    }
+    const spec = SESSION_AGENT_COMMANDS[subcommand];
+    const command = buildSessionCommand(spec);
 
     let parsedSessionId: string | undefined;
     let parsedOptions: {
@@ -717,7 +746,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     );
 
     if (rest.includes("--help") || rest.includes("-h")) {
-      return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+      return sessionCommandHelpText(command, spec);
     }
 
     await parseStandaloneCommand(command, rest);
@@ -741,17 +770,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
   }
 
   if (subcommand === "navigate") {
-    const command = new Command("session navigate")
-      .description("move a live Hunk session to one diff hunk")
-      .argument("[sessionId]")
-      .option("--file <path>", "diff file path as shown by Hunk")
-      .option("--repo <path>", "target the live session whose repo root matches this path")
-      .option("--hunk <n>", "1-based hunk number within the file", parsePositiveInt)
-      .option("--old-line <n>", "1-based line number on the old side", parsePositiveInt)
-      .option("--new-line <n>", "1-based line number on the new side", parsePositiveInt)
-      .option("--next-comment", "jump to the next annotated hunk")
-      .option("--prev-comment", "jump to the previous annotated hunk")
-      .option("--json", "emit structured JSON");
+    const command = buildSessionCommand(SESSION_AGENT_COMMANDS.navigate);
 
     let parsedSessionId: string | undefined;
     let parsedOptions: {
@@ -785,7 +804,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     );
 
     if (rest.includes("--help") || rest.includes("-h")) {
-      return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+      return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS.navigate);
     }
 
     await parseStandaloneCommand(command, rest);
@@ -793,7 +812,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     /** Relative comment navigation mode. */
     if (parsedOptions.nextComment || parsedOptions.prevComment) {
       if (parsedOptions.nextComment && parsedOptions.prevComment) {
-        throw new Error("Specify either --next-comment or --prev-comment, not both.");
+        throw new Error(atMostOneFlagMessage(COMMENT_DIRECTION_FLAGS));
       }
 
       return {
@@ -818,9 +837,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       parsedOptions.newLine !== undefined,
     ].filter(Boolean);
     if (selectors.length !== 1) {
-      throw new Error(
-        "Specify exactly one navigation target: --hunk <n>, --old-line <n>, or --new-line <n>.",
-      );
+      throw new Error(exactlyOneTargetMessage("navigation target", NAVIGATE_TARGET_FLAGS));
     }
 
     return {
@@ -844,13 +861,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     const separatorIndex = rest.indexOf("--");
     const outerTokens = separatorIndex === -1 ? rest : rest.slice(0, separatorIndex);
 
-    const command = new Command("session reload")
-      .description("replace the contents of one live Hunk session")
-      .argument("[sessionId]")
-      .option("--repo <path>", "target the live session whose repo root matches this path")
-      .option("--session-path <path>", "target a live session rooted at a different path")
-      .option("--source <path>", "load the diff from this directory instead of the session's own")
-      .option("--json", "emit structured JSON");
+    const command = buildSessionCommand(SESSION_AGENT_COMMANDS.reload);
 
     let parsedSessionId: string | undefined;
     let parsedOptions: { sessionPath?: string; repo?: string; source?: string; json?: boolean } =
@@ -867,32 +878,16 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     );
 
     if (outerTokens.includes("--help") || outerTokens.includes("-h")) {
-      return {
-        kind: "help",
-        text:
-          `${command.helpInformation().trimEnd()}\n\n` +
-          [
-            "Examples:",
-            "  hunk session reload --repo . -- diff",
-            "  hunk session reload --repo . -- diff main...feature -- src/ui",
-            "  hunk session reload --repo . -- show HEAD~1 -- README.md",
-            "  hunk session reload --session-path /path/to/session --source /path/to/repo -- diff",
-          ].join("\n") +
-          "\n",
-      };
+      return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS.reload);
     }
 
     if (separatorIndex === -1) {
-      throw new Error(
-        "Pass the replacement Hunk command after `--`, for example `hunk session reload <session-id> -- diff`.",
-      );
+      throw new Error(RELOAD_SEPARATOR_MESSAGE);
     }
 
     const nestedTokens = rest.slice(separatorIndex + 1);
     if (nestedTokens.length === 0) {
-      throw new Error(
-        "Pass the replacement Hunk command after `--`, for example `hunk session reload <session-id> -- diff`.",
-      );
+      throw new Error(RELOAD_SEPARATOR_MESSAGE);
     }
 
     await parseStandaloneCommand(command, outerTokens);
@@ -919,32 +914,12 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     if (!commentSubcommand || commentSubcommand === "--help" || commentSubcommand === "-h") {
       return {
         kind: "help",
-        text:
-          [
-            "Usage:",
-            "  hunk session comment add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --summary <text> [--focus]",
-            "  hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
-            "  hunk session comment list (<session-id> | --repo <path>) [--file <path>] [--type <live|all|ai|agent|user>]",
-            "  hunk session comment rm (<session-id> | --repo <path>) <comment-id>",
-            "  hunk session comment clear (<session-id> | --repo <path>) [--file <path>] [--include-user|--all] --yes",
-          ].join("\n") + "\n",
+        text: ["Usage:", ...sessionUsageLines(SESSION_COMMENT_COMMAND_LIST)].join("\n") + "\n",
       };
     }
 
     if (commentSubcommand === "add") {
-      const command = new Command("session comment add")
-        .description("attach one live inline review note")
-        .argument("[sessionId]")
-        .requiredOption("--file <path>", "diff file path as shown by Hunk")
-        .requiredOption("--summary <text>", "short review note")
-        .option("--repo <path>", "target the live session whose repo root matches this path")
-        .option("--old-line <n>", "1-based line number on the old side", parsePositiveInt)
-        .option("--new-line <n>", "1-based line number on the new side", parsePositiveInt)
-        .option("--rationale <text>", "optional longer explanation")
-        .option("--markup <stml>", "experimental STML body (target session must opt in)")
-        .option("--author <name>", "optional author label")
-        .option("--focus", "add the note and focus the viewport on it")
-        .option("--json", "emit structured JSON");
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-add"]);
 
       let parsedSessionId: string | undefined;
       let parsedOptions: {
@@ -985,7 +960,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       );
 
       if (commentRest.includes("--help") || commentRest.includes("-h")) {
-        return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["comment-add"]);
       }
 
       await parseStandaloneCommand(command, commentRest);
@@ -995,7 +970,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
         parsedOptions.newLine !== undefined,
       ].filter(Boolean);
       if (selectors.length !== 1) {
-        throw new Error("Specify exactly one comment target: --old-line <n> or --new-line <n>.");
+        throw new Error(exactlyOneTargetMessage("comment target", COMMENT_TARGET_FLAGS));
       }
 
       return {
@@ -1015,13 +990,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     }
 
     if (commentSubcommand === "apply") {
-      const command = new Command("session comment apply")
-        .description("apply many live inline review notes from stdin JSON")
-        .argument("[sessionId]")
-        .option("--repo <path>", "target the live session whose repo root matches this path")
-        .option("--stdin", "read the comment batch from stdin as JSON")
-        .option("--focus", "apply the batch and focus the first note")
-        .option("--json", "emit structured JSON");
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-apply"]);
 
       let parsedSessionId: string | undefined;
       let parsedOptions: {
@@ -1047,31 +1016,12 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       );
 
       if (commentRest.includes("--help") || commentRest.includes("-h")) {
-        return {
-          kind: "help",
-          text:
-            `${command.helpInformation().trimEnd()}\n\n` +
-            [
-              "Stdin JSON shape:",
-              "  {",
-              '    "comments": [',
-              "      {",
-              '        "filePath": "README.md",',
-              '        "hunk": 2,',
-              '        "summary": "Explain this hunk",',
-              '        "rationale": "Optional detail",',
-              '        "author": "Pi"',
-              "      }",
-              "    ]",
-              "  }",
-            ].join("\n") +
-            "\n",
-        };
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["comment-apply"]);
       }
 
       await parseStandaloneCommand(command, commentRest);
       if (!parsedOptions.stdin) {
-        throw new Error("Pass --stdin to read batch comments from stdin JSON.");
+        throw new Error(COMMENT_APPLY_STDIN_MESSAGE);
       }
 
       const comments = parseSessionCommentApplyPayload(
@@ -1089,13 +1039,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     }
 
     if (commentSubcommand === "list") {
-      const command = new Command("session comment list")
-        .description("list live inline review notes")
-        .argument("[sessionId]")
-        .option("--repo <path>", "target the live session whose repo root matches this path")
-        .option("--file <path>", "filter comments to one diff file")
-        .option("--type <type>", "filter to live, all, ai, agent, or user comments")
-        .option("--json", "emit structured JSON");
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-list"]);
 
       let parsedSessionId: string | undefined;
       let parsedOptions: { repo?: string; file?: string; type?: string; json?: boolean } = {};
@@ -1111,7 +1055,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       );
 
       if (commentRest.includes("--help") || commentRest.includes("-h")) {
-        return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["comment-list"]);
       }
 
       await parseStandaloneCommand(command, commentRest);
@@ -1137,11 +1081,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     }
 
     if (commentSubcommand === "rm") {
-      const command = new Command("session comment rm")
-        .description("remove one inline review note")
-        .argument("[targets...]", "<session-id> <comment-id>, or <comment-id> with --repo")
-        .option("--repo <path>", "target the live session whose repo root matches this path")
-        .option("--json", "emit structured JSON");
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-rm"]);
 
       let parsedTargets: string[] = [];
       let parsedOptions: { repo?: string; json?: boolean } = {};
@@ -1152,7 +1092,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       });
 
       if (commentRest.includes("--help") || commentRest.includes("-h")) {
-        return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["comment-rm"]);
       }
 
       await parseStandaloneCommand(command, commentRest);
@@ -1179,15 +1119,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     }
 
     if (commentSubcommand === "clear") {
-      const command = new Command("session comment clear")
-        .description("clear inline review notes")
-        .argument("[sessionId]")
-        .option("--repo <path>", "target the live session whose repo root matches this path")
-        .option("--file <path>", "clear only one diff file's comments")
-        .option("--include-user", "also clear human notes created with the TUI `c` action")
-        .option("--all", "clear both live agent comments and human user notes")
-        .option("--yes", "confirm destructive comment clearing")
-        .option("--json", "emit structured JSON");
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["comment-clear"]);
 
       let parsedSessionId: string | undefined;
       let parsedOptions: {
@@ -1217,7 +1149,7 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
       );
 
       if (commentRest.includes("--help") || commentRest.includes("-h")) {
-        return { kind: "help", text: `${command.helpInformation().trimEnd()}\n` };
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["comment-clear"]);
       }
 
       await parseStandaloneCommand(command, commentRest);

--- a/src/hunk-review/skillDocument.test.ts
+++ b/src/hunk-review/skillDocument.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { agentOptionFlagName, SESSION_AGENT_COMMAND_LIST } from "../hunk-session/agentSurface";
+import { renderHunkReviewSkill } from "./skillDocument";
+
+const SKILL_PATH = join(import.meta.dir, "..", "..", "skills", "hunk-review", "SKILL.md");
+
+/** Flags the skill documents for non-session commands (`hunk diff`, `hunk markup render`). */
+const NON_SESSION_DOCUMENTED_FLAGS = ["--exclude-untracked", "--experimental", "--width"];
+
+/** Normalize checkout line endings so the comparison stays portable on Windows. */
+function normalizeNewlines(text: string) {
+  return text.replaceAll("\r\n", "\n");
+}
+
+describe("hunk-review skill document", () => {
+  test("checked-in SKILL.md matches the generated document", () => {
+    const checkedIn = normalizeNewlines(readFileSync(SKILL_PATH, "utf8"));
+    const rendered = renderHunkReviewSkill();
+
+    if (checkedIn !== rendered) {
+      throw new Error(
+        "skills/hunk-review/SKILL.md is out of date. Run `bun run generate:skill` and commit the result.",
+      );
+    }
+
+    expect(checkedIn).toBe(rendered);
+  });
+
+  test("only mentions flags that exist on the session command surface", () => {
+    const declared = new Set([
+      ...SESSION_AGENT_COMMAND_LIST.flatMap((spec) => spec.options.map(agentOptionFlagName)),
+      ...NON_SESSION_DOCUMENTED_FLAGS,
+    ]);
+    const mentioned = renderHunkReviewSkill().match(/--[a-z][a-z-]*/g) ?? [];
+
+    expect(mentioned.length).toBeGreaterThan(0);
+    for (const flag of mentioned) {
+      expect(declared).toContain(flag);
+    }
+  });
+
+  test("documents every session command's synopsis", () => {
+    const rendered = renderHunkReviewSkill();
+    for (const spec of SESSION_AGENT_COMMAND_LIST) {
+      for (const line of spec.synopsis) {
+        expect(rendered).toContain(line);
+      }
+    }
+  });
+});

--- a/src/hunk-review/skillDocument.test.ts
+++ b/src/hunk-review/skillDocument.test.ts
@@ -1,13 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { agentOptionFlagName, SESSION_AGENT_COMMAND_LIST } from "../hunk-session/agentSurface";
+import {
+  agentOptionFlagName,
+  AUXILIARY_AGENT_OPTIONS,
+  SESSION_AGENT_COMMAND_LIST,
+} from "../hunk-session/agentSurface";
 import { renderHunkReviewSkill } from "./skillDocument";
 
 const SKILL_PATH = join(import.meta.dir, "..", "..", "skills", "hunk-review", "SKILL.md");
+const AGENT_WORKFLOWS_PATH = join(import.meta.dir, "..", "..", "docs", "agent-workflows.md");
 
-/** Flags the skill documents for non-session commands (`hunk diff`, `hunk markup render`). */
-const NON_SESSION_DOCUMENTED_FLAGS = ["--exclude-untracked", "--experimental", "--width"];
+/** Every flag the agent-facing docs may reference: the session surface plus auxiliary options. */
+const DOCUMENTED_AGENT_FLAGS = new Set([
+  ...SESSION_AGENT_COMMAND_LIST.flatMap((spec) => spec.options.map(agentOptionFlagName)),
+  ...Object.values(AUXILIARY_AGENT_OPTIONS).map(agentOptionFlagName),
+]);
+
+/** Flags of non-hunk shell tools that appear inside doc examples (e.g. curl). */
+const NON_HUNK_SHELL_FLAGS = new Set(["--data"]);
 
 /** Normalize checkout line endings so the comparison stays portable on Windows. */
 function normalizeNewlines(text: string) {
@@ -28,16 +39,24 @@ describe("hunk-review skill document", () => {
     expect(checkedIn).toBe(rendered);
   });
 
-  test("only mentions flags that exist on the session command surface", () => {
-    const declared = new Set([
-      ...SESSION_AGENT_COMMAND_LIST.flatMap((spec) => spec.options.map(agentOptionFlagName)),
-      ...NON_SESSION_DOCUMENTED_FLAGS,
-    ]);
+  test("only mentions flags that exist on the declared agent surface", () => {
     const mentioned = renderHunkReviewSkill().match(/--[a-z][a-z-]*/g) ?? [];
 
     expect(mentioned.length).toBeGreaterThan(0);
     for (const flag of mentioned) {
-      expect(declared).toContain(flag);
+      expect(DOCUMENTED_AGENT_FLAGS).toContain(flag);
+    }
+  });
+
+  test("docs/agent-workflows.md only references declared agent flags", () => {
+    const mentioned = readFileSync(AGENT_WORKFLOWS_PATH, "utf8").match(/--[a-z][a-z-]*/g) ?? [];
+
+    expect(mentioned.length).toBeGreaterThan(0);
+    for (const flag of mentioned) {
+      if (NON_HUNK_SHELL_FLAGS.has(flag)) {
+        continue;
+      }
+      expect(DOCUMENTED_AGENT_FLAGS).toContain(flag);
     }
   });
 

--- a/src/hunk-review/skillDocument.ts
+++ b/src/hunk-review/skillDocument.ts
@@ -12,7 +12,7 @@ import { SESSION_AGENT_COMMANDS, type AgentCommandSpec } from "../hunk-session/a
  */
 
 /** Render one bash-highlighted code fence. */
-function bashFence(lines: string[]) {
+function bashFence(lines: readonly string[]) {
   return ["```bash", ...lines, "```"];
 }
 

--- a/src/hunk-review/skillDocument.ts
+++ b/src/hunk-review/skillDocument.ts
@@ -1,0 +1,227 @@
+import { AGENT_ERROR_DOCS } from "../hunk-session/agentErrors";
+import { SESSION_AGENT_COMMANDS, type AgentCommandSpec } from "../hunk-session/agentSurface";
+
+/**
+ * Deterministic renderer for `skills/hunk-review/SKILL.md`.
+ *
+ * The command reference blocks and the "Common errors" section are derived from
+ * `agentSurface.ts` and `agentErrors.ts` so the skill can never disagree with the parser or the
+ * messages the CLI actually throws. The narrative prose lives here as authored strings, next to
+ * the specs it explains. Regenerate with `bun run generate:skill`; never hand-edit the output —
+ * `skillDocument.test.ts` fails CI when the checked-in file drifts from this renderer.
+ */
+
+/** Render one bash-highlighted code fence. */
+function bashFence(lines: string[]) {
+  return ["```bash", ...lines, "```"];
+}
+
+/** Canonical synopsis lines for one or more session commands, in the given order. */
+function synopsisLines(...specs: AgentCommandSpec[]) {
+  return specs.flatMap((spec) => spec.synopsis);
+}
+
+const commands = SESSION_AGENT_COMMANDS;
+
+/** Navigate examples that anchor on a file are absolute; the rest jump between comments. */
+function navigateExamples(kind: "absolute" | "relative") {
+  const examples = commands.navigate.examples ?? [];
+  return examples.filter((example) => example.includes("--file") === (kind === "absolute"));
+}
+
+const FRONTMATTER = [
+  "---",
+  "name: hunk-review",
+  "description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files and hunks, reloads session contents, and adds inline review comments. Use when the user has a Hunk session running or wants to review diffs interactively.",
+  "---",
+];
+
+const INTRO = [
+  "# Hunk Review",
+  "",
+  "Hunk is an interactive terminal diff viewer. The TUI is for the user -- do NOT run `hunk diff`, `hunk show`, or other interactive commands directly. Use `hunk session *` CLI commands to inspect and control live sessions through the local daemon.",
+  "",
+  "If no session exists, ask the user to launch Hunk in their terminal first.",
+];
+
+const WORKFLOW = [
+  "## Workflow",
+  "",
+  "```text",
+  "1. hunk session list                                    # find live sessions",
+  "2. hunk session get --repo .                            # inspect path / repo / source",
+  "3. hunk session review --repo . --json                  # inspect file/hunk structure first",
+  "4. hunk session review --repo . --include-patch --json  # opt into raw diff text only when needed",
+  "5. hunk session context --repo .                        # check current focus when needed",
+  "6. hunk session navigate ...                            # move to the right place",
+  "7. hunk session reload -- <command>                     # swap contents if needed",
+  "8. hunk session comment add ...                         # leave one review note",
+  "9. hunk session comment apply ...                       # apply many agent notes in one stdin batch",
+  "```",
+];
+
+const SESSION_SELECTION = [
+  "## Session selection",
+  "",
+  "Most session commands accept:",
+  "",
+  "- `--repo <path>` -- match the live session by its current loaded repo root (most common)",
+  "- `<session-id>` -- match by exact ID (use when multiple sessions share a repo)",
+  "- If only one session exists, it auto-resolves",
+  "",
+  "`reload` also supports:",
+  "",
+  "- `--session-path <path>` -- match the live Hunk window by its current working directory",
+  "- `--source <path>` -- load the replacement `diff` / `show` command from a different directory",
+  "",
+  "Use `--source` only for advanced reloads where the live session you want to control is not already associated with the checkout you want to load next. For a normal worktree session, prefer selecting it directly with `--repo /path/to/worktree`.",
+];
+
+const INSPECT_SECTION = [
+  "### Inspect",
+  "",
+  ...bashFence(synopsisLines(commands.list, commands.get, commands.context, commands.review)),
+  "",
+  "- `get` shows the session `Path`, `Repo`, and `Source`, which helps when choosing between `--repo` and `--session-path`",
+  "- `Repo` is what `--repo` matches; `Path` is what `--session-path` matches",
+  "- `review --json` returns file and hunk structure by default; add `--include-patch` only when a caller truly needs raw unified diff text",
+  "- `review --include-notes` also returns the live review notes alongside the file and hunk structure",
+];
+
+const NAVIGATE_SECTION = [
+  "### Navigate",
+  "",
+  ...bashFence(synopsisLines(commands.navigate)),
+  "",
+  "Absolute navigation requires `--file` and exactly one of `--hunk`, `--new-line`, or `--old-line`:",
+  "",
+  ...bashFence(navigateExamples("absolute")),
+  "",
+  "Relative comment navigation jumps between annotated hunks and does not require `--file`:",
+  "",
+  ...bashFence(navigateExamples("relative")),
+  "",
+  "- `--hunk <n>` is 1-based",
+  "- `--new-line` / `--old-line` are 1-based line numbers on that diff side",
+  "- Use either `--next-comment` or `--prev-comment`, not both",
+];
+
+const RELOAD_SECTION = [
+  "### Reload",
+  "",
+  "Swaps the live session's contents. Pass a Hunk review command after `--`:",
+  "",
+  ...bashFence(synopsisLines(commands.reload)),
+  "",
+  "Examples:",
+  "",
+  ...bashFence(commands.reload.examples ?? []),
+  "",
+  "- Always include `--` before the nested Hunk command",
+  "- `--repo` or `<session-id>` usually selects the session you want",
+  "- `--source` is advanced: it does not select the session; it only changes where the replacement review command runs",
+  "- If the live session is already showing the target worktree, prefer `hunk session reload --repo /path/to/worktree -- diff`",
+  "- `--session-path` targets the live window when you need to keep session selection separate from reload source",
+];
+
+const COMMENTS_SECTION = [
+  "### Comments",
+  "",
+  ...bashFence(
+    synopsisLines(
+      commands["comment-add"],
+      commands["comment-apply"],
+      commands["comment-list"],
+      commands["comment-rm"],
+      commands["comment-clear"],
+    ),
+  ),
+  "",
+  "Examples:",
+  "",
+  ...bashFence([
+    ...(commands["comment-add"].examples ?? []),
+    ...(commands["comment-apply"].examples ?? []),
+  ]),
+  "",
+  "- `comment list --type user` shows human-authored inline notes; without `--type`, `comment list` preserves the legacy live-agent-comment view",
+  "- `comment add` is best for one note; `comment apply` is best when an agent already has several notes ready",
+  "- `comment add` requires `--file`, `--summary`, and exactly one of `--old-line` or `--new-line`",
+  "- `comment apply` payload items require `filePath`, `summary`, and exactly one target such as `hunk`, `hunkNumber`, `oldLine`, or `newLine`",
+  "- `comment apply` reads a JSON batch from stdin and validates the full batch before mutating the live session",
+  "- Pass `--focus` when you want to jump to the new note or the first note in a batch",
+  "- `comment list` and `comment clear` accept optional `--file`",
+  "- Quote `--summary` and `--rationale` defensively in the shell",
+];
+
+const STML_SECTION = [
+  "### Experimental rich markup notes (STML)",
+  "",
+  "Only use STML when `hunk session context --json` lists `stml` in `experimentalFeatures`. The user opts into that experience by launching the review with `--experimental`; do not ask a normal session to render markup.",
+  "",
+  "For an opted-in session, `--markup` (or a `markup` field on apply items) renders the note body as STML — a small HTML-like markup for terminal UI (boxes, rows, gauges, badges, lists, code). Keep `--summary` a real sentence: it is the fallback and the `comment list` text.",
+  "",
+  "Before writing markup, run `hunk markup guide` once — it has copy-paste patterns and the width rules. The session context also reports `noteMarkupWidth` (the live render width); preview with `hunk markup render - --width <that>`. Comment responses echo `markupWidth` and return `markupNotes` when markup degraded — fix what they flag.",
+];
+
+const NEW_FILES_SECTION = [
+  "## New files in working-tree reviews",
+  "",
+  "`hunk diff` includes untracked files by default. If the user wants tracked changes only, reload with `--exclude-untracked`:",
+  "",
+  ...bashFence(["hunk session reload --repo . -- diff --exclude-untracked"]),
+];
+
+const GUIDING_SECTION = [
+  "## Guiding a review",
+  "",
+  "The user may ask you to walk them through a changeset or review code using Hunk. Start with `hunk session review --json` to understand the file/hunk structure without inflating agent context, then use `--include-patch` only for the files you truly need to read in raw diff form. Use `context` and `navigate` to line up the user's current view before adding comments.",
+  "",
+  "Your role is to narrate: steer the user's view to what matters and leave comments that explain what they're looking at.",
+  "",
+  "Typical flow:",
+  "",
+  "1. Load the right content (`reload` if needed)",
+  "2. Navigate to the first interesting file / hunk",
+  "3. Add a comment explaining what's happening and why",
+  "4. If you already have several notes ready, prefer one `comment apply` batch over many separate shell invocations",
+  "5. Summarize when done",
+  "",
+  "Guidelines:",
+  "",
+  "- Work in the order that tells the clearest story, not necessarily file order",
+  "- Navigate before commenting so the user sees the code you're discussing",
+  "- Use `comment apply` for agent-generated batches and `comment add` for one-off notes",
+  "- Use `--focus` sparingly when the note itself should actively steer the review",
+  "- Keep comments focused: intent, structure, risks, or follow-ups",
+  "- Don't comment on every hunk -- highlight what the user wouldn't spot themselves",
+];
+
+/** Render the "Common errors" section from the shared agent error catalog. */
+function commonErrorsSection() {
+  return [
+    "## Common errors",
+    "",
+    ...AGENT_ERROR_DOCS.map((doc) => `- **"${doc.quote}"** -- ${doc.remedy}`),
+  ];
+}
+
+/** Render the complete hunk-review SKILL.md content. */
+export function renderHunkReviewSkill() {
+  const sections = [
+    [...FRONTMATTER, "", ...INTRO],
+    WORKFLOW,
+    SESSION_SELECTION,
+    ["## Commands"],
+    INSPECT_SECTION,
+    NAVIGATE_SECTION,
+    RELOAD_SECTION,
+    COMMENTS_SECTION,
+    STML_SECTION,
+    NEW_FILES_SECTION,
+    GUIDING_SECTION,
+    commonErrorsSection(),
+  ];
+
+  return `${sections.map((section) => section.join("\n")).join("\n\n")}\n`;
+}

--- a/src/hunk-session/agentErrors.test.ts
+++ b/src/hunk-session/agentErrors.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSessionTarget } from "@hunk/session-broker-core";
+import {
+  AGENT_ERROR_DOCS,
+  agentErrorQuotePrefix,
+  atMostOneFlagMessage,
+  COMMENT_APPLY_STDIN_MESSAGE,
+  exactlyOneTargetMessage,
+  NO_ACTIVE_SESSIONS_MESSAGE,
+  noDiffFileMatchesMessage,
+  RELOAD_SEPARATOR_MESSAGE,
+} from "./agentErrors";
+import {
+  COMMENT_DIRECTION_FLAGS,
+  COMMENT_TARGET_FLAGS,
+  NAVIGATE_TARGET_FLAGS,
+} from "./agentSurface";
+
+function createTestBrokerSession(sessionId: string) {
+  return {
+    sessionId,
+    cwd: `/tmp/${sessionId}`,
+    repoRoot: "/tmp/shared-repo",
+    title: `title-${sessionId}`,
+    snapshot: { updatedAt: "2026-01-01T00:00:00.000Z" },
+  };
+}
+
+/** Capture the message a callback throws so broker errors can be prefix-checked. */
+function thrownMessage(callback: () => unknown) {
+  try {
+    callback();
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  throw new Error("Expected the callback to throw.");
+}
+
+describe("agent error messages", () => {
+  test("formats exactly-one constraints with an Oxford-comma flag list", () => {
+    expect(exactlyOneTargetMessage("navigation target", NAVIGATE_TARGET_FLAGS)).toBe(
+      "Specify exactly one navigation target: --hunk <n>, --old-line <n>, or --new-line <n>.",
+    );
+    expect(exactlyOneTargetMessage("comment target", COMMENT_TARGET_FLAGS)).toBe(
+      "Specify exactly one comment target: --old-line <n> or --new-line <n>.",
+    );
+  });
+
+  test("formats at-most-one constraints as an either/or message", () => {
+    expect(atMostOneFlagMessage(COMMENT_DIRECTION_FLAGS)).toBe(
+      "Specify either --next-comment or --prev-comment, not both.",
+    );
+  });
+
+  test("binds every documented quote to a real thrown message", () => {
+    const sessions = [createTestBrokerSession("one"), createTestBrokerSession("two")];
+    // One real message per AGENT_ERROR_DOCS entry, in the same display order. Broker-owned
+    // messages are produced by the broker itself so the doc quotes track its actual wording.
+    const realMessages = [
+      noDiffFileMatchesMessage("src/App.tsx"),
+      NO_ACTIVE_SESSIONS_MESSAGE,
+      thrownMessage(() => resolveSessionTarget(sessions, { repoRoot: "/tmp/shared-repo" })),
+      thrownMessage(() => resolveSessionTarget(sessions, { sessionPath: "/tmp/missing" })),
+      RELOAD_SEPARATOR_MESSAGE,
+      COMMENT_APPLY_STDIN_MESSAGE,
+      exactlyOneTargetMessage("navigation target", NAVIGATE_TARGET_FLAGS),
+      atMostOneFlagMessage(COMMENT_DIRECTION_FLAGS),
+    ];
+
+    expect(realMessages).toHaveLength(AGENT_ERROR_DOCS.length);
+    for (const [index, doc] of AGENT_ERROR_DOCS.entries()) {
+      expect(realMessages[index]!).toStartWith(agentErrorQuotePrefix(doc));
+    }
+  });
+});

--- a/src/hunk-session/agentErrors.test.ts
+++ b/src/hunk-session/agentErrors.test.ts
@@ -64,12 +64,23 @@ describe("agent error messages", () => {
       RELOAD_SEPARATOR_MESSAGE,
       COMMENT_APPLY_STDIN_MESSAGE,
       constraintViolationMessage(NAVIGATE_TARGET_CONSTRAINT),
+      constraintViolationMessage(COMMENT_TARGET_CONSTRAINT),
       constraintViolationMessage(COMMENT_DIRECTION_CONSTRAINT),
     ];
 
+    // Quotes match messages by prefix rather than array position, so reordering
+    // AGENT_ERROR_DOCS cannot silently pair a quote with the wrong message.
     expect(realMessages).toHaveLength(AGENT_ERROR_DOCS.length);
-    for (const [index, doc] of AGENT_ERROR_DOCS.entries()) {
-      expect(realMessages[index]!).toStartWith(agentErrorQuotePrefix(doc));
+    for (const doc of AGENT_ERROR_DOCS) {
+      const prefix = agentErrorQuotePrefix(doc);
+      expect(realMessages.some((message) => message.startsWith(prefix))).toBe(true);
+    }
+
+    for (const message of realMessages) {
+      const claims = AGENT_ERROR_DOCS.filter((doc) =>
+        message.startsWith(agentErrorQuotePrefix(doc)),
+      );
+      expect(claims).toHaveLength(1);
     }
   });
 });

--- a/src/hunk-session/agentErrors.test.ts
+++ b/src/hunk-session/agentErrors.test.ts
@@ -3,17 +3,16 @@ import { resolveSessionTarget } from "@hunk/session-broker-core";
 import {
   AGENT_ERROR_DOCS,
   agentErrorQuotePrefix,
-  atMostOneFlagMessage,
   COMMENT_APPLY_STDIN_MESSAGE,
-  exactlyOneTargetMessage,
+  constraintViolationMessage,
   NO_ACTIVE_SESSIONS_MESSAGE,
   noDiffFileMatchesMessage,
   RELOAD_SEPARATOR_MESSAGE,
 } from "./agentErrors";
 import {
-  COMMENT_DIRECTION_FLAGS,
-  COMMENT_TARGET_FLAGS,
-  NAVIGATE_TARGET_FLAGS,
+  COMMENT_DIRECTION_CONSTRAINT,
+  COMMENT_TARGET_CONSTRAINT,
+  NAVIGATE_TARGET_CONSTRAINT,
 } from "./agentSurface";
 
 function createTestBrokerSession(sessionId: string) {
@@ -39,16 +38,16 @@ function thrownMessage(callback: () => unknown) {
 
 describe("agent error messages", () => {
   test("formats exactly-one constraints with an Oxford-comma flag list", () => {
-    expect(exactlyOneTargetMessage("navigation target", NAVIGATE_TARGET_FLAGS)).toBe(
+    expect(constraintViolationMessage(NAVIGATE_TARGET_CONSTRAINT)).toBe(
       "Specify exactly one navigation target: --hunk <n>, --old-line <n>, or --new-line <n>.",
     );
-    expect(exactlyOneTargetMessage("comment target", COMMENT_TARGET_FLAGS)).toBe(
+    expect(constraintViolationMessage(COMMENT_TARGET_CONSTRAINT)).toBe(
       "Specify exactly one comment target: --old-line <n> or --new-line <n>.",
     );
   });
 
   test("formats at-most-one constraints as an either/or message", () => {
-    expect(atMostOneFlagMessage(COMMENT_DIRECTION_FLAGS)).toBe(
+    expect(constraintViolationMessage(COMMENT_DIRECTION_CONSTRAINT)).toBe(
       "Specify either --next-comment or --prev-comment, not both.",
     );
   });
@@ -64,8 +63,8 @@ describe("agent error messages", () => {
       thrownMessage(() => resolveSessionTarget(sessions, { sessionPath: "/tmp/missing" })),
       RELOAD_SEPARATOR_MESSAGE,
       COMMENT_APPLY_STDIN_MESSAGE,
-      exactlyOneTargetMessage("navigation target", NAVIGATE_TARGET_FLAGS),
-      atMostOneFlagMessage(COMMENT_DIRECTION_FLAGS),
+      constraintViolationMessage(NAVIGATE_TARGET_CONSTRAINT),
+      constraintViolationMessage(COMMENT_DIRECTION_CONSTRAINT),
     ];
 
     expect(realMessages).toHaveLength(AGENT_ERROR_DOCS.length);

--- a/src/hunk-session/agentErrors.ts
+++ b/src/hunk-session/agentErrors.ts
@@ -1,0 +1,100 @@
+/**
+ * Agent-facing error messages for the `hunk session` surface.
+ *
+ * Every message quoted by the generated `skills/hunk-review/SKILL.md` "Common errors" section is
+ * defined (or contract-tested) here, so the skill can never quote wording the CLI no longer
+ * throws. Throw sites import these builders instead of repeating string literals.
+ */
+
+/** Format flag choices as a human list: `--a, --b, or --c` for three, `--a or --b` for two. */
+function formatFlagChoices(flags: string[]) {
+  if (flags.length <= 2) {
+    return flags.join(" or ");
+  }
+
+  return `${flags.slice(0, -1).join(", ")}, or ${flags[flags.length - 1]}`;
+}
+
+/** "Exactly one of these flags" constraint violation, e.g. absolute navigation targets. */
+export function exactlyOneTargetMessage(label: string, flags: string[]) {
+  return `Specify exactly one ${label}: ${formatFlagChoices(flags)}.`;
+}
+
+/** "At most one of these flags" constraint violation, e.g. comment navigation directions. */
+export function atMostOneFlagMessage(flags: string[]) {
+  return `Specify either ${formatFlagChoices(flags)}, not both.`;
+}
+
+/** Reload invoked without the `--` separator or without a nested review command. */
+export const RELOAD_SEPARATOR_MESSAGE =
+  "Pass the replacement Hunk command after `--`, for example `hunk session reload <session-id> -- diff`.";
+
+/** `comment apply` invoked without opting into the stdin JSON batch. */
+export const COMMENT_APPLY_STDIN_MESSAGE = "Pass --stdin to read batch comments from stdin JSON.";
+
+/** The daemon is reachable but no live Hunk session has registered with it. */
+export const NO_ACTIVE_SESSIONS_MESSAGE =
+  "No active Hunk sessions are registered with the daemon. Open Hunk and wait for it to connect.";
+
+/** A navigation or comment target referenced a file outside the loaded review. */
+export function noDiffFileMatchesMessage(filePath: string) {
+  return `No diff file matches ${filePath}.`;
+}
+
+/** One skill-documented error: the quoted message (or prefix) plus the remedy agents should try. */
+export interface AgentErrorDoc {
+  /**
+   * Text quoted in the skill. A trailing ` ...` marks a prefix of a longer dynamic message;
+   * tests strip it and assert the real thrown message starts with the rest.
+   */
+  quote: string;
+  /** Skill guidance rendered after the quote. */
+  remedy: string;
+}
+
+/**
+ * The generated skill's "Common errors" section, in display order. Messages owned by
+ * `@hunk/session-broker-core` stay defined there (the broker core is app-agnostic); their quotes
+ * are bound to the real wording by contract tests in `agentErrors.test.ts`.
+ */
+export const AGENT_ERROR_DOCS: AgentErrorDoc[] = [
+  {
+    quote: "No diff file matches ...",
+    remedy: "the file is not in the loaded review. Check `context`, then `reload` if needed.",
+  },
+  {
+    quote: "No active Hunk sessions",
+    remedy:
+      "if Hunk is visibly running, localhost may be blocked by the agent sandbox; retry with network/sandbox escalation. Otherwise ask the user to open Hunk.",
+  },
+  {
+    quote: "Multiple active sessions match",
+    remedy: "pass `<session-id>` explicitly.",
+  },
+  {
+    quote: "No active session matches session path ...",
+    remedy:
+      "for advanced split-path reloads, verify the live window `Path` via `hunk session get` or `list`, then use `--session-path`.",
+  },
+  {
+    quote: "Pass the replacement Hunk command after `--`",
+    remedy: "include `--` before the nested `diff` / `show` command.",
+  },
+  {
+    quote: COMMENT_APPLY_STDIN_MESSAGE,
+    remedy: "`comment apply` only reads its batch payload from stdin.",
+  },
+  {
+    quote: "Specify exactly one navigation target",
+    remedy: "pick one of `--hunk`, `--old-line`, or `--new-line`.",
+  },
+  {
+    quote: "Specify either --next-comment or --prev-comment, not both.",
+    remedy: "choose one comment-navigation direction.",
+  },
+];
+
+/** Strip the trailing ` ...` prefix marker from one documented quote. */
+export function agentErrorQuotePrefix(doc: AgentErrorDoc) {
+  return doc.quote.endsWith(" ...") ? doc.quote.slice(0, -" ...".length) : doc.quote;
+}

--- a/src/hunk-session/agentErrors.ts
+++ b/src/hunk-session/agentErrors.ts
@@ -90,6 +90,10 @@ export const AGENT_ERROR_DOCS: AgentErrorDoc[] = [
     remedy: "pick one of `--hunk`, `--old-line`, or `--new-line`.",
   },
   {
+    quote: "Specify exactly one comment target",
+    remedy: "pass `comment add` one of `--old-line` or `--new-line`.",
+  },
+  {
     quote: "Specify either --next-comment or --prev-comment, not both.",
     remedy: "choose one comment-navigation direction.",
   },

--- a/src/hunk-session/agentErrors.ts
+++ b/src/hunk-session/agentErrors.ts
@@ -6,8 +6,10 @@
  * throws. Throw sites import these builders instead of repeating string literals.
  */
 
+import type { AgentCommandConstraint } from "./agentSurface";
+
 /** Format flag choices as a human list: `--a, --b, or --c` for three, `--a or --b` for two. */
-function formatFlagChoices(flags: string[]) {
+function formatFlagChoices(flags: readonly string[]) {
   if (flags.length <= 2) {
     return flags.join(" or ");
   }
@@ -15,14 +17,13 @@ function formatFlagChoices(flags: string[]) {
   return `${flags.slice(0, -1).join(", ")}, or ${flags[flags.length - 1]}`;
 }
 
-/** "Exactly one of these flags" constraint violation, e.g. absolute navigation targets. */
-export function exactlyOneTargetMessage(label: string, flags: string[]) {
-  return `Specify exactly one ${label}: ${formatFlagChoices(flags)}.`;
-}
+/** The message thrown when one declared flag-group constraint is violated. */
+export function constraintViolationMessage(constraint: AgentCommandConstraint) {
+  if (constraint.kind === "exactly-one") {
+    return `Specify exactly one ${constraint.label}: ${formatFlagChoices(constraint.flags)}.`;
+  }
 
-/** "At most one of these flags" constraint violation, e.g. comment navigation directions. */
-export function atMostOneFlagMessage(flags: string[]) {
-  return `Specify either ${formatFlagChoices(flags)}, not both.`;
+  return `Specify either ${formatFlagChoices(constraint.flags)}, not both.`;
 }
 
 /** Reload invoked without the `--` separator or without a nested review command. */

--- a/src/hunk-session/agentSurface.test.ts
+++ b/src/hunk-session/agentSurface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   agentOptionFlagName,
+  optionKeyFromFlag,
   type AgentCommandOption,
   SESSION_AGENT_COMMAND_LIST,
   SESSION_AGENT_COMMANDS,
@@ -55,6 +56,23 @@ describe("session agent command surface", () => {
     for (const spec of SESSION_AGENT_COMMAND_LIST) {
       for (const line of spec.synopsis) {
         expect(line.startsWith(`hunk ${spec.name}`)).toBe(true);
+      }
+    }
+  });
+
+  test("camelizes flag definitions into Commander option keys", () => {
+    expect(optionKeyFromFlag("--old-line <n>")).toBe("oldLine");
+    expect(optionKeyFromFlag("--next-comment")).toBe("nextComment");
+    expect(optionKeyFromFlag("--json")).toBe("json");
+  });
+
+  test("declares every constraint flag as an option on its command", () => {
+    for (const spec of SESSION_AGENT_COMMAND_LIST) {
+      const declared = new Set(spec.options.map(agentOptionFlagName));
+      for (const constraint of spec.constraints ?? []) {
+        for (const flag of constraint.flags) {
+          expect(declared).toContain(flag.split(" ")[0]!);
+        }
       }
     }
   });

--- a/src/hunk-session/agentSurface.test.ts
+++ b/src/hunk-session/agentSurface.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   agentOptionFlagName,
+  type AgentCommandOption,
   SESSION_AGENT_COMMAND_LIST,
   SESSION_AGENT_COMMANDS,
   SESSION_COMMENT_COMMAND_LIST,
+  type SessionCommandOptions,
 } from "./agentSurface";
 
 const FLAG_TOKEN_PATTERN = /--[a-z][a-z-]*/g;
@@ -57,10 +59,28 @@ describe("session agent command surface", () => {
     }
   });
 
+  test("derives parsed-option shapes from the specs at compile time", () => {
+    // These assignments are the assertions; `bun run typecheck` enforces them.
+    const navigate: SessionCommandOptions<"navigate"> = { repo: ".", hunk: 2, json: true };
+    // @ts-expect-error --hunk parses to a number, not a string
+    const badHunk: SessionCommandOptions<"navigate"> = { hunk: "2" };
+    // @ts-expect-error comment add requires --file and --summary
+    const missingRequired: SessionCommandOptions<"comment-add"> = { newLine: 3 };
+    const add: SessionCommandOptions<"comment-add"> = {
+      file: "a.ts",
+      summary: "note",
+      newLine: 3,
+    };
+    // @ts-expect-error unknown flags are rejected
+    const unknownFlag: SessionCommandOptions<"list"> = { repo: "." };
+
+    expect([navigate, badHunk, missingRequired, add, unknownFlag]).toBeTruthy();
+  });
+
   test("marks navigation and comment targets with positive-int parsing", () => {
-    const navigate = SESSION_AGENT_COMMANDS.navigate;
+    const navigateOptions: readonly AgentCommandOption[] = SESSION_AGENT_COMMANDS.navigate.options;
     const targetFlags = ["--hunk", "--old-line", "--new-line"];
-    for (const option of navigate.options) {
+    for (const option of navigateOptions) {
       if (targetFlags.includes(agentOptionFlagName(option))) {
         expect(option.parse).toBe("positiveInt");
       }

--- a/src/hunk-session/agentSurface.test.ts
+++ b/src/hunk-session/agentSurface.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  agentOptionFlagName,
+  SESSION_AGENT_COMMAND_LIST,
+  SESSION_AGENT_COMMANDS,
+  SESSION_COMMENT_COMMAND_LIST,
+} from "./agentSurface";
+
+const FLAG_TOKEN_PATTERN = /--[a-z][a-z-]*/g;
+
+describe("session agent command surface", () => {
+  test("covers every daemon action with a uniquely named command", () => {
+    const names = SESSION_AGENT_COMMAND_LIST.map((spec) => spec.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(SESSION_COMMENT_COMMAND_LIST.map((spec) => spec.name)).toEqual([
+      "session comment add",
+      "session comment apply",
+      "session comment list",
+      "session comment rm",
+      "session comment clear",
+    ]);
+  });
+
+  test("declares each option flag once per command", () => {
+    for (const spec of SESSION_AGENT_COMMAND_LIST) {
+      const flagNames = spec.options.map(agentOptionFlagName);
+      expect(new Set(flagNames).size).toBe(flagNames.length);
+    }
+  });
+
+  test("mentions every declared option in the command synopsis", () => {
+    for (const spec of SESSION_AGENT_COMMAND_LIST) {
+      const synopsis = spec.synopsis.join(" ");
+      for (const option of spec.options) {
+        expect(synopsis).toContain(agentOptionFlagName(option));
+      }
+    }
+  });
+
+  test("only references declared flags in synopsis and examples", () => {
+    for (const spec of SESSION_AGENT_COMMAND_LIST) {
+      const declared = new Set(spec.options.map(agentOptionFlagName));
+      const referenced = [...spec.synopsis, ...(spec.examples ?? [])]
+        .join(" ")
+        .match(FLAG_TOKEN_PATTERN);
+      for (const flag of referenced ?? []) {
+        expect(declared).toContain(flag);
+      }
+    }
+  });
+
+  test("keeps synopsis lines runnable as `hunk ...` invocations", () => {
+    for (const spec of SESSION_AGENT_COMMAND_LIST) {
+      for (const line of spec.synopsis) {
+        expect(line.startsWith(`hunk ${spec.name}`)).toBe(true);
+      }
+    }
+  });
+
+  test("marks navigation and comment targets with positive-int parsing", () => {
+    const navigate = SESSION_AGENT_COMMANDS.navigate;
+    const targetFlags = ["--hunk", "--old-line", "--new-line"];
+    for (const option of navigate.options) {
+      if (targetFlags.includes(agentOptionFlagName(option))) {
+        expect(option.parse).toBe("positiveInt");
+      }
+    }
+  });
+});

--- a/src/hunk-session/agentSurface.ts
+++ b/src/hunk-session/agentSurface.ts
@@ -38,6 +38,8 @@ export interface AgentCommandSpec {
   readonly options: readonly AgentCommandOption[];
   /** Canonical usage lines shared by `hunk session --help` and the generated skill. */
   readonly synopsis: readonly string[];
+  /** Flag-group rules the parser enforces; also rendered into synopsis fragments. */
+  readonly constraints?: readonly AgentCommandConstraint[];
   /** Copy-paste invocations appended to `--help` output and reused in the generated skill. */
   readonly examples?: readonly string[];
   /** Extra literal help lines (e.g. a stdin payload shape) appended after examples. */
@@ -83,6 +85,34 @@ export type SessionCommandOptions<Action extends SessionDaemonAction> = ParsedCo
   (typeof SESSION_AGENT_COMMANDS)[Action]
 >;
 
+/**
+ * One declared flag-group rule on a command. The same object drives three surfaces: the
+ * `(--a | --b)` synopsis fragment, the CLI validator, and the error message agents see — so a
+ * flag rename or group change propagates everywhere from this one declaration.
+ */
+export type AgentCommandConstraint =
+  | {
+      readonly kind: "exactly-one";
+      /** Names the choice in the error message, e.g. "navigation target". */
+      readonly label: string;
+      readonly flags: readonly string[];
+    }
+  | {
+      readonly kind: "at-most-one";
+      readonly flags: readonly string[];
+    };
+
+/** Render one constraint as its synopsis fragment, e.g. `(--hunk <n> | --old-line <n>)`. */
+export function constraintSynopsis(constraint: AgentCommandConstraint) {
+  return `(${constraint.flags.join(" | ")})`;
+}
+
+/** Camelize one flag definition into the key Commander stores its parsed value under. */
+export function optionKeyFromFlag(flag: string) {
+  const body = flag.split(" ")[0]!.replace(/^--/, "");
+  return body.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
 /** Selector notation shared by every synopsis line that targets one live session. */
 export const SESSION_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path>)";
 
@@ -90,13 +120,24 @@ export const SESSION_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path>)";
 export const RELOAD_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path> | --session-path <path>)";
 
 /** Absolute navigation targets: callers must pass exactly one. */
-export const NAVIGATE_TARGET_FLAGS = ["--hunk <n>", "--old-line <n>", "--new-line <n>"];
+export const NAVIGATE_TARGET_CONSTRAINT = {
+  kind: "exactly-one",
+  label: "navigation target",
+  flags: ["--hunk <n>", "--old-line <n>", "--new-line <n>"],
+} as const satisfies AgentCommandConstraint;
 
 /** Comment anchoring targets: callers must pass exactly one. */
-export const COMMENT_TARGET_FLAGS = ["--old-line <n>", "--new-line <n>"];
+export const COMMENT_TARGET_CONSTRAINT = {
+  kind: "exactly-one",
+  label: "comment target",
+  flags: ["--old-line <n>", "--new-line <n>"],
+} as const satisfies AgentCommandConstraint;
 
 /** Relative comment navigation directions: callers may pass at most one. */
-export const COMMENT_DIRECTION_FLAGS = ["--next-comment", "--prev-comment"];
+export const COMMENT_DIRECTION_CONSTRAINT = {
+  kind: "at-most-one",
+  flags: ["--next-comment", "--prev-comment"],
+} as const satisfies AgentCommandConstraint;
 
 const repoOption = {
   flag: "--repo <path>",
@@ -190,9 +231,10 @@ export const SESSION_AGENT_COMMANDS = {
       { flag: "--prev-comment", description: "jump to the previous annotated hunk" },
       jsonOption,
     ],
+    constraints: [NAVIGATE_TARGET_CONSTRAINT, COMMENT_DIRECTION_CONSTRAINT],
     synopsis: [
-      `hunk session navigate ${SESSION_SELECTOR_SYNOPSIS} --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) [--json]`,
-      `hunk session navigate ${SESSION_SELECTOR_SYNOPSIS} (--next-comment | --prev-comment) [--json]`,
+      `hunk session navigate ${SESSION_SELECTOR_SYNOPSIS} --file <path> ${constraintSynopsis(NAVIGATE_TARGET_CONSTRAINT)} [--json]`,
+      `hunk session navigate ${SESSION_SELECTOR_SYNOPSIS} ${constraintSynopsis(COMMENT_DIRECTION_CONSTRAINT)} [--json]`,
     ],
     examples: [
       "hunk session navigate --repo . --file src/App.tsx --hunk 2",
@@ -250,8 +292,9 @@ export const SESSION_AGENT_COMMANDS = {
       { flag: "--focus", description: "add the note and focus the viewport on it" },
       jsonOption,
     ],
+    constraints: [COMMENT_TARGET_CONSTRAINT],
     synopsis: [
-      `hunk session comment add ${SESSION_SELECTOR_SYNOPSIS} --file <path> (--old-line <n> | --new-line <n>) --summary <text> [--rationale <text>] [--author <name>] [--markup <stml>] [--focus] [--json]`,
+      `hunk session comment add ${SESSION_SELECTOR_SYNOPSIS} --file <path> ${constraintSynopsis(COMMENT_TARGET_CONSTRAINT)} --summary <text> [--rationale <text>] [--author <name>] [--markup <stml>] [--focus] [--json]`,
     ],
     examples: [
       'hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording"',

--- a/src/hunk-session/agentSurface.ts
+++ b/src/hunk-session/agentSurface.ts
@@ -1,0 +1,310 @@
+import type { SessionDaemonAction } from "../session/protocol";
+
+/**
+ * Declarative description of the agent-facing `hunk session` command surface.
+ *
+ * This module is the single source of truth for what agents can invoke: the Commander commands in
+ * `src/core/cli.ts`, the `hunk session --help` usage text, and the generated
+ * `skills/hunk-review/SKILL.md` reference sections are all derived from these specs, so the parser
+ * and the docs cannot drift apart. Keep it pure data with no runtime dependencies.
+ */
+
+/** One agent-facing CLI option on a `hunk session` command. */
+export interface AgentCommandOption {
+  /** Commander flag definition, e.g. `--repo <path>`. */
+  flag: string;
+  /** Description shared by `--help` output and generated docs. */
+  description: string;
+  /** Parse the option value as a 1-based positive integer. */
+  parse?: "positiveInt";
+  /** Register with Commander as a required option. */
+  required?: boolean;
+}
+
+/** One positional argument on a `hunk session` command. */
+export interface AgentCommandPositional {
+  /** Commander argument token, e.g. `[sessionId]` or `[targets...]`. */
+  token: string;
+  description?: string;
+}
+
+/** Declarative spec for one agent-facing `hunk session` command. */
+export interface AgentCommandSpec {
+  /** Commander command path without the binary name, e.g. `session comment add`. */
+  name: string;
+  /** One-line description used by Commander help. */
+  summary: string;
+  positionals: AgentCommandPositional[];
+  options: AgentCommandOption[];
+  /** Canonical usage lines shared by `hunk session --help` and the generated skill. */
+  synopsis: string[];
+  /** Copy-paste invocations appended to `--help` output and reused in the generated skill. */
+  examples?: string[];
+  /** Extra literal help lines (e.g. a stdin payload shape) appended after examples. */
+  helpExtra?: string[];
+}
+
+/** Selector notation shared by every synopsis line that targets one live session. */
+export const SESSION_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path>)";
+
+/** Reload additionally accepts `--session-path` as a selector. */
+export const RELOAD_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path> | --session-path <path>)";
+
+/** Absolute navigation targets: callers must pass exactly one. */
+export const NAVIGATE_TARGET_FLAGS = ["--hunk <n>", "--old-line <n>", "--new-line <n>"];
+
+/** Comment anchoring targets: callers must pass exactly one. */
+export const COMMENT_TARGET_FLAGS = ["--old-line <n>", "--new-line <n>"];
+
+/** Relative comment navigation directions: callers may pass at most one. */
+export const COMMENT_DIRECTION_FLAGS = ["--next-comment", "--prev-comment"];
+
+const repoOption: AgentCommandOption = {
+  flag: "--repo <path>",
+  description: "target the live session whose repo root matches this path",
+};
+
+const jsonOption: AgentCommandOption = {
+  flag: "--json",
+  description: "emit structured JSON",
+};
+
+const diffFileOption: AgentCommandOption = {
+  flag: "--file <path>",
+  description: "diff file path as shown by Hunk",
+};
+
+const oldLineOption: AgentCommandOption = {
+  flag: "--old-line <n>",
+  description: "1-based line number on the old side",
+  parse: "positiveInt",
+};
+
+const newLineOption: AgentCommandOption = {
+  flag: "--new-line <n>",
+  description: "1-based line number on the new side",
+  parse: "positiveInt",
+};
+
+/**
+ * Every live-session daemon action, described as one CLI command. `satisfies` keeps this map in
+ * lockstep with the daemon protocol: adding a `SessionDaemonAction` without describing its CLI
+ * surface here is a compile error, so the generated docs always cover the full surface.
+ */
+export const SESSION_AGENT_COMMANDS = {
+  list: {
+    name: "session list",
+    summary: "list live Hunk sessions",
+    positionals: [],
+    options: [jsonOption],
+    synopsis: ["hunk session list [--json]"],
+  },
+  get: {
+    name: "session get",
+    summary: "show one live Hunk session",
+    positionals: [{ token: "[sessionId]" }],
+    options: [repoOption, jsonOption],
+    synopsis: [`hunk session get ${SESSION_SELECTOR_SYNOPSIS} [--json]`],
+  },
+  context: {
+    name: "session context",
+    summary: "show the selected file and hunk for one live Hunk session",
+    positionals: [{ token: "[sessionId]" }],
+    options: [repoOption, jsonOption],
+    synopsis: [`hunk session context ${SESSION_SELECTOR_SYNOPSIS} [--json]`],
+  },
+  review: {
+    name: "session review",
+    summary: "export the live review model for one Hunk session",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      repoOption,
+      {
+        flag: "--include-patch",
+        description: "include raw unified diff text for each file in review output",
+      },
+      {
+        flag: "--include-notes",
+        description: "include live review notes in review output",
+      },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session review ${SESSION_SELECTOR_SYNOPSIS} [--include-patch] [--include-notes] [--json]`,
+    ],
+  },
+  navigate: {
+    name: "session navigate",
+    summary: "move a live Hunk session to one diff hunk",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      diffFileOption,
+      repoOption,
+      {
+        flag: "--hunk <n>",
+        description: "1-based hunk number within the file",
+        parse: "positiveInt",
+      },
+      oldLineOption,
+      newLineOption,
+      { flag: "--next-comment", description: "jump to the next annotated hunk" },
+      { flag: "--prev-comment", description: "jump to the previous annotated hunk" },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session navigate ${SESSION_SELECTOR_SYNOPSIS} --file <path> (--hunk <n> | --old-line <n> | --new-line <n>) [--json]`,
+      `hunk session navigate ${SESSION_SELECTOR_SYNOPSIS} (--next-comment | --prev-comment) [--json]`,
+    ],
+    examples: [
+      "hunk session navigate --repo . --file src/App.tsx --hunk 2",
+      "hunk session navigate --repo . --file src/App.tsx --new-line 372",
+      "hunk session navigate --repo . --file src/App.tsx --old-line 355",
+      "hunk session navigate --repo . --next-comment",
+      "hunk session navigate --repo . --prev-comment",
+    ],
+  },
+  reload: {
+    name: "session reload",
+    summary: "replace the contents of one live Hunk session",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      repoOption,
+      {
+        flag: "--session-path <path>",
+        description: "target a live session rooted at a different path",
+      },
+      {
+        flag: "--source <path>",
+        description: "load the diff from this directory instead of the session's own",
+      },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session reload ${RELOAD_SELECTOR_SYNOPSIS} [--source <path>] [--json] -- diff [ref] [-- <pathspec...>]`,
+      `hunk session reload ${RELOAD_SELECTOR_SYNOPSIS} [--source <path>] [--json] -- show [ref] [-- <pathspec...>]`,
+    ],
+    examples: [
+      "hunk session reload --repo . -- diff",
+      "hunk session reload --repo . -- diff main...feature -- src/ui",
+      "hunk session reload --repo . -- show HEAD~1",
+      "hunk session reload --repo . -- show HEAD~1 -- README.md",
+      "hunk session reload --repo /path/to/worktree -- diff",
+      "hunk session reload --session-path /path/to/live-window --source /path/to/other-checkout -- diff",
+    ],
+  },
+  "comment-add": {
+    name: "session comment add",
+    summary: "attach one live inline review note",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      { ...diffFileOption, required: true },
+      { flag: "--summary <text>", description: "short review note", required: true },
+      repoOption,
+      oldLineOption,
+      newLineOption,
+      { flag: "--rationale <text>", description: "optional longer explanation" },
+      {
+        flag: "--markup <stml>",
+        description: "experimental STML body (target session must opt in)",
+      },
+      { flag: "--author <name>", description: "optional author label" },
+      { flag: "--focus", description: "add the note and focus the viewport on it" },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session comment add ${SESSION_SELECTOR_SYNOPSIS} --file <path> (--old-line <n> | --new-line <n>) --summary <text> [--rationale <text>] [--author <name>] [--markup <stml>] [--focus] [--json]`,
+    ],
+    examples: [
+      'hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording"',
+    ],
+  },
+  "comment-apply": {
+    name: "session comment apply",
+    summary: "apply many live inline review notes from stdin JSON",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      repoOption,
+      { flag: "--stdin", description: "read the comment batch from stdin as JSON" },
+      { flag: "--focus", description: "apply the batch and focus the first note" },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session comment apply ${SESSION_SELECTOR_SYNOPSIS} --stdin [--focus] [--json]`,
+    ],
+    examples: [
+      `printf '%s\\n' '{"comments":[{"filePath":"README.md","newLine":103,"summary":"Tighten this wording"}]}' | hunk session comment apply --repo . --stdin`,
+    ],
+    helpExtra: [
+      "Stdin JSON shape:",
+      "  {",
+      '    "comments": [',
+      "      {",
+      '        "filePath": "README.md",',
+      '        "hunk": 2,',
+      '        "summary": "Explain this hunk",',
+      '        "rationale": "Optional detail",',
+      '        "author": "Pi"',
+      "      }",
+      "    ]",
+      "  }",
+    ],
+  },
+  "comment-list": {
+    name: "session comment list",
+    summary: "list live inline review notes",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      repoOption,
+      { flag: "--file <path>", description: "filter comments to one diff file" },
+      { flag: "--type <type>", description: "filter to live, all, ai, agent, or user comments" },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session comment list ${SESSION_SELECTOR_SYNOPSIS} [--file <path>] [--type <live|all|ai|agent|user>] [--json]`,
+    ],
+  },
+  "comment-rm": {
+    name: "session comment rm",
+    summary: "remove one inline review note",
+    positionals: [
+      {
+        token: "[targets...]",
+        description: "<session-id> <comment-id>, or <comment-id> with --repo",
+      },
+    ],
+    options: [repoOption, jsonOption],
+    synopsis: [`hunk session comment rm ${SESSION_SELECTOR_SYNOPSIS} <comment-id> [--json]`],
+  },
+  "comment-clear": {
+    name: "session comment clear",
+    summary: "clear inline review notes",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      repoOption,
+      { flag: "--file <path>", description: "clear only one diff file's comments" },
+      {
+        flag: "--include-user",
+        description: "also clear human notes created with the TUI `c` action",
+      },
+      { flag: "--all", description: "clear both live agent comments and human user notes" },
+      { flag: "--yes", description: "confirm destructive comment clearing" },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session comment clear ${SESSION_SELECTOR_SYNOPSIS} [--file <path>] [--include-user|--all] --yes [--json]`,
+    ],
+  },
+} satisfies Record<SessionDaemonAction, AgentCommandSpec>;
+
+/** Specs in display order for help text and generated docs. */
+export const SESSION_AGENT_COMMAND_LIST: AgentCommandSpec[] = Object.values(SESSION_AGENT_COMMANDS);
+
+/** Specs for the `hunk session comment` subcommand family, in display order. */
+export const SESSION_COMMENT_COMMAND_LIST = SESSION_AGENT_COMMAND_LIST.filter((spec) =>
+  spec.name.startsWith("session comment "),
+);
+
+/** Extract the flag name (e.g. `--old-line`) from a Commander flag definition. */
+export function agentOptionFlagName(option: AgentCommandOption) {
+  return option.flag.split(" ")[0]!;
+}

--- a/src/hunk-session/agentSurface.ts
+++ b/src/hunk-session/agentSurface.ts
@@ -12,37 +12,76 @@ import type { SessionDaemonAction } from "../session/protocol";
 /** One agent-facing CLI option on a `hunk session` command. */
 export interface AgentCommandOption {
   /** Commander flag definition, e.g. `--repo <path>`. */
-  flag: string;
+  readonly flag: string;
   /** Description shared by `--help` output and generated docs. */
-  description: string;
+  readonly description: string;
   /** Parse the option value as a 1-based positive integer. */
-  parse?: "positiveInt";
+  readonly parse?: "positiveInt";
   /** Register with Commander as a required option. */
-  required?: boolean;
+  readonly required?: boolean;
 }
 
 /** One positional argument on a `hunk session` command. */
 export interface AgentCommandPositional {
   /** Commander argument token, e.g. `[sessionId]` or `[targets...]`. */
-  token: string;
-  description?: string;
+  readonly token: string;
+  readonly description?: string;
 }
 
 /** Declarative spec for one agent-facing `hunk session` command. */
 export interface AgentCommandSpec {
   /** Commander command path without the binary name, e.g. `session comment add`. */
-  name: string;
+  readonly name: string;
   /** One-line description used by Commander help. */
-  summary: string;
-  positionals: AgentCommandPositional[];
-  options: AgentCommandOption[];
+  readonly summary: string;
+  readonly positionals: readonly AgentCommandPositional[];
+  readonly options: readonly AgentCommandOption[];
   /** Canonical usage lines shared by `hunk session --help` and the generated skill. */
-  synopsis: string[];
+  readonly synopsis: readonly string[];
   /** Copy-paste invocations appended to `--help` output and reused in the generated skill. */
-  examples?: string[];
+  readonly examples?: readonly string[];
   /** Extra literal help lines (e.g. a stdin payload shape) appended after examples. */
-  helpExtra?: string[];
+  readonly helpExtra?: readonly string[];
 }
+
+/** Kebab-case flag body converted to the camelCase key Commander stores parsed values under. */
+type CamelCase<Text extends string> = Text extends `${infer Head}-${infer Tail}`
+  ? `${Head}${Capitalize<CamelCase<Tail>>}`
+  : Text;
+
+/** Flag name without the leading dashes or value token, e.g. `--old-line <n>` -> `old-line`. */
+type FlagBody<Flag extends string> = Flag extends `--${infer Name} ${string}`
+  ? Name
+  : Flag extends `--${infer Name}`
+    ? Name
+    : never;
+
+/** The parsed value Commander produces for one option: boolean flag, string value, or number. */
+type OptionValue<Option extends AgentCommandOption> = Option["flag"] extends `${string} <${string}>`
+  ? Option extends { readonly parse: "positiveInt" }
+    ? number
+    : string
+  : boolean;
+
+/**
+ * The parsed-options shape one spec produces. Deriving this from the manifest means adding or
+ * renaming an option automatically updates the action handler's type in `src/core/cli.ts` —
+ * hand-written option interfaces could silently drift from the declared surface.
+ */
+export type ParsedCommandOptions<Spec extends AgentCommandSpec> = {
+  [Option in Spec["options"][number] as Option extends { readonly required: true }
+    ? CamelCase<FlagBody<Option["flag"]>>
+    : never]: OptionValue<Option>;
+} & {
+  [Option in Spec["options"][number] as Option extends { readonly required: true }
+    ? never
+    : CamelCase<FlagBody<Option["flag"]>>]?: OptionValue<Option>;
+};
+
+/** Parsed-options shape for one daemon action's CLI command. */
+export type SessionCommandOptions<Action extends SessionDaemonAction> = ParsedCommandOptions<
+  (typeof SESSION_AGENT_COMMANDS)[Action]
+>;
 
 /** Selector notation shared by every synopsis line that targets one live session. */
 export const SESSION_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path>)";
@@ -59,32 +98,32 @@ export const COMMENT_TARGET_FLAGS = ["--old-line <n>", "--new-line <n>"];
 /** Relative comment navigation directions: callers may pass at most one. */
 export const COMMENT_DIRECTION_FLAGS = ["--next-comment", "--prev-comment"];
 
-const repoOption: AgentCommandOption = {
+const repoOption = {
   flag: "--repo <path>",
   description: "target the live session whose repo root matches this path",
-};
+} as const satisfies AgentCommandOption;
 
-const jsonOption: AgentCommandOption = {
+const jsonOption = {
   flag: "--json",
   description: "emit structured JSON",
-};
+} as const satisfies AgentCommandOption;
 
-const diffFileOption: AgentCommandOption = {
+const diffFileOption = {
   flag: "--file <path>",
   description: "diff file path as shown by Hunk",
-};
+} as const satisfies AgentCommandOption;
 
-const oldLineOption: AgentCommandOption = {
+const oldLineOption = {
   flag: "--old-line <n>",
   description: "1-based line number on the old side",
   parse: "positiveInt",
-};
+} as const satisfies AgentCommandOption;
 
-const newLineOption: AgentCommandOption = {
+const newLineOption = {
   flag: "--new-line <n>",
   description: "1-based line number on the new side",
   parse: "positiveInt",
-};
+} as const satisfies AgentCommandOption;
 
 /**
  * Every live-session daemon action, described as one CLI command. `satisfies` keeps this map in
@@ -294,10 +333,11 @@ export const SESSION_AGENT_COMMANDS = {
       `hunk session comment clear ${SESSION_SELECTOR_SYNOPSIS} [--file <path>] [--include-user|--all] --yes [--json]`,
     ],
   },
-} satisfies Record<SessionDaemonAction, AgentCommandSpec>;
+} as const satisfies Record<SessionDaemonAction, AgentCommandSpec>;
 
 /** Specs in display order for help text and generated docs. */
-export const SESSION_AGENT_COMMAND_LIST: AgentCommandSpec[] = Object.values(SESSION_AGENT_COMMANDS);
+export const SESSION_AGENT_COMMAND_LIST: readonly AgentCommandSpec[] =
+  Object.values(SESSION_AGENT_COMMANDS);
 
 /** Specs for the `hunk session comment` subcommand family, in display order. */
 export const SESSION_COMMENT_COMMAND_LIST = SESSION_AGENT_COMMAND_LIST.filter((spec) =>

--- a/src/hunk-session/agentSurface.ts
+++ b/src/hunk-session/agentSurface.ts
@@ -113,6 +113,30 @@ export function optionKeyFromFlag(flag: string) {
   return body.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
 }
 
+/**
+ * Options owned by non-session commands (`hunk diff`, `hunk markup render`, shared review flags)
+ * that agent-facing docs also reference. `src/core/cli.ts` registers them from these constants,
+ * so the docs' flag-consistency tests verify real parser flags instead of a hand-kept allowlist.
+ */
+export const AUXILIARY_AGENT_OPTIONS = {
+  agentContext: {
+    flag: "--agent-context <path>",
+    description: "JSON sidecar with agent rationale",
+  },
+  excludeUntracked: {
+    flag: "--exclude-untracked",
+    description: "exclude untracked files from working tree reviews",
+  },
+  experimental: {
+    flag: "--experimental",
+    description: "enable experimental features (currently STML agent-note markup)",
+  },
+  markupWidth: {
+    flag: "--width <n>",
+    description: "layout width in columns",
+  },
+} as const satisfies Record<string, AgentCommandOption>;
+
 /** Selector notation shared by every synopsis line that targets one live session. */
 export const SESSION_SELECTOR_SYNOPSIS = "(<session-id> | --repo <path>)";
 

--- a/src/session-broker/brokerServer.ts
+++ b/src/session-broker/brokerServer.ts
@@ -37,9 +37,9 @@ import {
   HUNK_SESSION_DAEMON_VERSION,
   type SessionDaemonAction,
   type SessionDaemonCapabilities,
-  type SessionDaemonRequest,
   type SessionDaemonResponse,
 } from "../session/protocol";
+import { parseSessionDaemonRequest } from "../session/protocolSchemas";
 
 const DEFAULT_STALE_SESSION_TTL_MS = 45_000;
 const DEFAULT_STALE_SESSION_SWEEP_INTERVAL_MS = 15_000;
@@ -208,11 +208,14 @@ export function validateOriginHeader(request: Request, expectedPort: number, all
 
 async function parseJsonRequest(request: Request) {
   const text = await readRequestTextWithLimit(request, MAX_HTTP_BODY_BYTES);
+  let raw: unknown;
   try {
-    return JSON.parse(text) as SessionDaemonRequest;
+    raw = JSON.parse(text);
   } catch {
     throw new Error("Expected one JSON request body.");
   }
+
+  return parseSessionDaemonRequest(raw);
 }
 
 export async function handleSessionApiRequest(state: HunkSessionBrokerState, request: Request) {

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -4,6 +4,7 @@ import type {
   SessionSelectorInput,
 } from "../core/types";
 import type { SessionLiveCommentSummary, SessionReviewNoteSummary } from "../hunk-session/types";
+import { NO_ACTIVE_SESSIONS_MESSAGE } from "../hunk-session/agentErrors";
 import {
   ensureSessionBrokerAvailable,
   isSessionBrokerHealthy,
@@ -163,9 +164,7 @@ async function resolveDaemonAvailability(action: SessionCommandInput["action"]) 
     return false;
   }
 
-  throw new Error(
-    "No active Hunk sessions are registered with the daemon. Open Hunk and wait for it to connect.",
-  );
+  throw new Error(NO_ACTIVE_SESSIONS_MESSAGE);
 }
 
 function renderOutput(output: SessionCommandOutput, value: unknown, formatText: () => string) {

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -68,8 +68,8 @@ export type SessionDaemonRequest =
   | {
       action: "review";
       selector: SessionSelectorInput;
-      includePatch: SessionReviewCommandInput["includePatch"];
-      includeNotes: SessionReviewCommandInput["includeNotes"];
+      includePatch?: SessionReviewCommandInput["includePatch"];
+      includeNotes?: SessionReviewCommandInput["includeNotes"];
     }
   | {
       action: "navigate";

--- a/src/session/protocolSchemas.test.ts
+++ b/src/session/protocolSchemas.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import type { z } from "zod";
+import type { SessionDaemonRequest } from "./protocol";
+import { parseSessionDaemonRequest, sessionDaemonRequestSchema } from "./protocolSchemas";
+
+/** Strict structural equality; `true` only when A and B are the same type. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+// Type-lock: the schema's inferred output must be exactly SessionDaemonRequest. A schema that
+// forgets a field, widens a union, or misses a new action fails this line at `bun run typecheck`.
+const _schemaMatchesProtocol: Equal<
+  z.infer<typeof sessionDaemonRequestSchema>,
+  SessionDaemonRequest
+> = true;
+void _schemaMatchesProtocol;
+
+describe("session daemon request validation", () => {
+  test("accepts every wire-shaped action payload", () => {
+    const requests: unknown[] = [
+      { action: "list" },
+      { action: "get", selector: { sessionId: "s-1" } },
+      { action: "context", selector: { repoRoot: "/repo" } },
+      { action: "review", selector: { sessionId: "s-1" } },
+      { action: "review", selector: { sessionId: "s-1" }, includePatch: true, includeNotes: true },
+      { action: "navigate", selector: { sessionId: "s-1" }, hunkNumber: 2 },
+      {
+        action: "navigate",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        side: "new",
+        line: 12,
+      },
+      { action: "navigate", selector: { sessionId: "s-1" }, commentDirection: "next" },
+      {
+        action: "reload",
+        selector: { sessionId: "s-1" },
+        nextInput: { kind: "show", ref: "HEAD~1", options: {} },
+      },
+      {
+        action: "comment-add",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        side: "new",
+        line: 1,
+        summary: "note",
+        reveal: false,
+      },
+      {
+        action: "comment-apply",
+        selector: { sessionId: "s-1" },
+        comments: [{ filePath: "a.ts", summary: "note", hunkNumber: 2 }],
+        revealMode: "first",
+      },
+      { action: "comment-list", selector: { sessionId: "s-1" }, type: "user" },
+      { action: "comment-rm", selector: { sessionId: "s-1" }, commentId: "c-1" },
+      { action: "comment-clear", selector: { sessionId: "s-1" }, includeUser: true },
+    ];
+
+    for (const request of requests) {
+      expect(() => parseSessionDaemonRequest(request)).not.toThrow();
+    }
+  });
+
+  test("rejects unknown actions with a readable error", () => {
+    expect(() => parseSessionDaemonRequest({ action: "self-destruct" })).toThrow(
+      /Invalid session API request/,
+    );
+  });
+
+  test("rejects wrong field types and unknown keys", () => {
+    expect(() =>
+      parseSessionDaemonRequest({
+        action: "navigate",
+        selector: { sessionId: "s-1" },
+        hunkNumber: "2",
+      }),
+    ).toThrow(/hunkNumber/);
+    expect(() =>
+      parseSessionDaemonRequest({
+        action: "comment-rm",
+        selector: { sessionId: "s-1" },
+        commentId: "c-1",
+        extra: true,
+      }),
+    ).toThrow(/Invalid session API request/);
+    expect(() =>
+      parseSessionDaemonRequest({
+        action: "comment-add",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        side: "sideways",
+        line: 1,
+        summary: "note",
+        reveal: false,
+      }),
+    ).toThrow(/side/);
+  });
+
+  test("rejects non-object payloads and missing required fields", () => {
+    expect(() => parseSessionDaemonRequest("list")).toThrow(/Invalid session API request/);
+    expect(() => parseSessionDaemonRequest(null)).toThrow(/Invalid session API request/);
+    expect(() =>
+      parseSessionDaemonRequest({ action: "comment-rm", selector: { sessionId: "s-1" } }),
+    ).toThrow(/commentId/);
+    expect(() =>
+      parseSessionDaemonRequest({ action: "reload", selector: { sessionId: "s-1" } }),
+    ).toThrow(/nextInput/);
+  });
+});

--- a/src/session/protocolSchemas.ts
+++ b/src/session/protocolSchemas.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import type { CliInput } from "../core/types";
+import type { SessionDaemonRequest } from "./protocol";
+
+/**
+ * Runtime validation for the session daemon's HTTP action surface.
+ *
+ * `SessionDaemonRequest` is erased at compile time, so without these schemas the daemon trusted
+ * whatever JSON arrived on the loopback port. Objects are strict on purpose: an unknown key fails
+ * loudly instead of being silently stripped, which also catches a schema that forgot a field the
+ * moment a real client sends it. `protocolSchemas.test.ts` type-locks the inferred output to
+ * `SessionDaemonRequest`, so protocol and schema cannot drift.
+ */
+
+const selectorSchema = z.strictObject({
+  sessionId: z.string().optional(),
+  sessionPath: z.string().optional(),
+  repoRoot: z.string().optional(),
+});
+
+const sideSchema = z.enum(["old", "new"]);
+
+/**
+ * Reload payloads embed a full parsed CLI input tree. Its deep shape is owned by the CLI parser
+ * and re-validated by the receiving session when it runs the command, so the envelope only
+ * requires one object here.
+ */
+const nextInputSchema = z.custom<CliInput>(
+  (value) => typeof value === "object" && value !== null && !Array.isArray(value),
+);
+
+const commentApplyItemSchema = z.strictObject({
+  filePath: z.string(),
+  hunkNumber: z.int().positive().optional(),
+  side: sideSchema.optional(),
+  line: z.int().positive().optional(),
+  summary: z.string(),
+  rationale: z.string().optional(),
+  markup: z.string().optional(),
+  author: z.string().optional(),
+});
+
+export const sessionDaemonRequestSchema = z.discriminatedUnion("action", [
+  z.strictObject({ action: z.literal("list") }),
+  z.strictObject({ action: z.literal("get"), selector: selectorSchema }),
+  z.strictObject({ action: z.literal("context"), selector: selectorSchema }),
+  z.strictObject({
+    action: z.literal("review"),
+    selector: selectorSchema,
+    includePatch: z.boolean().optional(),
+    includeNotes: z.boolean().optional(),
+  }),
+  z.strictObject({
+    action: z.literal("navigate"),
+    selector: selectorSchema,
+    filePath: z.string().optional(),
+    hunkNumber: z.int().positive().optional(),
+    side: sideSchema.optional(),
+    line: z.int().positive().optional(),
+    commentDirection: z.enum(["next", "prev"]).optional(),
+  }),
+  z.strictObject({
+    action: z.literal("reload"),
+    selector: selectorSchema,
+    nextInput: nextInputSchema,
+    sourcePath: z.string().optional(),
+  }),
+  z.strictObject({
+    action: z.literal("comment-add"),
+    selector: selectorSchema,
+    filePath: z.string(),
+    side: sideSchema,
+    line: z.int().positive(),
+    summary: z.string(),
+    rationale: z.string().optional(),
+    markup: z.string().optional(),
+    author: z.string().optional(),
+    reveal: z.boolean(),
+  }),
+  z.strictObject({
+    action: z.literal("comment-apply"),
+    selector: selectorSchema,
+    comments: z.array(commentApplyItemSchema),
+    revealMode: z.enum(["none", "first"]),
+  }),
+  z.strictObject({
+    action: z.literal("comment-list"),
+    selector: selectorSchema,
+    filePath: z.string().optional(),
+    type: z.enum(["live", "all", "ai", "agent", "user"]).optional(),
+  }),
+  z.strictObject({
+    action: z.literal("comment-rm"),
+    selector: selectorSchema,
+    commentId: z.string(),
+  }),
+  z.strictObject({
+    action: z.literal("comment-clear"),
+    selector: selectorSchema,
+    filePath: z.string().optional(),
+    includeUser: z.boolean().optional(),
+  }),
+]);
+
+/** Compose one readable rejection reason from the first schema issue. */
+function describeFirstIssue(error: z.ZodError) {
+  const issue = error.issues[0];
+  if (!issue) {
+    return "invalid request";
+  }
+
+  const path = issue.path.join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+/** Validate one raw daemon HTTP body into a typed session request. */
+export function parseSessionDaemonRequest(value: unknown): SessionDaemonRequest {
+  const result = sessionDaemonRequestSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(`Invalid session API request: ${describeFirstIssue(result.error)}`);
+  }
+
+  return result.data;
+}

--- a/src/session/protocolSchemas.ts
+++ b/src/session/protocolSchemas.ts
@@ -21,12 +21,17 @@ const selectorSchema = z.strictObject({
 const sideSchema = z.enum(["old", "new"]);
 
 /**
- * Reload payloads embed a full parsed CLI input tree. Its deep shape is owned by the CLI parser
- * and re-validated by the receiving session when it runs the command, so the envelope only
- * requires one object here.
+ * Reload payloads embed a full parsed CLI input tree whose deep shape is owned by the CLI
+ * parser, so this envelope check is intentionally shallow: an object with a string `kind`
+ * discriminant. A well-formed-but-wrong tree still reaches the reload path, where thrown errors
+ * surface through the daemon's JSON error response rather than a schema rejection.
  */
 const nextInputSchema = z.custom<CliInput>(
-  (value) => typeof value === "object" && value !== null && !Array.isArray(value),
+  (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as { kind?: unknown }).kind === "string",
 );
 
 const commentApplyItemSchema = z.strictObject({

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -22,6 +22,7 @@ import {
   resolveCommentTarget,
 } from "../../core/liveComments";
 import { SourceTextTooLargeError } from "../../core/fileSource";
+import { noDiffFileMatchesMessage } from "../../hunk-session/agentErrors";
 import type { AgentAnnotation, DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
 import type {
   AppliedCommentBatchResult,
@@ -625,7 +626,7 @@ export function useReviewController({
     ): AppliedCommentResult => {
       const file = findDiffFileByPath(allFiles, input.filePath);
       if (!file) {
-        throw new Error(`No diff file matches ${input.filePath}.`);
+        throw new Error(noDiffFileMatchesMessage(input.filePath));
       }
 
       const target = resolveCommentTarget(file, input);
@@ -674,7 +675,7 @@ export function useReviewController({
       const prepared = inputs.map((input, index) => {
         const file = findDiffFileByPath(allFiles, input.filePath);
         if (!file) {
-          throw new Error(`No diff file matches ${input.filePath}.`);
+          throw new Error(noDiffFileMatchesMessage(input.filePath));
         }
 
         const target = resolveCommentTarget(file, input);
@@ -793,7 +794,7 @@ export function useReviewController({
     (filePath?: string, options: { includeUser?: boolean } = {}): ClearedCommentsResult => {
       const file = filePath ? findDiffFileByPath(allFiles, filePath) : undefined;
       if (filePath && !file) {
-        throw new Error(`No diff file matches ${filePath}.`);
+        throw new Error(noDiffFileMatchesMessage(filePath));
       }
 
       let removedLiveCommentCount = 0;

--- a/src/ui/lib/reviewState.ts
+++ b/src/ui/lib/reviewState.ts
@@ -7,6 +7,7 @@
  * tested without React state in the loop.
  */
 import { findDiffFileByPath, findHunkIndexForLine, hunkLineRange } from "../../core/liveComments";
+import { noDiffFileMatchesMessage } from "../../hunk-session/agentErrors";
 import type { AgentAnnotation, DiffFile } from "../../core/types";
 import type { NavigateToHunkToolInput, SelectedHunkSummary } from "../../hunk-session/types";
 import {
@@ -160,7 +161,7 @@ export function resolveReviewNavigationTarget({
 
   const file = findDiffFileByPath(allFiles, input.filePath);
   if (!file) {
-    throw new Error(`No diff file matches ${input.filePath}.`);
+    throw new Error(noDiffFileMatchesMessage(input.filePath));
   }
 
   let hunkIndex = input.hunkIndex;

--- a/test/cli/entrypoint.test.ts
+++ b/test/cli/entrypoint.test.ts
@@ -85,8 +85,9 @@ describe("CLI entrypoint contracts", () => {
 
     expect(proc.exitCode).toBe(0);
     expect(stderr).toBe("");
-    expect(stdout).toContain("hunk session review <session-id> [--include-patch]");
-    expect(stdout).toContain("hunk session review --repo <path> [--include-patch]");
+    expect(stdout).toContain(
+      "hunk session review (<session-id> | --repo <path>) [--include-patch] [--include-notes]",
+    );
     expect(stdout).toContain(
       "hunk session comment apply (<session-id> | --repo <path>) --stdin [--focus]",
     );


### PR DESCRIPTION
## Why

`skills/hunk-review/SKILL.md` was hand-maintained prose and had already drifted from the real CLI: it quoted error messages that no longer exist anywhere in the code (`"No visible diff file matches"`, `"No active Hunk session matches session path"`) and omitted flags the commands actually accept (`--include-notes`, `--markup`, `--rationale`, `--author`). This PR makes that class of drift structurally impossible: the agent-facing `hunk session` surface is declared once as typed data, and the parser, help text, skill doc, and error messages are all projections of it.

## What

**Single source of truth**
- `src/hunk-session/agentSurface.ts` — every `hunk session` command declared as data (options, synopsis, constraint groups, examples), keyed `satisfies Record<SessionDaemonAction, …>` so adding a daemon action without describing its CLI surface is a compile error. Commander registration and `hunk session --help` are built from these specs.
- `src/hunk-session/agentErrors.ts` — the error messages the skill quotes; throw sites import them, and broker-core-owned wording is bound by contract tests against the real `resolveSessionTarget`.
- `src/hunk-review/skillDocument.ts` + `bun run generate:skill` — deterministically render SKILL.md; a drift test fails CI when the checked-in file doesn't match the renderer, and consistency tests reject any documented flag the parser doesn't declare (now also covering `docs/agent-workflows.md`).

**Hardening on top**
- Parsed-option types are derived from the specs via template-literal types (`SessionCommandOptions<Action>`), replacing hand-written interfaces that could silently drift; pinned by `@ts-expect-error` compile-time assertions.
- Exactly-one/at-most-one flag groups are declared once per command and drive the synopsis fragment, the validator, and the error message.
- Daemon HTTP requests are now validated with zod at the boundary (previously a blind `as SessionDaemonRequest` cast), with strict objects and a type-lock pinning `z.infer` to exactly `SessionDaemonRequest`. Wire compatibility with the unchanged client was verified field-by-field; no daemon version bump needed.
- Auxiliary flags the docs reference (`--exclude-untracked`, `--experimental`, `--width`, `--agent-context`) are registered from shared constants instead of being allowlisted as strings.

**Generated SKILL.md changes** (visible in the diff): normalized synopsis blocks, corrected the two stale error quotes, documented the previously missing flags, and added a Common-errors entry for the comment-target constraint.

## Review

A model-based code review of the full branch diff ran before opening this PR; its four findings (missing comment-target error doc, order-coupled contract test, shallow `nextInput` envelope check, two remaining hardcoded flag literals) are fixed in the final commit.

## Testing

- `bun run typecheck`, `bun test` (1229 tests), `bun run lint`, `bun run format:check` — clean
- `bun run test:integration` — 57/58; the one failure (`filter focus narrows the visible review stream`) reproduces on pristine `main` in the same container, so it is a pre-existing environment flake, not from this branch
- `bun run test:tty-smoke` — clean
- Changeset included (`patch`, user-visible skill/help corrections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112uw6mUsLjKP5KndXeVRBB

---
_Generated by [Claude Code](https://claude.ai/code/session_0112uw6mUsLjKP5KndXeVRBB)_