### PR TITLE
fix(update): show Nix-aware upgrade guidance

### DIFF
--- a/.changeset/wise-pandas-update.md
+++ b/.changeset/wise-pandas-update.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Show Nix-aware update guidance instead of suggesting an npm install command for Hunk's Nix package.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,6 +2,7 @@
   bun,
   bun2nix,
   lib,
+  makeWrapper,
   ...
 }: let
   packageJson = lib.importJSON ../package.json;
@@ -15,6 +16,8 @@ in
     bunDeps = bun2nix.fetchBunDeps {
       bunNix = ./bun.lock.nix;
     };
+
+    nativeBuildInputs = [makeWrapper];
 
     buildPhase = ''
       runHook preBuild
@@ -33,6 +36,7 @@ in
       mkdir -p $out/bin
       cp -p ./hunk-bin $out/bin/hunk
       cp -r ./skills $out/
+      wrapProgram $out/bin/hunk --set HUNK_INSTALL_SOURCE nix
       runHook postInstall
     '';
 

--- a/src/core/updateNotice.test.ts
+++ b/src/core/updateNotice.test.ts
@@ -114,6 +114,52 @@ describe("startup update notice", () => {
     });
   });
 
+  test("uses a neutral Nix update instruction for Nix installs", async () => {
+    await withTempStatePath(async (statePath) => {
+      await expect(
+        resolveStartupUpdateNotice({
+          env: { HUNK_INSTALL_SOURCE: "nix" },
+          fetchImpl: async () => createDistTagsResponse({ latest: "0.7.1", beta: "0.8.0-beta.1" }),
+          resolveInstalledVersion: () => "0.7.0",
+          statePath,
+        }),
+      ).resolves.toEqual({
+        key: "latest:0.7.1",
+        message: "Update available: 0.7.1 (latest) • update Hunk through your Nix configuration",
+      });
+    });
+  });
+
+  test("detects unmarked nixpkgs installs from their Nix store executable", async () => {
+    await withTempStatePath(async (statePath) => {
+      await expect(
+        resolveStartupUpdateNotice({
+          env: {},
+          fetchImpl: async () => createDistTagsResponse({ latest: "0.7.1" }),
+          resolveExecutablePath: () => "/nix/store/hash-hunk/bin/hunk",
+          resolveInstalledVersion: () => "0.7.0",
+          statePath,
+        }),
+      ).resolves.toEqual({
+        key: "latest:0.7.1",
+        message: "Update available: 0.7.1 (latest) • update Hunk through your Nix configuration",
+      });
+    });
+  });
+
+  test("ignores beta updates for Nix installs", async () => {
+    await withTempStatePath(async (statePath) => {
+      await expect(
+        resolveStartupUpdateNotice({
+          env: { HUNK_INSTALL_SOURCE: "nix" },
+          fetchImpl: async () => createDistTagsResponse({ latest: "0.7.0", beta: "0.8.0-beta.1" }),
+          resolveInstalledVersion: () => "0.7.0",
+          statePath,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+
   test("returns null when already up to date", async () => {
     await withTempStatePath(async (statePath) => {
       await expect(

--- a/src/core/updateNotice.ts
+++ b/src/core/updateNotice.ts
@@ -18,7 +18,7 @@ interface PersistedStartupState {
 }
 
 export type UpdateChannel = "latest" | "beta";
-export type InstallSource = "npm" | "homebrew";
+export type InstallSource = "npm" | "homebrew" | "nix";
 
 type FetchImpl = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -33,6 +33,7 @@ export interface UpdateNoticeDeps {
   fetchTimeoutMs?: number;
   resolveInstalledVersion?: () => string;
   resolveInstallSource?: () => InstallSource;
+  resolveExecutablePath?: () => string;
   statePath?: string;
 }
 
@@ -69,14 +70,26 @@ function isNewerVersion(current: string, candidate: string) {
 }
 
 /** Resolve which package manager installed this binary, defaulting to the npm package path. */
-function resolveInstallSourceFromEnv(env: NodeJS.ProcessEnv = process.env): InstallSource {
-  return env[INSTALL_SOURCE_ENV] === "homebrew" ? "homebrew" : "npm";
+function resolveInstallSourceFromRuntime(
+  env: NodeJS.ProcessEnv = process.env,
+  executablePath = process.execPath,
+): InstallSource {
+  const installSource = env[INSTALL_SOURCE_ENV];
+  if (installSource === "homebrew" || installSource === "nix") {
+    return installSource;
+  }
+
+  return executablePath.startsWith("/nix/store/") ? "nix" : "npm";
 }
 
-/** Build the install command shown in the transient notice for one channel. */
-function commandForChannel(channel: UpdateChannel, installSource: InstallSource) {
+/** Build the install-aware update instruction shown for one release channel. */
+function updateInstructionForChannel(channel: UpdateChannel, installSource: InstallSource) {
   if (installSource === "homebrew") {
     return "brew update && brew upgrade hunk";
+  }
+
+  if (installSource === "nix") {
+    return "update Hunk through your Nix configuration";
   }
 
   return channel === "latest" ? "npm i -g hunkdiff" : "npm i -g hunkdiff@beta";
@@ -88,10 +101,10 @@ function createUpdateNotice(
   channel: UpdateChannel,
   installSource: InstallSource,
 ): StartupNotice {
-  const command = commandForChannel(channel, installSource);
+  const instruction = updateInstructionForChannel(channel, installSource);
   return {
     key: `${channel}:${version}`,
-    message: `Update available: ${version} (${channel}) • ${command}`,
+    message: `Update available: ${version} (${channel}) • ${instruction}`,
   };
 }
 
@@ -265,7 +278,8 @@ export async function resolveStartupUpdateNotice(
   const fetchTimeoutMs = deps.fetchTimeoutMs ?? DEFAULT_UPDATE_NOTICE_FETCH_TIMEOUT_MS;
   const resolveInstalledVersion = deps.resolveInstalledVersion ?? resolveCliVersion;
   const resolveInstallSource =
-    deps.resolveInstallSource ?? (() => resolveInstallSourceFromEnv(env));
+    deps.resolveInstallSource ??
+    (() => resolveInstallSourceFromRuntime(env, deps.resolveExecutablePath?.()));
   const { signal, dispose } = createFetchTimeoutSignal(fetchTimeoutMs);
 
   try {


### PR DESCRIPTION
## Summary

- recognize Nix installs from either the package marker or a `/nix/store` executable
- show neutral Nix-specific update guidance instead of an npm command
- mark Hunk's flake package explicitly and keep Nix installs on stable release notices

Closes #549

## Testing

- `bun test src/core/updateNotice.test.ts`
- `bun test "$PWD/src/core"`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- tmux 3.6b smoke test with `HUNK_INSTALL_SOURCE=nix`; confirmed the live footer shows the Nix guidance and no npm command

*This PR description was generated by Pi using OpenAI GPT-5.2*
