### PR TITLE
feat(website): unify marketing and docs design

### DIFF
--- a/.changeset/align-unified-site-design.md
+++ b/.changeset/align-unified-site-design.md
@@ -1,0 +1,4 @@
+---
+---
+
+Align the documentation shell with the canonical Hunk website through shared design tokens, navigation, typography, cards, and footer treatments. This is a website-only change with no published package bump.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -38,6 +38,13 @@ export default defineConfig({
       lastUpdated: true,
       pagination: true,
       customCss: ["./src/styles/starlight.css"],
+      components: {
+        Footer: "./src/components/docs/DocsFooter.astro",
+        Header: "./src/components/docs/DocsHeader.astro",
+        MobileMenuFooter: "./src/components/docs/DocsMobileMenuFooter.astro",
+        Sidebar: "./src/components/docs/DocsSidebar.astro",
+        ThemeProvider: "./src/components/docs/LightThemeProvider.astro",
+      },
       sidebar: [
         {
           label: "Start here",

--- a/website/src/components/BrandFooter.astro
+++ b/website/src/components/BrandFooter.astro
@@ -1,0 +1,28 @@
+---
+interface Props {
+  context?: "marketing" | "docs";
+}
+
+const { context = "marketing" } = Astro.props;
+const REPO = "https://github.com/modem-dev/hunk";
+const DISCORD = "https://discord.gg/WZFjaP6Gt8";
+const NPM = "https://www.npmjs.com/package/hunkdiff";
+---
+
+<footer class="brand-footer" data-context={context}>
+  <div class="brand-footer-links">
+    <a href="/docs/">Docs</a>
+    <a href={REPO}>GitHub</a>
+    <a href={NPM}>npm</a>
+    <a href={DISCORD}>Discord</a>
+    <a href={`${REPO}/blob/main/LICENSE`}>MIT</a>
+  </div>
+  <a
+    class="brand-modem"
+    href="https://modem.dev?utm_source=hunk_web&utm_medium=oss&utm_campaign=oss_hunk"
+    aria-label="Built by Modem"
+  >
+    <span>Built by</span>
+    <img src="/modem-light.svg" alt="Modem" width="82" height="16" />
+  </a>
+</footer>

--- a/website/src/components/BrandHeader.astro
+++ b/website/src/components/BrandHeader.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+  current?: "home" | "docs";
+  context?: "marketing" | "docs";
+}
+
+const { current, context = "marketing" } = Astro.props;
+const hasTools = Astro.slots.has("tools");
+const REPO = "https://github.com/modem-dev/hunk";
+const DISCORD = "https://discord.gg/WZFjaP6Gt8";
+const installHref = context === "docs" ? "/docs/start/install/" : "/#install";
+---
+
+<div class="brand-header-inner" data-context={context}>
+  <a class="brand-logo" href="/" aria-label="Hunk home">hunk</a>
+  <div class="brand-header-actions">
+    <nav class="brand-nav" aria-label="Main navigation">
+      <a href={installHref}>Install</a>
+      <a href="/docs/" aria-current={current === "docs" ? "page" : undefined}>Docs</a>
+      <a class="brand-discord" href={DISCORD}>Discord</a>
+      <a href={REPO}>GitHub ↗</a>
+    </nav>
+    {
+      hasTools && (
+        <div class="brand-tools">
+          <slot name="tools" />
+        </div>
+      )
+    }
+  </div>
+</div>

--- a/website/src/components/docs/DocsFooter.astro
+++ b/website/src/components/docs/DocsFooter.astro
@@ -1,0 +1,5 @@
+---
+import StarlightFooter from "@astrojs/starlight/components/Footer.astro";
+---
+
+<StarlightFooter />

--- a/website/src/components/docs/DocsHeader.astro
+++ b/website/src/components/docs/DocsHeader.astro
@@ -1,0 +1,20 @@
+---
+import Search from "@astrojs/starlight/components/Search.astro";
+import BrandHeader from "../BrandHeader.astro";
+---
+
+<BrandHeader current="docs" context="docs">
+  <div slot="tools" class="docs-header-tools print:hidden">
+    <Search />
+  </div>
+</BrandHeader>
+
+<style>
+  .docs-header-tools {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    gap: 14px;
+  }
+
+</style>

--- a/website/src/components/docs/DocsMobileMenuFooter.astro
+++ b/website/src/components/docs/DocsMobileMenuFooter.astro
@@ -1,0 +1,9 @@
+---
+import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
+---
+
+<div class="mobile-preferences sl-flex">
+  <div class="social-icons">
+    <SocialIcons />
+  </div>
+</div>

--- a/website/src/components/docs/DocsSidebar.astro
+++ b/website/src/components/docs/DocsSidebar.astro
@@ -1,0 +1,52 @@
+---
+import DocsMobileMenuFooter from "./DocsMobileMenuFooter.astro";
+import SidebarPersister from "@astrojs/starlight/components/SidebarPersister.astro";
+import SidebarSublist from "@astrojs/starlight/components/SidebarSublist.astro";
+
+const { sidebar } = Astro.locals.starlightRoute;
+---
+
+<SidebarPersister>
+  <SidebarSublist sublist={sidebar} />
+</SidebarPersister>
+
+<a
+  class="docs-sidebar-modem sl-hidden md:sl-flex"
+  href="https://modem.dev?utm_source=hunk_web&utm_medium=oss&utm_campaign=oss_hunk"
+  aria-label="Built by Modem"
+>
+  <span>Built by</span>
+  <img src="/modem-light.svg" alt="Modem" width="82" height="16" />
+</a>
+
+<div class="md:sl-hidden">
+  <DocsMobileMenuFooter />
+</div>
+
+<style>
+  .docs-sidebar-modem {
+    align-items: center;
+    gap: 0.5rem;
+    position: fixed;
+    inset-inline-start: var(--sl-sidebar-pad-x);
+    bottom: 1rem;
+    z-index: 1;
+    width: calc(var(--sl-sidebar-width) - 2 * var(--sl-sidebar-pad-x));
+    border-top: 1px solid var(--hunk-rule);
+    padding-top: 1rem;
+    background: var(--hunk-bg);
+    color: var(--hunk-muted);
+    font-size: var(--sl-text-xs);
+    text-decoration: none;
+  }
+
+  .docs-sidebar-modem:hover {
+    color: var(--hunk-ink);
+  }
+
+  .docs-sidebar-modem img {
+    width: auto;
+    height: 0.875rem;
+    opacity: 0.82;
+  }
+</style>

--- a/website/src/components/docs/LightThemeProvider.astro
+++ b/website/src/components/docs/LightThemeProvider.astro
@@ -1,0 +1,7 @@
+---
+/** Keep documentation in the canonical light website theme until theme switching returns. */
+---
+
+<script is:inline>
+  document.documentElement.dataset.theme = "light";
+</script>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,12 +1,12 @@
 ---
+import BrandFooter from "../components/BrandFooter.astro";
+import BrandHeader from "../components/BrandHeader.astro";
 import CopyCommand from "../components/marketing/CopyCommand.astro";
 import PlatformIcons from "../components/marketing/PlatformIcons.astro";
 import ThemeShot from "../components/marketing/ThemeShot.astro";
 import "../styles/marketing.css";
 
 const REPO = "https://github.com/modem-dev/hunk";
-const DISCORD = "https://discord.gg/WZFjaP6Gt8";
-const NPM = "https://www.npmjs.com/package/hunkdiff";
 const title = "hunk — review-first terminal diff viewer";
 const description =
   "Hunk is a review-first terminal diff viewer for agent-authored changesets. Multi-file review stream, inline AI annotations, watch mode, and Git/Jujutsu integration.";
@@ -115,13 +115,7 @@ const formattedStars =
   <body>
     <div class="marketing">
       <header class="top">
-        <a class="logo" href="/" aria-label="Hunk home">hunk</a>
-        <nav aria-label="Main navigation">
-          <a href="#install">Install</a>
-          <a href="/docs/">Docs</a>
-          <a href={DISCORD}>Discord</a>
-          <a href={REPO}>GitHub ↗</a>
-        </nav>
+        <BrandHeader current="home" />
       </header>
 
       <main>
@@ -206,23 +200,7 @@ const formattedStars =
         </section>
       </main>
 
-      <footer class="bottom">
-        <div class="foot-links">
-          <a href="/docs/">Docs</a>
-          <a href={REPO}>GitHub</a>
-          <a href={NPM}>npm</a>
-          <a href={DISCORD}>Discord</a>
-          <a href={`${REPO}/blob/main/LICENSE`}>MIT</a>
-        </div>
-        <a
-          class="modem"
-          href="https://modem.dev?utm_source=hunk_web&utm_medium=oss&utm_campaign=oss_hunk"
-          aria-label="Built by Modem"
-        >
-          <span>Built by</span>
-          <img src="/modem-light.svg" alt="Modem" width="82" height="16" />
-        </a>
-      </footer>
+      <BrandFooter />
     </div>
   </body>
 </html>

--- a/website/src/styles/brand.css
+++ b/website/src/styles/brand.css
@@ -1,0 +1,193 @@
+@import "@fontsource-variable/jetbrains-mono/index.css";
+
+:root {
+  --hunk-font:
+    "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+    Consolas, "Liberation Mono", monospace;
+  --hunk-bg: #f4f1ea;
+  --hunk-paper: #fffdf8;
+  --hunk-paper-hover: #fff;
+  --hunk-panel: #e9e4d8;
+  --hunk-ink: #16140f;
+  --hunk-body: #3a352b;
+  --hunk-muted: #6b6557;
+  --hunk-rule: #dcd6c8;
+  --hunk-accent: #1f7a35;
+  --hunk-accent-soft: #bfe9c6;
+  --hunk-accent-ink: #0d3a18;
+  --hunk-strong-border: #16140f;
+  --hunk-shadow: #16140f;
+  --hunk-button-ink: #fffdf8;
+}
+
+:root[data-theme="dark"] {
+  --hunk-bg: #0c0e10;
+  --hunk-paper: #14181b;
+  --hunk-paper-hover: #1b1f24;
+  --hunk-panel: #1b1f24;
+  --hunk-ink: #f2f4f6;
+  --hunk-body: #c3c9cf;
+  --hunk-muted: #9aa4af;
+  --hunk-rule: #262d34;
+  --hunk-accent: #5dd06a;
+  --hunk-accent-soft: #2c6b34;
+  --hunk-accent-ink: #b9f2c0;
+  --hunk-strong-border: #3a444e;
+  --hunk-shadow: #050607;
+  --hunk-button-ink: #0c0e10;
+}
+
+.brand-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 960px;
+  min-width: 0;
+  height: 100%;
+  margin-inline: auto;
+  padding-inline: 36px;
+  color: var(--hunk-ink);
+  font-family: var(--hunk-font);
+}
+
+/* Documentation navigation intentionally uses the full browser width. */
+.brand-header-inner[data-context="docs"] {
+  max-width: none;
+}
+
+.brand-logo {
+  flex: none;
+  color: var(--hunk-ink);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+
+.brand-header-actions,
+.brand-nav,
+.brand-tools {
+  display: flex;
+  align-items: center;
+}
+
+.brand-header-actions {
+  min-width: 0;
+  gap: 22px;
+}
+
+.brand-nav {
+  gap: 22px;
+  font-size: 13.5px;
+}
+
+.brand-nav a {
+  color: var(--hunk-ink);
+  text-decoration: none;
+}
+
+.brand-nav a:hover,
+.brand-nav a[aria-current="page"] {
+  color: var(--hunk-accent);
+}
+
+.brand-tools {
+  min-width: 0;
+  gap: 14px;
+}
+
+.brand-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 960px;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-inline: auto;
+  padding: 26px 36px 52px;
+  border-top: 1.5px solid var(--hunk-strong-border);
+  color: var(--hunk-muted);
+  font-family: var(--hunk-font);
+  font-size: 12.5px;
+}
+
+.brand-footer[data-context="docs"] {
+  margin-top: 3rem;
+  padding: 24px 0 0;
+}
+
+.brand-footer-links,
+.brand-modem {
+  display: flex;
+  align-items: center;
+}
+
+.brand-footer-links {
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.brand-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-footer a:hover {
+  color: var(--hunk-accent);
+}
+
+.brand-modem {
+  gap: 10px;
+}
+
+.brand-modem img {
+  display: block;
+  width: auto;
+  height: 16px;
+  opacity: 0.82;
+}
+
+:root[data-theme="dark"] .brand-modem img {
+  filter: invert(1);
+}
+
+@media (max-width: 49.999rem) {
+  .brand-header-inner[data-context="docs"] {
+    padding-inline: 20px 72px;
+  }
+
+  .brand-header-inner[data-context="docs"] .brand-nav {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .brand-header-inner {
+    padding-inline: 20px;
+  }
+
+  .brand-header-inner[data-context="docs"] {
+    padding-inline-end: 72px;
+  }
+
+  .brand-footer {
+    padding-inline: 20px;
+  }
+
+  .brand-footer[data-context="docs"] {
+    padding-inline: 0;
+  }
+
+  .brand-nav {
+    gap: 15px;
+    font-size: 12.5px;
+  }
+}
+
+@media (max-width: 340px) {
+  .brand-header-inner[data-context="marketing"] .brand-discord {
+    display: none;
+  }
+}

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -1,9 +1,7 @@
-@import "@fontsource-variable/jetbrains-mono/index.css";
+@import "./brand.css";
 
 :root {
-  --mono:
-    "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas,
-    "Liberation Mono", monospace;
+  --mono: var(--hunk-font);
 }
 
 * {
@@ -22,8 +20,8 @@ body {
 
 body {
   overflow-x: hidden;
-  background: #f4f1ea;
-  color: #16140f;
+  background: var(--hunk-bg);
+  color: var(--hunk-ink);
   font-family: var(--mono);
   font-size: 15px;
   line-height: 1.65;
@@ -43,7 +41,7 @@ a {
 
 button:focus-visible,
 a:focus-visible {
-  outline: 3px solid #1f7a35;
+  outline: 3px solid var(--hunk-accent);
   outline-offset: 3px;
 }
 
@@ -67,46 +65,30 @@ a:focus-visible {
   position: relative;
   z-index: 2;
   min-height: 100vh;
-  background: #f4f1ea;
-  color: #16140f;
+  background: var(--hunk-bg);
+  color: var(--hunk-ink);
   font-family: var(--mono);
-  --acc: #1f7a35;
+  --acc: var(--hunk-accent);
   --del: #c0392b;
-  --paper: #fffdf8;
-  --rule: #dcd6c8;
-  --soft: #6b6557;
-  --ink: #16140f;
+  --paper: var(--hunk-paper);
+  --rule: var(--hunk-rule);
+  --soft: var(--hunk-muted);
+  --ink: var(--hunk-ink);
 }
 
 .marketing ::selection {
-  color: #0d3a18;
-  background: #bfe9c6;
+  color: var(--hunk-accent-ink);
+  background: var(--hunk-accent-soft);
 }
 
 .marketing .top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   max-width: 960px;
-  margin: 0 auto;
-  padding: 22px 36px;
+  height: 74px;
+  margin-inline: auto;
   border-bottom: 1.5px solid var(--ink);
 }
 
-.marketing .logo {
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-.marketing .top nav {
-  display: flex;
-  gap: 22px;
-  font-size: 13.5px;
-}
-
 .marketing .top nav a:hover,
-.marketing .foot-links a:hover,
 .marketing .says figcaption a:hover {
   color: var(--acc);
 }
@@ -119,7 +101,7 @@ a:focus-visible {
 
 .marketing h1 {
   margin: 0 0 24px;
-  font-size: clamp(34px, 7vw, 72px);
+  font-size: clamp(32px, 6vw, 60px);
   font-weight: 700;
   line-height: 0.99;
   letter-spacing: -0.04em;
@@ -148,7 +130,7 @@ a:focus-visible {
 .marketing .sub {
   max-width: 500px;
   margin: 0 0 30px;
-  color: #3a352b;
+  color: var(--hunk-body);
   font-size: 16.5px;
   line-height: 1.6;
 }
@@ -239,7 +221,7 @@ a:focus-visible {
   gap: 6px;
   padding: 10px 14px;
   border-bottom: 1.5px solid var(--ink);
-  background: #e9e4d8;
+  background: var(--hunk-panel);
 }
 
 .marketing .dot {
@@ -294,7 +276,7 @@ a:focus-visible {
 }
 
 .marketing .tpill:hover {
-  background: #fff;
+  background: var(--hunk-paper-hover);
 }
 
 .marketing .tpill.on {
@@ -389,7 +371,7 @@ a:focus-visible {
 }
 
 .marketing .grid article:hover {
-  background: #fff;
+  background: var(--hunk-paper-hover);
 }
 
 .marketing .num {
@@ -406,7 +388,7 @@ a:focus-visible {
 
 .marketing .grid p {
   margin: 0;
-  color: #3a352b;
+  color: var(--hunk-body);
   font-size: 13.5px;
   line-height: 1.6;
 }
@@ -478,46 +460,8 @@ a:focus-visible {
 
 .marketing .req {
   margin: 0;
-  color: #3a352b;
+  color: var(--hunk-body);
   font-size: 13.5px;
-}
-
-.marketing .bottom {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 960px;
-  gap: 20px;
-  flex-wrap: wrap;
-  margin: 0 auto;
-  padding: 26px 36px 52px;
-  border-top: 1.5px solid var(--ink);
-  font-size: 12.5px;
-}
-
-.marketing .foot-links {
-  display: flex;
-  gap: 18px;
-  flex-wrap: wrap;
-}
-
-.marketing .modem {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--soft);
-}
-
-.marketing .modem img {
-  display: block;
-  width: auto;
-  height: 16px;
-  opacity: 0.82;
-  transition: 0.15s;
-}
-
-.marketing .modem:hover img {
-  opacity: 1;
 }
 
 @media (max-width: 760px) {
@@ -530,23 +474,17 @@ a:focus-visible {
     font-size: 12.5px;
   }
 
-  .marketing .top,
   .marketing .intro,
   .marketing .paper,
   .marketing .says,
   .marketing .feats,
-  .marketing .install,
-  .marketing .bottom {
+  .marketing .install {
     padding-right: 20px;
     padding-left: 20px;
   }
 }
 
 @media (max-width: 680px) {
-  .marketing .top {
-    align-items: flex-start;
-  }
-
   .marketing .top nav {
     justify-content: flex-end;
     flex-wrap: wrap;

--- a/website/src/styles/starlight.css
+++ b/website/src/styles/starlight.css
@@ -1,24 +1,9 @@
-@import "@fontsource-variable/jetbrains-mono";
+@import "./brand.css";
 
 :root {
-  --hunk-bg: #f4f1ea;
-  --hunk-paper: #fffdf8;
-  --hunk-panel: #e9e4d8;
-  --hunk-ink: #16140f;
-  --hunk-body: #3a352b;
-  --hunk-muted: #6b6557;
-  --hunk-rule: #dcd6c8;
-  --hunk-accent: #1f7a35;
-  --hunk-accent-soft: #bfe9c6;
-  --hunk-accent-ink: #0d3a18;
-  --hunk-strong-border: #16140f;
-  --hunk-shadow: #16140f;
-  --hunk-button-ink: #fffdf8;
-
-  --sl-font:
-    "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
-    Consolas, "Liberation Mono", monospace;
-  --sl-font-mono: var(--sl-font);
+  --sl-font: var(--hunk-font);
+  --sl-font-mono: var(--hunk-font);
+  --sl-nav-height: 4.625rem;
   --sl-color-accent-low: var(--hunk-accent-soft);
   --sl-color-accent: var(--hunk-accent);
   --sl-color-accent-high: var(--hunk-accent-ink);
@@ -42,39 +27,11 @@
 }
 
 :root[data-theme="dark"] {
-  --hunk-bg: #0c0e10;
-  --hunk-paper: #14181b;
-  --hunk-panel: #1b1f24;
-  --hunk-ink: #f2f4f6;
-  --hunk-body: #c3c9cf;
-  --hunk-muted: #9aa4af;
-  --hunk-rule: #262d34;
-  --hunk-accent: #5dd06a;
-  --hunk-accent-soft: #2c6b34;
-  --hunk-accent-ink: #b9f2c0;
-  --hunk-strong-border: #3a444e;
-  --hunk-shadow: #050607;
-  --hunk-button-ink: #0c0e10;
-
-  --sl-color-accent-low: var(--hunk-accent-soft);
-  --sl-color-accent: var(--hunk-accent);
-  --sl-color-accent-high: var(--hunk-accent-ink);
-  --sl-color-text-accent: var(--hunk-accent);
-  --sl-color-white: var(--hunk-ink);
-  --sl-color-gray-1: var(--hunk-ink);
-  --sl-color-gray-2: var(--hunk-body);
-  --sl-color-gray-3: var(--hunk-muted);
   --sl-color-gray-4: #6b7681;
-  --sl-color-gray-5: var(--hunk-rule);
   --sl-color-gray-6: var(--hunk-paper);
   --sl-color-gray-7: var(--hunk-panel);
-  --sl-color-black: var(--hunk-bg);
-  --sl-color-bg: var(--hunk-bg);
   --sl-color-bg-nav: rgba(12, 14, 16, 0.96);
   --sl-color-bg-sidebar: var(--hunk-paper);
-  --sl-color-bg-inline-code: var(--hunk-panel);
-  --sl-color-hairline-light: var(--hunk-rule);
-  --sl-color-hairline: var(--hunk-rule);
   --sl-color-hairline-shade: #1d2329;
 }
 
@@ -100,11 +57,26 @@ h4,
 
 h1 {
   color: var(--hunk-ink);
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  line-height: 1;
   letter-spacing: -0.04em;
 }
 
 h2 {
+  color: var(--hunk-ink);
   letter-spacing: -0.03em;
+}
+
+h3,
+h4 {
+  color: var(--hunk-ink);
+  letter-spacing: -0.015em;
+}
+
+.sl-markdown-content > p,
+.sl-markdown-content > ul,
+.sl-markdown-content > ol {
+  max-width: 48rem;
 }
 
 a:focus-visible,
@@ -131,6 +103,7 @@ code:not(pre code) {
 }
 
 header.header {
+  padding: 0;
   border-bottom: 1.5px solid var(--hunk-strong-border);
 }
 
@@ -145,6 +118,12 @@ header.header {
   border-inline-end-color: var(--hunk-rule);
 }
 
+.sidebar-content summary {
+  color: var(--hunk-ink);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
 .sidebar-content a {
   border-radius: 0.25rem;
 }
@@ -155,8 +134,7 @@ header.header {
 }
 
 site-search button,
-starlight-menu-button button,
-starlight-theme-select select {
+starlight-menu-button button {
   border: 1.5px solid var(--hunk-strong-border);
   border-radius: 0.5rem;
   background: var(--hunk-paper);
@@ -166,7 +144,7 @@ starlight-theme-select select {
 }
 
 .hero h1 {
-  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-size: clamp(2.25rem, 5vw, 3.5rem);
   line-height: 1;
 }
 
@@ -214,7 +192,17 @@ starlight-theme-select select {
   color: var(--hunk-accent-ink);
 }
 
-.sl-link-card,
+.sl-link-card {
+  border: 1.5px solid var(--hunk-strong-border);
+  border-radius: 0;
+  background: var(--hunk-paper);
+  box-shadow: none;
+}
+
+.sl-link-card:hover {
+  background: color-mix(in srgb, var(--hunk-paper) 82%, var(--hunk-accent-soft));
+}
+
 .pagination-links > a {
   border: 1.5px solid var(--hunk-strong-border);
   border-radius: 0.5rem;
@@ -270,7 +258,6 @@ starlight-theme-select select {
 
 @media (hover: hover) {
   .sl-link-button:hover,
-  .sl-link-card:hover,
   .pagination-links > a:hover {
     transform: translate(2px, 2px);
     box-shadow: 1px 1px 0 var(--hunk-shadow);
@@ -279,7 +266,6 @@ starlight-theme-select select {
 
 @media (prefers-reduced-motion: reduce) {
   .sl-link-button,
-  .sl-link-card,
   .pagination-links > a {
     transition: none;
   }

--- a/website/tests/docs-smoke.spec.ts
+++ b/website/tests/docs-smoke.spec.ts
@@ -1,11 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test, type Page } from "@playwright/test";
-
-/** Open responsive navigation controls when the desktop sidebar is collapsed. */
-async function openMobileMenuIfNeeded(page: Page) {
-  const menu = page.getByRole("button", { name: "Menu" });
-  if (await menu.isVisible()) await menu.click();
-}
+import { expect, test } from "@playwright/test";
 
 test("responsive navigation and on-page table of contents are usable", async ({
   page,
@@ -17,7 +11,7 @@ test("responsive navigation and on-page table of contents are usable", async ({
   const quickStartLink = mainNavigation.getByRole("link", { name: "Quick start", exact: true });
   if (testInfo.project.name.startsWith("mobile")) {
     await expect(quickStartLink).toBeHidden();
-    const menu = page.getByRole("button", { name: "Menu" });
+    const menu = page.locator("starlight-menu-button button");
     await expect(menu).toBeVisible();
     await menu.click();
     await expect(quickStartLink).toBeVisible();
@@ -33,14 +27,28 @@ test("responsive navigation and on-page table of contents are usable", async ({
   }
 });
 
-test("theme choice persists while navigating", async ({ page }) => {
+test("documentation stays in the canonical light theme", async ({ page }) => {
   await page.goto("/docs/start/quick-start/");
-  await openMobileMenuIfNeeded(page);
-  const picker = page.getByLabel("Select theme").filter({ visible: true });
-  await picker.selectOption("dark");
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await expect(page.getByLabel("Select theme")).toHaveCount(0);
   await page.goto("/docs/agents/review-with-an-agent/");
-  await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+});
+
+test("left sidebar credits Modem at its bottom", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/docs/start/quick-start/");
+  const sidebar = page.locator("#starlight__sidebar");
+  const modem = page.getByRole("link", { name: "Built by Modem" });
+  await expect(modem).toBeVisible();
+  const sidebarBounds = await sidebar.boundingBox();
+  const modemBounds = await modem.boundingBox();
+  expect(sidebarBounds).not.toBeNull();
+  expect(modemBounds).not.toBeNull();
+  expect(modemBounds!.y + modemBounds!.height).toBeLessThanOrEqual(
+    sidebarBounds!.y + sidebarBounds!.height,
+  );
+  expect(modemBounds!.y).toBeGreaterThan(sidebarBounds!.y + sidebarBounds!.height / 2);
 });
 
 test("local Pagefind search opens and returns a documentation route", async ({ page }) => {

--- a/website/tests/marketing-smoke.spec.ts
+++ b/website/tests/marketing-smoke.spec.ts
@@ -15,6 +15,51 @@ test("marketing page links into documentation and preserves core calls to action
   await expect(page.getByRole("button", { name: "Copy: npm i -g hunkdiff" })).toBeVisible();
 });
 
+test("marketing and docs share the canonical brand shell", async ({ page }) => {
+  await page.goto("/");
+  const marketingStyles = await page.locator("body").evaluate((body) => {
+    const styles = getComputedStyle(body);
+    return { background: styles.backgroundColor, font: styles.fontFamily };
+  });
+  await expect(page.getByRole("link", { name: "Hunk home" })).toHaveAttribute("href", "/");
+  await expect(page.locator(".brand-footer")).toHaveCount(1);
+
+  await page.goto("/docs/");
+  const docsStyles = await page.locator("body").evaluate((body) => {
+    const styles = getComputedStyle(body);
+    return { background: styles.backgroundColor, font: styles.fontFamily };
+  });
+  expect(docsStyles).toEqual(marketingStyles);
+  const docsHeader = await page.locator(".brand-header-inner[data-context='docs']").boundingBox();
+  expect(docsHeader?.width).toBe(await page.evaluate(() => window.innerWidth));
+  await expect(page.getByRole("link", { name: "Hunk home" })).toHaveAttribute("href", "/");
+  await expect(page.locator(".brand-nav a[href='/docs/start/install/']")).toHaveCount(1);
+  await expect(page.locator(".brand-footer")).toHaveCount(0);
+});
+
+test("shared headers stay usable at narrow and tablet breakpoints", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 700 });
+  await page.goto("/");
+  const marketingNavigation = page.getByRole("navigation", { name: "Main navigation" });
+  await expect(marketingNavigation.getByRole("link", { name: "Discord" })).toBeHidden();
+  const marketingHeader = await page.locator(".top").boundingBox();
+  const marketingNav = await marketingNavigation.boundingBox();
+  expect(marketingHeader).not.toBeNull();
+  expect(marketingNav).not.toBeNull();
+  expect(marketingNav!.y + marketingNav!.height).toBeLessThanOrEqual(
+    marketingHeader!.y + marketingHeader!.height,
+  );
+
+  await page.setViewportSize({ width: 780, height: 800 });
+  await page.goto("/docs/");
+  await expect(page.getByRole("navigation", { name: "Main navigation" })).toBeHidden();
+  const search = await page.getByRole("button", { name: "Search" }).boundingBox();
+  const menu = await page.locator("starlight-menu-button button").boundingBox();
+  expect(search).not.toBeNull();
+  expect(menu).not.toBeNull();
+  expect(search!.x + search!.width).toBeLessThanOrEqual(menu!.x);
+});
+
 test("install command copies with accessible feedback", async ({ context, page }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.goto("/");


### PR DESCRIPTION
## Summary

- make the root Hunk website the canonical visual system through shared paper/ink/green palette tokens and JetBrains Mono typography
- reuse one branded header across the marketing page and Starlight documentation, with full-width documentation navigation
- reduce oversized marketing and documentation H1 scale
- keep documentation light-only and remove desktop/mobile theme pickers while retaining the existing dark-mode token system for a future return
- move the Modem attribution from the docs footer to below the desktop table of contents
- add narrow-phone, tablet, light-theme, full-width header, and sidebar-attribution coverage

## Validation

- `bun run website:check`
- `bun run website:build`
- `bun run website:links`
- `bun run website:test:browser` — 24 desktop/mobile tests
- formatting, lint, and diff checks

*This PR description was generated by Pi using OpenAI GPT-5.2*
