### PR TITLE
feat(extensions): folder extensions with package.json manifests

### DIFF
--- a/.changeset/extension-package-manifests.md
+++ b/.changeset/extension-package-manifests.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Folder extensions can now declare their entry points through a `package.json` `"hunk": { "extensions": [...] }` manifest, which takes precedence over the `index.*` fallback and lets an extension ship several entries and its own npm dependencies.

--- a/.changeset/folder-extension-paths.md
+++ b/.changeset/folder-extension-paths.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Pointing `--extension` or `[extensions] paths` at a directory that contains an `index.ts`/`index.js`/`index.mjs` now loads it as a single folder extension instead of scanning every file inside it as separate extensions.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -24,9 +24,9 @@ export default function (hunk: HunkExtensionAPI) {
 ## Where Hunk looks for extensions
 
 Discovery runs group by group, alphabetically by resolved path within each
-group. The first occurrence of a resolved path wins, so a path you pass
-explicitly keeps its origin even if the same file is also discovered somewhere
-else.
+group — a folder extension's entries sort together, at the folder's own path.
+The first occurrence of a resolved path wins, so a path you pass explicitly
+keeps its origin even if the same file is also discovered somewhere else.
 
 | Group | Source                                               | Trust                 |
 | ----- | ---------------------------------------------------- | --------------------- |
@@ -41,18 +41,41 @@ both are repo-controlled, so they share a trust decision and their paths are
 sorted together rather than one source being loaded ahead of the other.
 
 A directory source matches `*.ts`, `*.js`, `*.mjs` directly inside it, plus one
-level of `<name>/index.{ts,js,mjs}` so a folder extension can keep helper
-modules beside its entry file.
+level of folder extensions, so a folder extension can keep helper modules beside
+its entry file.
+
+A folder is an extension if it declares its entry files in a `package.json`, or
+failing that if it has an `index.{ts,js,mjs}`. The manifest field is `hunk`:
+
+```text
+~/.config/hunk/extensions/my-ext/
+  package.json          # {"hunk": {"extensions": ["./src/index.ts"]}}
+  node_modules/         # bun install / npm install, right here
+  src/
+    index.ts            # the declared entry
+    helper.ts
+```
+
+The manifest wins over the `index.*` fallback, and its paths resolve against the
+folder. It may list more than one entry, in which case each entry loads as its
+own extension in the order the manifest gives — name those files distinctly,
+because each one is then identified by its own file stem.
+
+Because the manifest is a real `package.json`, a folder extension may depend on
+npm packages: declare them, install them into the folder's own `node_modules`,
+and imports resolve from the entry file the way they do in any other package.
 
 Pointing `--extension` or `[extensions] paths` straight at a directory works
-either way: a directory containing `index.{ts,js,mjs}` loads as that one folder
-extension, so its helper modules stay helpers. A directory with no index is
+either way: a directory that is itself a folder extension loads as that one
+extension, so its helper modules stay helpers. A directory that is not is
 treated as a directory _of_ extensions and scanned with the patterns above.
 
 An extension's **id** is its file stem, or its folder name for
-`<name>/index.ts`. The id is what `[extension.<id>]` config tables key off, so
-moving a single-file extension into a folder of the same name keeps its config
-working.
+`<name>/index.ts`. A manifest that declares a single entry also keeps the
+folder's name, whatever the entry file is called. The id is what
+`[extension.<id>]` config tables key off, so moving a single-file extension into
+a folder of the same name — or later giving that folder a manifest — keeps its
+config working.
 
 `--no-extensions` disables user extensions for one run — nothing on disk is
 read, let alone executed. Use it when triaging a bug.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -58,8 +58,9 @@ failing that if it has an `index.{ts,js,mjs}`. The manifest field is `hunk`:
 
 The manifest wins over the `index.*` fallback, and its paths resolve against the
 folder. It may list more than one entry, in which case each entry loads as its
-own extension in the order the manifest gives — name those files distinctly,
-because each one is then identified by its own file stem.
+own extension in the order the manifest gives. Each one is identified by its
+file stem; when stems collide, later entries receive a numeric suffix while
+avoiding ids already claimed by other entries in the manifest.
 
 Because the manifest is a real `package.json`, a folder extension may depend on
 npm packages: declare them, install them into the folder's own `node_modules`,

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,8 +1,9 @@
 # Writing Hunk extensions
 
-A Hunk extension is one TypeScript (or JavaScript) file that default-exports a
-function. Hunk imports it at startup and hands it an API object. There is no
-manifest and no build step.
+A Hunk extension entry is one TypeScript (or JavaScript) file that
+default-exports a function. Hunk imports it at startup and hands it an API
+object. An entry may stand alone or be declared by a folder's optional
+`package.json` manifest; no build step is required.
 
 ```ts
 // ~/.config/hunk/extensions/hello.ts

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -44,6 +44,11 @@ A directory source matches `*.ts`, `*.js`, `*.mjs` directly inside it, plus one
 level of `<name>/index.{ts,js,mjs}` so a folder extension can keep helper
 modules beside its entry file.
 
+Pointing `--extension` or `[extensions] paths` straight at a directory works
+either way: a directory containing `index.{ts,js,mjs}` loads as that one folder
+extension, so its helper modules stay helpers. A directory with no index is
+treated as a directory _of_ extensions and scanned with the patterns above.
+
 An extension's **id** is its file stem, or its folder name for
 `<name>/index.ts`. The id is what `[extension.<id>]` config tables key off, so
 moving a single-file extension into a folder of the same name keeps its config
@@ -557,7 +562,8 @@ hunk diff --extension ./collapse-generated.ts
 ## CLI flags and config reference
 
 ```bash
-hunk diff --extension ./path/to/entry.ts   # load one entry file or directory (repeatable)
+hunk diff --extension ./path/to/entry.ts   # load one entry file (repeatable)
+hunk diff --extension ./my-ext             # a folder extension: loads ./my-ext/index.ts
 hunk diff --no-extensions                  # disable user extensions for this run
 ```
 

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -279,6 +279,32 @@ describe("folder extension manifests", () => {
     ]);
   });
 
+  test("disambiguates duplicate ids within a multi-entry manifest", () => {
+    const root = createTempDir("hunk-ext-manifest-duplicate-ids-");
+    const folder = join(root, "multi-ext");
+    const typescriptEntry = writeExtensionFile(folder, "alpha.ts");
+    const javascriptEntry = writeExtensionFile(folder, "alpha.js");
+    const reservedSuffixEntry = writeExtensionFile(folder, "alpha-2.ts");
+    writeExtensionManifest(
+      folder,
+      `{"hunk": {"extensions": ["./alpha.ts", "./alpha.js", "./alpha-2.ts"]}}`,
+    );
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [folder],
+      env: {},
+    });
+
+    expect(candidates).toEqual([
+      { id: "alpha", path: typescriptEntry, origin: "flag" },
+      { id: "alpha-3", path: javascriptEntry, origin: "flag" },
+      { id: "alpha-2", path: reservedSuffixEntry, origin: "flag" },
+    ]);
+  });
+
   test("falls back to the index entry when package.json is malformed", () => {
     const root = createTempDir("hunk-ext-manifest-broken-");
     const folder = join(root, "broken-manifest");

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -116,6 +116,58 @@ describe("extension discovery", () => {
     expect(candidates.map((candidate) => candidate.path)).toEqual([dirEntry, fileEntry]);
   });
 
+  test("loads an explicit folder-extension path as one extension, not as a container", () => {
+    const root = createTempDir("hunk-ext-folder-");
+    const folderIndex = writeExtensionFile(root, "my-ext", "index.ts");
+    // A helper beside the index is part of that extension, not an entry of its own.
+    writeExtensionFile(root, "my-ext", "helper.ts");
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      configPaths: ["my-ext"],
+      env: {},
+    });
+
+    expect(candidates).toEqual([{ id: "my-ext", path: folderIndex, origin: "config" }]);
+  });
+
+  test("prefers index.ts over index.js for an explicit folder-extension path", () => {
+    const root = createTempDir("hunk-ext-folder-index-");
+    const typescriptIndex = writeExtensionFile(root, "dual", "index.ts");
+    writeExtensionFile(root, "dual", "index.js");
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [join(root, "dual")],
+      env: {},
+    });
+
+    expect(candidates).toEqual([{ id: "dual", path: typescriptIndex, origin: "flag" }]);
+  });
+
+  test("scans an explicit directory without an index as a container of extensions", () => {
+    const root = createTempDir("hunk-ext-container-");
+    const first = writeExtensionFile(root, "pack", "alpha.ts");
+    const second = writeExtensionFile(root, "pack", "beta.ts");
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [join(root, "pack")],
+      env: {},
+    });
+
+    expect(candidates).toEqual([
+      { id: "alpha", path: first, origin: "flag" },
+      { id: "beta", path: second, origin: "flag" },
+    ]);
+  });
+
   test("keeps a missing explicit path so the host can report it", () => {
     const root = createTempDir("hunk-ext-missing-");
     const missing = join(root, "absent.ts");

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -20,6 +20,12 @@ function writeExtensionFile(...segments: string[]) {
   return path;
 }
 
+/** Write one folder extension's `package.json`, creating the folder as needed. */
+function writeExtensionManifest(dir: string, contents: string) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "package.json"), contents);
+}
+
 /** Create a repo root discovery can find without shelling out to a VCS. */
 function createRepo(prefix: string) {
   const repo = createTempDir(prefix);
@@ -209,6 +215,120 @@ describe("extension discovery", () => {
     });
 
     expect(candidates).toEqual([{ id: "themed", path: globalPath, origin: "global" }]);
+  });
+});
+
+describe("folder extension manifests", () => {
+  test("prefers a package.json manifest over the index fallback when scanning", () => {
+    const globalDir = createTempDir("hunk-ext-manifest-scan-");
+    const folder = join(globalDir, "manifest-ext");
+    const entry = writeExtensionFile(folder, "src", "main.ts");
+    writeExtensionManifest(folder, `{"hunk": {"extensions": ["./src/main.ts"]}}`);
+    // The index is only reached when no manifest declares entries.
+    writeExtensionFile(folder, "index.ts");
+
+    const candidates = discoverExtensions({
+      cwd: globalDir,
+      repoRoot: undefined,
+      globalExtensionsDir: globalDir,
+      env: {},
+    });
+
+    // A single declared entry still answers to the folder's name, so
+    // `[extension.manifest-ext]` keeps working.
+    expect(candidates).toEqual([{ id: "manifest-ext", path: entry, origin: "global" }]);
+  });
+
+  test("resolves a manifest for an explicit folder path", () => {
+    const root = createTempDir("hunk-ext-manifest-explicit-");
+    const folder = join(root, "manifest-ext");
+    const entry = writeExtensionFile(folder, "src", "main.ts");
+    writeExtensionManifest(folder, `{"hunk": {"extensions": ["./src/main.ts"]}}`);
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      configPaths: ["manifest-ext"],
+      env: {},
+    });
+
+    expect(candidates).toEqual([{ id: "manifest-ext", path: entry, origin: "config" }]);
+  });
+
+  test("keeps manifest order and per-file ids when a manifest declares several entries", () => {
+    const root = createTempDir("hunk-ext-manifest-multi-");
+    const folder = join(root, "multi-ext");
+    const alpha = writeExtensionFile(folder, "alpha.ts");
+    const beta = writeExtensionFile(folder, "beta.ts");
+    // Declared out of alphabetical order on purpose: a folder's entries sort as
+    // one unit at the folder's position and keep the order the manifest gave.
+    writeExtensionManifest(folder, `{"hunk": {"extensions": ["./beta.ts", "./alpha.ts"]}}`);
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [folder],
+      env: {},
+    });
+
+    expect(candidates).toEqual([
+      { id: "beta", path: beta, origin: "flag" },
+      { id: "alpha", path: alpha, origin: "flag" },
+    ]);
+  });
+
+  test("falls back to the index entry when package.json is malformed", () => {
+    const root = createTempDir("hunk-ext-manifest-broken-");
+    const folder = join(root, "broken-manifest");
+    const index = writeExtensionFile(folder, "index.ts");
+    writeExtensionManifest(folder, `{ not json`);
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [folder],
+      env: {},
+    });
+
+    expect(candidates).toEqual([{ id: "broken-manifest", path: index, origin: "flag" }]);
+  });
+
+  test("falls back to the index entry for a package.json without a hunk field", () => {
+    const root = createTempDir("hunk-ext-manifest-plain-");
+    const folder = join(root, "plain-package");
+    const index = writeExtensionFile(folder, "index.ts");
+    writeExtensionManifest(folder, `{"name": "x", "dependencies": {}}`);
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [folder],
+      env: {},
+    });
+
+    expect(candidates).toEqual([{ id: "plain-package", path: index, origin: "flag" }]);
+  });
+
+  test("keeps a manifest entry pointing at a missing file so the host can report it", () => {
+    const root = createTempDir("hunk-ext-manifest-missing-");
+    const folder = join(root, "missing-entry");
+    writeExtensionManifest(folder, `{"hunk": {"extensions": ["./src/main.ts"]}}`);
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [folder],
+      env: {},
+    });
+
+    expect(candidates).toEqual([
+      { id: "missing-entry", path: join(folder, "src", "main.ts"), origin: "flag" },
+    ]);
   });
 });
 

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -45,6 +45,19 @@ function readSortedDirEntries(dir: string) {
 }
 
 /**
+ * Return the index entry directly inside one folder extension, if it has one.
+ *
+ * Preference order follows `EXTENSION_INDEX_BASENAMES`, so a folder shipping
+ * both a source and a built entry resolves to the same one everywhere.
+ */
+function findFolderExtensionIndex(dir: string) {
+  const indexBasename = EXTENSION_INDEX_BASENAMES.find((basename) =>
+    fs.existsSync(join(dir, basename)),
+  );
+  return indexBasename ? join(dir, indexBasename) : undefined;
+}
+
+/**
  * Scan one extensions directory for entry files.
  *
  * Matches `<dir>/*.{ts,js,mjs}` plus exactly one level of
@@ -58,11 +71,9 @@ function scanExtensionsDir(dir: string) {
     const entryPath = join(dir, entry.name);
 
     if (entry.isDirectory()) {
-      const indexBasename = EXTENSION_INDEX_BASENAMES.find((basename) =>
-        fs.existsSync(join(entryPath, basename)),
-      );
-      if (indexBasename) {
-        entryPaths.push(join(entryPath, indexBasename));
+      const folderIndex = findFolderExtensionIndex(entryPath);
+      if (folderIndex) {
+        entryPaths.push(folderIndex);
       }
       continue;
     }
@@ -99,16 +110,25 @@ function expandHomePath(path: string) {
 /**
  * Expand one explicit path into entry files.
  *
- * A directory is scanned with the standard patterns; anything else is taken as
- * a literal entry file so a mistyped path still reaches the host and is
- * reported as a load issue rather than vanishing.
+ * A directory holding its own `index.{ts,js,mjs}` is one folder extension and
+ * expands to just that entry: its helper modules sit beside the index and must
+ * not be loaded as separate extensions. Only a directory without an index is a
+ * container of extensions and gets scanned. Anything else is taken as a literal
+ * entry file so a mistyped path still reaches the host and is reported as a
+ * load issue rather than vanishing.
  */
 function expandExplicitPath(path: string, cwd: string) {
   const homeExpanded = expandHomePath(path);
   const resolvedPath = isAbsolute(homeExpanded)
     ? resolve(homeExpanded)
     : resolve(cwd, homeExpanded);
-  return isDirectory(resolvedPath) ? scanExtensionsDir(resolvedPath) : [resolvedPath];
+
+  if (!isDirectory(resolvedPath)) {
+    return [resolvedPath];
+  }
+
+  const folderIndex = findFolderExtensionIndex(resolvedPath);
+  return folderIndex ? [folderIndex] : scanExtensionsDir(resolvedPath);
 }
 
 /**

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -118,6 +118,31 @@ function readManifestEntryPaths(dir: string) {
     .map((entry) => resolve(dir, entry));
 }
 
+/** Assign deterministic, distinct ids to every entry in one manifest. */
+function deriveManifestEntryIds(paths: readonly string[]) {
+  const baseIds = paths.map((path) => deriveExtensionId(path));
+  // Reserve natural stems up front so a generated suffix cannot steal a later entry's id.
+  const reservedIds = new Set(baseIds);
+  const assignedIds = new Set<string>();
+
+  return baseIds.map((baseId) => {
+    if (!assignedIds.has(baseId)) {
+      assignedIds.add(baseId);
+      return baseId;
+    }
+
+    let suffix = 2;
+    let id = `${baseId}-${suffix}`;
+    while (reservedIds.has(id) || assignedIds.has(id)) {
+      suffix += 1;
+      id = `${baseId}-${suffix}`;
+    }
+
+    assignedIds.add(id);
+    return id;
+  });
+}
+
 /**
  * Resolve the entry files of one folder extension.
  *
@@ -128,8 +153,8 @@ function readManifestEntryPaths(dir: string) {
  * A single-entry manifest keeps the folder's name as the extension id — the
  * same id the index fallback would produce — so `[extension.<id>]` config tables
  * stay keyed by the folder the user installed, whatever the entry file is
- * called. Multiple entries have no single owner, so each is named by its own
- * file stem; entry files should be named distinctly for that reason.
+ * called. Multiple entries are named by file stem, with a numeric suffix when
+ * stems collide so configuration and registry ownership remain unambiguous.
  *
  * Returns an empty list when the folder is not an extension at all.
  */
@@ -138,9 +163,12 @@ function resolveFolderExtensionEntries(dir: string): DiscoveredExtensionEntry[] 
 
   if (manifestPaths && manifestPaths.length > 0) {
     const folderName = basename(dir);
-    return manifestPaths.map((path) => ({
+    const manifestIds = deriveManifestEntryIds(manifestPaths);
+    return manifestPaths.map((path, index) => ({
       id:
-        manifestPaths.length === 1 && folderName.length > 0 ? folderName : deriveExtensionId(path),
+        manifestPaths.length === 1 && folderName.length > 0
+          ? folderName
+          : (manifestIds[index] ?? deriveExtensionId(path)),
       path,
       sortKey: dir,
     }));

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute, join, resolve } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 import { resolveGlobalExtensionsDir } from "../core/paths";
 import { findVcsRepoRootCandidate } from "../core/vcs";
 import { deriveExtensionId, type ExtensionCandidate, type ExtensionOrigin } from "./types";
@@ -8,6 +8,26 @@ import { deriveExtensionId, type ExtensionCandidate, type ExtensionOrigin } from
 /** Entry-file suffixes Hunk will import directly, in preference order. */
 const EXTENSION_ENTRY_SUFFIXES = [".ts", ".js", ".mjs"] as const;
 const EXTENSION_INDEX_BASENAMES = EXTENSION_ENTRY_SUFFIXES.map((suffix) => `index${suffix}`);
+/** `package.json` field a folder extension declares its entry files under. */
+const EXTENSION_MANIFEST_FIELD = "hunk";
+
+/**
+ * One entry file discovery found, with the identity and sort position it carries.
+ *
+ * `sortKey` keeps a folder's entries together: every entry a manifest declares
+ * sorts at the folder's own position, so a multi-entry extension stays in
+ * manifest order instead of being scattered by its individual file paths.
+ */
+interface DiscoveredExtensionEntry {
+  id: string;
+  path: string;
+  sortKey: string;
+}
+
+/** Describe one standalone entry file, which sorts and is named by its own path. */
+function toStandaloneEntry(path: string): DiscoveredExtensionEntry {
+  return { id: deriveExtensionId(path), path, sortKey: path };
+}
 
 export interface DiscoverExtensionsOptions {
   cwd?: string;
@@ -58,32 +78,103 @@ function findFolderExtensionIndex(dir: string) {
 }
 
 /**
+ * Read the entry paths one folder extension declares in its `package.json`.
+ *
+ * The manifest field is `"hunk": { "extensions": ["./src/index.ts"] }`, and each
+ * declared path resolves against the folder. A declared path that does not exist
+ * is kept rather than filtered out, matching the posture for explicit paths: the
+ * host reports it as a load issue instead of the entry silently vanishing.
+ *
+ * Anything that goes wrong — no `package.json`, an unreadable one, malformed
+ * JSON, or a field of the wrong shape — means "no manifest", so a folder that
+ * merely happens to ship a `package.json` still falls back to its index entry.
+ */
+function readManifestEntryPaths(dir: string) {
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(fs.readFileSync(join(dir, "package.json"), "utf8"));
+  } catch {
+    return undefined;
+  }
+
+  if (typeof manifest !== "object" || manifest === null) {
+    return undefined;
+  }
+
+  const section = (manifest as Record<string, unknown>)[EXTENSION_MANIFEST_FIELD];
+  if (typeof section !== "object" || section === null) {
+    return undefined;
+  }
+
+  const declared = (section as Record<string, unknown>).extensions;
+  if (!Array.isArray(declared)) {
+    return undefined;
+  }
+
+  // Non-string items are skipped rather than fatal; one bad array item should
+  // not cost the folder the entries it declared correctly.
+  return declared
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => resolve(dir, entry));
+}
+
+/**
+ * Resolve the entry files of one folder extension.
+ *
+ * A `package.json` manifest wins over the `index.{ts,js,mjs}` fallback, and may
+ * declare several entries. A manifest that declares no usable entry is treated
+ * as no manifest at all, so such a folder still loads its index if it has one.
+ *
+ * A single-entry manifest keeps the folder's name as the extension id — the
+ * same id the index fallback would produce — so `[extension.<id>]` config tables
+ * stay keyed by the folder the user installed, whatever the entry file is
+ * called. Multiple entries have no single owner, so each is named by its own
+ * file stem; entry files should be named distinctly for that reason.
+ *
+ * Returns an empty list when the folder is not an extension at all.
+ */
+function resolveFolderExtensionEntries(dir: string): DiscoveredExtensionEntry[] {
+  const manifestPaths = readManifestEntryPaths(dir);
+
+  if (manifestPaths && manifestPaths.length > 0) {
+    const folderName = basename(dir);
+    return manifestPaths.map((path) => ({
+      id:
+        manifestPaths.length === 1 && folderName.length > 0 ? folderName : deriveExtensionId(path),
+      path,
+      sortKey: dir,
+    }));
+  }
+
+  const folderIndex = findFolderExtensionIndex(dir);
+  return folderIndex ? [toStandaloneEntry(folderIndex)] : [];
+}
+
+/**
  * Scan one extensions directory for entry files.
  *
- * Matches `<dir>/*.{ts,js,mjs}` plus exactly one level of
- * `<dir>/<name>/index.{ts,js,mjs}`, so folder extensions can keep helper
- * modules beside their entry file without being scanned as entries themselves.
+ * Matches `<dir>/*.{ts,js,mjs}` plus exactly one level of folder extensions —
+ * either a `package.json` manifest or `<dir>/<name>/index.{ts,js,mjs}` — so
+ * folder extensions can keep helper modules beside their entry file without
+ * being scanned as entries themselves.
  */
-function scanExtensionsDir(dir: string) {
-  const entryPaths: string[] = [];
+function scanExtensionsDir(dir: string): DiscoveredExtensionEntry[] {
+  const entries: DiscoveredExtensionEntry[] = [];
 
   for (const entry of readSortedDirEntries(dir)) {
     const entryPath = join(dir, entry.name);
 
     if (entry.isDirectory()) {
-      const folderIndex = findFolderExtensionIndex(entryPath);
-      if (folderIndex) {
-        entryPaths.push(folderIndex);
-      }
+      entries.push(...resolveFolderExtensionEntries(entryPath));
       continue;
     }
 
     if (EXTENSION_ENTRY_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) {
-      entryPaths.push(entryPath);
+      entries.push(toStandaloneEntry(entryPath));
     }
   }
 
-  return entryPaths;
+  return entries;
 }
 
 /**
@@ -110,25 +201,26 @@ function expandHomePath(path: string) {
 /**
  * Expand one explicit path into entry files.
  *
- * A directory holding its own `index.{ts,js,mjs}` is one folder extension and
- * expands to just that entry: its helper modules sit beside the index and must
- * not be loaded as separate extensions. Only a directory without an index is a
- * container of extensions and gets scanned. Anything else is taken as a literal
- * entry file so a mistyped path still reaches the host and is reported as a
- * load issue rather than vanishing.
+ * A directory that resolves as a folder extension — by `package.json` manifest
+ * or by its own `index.{ts,js,mjs}` — expands to just those entries: its helper
+ * modules sit beside the entry file and must not be loaded as separate
+ * extensions. Only a directory that is not a folder extension is a container of
+ * extensions and gets scanned. Anything else is taken as a literal entry file so
+ * a mistyped path still reaches the host and is reported as a load issue rather
+ * than vanishing.
  */
-function expandExplicitPath(path: string, cwd: string) {
+function expandExplicitPath(path: string, cwd: string): DiscoveredExtensionEntry[] {
   const homeExpanded = expandHomePath(path);
   const resolvedPath = isAbsolute(homeExpanded)
     ? resolve(homeExpanded)
     : resolve(cwd, homeExpanded);
 
   if (!isDirectory(resolvedPath)) {
-    return [resolvedPath];
+    return [toStandaloneEntry(resolvedPath)];
   }
 
-  const folderIndex = findFolderExtensionIndex(resolvedPath);
-  return folderIndex ? [folderIndex] : scanExtensionsDir(resolvedPath);
+  const folderEntries = resolveFolderExtensionEntries(resolvedPath);
+  return folderEntries.length > 0 ? folderEntries : scanExtensionsDir(resolvedPath);
 }
 
 /**
@@ -145,22 +237,22 @@ export function discoverExtensions(options: DiscoverExtensionsOptions = {}): Ext
   const repoRoot = options.repoRoot ?? findVcsRepoRootCandidate(cwd);
   const globalExtensionsDir = options.globalExtensionsDir ?? resolveGlobalExtensionsDir(env);
 
-  const groups: Array<{ origin: ExtensionOrigin; paths: string[] }> = [
+  const groups: Array<{ origin: ExtensionOrigin; entries: DiscoveredExtensionEntry[] }> = [
     {
       origin: "flag",
-      paths: (options.flagPaths ?? []).flatMap((path) => expandExplicitPath(path, cwd)),
+      entries: (options.flagPaths ?? []).flatMap((path) => expandExplicitPath(path, cwd)),
     },
     {
       origin: "config",
-      paths: (options.configPaths ?? []).flatMap((path) => expandExplicitPath(path, cwd)),
+      entries: (options.configPaths ?? []).flatMap((path) => expandExplicitPath(path, cwd)),
     },
     {
       origin: "global",
-      paths: globalExtensionsDir ? scanExtensionsDir(globalExtensionsDir) : [],
+      entries: globalExtensionsDir ? scanExtensionsDir(globalExtensionsDir) : [],
     },
     {
       origin: "repo",
-      paths: [
+      entries: [
         ...(repoRoot ? scanExtensionsDir(join(repoRoot, ".hunk", "extensions")) : []),
         // Repo config contributes arbitrary paths, so treat them with the same
         // trust posture as `.hunk/extensions` rather than as user intent.
@@ -175,13 +267,18 @@ export function discoverExtensions(options: DiscoverExtensionsOptions = {}): Ext
   const seenPaths = new Set<string>();
 
   for (const group of groups) {
-    for (const path of [...group.paths].sort((a, b) => a.localeCompare(b))) {
-      if (seenPaths.has(path)) {
+    // Sorting by `sortKey` rather than by path keeps every entry of one folder
+    // extension at the folder's position, and the sort's stability preserves
+    // the order a manifest declared them in.
+    const sorted = [...group.entries].sort((a, b) => a.sortKey.localeCompare(b.sortKey));
+
+    for (const entry of sorted) {
+      if (seenPaths.has(entry.path)) {
         continue;
       }
 
-      seenPaths.add(path);
-      candidates.push({ id: deriveExtensionId(path), path, origin: group.origin });
+      seenPaths.add(entry.path);
+      candidates.push({ id: entry.id, path: entry.path, origin: group.origin });
     }
   }
 

--- a/src/extensions/host.test.ts
+++ b/src/extensions/host.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { Changeset } from "../core/types";
 import { getVcsOperation } from "../core/vcs";
 import type { VcsAdapter } from "../core/vcs/types";
+import { discoverExtensions } from "./discovery";
 import { loadExtensions } from "./host";
 import { createExtensionNotificationHub } from "./notifications";
 import { deriveExtensionId, type ExtensionCandidate, type ExtensionOrigin } from "./types";
@@ -15,6 +16,14 @@ function createTempDir(prefix: string) {
   const dir = mkdtempSync(join(tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+/** Write one file on disk, creating parent directories as needed. */
+function writeTestFile(dir: string, fileName: string, source: string) {
+  const path = join(dir, fileName);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, source);
+  return path;
 }
 
 /**
@@ -29,9 +38,7 @@ function createTestExtension(
   source: string,
   origin: ExtensionOrigin = "flag",
 ): ExtensionCandidate {
-  const path = join(dir, fileName);
-  mkdirSync(join(path, ".."), { recursive: true });
-  writeFileSync(path, source);
+  const path = writeTestFile(dir, fileName, source);
   return { id: deriveExtensionId(path), path, origin };
 }
 
@@ -123,6 +130,56 @@ export default function (hunk: { registerFileLanguage: (e: string, l: string) =>
     ]);
     expect(result.registry.fileLanguages).toEqual([
       { extensionId: "folder-ext", extension: "proof", language: "graphql" },
+    ]);
+  });
+
+  test("loads a manifest folder extension against its own node_modules", async () => {
+    const root = createTempDir("hunk-host-manifest-dep-");
+    const folder = join(root, "dep-ext");
+    writeTestFile(
+      folder,
+      "package.json",
+      `{"name":"dep-ext","hunk":{"extensions":["./src/index.ts"]},"dependencies":{"fake-dep":"1.0.0"}}`,
+    );
+    // A hand-written dependency stands in for an installed one: the point is
+    // that the entry file resolves imports from the extension's own folder.
+    writeTestFile(
+      join(folder, "node_modules", "fake-dep"),
+      "package.json",
+      `{"name":"fake-dep","version":"1.0.0","main":"index.js"}`,
+    );
+    writeTestFile(
+      join(folder, "node_modules", "fake-dep"),
+      "index.js",
+      `module.exports = { language: "graphql" };\n`,
+    );
+    const entryPath = writeTestFile(
+      folder,
+      join("src", "index.ts"),
+      `import fakeDep from "fake-dep";
+
+export default function (hunk: { registerFileLanguage: (e: string, l: string) => void }) {
+  hunk.registerFileLanguage("dep", fakeDep.language);
+}
+`,
+    );
+
+    // Going through discovery is the point: the manifest is what turns the
+    // folder into this one entry, and what keeps the folder's name as the id.
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [folder],
+      env: {},
+    });
+    const result = await loadExtensions({ candidates, cwd: root });
+
+    expect(candidates).toEqual([{ id: "dep-ext", path: entryPath, origin: "flag" }]);
+    expect(result.issues).toEqual([]);
+    expect(result.loaded).toEqual([{ id: "dep-ext", sourcePath: entryPath, origin: "flag" }]);
+    expect(result.registry.fileLanguages).toEqual([
+      { extensionId: "dep-ext", extension: "dep", language: "graphql" },
     ]);
   });
 

--- a/src/extensions/host.test.ts
+++ b/src/extensions/host.test.ts
@@ -94,6 +94,38 @@ export default function (hunk: HunkExtensionAPI) {
     ).toBe("transformed");
   });
 
+  test("loads a folder extension whose index imports a sibling module", async () => {
+    const dir = createTempDir("hunk-host-folder-");
+    // The helper is written first so the index's relative import resolves.
+    createTestExtension(
+      dir,
+      join("folder-ext", "helper.ts"),
+      `export const language = "graphql";\n`,
+    );
+    const candidate = createTestExtension(
+      dir,
+      join("folder-ext", "index.ts"),
+      `import { language } from "./helper";
+
+export default function (hunk: { registerFileLanguage: (e: string, l: string) => void }) {
+  hunk.registerFileLanguage("proof", language);
+}
+`,
+      "config",
+    );
+
+    const result = await loadExtensions({ candidates: [candidate], cwd: dir });
+
+    // The id comes from the folder, and the sibling import resolved at load time.
+    expect(result.issues).toEqual([]);
+    expect(result.loaded).toEqual([
+      { id: "folder-ext", sourcePath: candidate.path, origin: "config" },
+    ]);
+    expect(result.registry.fileLanguages).toEqual([
+      { extensionId: "folder-ext", extension: "proof", language: "graphql" },
+    ]);
+  });
+
   test("awaits an async factory before sealing the API", async () => {
     const dir = createTempDir("hunk-host-async-");
     const candidate = createTestExtension(


### PR DESCRIPTION
Extensions can now be folders, matching the pi coding agent's resolution model so a multi-file extension keeps its helper modules (and dependencies) organized in one directory.

## What changed

**Explicit directory paths load as folder extensions** (`b0d32bc`)
- Pointing `--extension <dir>` or `[extensions] paths` at a directory that contains an `index.{ts,js,mjs}` now loads it as **one** folder extension instead of scanning every file inside as a separate extension — previously `git/index.ts` and `git/git.ts` would both have registered.
- Directories without an index keep the existing container-scan behavior, and the scanned locations (`~/.config/hunk/extensions/`, `.hunk/extensions/`) already supported `<name>/index.*` folders — index precedence now has one source of truth (`findFolderExtensionIndex`).

**`package.json` manifests** (`5472a36`)
- A folder's `package.json` may declare entry points via `"hunk": { "extensions": ["./src/index.ts"] }`, which takes precedence over the `index.*` fallback — same priority order as pi's `"pi": { "extensions": [...] }` manifest.
- A manifest may declare multiple entries; they load in manifest order and sort as one unit at the folder's path within their discovery group.
- A single-entry manifest keeps the **folder name** as the extension id, so `[extension.<id>]` config tables stay keyed by the folder the user sees even when the entry is `src/index.ts`.
- The same `package.json` can declare npm dependencies installed into the folder's own `node_modules/`; imports resolve from the entry file as usual (covered by an end-to-end test against a hand-written `node_modules`).
- Malformed or manifest-less `package.json` files fall back to the index entry; manifest entries pointing at missing files are kept so the host reports them as load issues instead of silently vanishing.

## Testing

- 10 new tests: 9 discovery tests (folder-vs-container semantics, index precedence, manifest precedence/ordering/ids, malformed-manifest and missing-entry fallbacks) plus 2 end-to-end `loadExtensions` tests proving sibling `./helper` imports and folder-local `node_modules` resolution actually work at load time.
- `bun run typecheck`, `bun test src/extensions/` (164 pass), `bun run lint`, `bun run check:docs` all clean; full-suite failures confirmed pre-existing at `HEAD~1`.
- Docs updated in `docs/extensions.md` (discovery section + CLI examples); two patch changesets added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016N9gUSDJL41huKuRTHsELb

---
_Generated by [Claude Code](https://claude.ai/code/session_016N9gUSDJL41huKuRTHsELb)_