### PR TITLE
perf(ui): keep wrapped large diffs responsive

### DIFF
--- a/.changeset/calm-diffs-window.md
+++ b/.changeset/calm-diffs-window.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep large wrapped reviews responsive by rendering nearby files and deferring offscreen highlighting.

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -62,7 +62,6 @@ import { createReviewMouseWheelScrollAcceleration } from "../../lib/scrollAccele
 import {
   buildFileSectionLayouts,
   buildInStreamFileHeaderHeights,
-  collectIntersectingFileSectionIds,
   findHeaderOwningFileSection,
   shouldRenderInStreamFileHeader,
   type FileSectionLayout,
@@ -91,10 +90,11 @@ import { measureFileViewGeometry } from "../../fileViews/geometry";
 import { buildFileViewRenderPlan } from "../../fileViews/renderPlan";
 import { prefetchHighlightedDiff } from "../../diff/useHighlightedDiff";
 import {
-  buildFileRenderWindow,
-  buildFileSectionIndexById,
-  type FileRenderWindowItem,
-} from "../../lib/fileRenderWindow";
+  buildHighlightPrefetchPlan,
+  prefetchImmediateHighlightedFiles,
+  scheduleSpeculativeHighlightedFiles,
+} from "../../diff/highlightPrefetch";
+import { buildFileRenderWindow, buildFileSectionIndexById } from "../../lib/fileRenderWindow";
 import {
   buildCopySelectedRowKeys,
   clampCopyColumn,
@@ -143,75 +143,6 @@ function streamRowBoundsAt(
   return section && bounds
     ? { top: section.bodyTop + bounds.top, height: bounds.height }
     : undefined;
-}
-
-/** Keep syntax highlighting warm for files immediately adjacent to the selection. */
-function buildAdjacentPrefetchFileIds(files: DiffFile[], selectedFileId?: string) {
-  if (!selectedFileId) {
-    return new Set<string>();
-  }
-
-  const selectedIndex = files.findIndex((file) => file.id === selectedFileId);
-  if (selectedIndex < 0) {
-    return new Set<string>();
-  }
-
-  const next = new Set<string>();
-  const previousFile = files[selectedIndex - 1];
-  const nextFile = files[selectedIndex + 1];
-
-  if (previousFile) {
-    next.add(previousFile.id);
-  }
-
-  if (nextFile) {
-    next.add(nextFile.id);
-  }
-
-  return next;
-}
-
-/**
- * Start highlight work before files visibly enter the review stream.
- *
- * Selected and adjacent files cover direct navigation, while the larger viewport halo keeps
- * wheel and track scrolling warm. Highlight prefetch does not force these files to mount.
- */
-function buildHighlightPrefetchFileIds({
-  adjacentPrefetchFileIds,
-  fileSectionLayouts,
-  rapidScrollOverscanRows,
-  scrollTop,
-  viewportHeight,
-  selectedFileId,
-}: {
-  adjacentPrefetchFileIds: Set<string>;
-  fileSectionLayouts: FileSectionLayout[];
-  rapidScrollOverscanRows: number;
-  scrollTop: number;
-  viewportHeight: number;
-  selectedFileId?: string;
-}) {
-  const next = new Set(adjacentPrefetchFileIds);
-
-  if (selectedFileId) {
-    next.add(selectedFileId);
-  }
-
-  const clampedViewportHeight = Math.max(1, viewportHeight);
-  const prefetchRows = Math.max(24, clampedViewportHeight * 3, rapidScrollOverscanRows);
-  const minPrefetchY = Math.max(0, scrollTop - prefetchRows);
-  const maxPrefetchY = scrollTop + viewportHeight + prefetchRows;
-
-  for (const fileId of collectIntersectingFileSectionIds(
-    fileSectionLayouts,
-    minPrefetchY,
-    maxPrefetchY,
-  )) {
-    next.add(fileId);
-  }
-
-  return next;
 }
 
 const EMPTY_EXPANDED_GAP_KEYS: ReadonlySet<string> = new Set();
@@ -380,11 +311,6 @@ export function DiffPane({
     hoveredFileIdRef.current = null;
     onActiveAddNoteAffordanceChangeRef.current?.(null);
   }, []);
-
-  const adjacentPrefetchFileIds = useMemo(
-    () => buildAdjacentPrefetchFileIds(files, selectedFileId),
-    [files, selectedFileId],
-  );
 
   // Stable per-file select callbacks keep memoized sections from re-rendering just because
   // DiffPane re-rendered. The latest-onSelectFile ref means the cached closures never go
@@ -595,9 +521,6 @@ export function DiffPane({
     return next;
   }, [allAgentNotesByFile, fileViews, files]);
 
-  // Keep the full file-section path for wrapped lines, where exact wrapped heights depend on
-  // mounting each section; nowrap reviews can window offscreen files behind exact spacers.
-  const windowingEnabled = !wrapLines;
   const [scrollViewport, setScrollViewport] = useState({ top: 0, height: 0 });
   const [initialWrappedRenderWindowWarmed, setInitialWrappedRenderWindowWarmed] = useState(
     () => !wrapLines,
@@ -1350,10 +1273,10 @@ export function DiffPane({
     [totalContentHeight],
   );
 
-  const highlightPrefetchFileIds = useMemo(
+  const highlightPrefetchPlan = useMemo(
     () =>
-      buildHighlightPrefetchFileIds({
-        adjacentPrefetchFileIds,
+      buildHighlightPrefetchPlan({
+        files,
         fileSectionLayouts,
         rapidScrollOverscanRows,
         scrollTop: scrollViewport.top,
@@ -1361,7 +1284,7 @@ export function DiffPane({
         selectedFileId,
       }),
     [
-      adjacentPrefetchFileIds,
+      files,
       fileSectionLayouts,
       rapidScrollOverscanRows,
       scrollViewport.height,
@@ -1370,27 +1293,45 @@ export function DiffPane({
     ],
   );
 
-  // Kick off highlight work from viewport planning rather than waiting for the section to mount.
-  // That avoids the "plain rows first, color later" stutter when a file is about to scroll onscreen.
+  // Selected and visible files must be ready for the next frame, so they bypass speculative work.
   useEffect(() => {
     if (files.length === 0 || (wrapLines && !initialWrappedRenderWindowWarmed)) {
       return;
     }
 
-    for (const file of files) {
-      if (!highlightPrefetchFileIds.has(file.id)) {
-        continue;
-      }
-
-      void prefetchHighlightedDiff({
-        file,
-        offloadLargeDiff,
-        theme,
-      });
-    }
+    prefetchImmediateHighlightedFiles({
+      files,
+      immediateFileIds: highlightPrefetchPlan.immediateFileIds,
+      offloadLargeDiff,
+      prefetch: prefetchHighlightedDiff,
+      theme,
+    });
   }, [
     files,
-    highlightPrefetchFileIds,
+    highlightPrefetchPlan.immediateFileIds,
+    initialWrappedRenderWindowWarmed,
+    offloadLargeDiff,
+    theme,
+    wrapLines,
+  ]);
+
+  useEffect(() => {
+    if (files.length === 0 || (wrapLines && !initialWrappedRenderWindowWarmed)) {
+      return;
+    }
+
+    // Highlighting is non-preemptible main-thread work. Delay speculative neighbors until review
+    // navigation and scrolling have been idle long enough to keep the next interaction frame free.
+    return scheduleSpeculativeHighlightedFiles({
+      files,
+      offloadLargeDiff,
+      prefetch: prefetchHighlightedDiff,
+      speculativeFileIds: highlightPrefetchPlan.speculativeFileIds,
+      theme,
+    });
+  }, [
+    files,
+    highlightPrefetchPlan.speculativeFileIds,
     initialWrappedRenderWindowWarmed,
     offloadLargeDiff,
     theme,
@@ -1470,35 +1411,29 @@ export function DiffPane({
     renderer.intermediateRender();
   }, [renderer, pinnedHeaderFileId]);
 
-  const fullFileRenderItems = useMemo(
-    (): FileRenderWindowItem[] =>
-      files.map((file, sectionIndex) => ({ kind: "file", fileId: file.id, sectionIndex })),
-    [files],
-  );
+  // Exact full-stream geometry is available before mount in both modes, so wrapped files can use
+  // the same file-level spacers as nowrap files without changing scrollbar or navigation math.
   const fileRenderWindow = useMemo(
     () =>
-      windowingEnabled
-        ? buildFileRenderWindow({
-            fileSectionLayouts,
-            indexByFileId: fileSectionIndexById,
-            overscanFiles: 1,
-            scrollTop: scrollViewport.top,
-            selectedFileId,
-            viewportHeight: scrollViewport.height,
-          })
-        : null,
+      buildFileRenderWindow({
+        fileSectionLayouts,
+        indexByFileId: fileSectionIndexById,
+        overscanFiles: 1,
+        scrollTop: scrollViewport.top,
+        selectedFileId,
+        viewportHeight: scrollViewport.height,
+      }),
     [
       fileSectionIndexById,
       fileSectionLayouts,
       scrollViewport.height,
       scrollViewport.top,
       selectedFileId,
-      windowingEnabled,
     ],
   );
-  const fileRenderItems = fileRenderWindow?.items ?? fullFileRenderItems;
-  const mountedFileIndices = fileRenderWindow?.mountedFileIndices ?? null;
-  // Render note rows for exactly the mounted sections (all sections when windowing is off).
+  const fileRenderItems = fileRenderWindow.items;
+  const mountedFileIndices = fileRenderWindow.mountedFileIndices;
+  // Render note rows for exactly the mounted sections.
   // Section layouts and spacer heights are measured with the full note set, so a mounted section
   // that skipped its notes would paint shorter than its layout height and transiently shrink the
   // scrollbox content height, clamping bottom-edge scrolls. A viewport-proximity set cannot be
@@ -1507,11 +1442,8 @@ export function DiffPane({
   const visibleAgentNotesByFile = useMemo(() => {
     const next = new Map<string, VisibleAgentNote[]>();
 
-    const mountedFileIds = mountedFileIndices
-      ? mountedFileIndices.map((index) => files[index]?.id)
-      : files.map((file) => file.id);
-
-    for (const fileId of mountedFileIds) {
+    for (const index of mountedFileIndices) {
+      const fileId = files[index]?.id;
       if (!fileId) {
         continue;
       }
@@ -1558,9 +1490,7 @@ export function DiffPane({
       rapidScrollOverscanRows,
     );
 
-    const indicesToMeasure = mountedFileIndices ?? files.map((_, index) => index);
-
-    for (const index of indicesToMeasure) {
+    for (const index of mountedFileIndices) {
       const file = files[index];
       const sectionLayout = fileSectionLayouts[index];
       const geometry = sectionGeometry[index];
@@ -2415,7 +2345,7 @@ export function DiffPane({
                         }
                         shouldLoadHighlight={
                           (!wrapLines || initialWrappedRenderWindowWarmed) &&
-                          highlightPrefetchFileIds.has(file.id)
+                          highlightPrefetchPlan.immediateFileIds.has(file.id)
                         }
                         sectionGeometry={sectionGeometry[index]}
                         separatorWidth={separatorWidth}

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1,9 +1,10 @@
-import { describe, expect, mock, spyOn, test } from "bun:test";
+import { describe, expect, jest, mock, spyOn, test } from "bun:test";
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
 import { act, createRef, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type { AppBootstrap } from "../../core/bootstrap";
 import type { DiffFile } from "../../core/changeset/model";
+import type { ExtensionFileViewLayout } from "../../extension-api/types";
 import { createTestVcsAppBootstrap } from "../../../test/helpers/app-bootstrap";
 import { capturedTestColorToHex } from "../../../test/helpers/test-color-helpers";
 import {
@@ -14,13 +15,17 @@ import {
 import { createVisibleAgentNote } from "../lib/agentAnnotations";
 import { hexColorDistance } from "../lib/color";
 import { RAPID_SCROLL_OVERSCAN_IDLE_MS } from "../lib/adaptiveScrollOverscan";
+import { VIEWPORT_READ_COALESCE_MS } from "../lib/viewportTiming";
 import { resolveTheme } from "../themes";
 import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts, buildInStreamFileHeaderHeights } from "../lib/fileSectionLayout";
 import { builtinCommandKeyDefaults, builtinCommandMatchProbes } from "../lib/appCommands";
 import { resolveCommandKeys } from "../lib/keymap";
 import type { CurrentLineAlignment, LineRevealPlacement } from "../lib/hunkScroll";
+import type { DiffRow } from "../diff/diffRows";
 import type { LineCursor } from "../lib/lineCursors";
+import { validateFileViewLayout } from "../fileViews/layout";
+import type { ResolvedFileViewLayout } from "../fileViews/useFileViews";
 
 const { AppHost } = await import("../AppHost");
 const { toReadOnlyFileViews } = await import("../../extensions/events");
@@ -28,6 +33,7 @@ const { BuiltInSidebarView } = await import("../../extensions/default/ui/sidebar
 const { HelpDialog } = await import("./chrome/HelpDialog");
 const { AgentCard } = await import("./panes/AgentCard");
 const { AgentInlineNote, measureAgentInlineNoteHeight } = await import("./panes/AgentInlineNote");
+const highlightPrefetchModule = await import("../diff/highlightPrefetch");
 const { DiffPane } = await import("./panes/DiffPane");
 const { MenuDropdown } = await import("./chrome/MenuDropdown");
 const { StatusBar } = await import("./chrome/StatusBar");
@@ -80,28 +86,30 @@ function createWindowingFiles(count: number) {
   );
 }
 
-function createHighlightPrefetchWindowFiles() {
-  return Array.from({ length: 4 }, (_, index) => {
-    const marker = `prefetchMarker${index + 1}`;
-    const before = lines(
-      `export const ${marker} = ${index + 1};`,
-      ...Array.from(
-        { length: 8 },
-        (_, lineIndex) =>
-          `export function keep${index + 1}_${lineIndex}(value: number) { return value + ${lineIndex}; }`,
-      ),
-    );
-    const after = lines(
-      `export const ${marker} = ${index + 100};`,
-      ...Array.from(
-        { length: 8 },
-        (_, lineIndex) =>
-          `export function keep${index + 1}_${lineIndex}(value: number) { return value * ${lineIndex + 2}; }`,
-      ),
-    );
+/** Build validated custom FileViews so scheduler wiring tests never mount the real diff highlighter. */
+function createSchedulerTestFileViews(files: DiffFile[], width: number) {
+  return new Map<string, ResolvedFileViewLayout>(
+    files.map((file, index) => {
+      const layout: ExtensionFileViewLayout = {
+        rows: [{ id: "summary", spans: [{ text: `custom view ${index + 1}` }] }],
+        hunkRows: file.metadata.hunks.map(() => ({ startRow: 0, endRow: 0 })),
+      };
+      const checked = validateFileViewLayout(layout, file.metadata.hunks.length, width);
+      if (!checked.valid) throw new Error(checked.issue);
 
-    return createTestDiffFile(`prefetch-${index + 1}`, `prefetch-${index + 1}.ts`, before, after);
-  });
+      return [
+        file.id,
+        {
+          ...checked.value,
+          key: `test:scheduler:${file.id}`,
+          extensionId: "test",
+          viewId: "scheduler",
+          registrationIdentity: index + 1,
+          layoutGeneration: 1,
+        },
+      ];
+    }),
+  );
 }
 
 function createMultiHunkDiffFile(id: string, path: string) {
@@ -804,7 +812,13 @@ describe("UI components", () => {
         spans: [{ text: "ำำ" }],
       },
     };
-    const measuredHeight = measureRenderedRowHeight(row, 4, 1, false, true, true, theme);
+    const measuredHeight = measureRenderedRowHeight(row, {
+      width: 4,
+      lineNumberDigits: 1,
+      showLineNumbers: false,
+      showHunkHeaders: true,
+      wrapLines: true,
+    });
     const setup = await testRender(
       <DiffRowView
         row={row}
@@ -901,7 +915,13 @@ describe("UI components", () => {
           spans,
         },
       };
-      const measuredHeight = measureRenderedRowHeight(row, 4, 1, false, true, true, theme);
+      const measuredHeight = measureRenderedRowHeight(row, {
+        width: 4,
+        lineNumberDigits: 1,
+        showLineNumbers: false,
+        showHunkHeaders: true,
+        wrapLines: true,
+      });
       const setup = await testRender(
         <DiffRowView
           row={row}
@@ -935,6 +955,100 @@ describe("UI components", () => {
         await act(async () => {
           setup.renderer.destroy();
         });
+      }
+    }
+  });
+
+  test("DiffRowView rendering matches wrapped width reservations at exact boundaries", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const width = 24;
+
+    for (const layout of ["split", "stack"] as const) {
+      const rowForLength = (length: number): DiffRow =>
+        layout === "split"
+          ? {
+              type: "split-line",
+              key: `alpha:split:${length}`,
+              fileId: "alpha",
+              hunkIndex: 0,
+              left: {
+                kind: "context",
+                sign: " ",
+                lineNumber: 1,
+                spans: [{ text: "old" }],
+              },
+              right: {
+                kind: "addition",
+                sign: "+",
+                lineNumber: 1,
+                spans: [{ text: "x".repeat(length) }],
+              },
+            }
+          : {
+              type: "stack-line",
+              key: `alpha:stack:${length}`,
+              fileId: "alpha",
+              hunkIndex: 0,
+              cell: {
+                kind: "addition",
+                sign: "+",
+                newLineNumber: 1,
+                spans: [{ text: "x".repeat(length) }],
+              },
+            };
+      const measure = (length: number) =>
+        measureRenderedRowHeight(rowForLength(length), {
+          width,
+          lineNumberDigits: 1,
+          showLineNumbers: false,
+          showHunkHeaders: true,
+          wrapLines: true,
+          noteGuideSide: "new",
+          reserveAddNoteColumn: true,
+        });
+      let boundary = 1;
+      while (measure(boundary + 1) === 1) {
+        boundary += 1;
+      }
+
+      for (const length of [boundary, boundary + 1]) {
+        const row = rowForLength(length);
+        const measuredHeight = measure(length);
+        const setup = await testRender(
+          <DiffRowView
+            row={row}
+            width={width}
+            lineNumberDigits={1}
+            showLineNumbers={false}
+            showHunkHeaders={true}
+            wrapLines={true}
+            codeHorizontalOffset={0}
+            theme={theme}
+            selected={false}
+            noteGuideSide="new"
+            onStartUserNoteAtHunk={() => {}}
+          />,
+          { width: width + 4, height: 4 },
+        );
+
+        try {
+          await act(async () => {
+            await setup.renderOnce();
+          });
+          const renderedHeight = setup
+            .captureSpans()
+            .lines.filter((line) =>
+              line.spans.some(
+                (span) =>
+                  capturedTestColorToHex(span.bg)?.toLowerCase() === theme.addedBg.toLowerCase(),
+              ),
+            ).length;
+          expect(renderedHeight).toBe(measuredHeight);
+        } finally {
+          await act(async () => {
+            setup.renderer.destroy();
+          });
+        }
       }
     }
   });
@@ -1148,6 +1262,146 @@ describe("UI components", () => {
       await act(async () => {
         setup.renderer.destroy();
       });
+    }
+  });
+
+  test("DiffPane keeps wrapped reviews bounded to nearby file sections", async () => {
+    const files = createWindowingFiles(12);
+    const theme = resolveTheme("github-dark-default", null);
+    const scrollRef = createRef<ScrollBoxRenderable>();
+    const props = createDiffPaneProps(files, theme, {
+      diffContentWidth: 48,
+      scrollRef,
+      separatorWidth: 44,
+      width: 52,
+      wrapLines: true,
+    });
+    const setup = await testRender(<DiffPane {...props} />, {
+      width: 56,
+      height: 12,
+    });
+
+    try {
+      await settleDiffPane(setup);
+
+      const mountedFileIds = files
+        .filter((file) => scrollRef.current?.content.findDescendantById(`diff-section:${file.id}`))
+        .map((file) => file.id);
+
+      expect(mountedFileIds).toContain(files[0]!.id);
+      expect(mountedFileIds.length).toBeLessThan(files.length);
+      expect(mountedFileIds).not.toContain(files.at(-1)!.id);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("DiffPane cleans up and reschedules speculative highlighting for selection and coalesced viewport changes", async () => {
+    jest.useFakeTimers();
+    const files = createWindowingFiles(8);
+    const theme = resolveTheme("github-dark-default", null);
+    const scrollRef = createRef<ScrollBoxRenderable>();
+    const fileViews = createSchedulerTestFileViews(files, 48);
+    const cleanupCalls: Array<ReturnType<typeof mock<() => void>>> = [];
+    const immediateSpy = spyOn(
+      highlightPrefetchModule,
+      "prefetchImmediateHighlightedFiles",
+    ).mockImplementation(() => {});
+    const scheduleSpy = spyOn(
+      highlightPrefetchModule,
+      "scheduleSpeculativeHighlightedFiles",
+    ).mockImplementation(() => {
+      const cleanup = mock(() => {});
+      cleanupCalls.push(cleanup);
+      return cleanup;
+    });
+    let selectFile: ((fileId: string) => void) | undefined;
+    let setup: Awaited<ReturnType<typeof testRender>> | undefined;
+    let destroyed = false;
+
+    function SelectionHarness() {
+      const [selectedFileId, setSelectedFileId] = useState(files[0]!.id);
+      selectFile = setSelectedFileId;
+      return (
+        <DiffPane
+          {...createDiffPaneProps(files, theme, {
+            diffContentWidth: 48,
+            fileViews,
+            offloadLargeDiff: true,
+            scrollRef,
+            selectedFileId,
+            separatorWidth: 44,
+            width: 52,
+            wrapLines: true,
+          })}
+        />
+      );
+    }
+
+    try {
+      setup = await testRender(<SelectionHarness />, { width: 56, height: 12 });
+      await act(async () => {
+        await setup!.renderOnce();
+        jest.advanceTimersByTime(VIEWPORT_READ_COALESCE_MS);
+        await setup!.renderOnce();
+      });
+
+      expect(scheduleSpy).toHaveBeenCalledTimes(1);
+      expect(immediateSpy).toHaveBeenCalled();
+      const initialCleanup = cleanupCalls[0]!;
+      scheduleSpy.mockClear();
+
+      await act(async () => {
+        selectFile?.(files[1]!.id);
+        await setup!.renderOnce();
+      });
+
+      expect(initialCleanup).toHaveBeenCalledTimes(1);
+      expect(scheduleSpy).toHaveBeenCalledTimes(1);
+      const selectionCleanup = cleanupCalls[1]!;
+      scheduleSpy.mockClear();
+
+      scrollRef.current?.scrollTo(1);
+      expect(selectionCleanup).not.toHaveBeenCalled();
+      expect(scheduleSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(Math.floor(VIEWPORT_READ_COALESCE_MS / 2) - 1);
+        await setup!.renderOnce();
+      });
+      expect(selectionCleanup).not.toHaveBeenCalled();
+      expect(scheduleSpy).not.toHaveBeenCalled();
+
+      await act(async () => {
+        jest.advanceTimersByTime(1);
+        await setup!.renderOnce();
+      });
+      expect(selectionCleanup).toHaveBeenCalledTimes(1);
+      expect(scheduleSpy).toHaveBeenCalledTimes(1);
+      const viewportCleanup = cleanupCalls[2]!;
+
+      await act(async () => {
+        setup!.renderer.destroy();
+      });
+      destroyed = true;
+
+      expect(viewportCleanup).toHaveBeenCalledTimes(1);
+      // OpenTUI's test renderer retains one host timer after destruction; clear the isolated fake
+      // clock explicitly so no renderer or component work can escape into the next timer case.
+      jest.clearAllTimers();
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      if (setup && !destroyed) {
+        await act(async () => {
+          setup!.renderer.destroy();
+        });
+      }
+      jest.clearAllTimers();
+      scheduleSpy.mockRestore();
+      immediateSpy.mockRestore();
+      jest.useRealTimers();
     }
   });
 
@@ -3586,6 +3840,33 @@ describe("UI components", () => {
     expect(binaryFileFrame).toContain("Binary file skipped");
   });
 
+  test("DiffSectionBody reserves two rendered rows for a no-hunk message", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const frame = await captureFrame(
+      <box style={{ width: 72, flexDirection: "column" }}>
+        <DiffSectionBody
+          file={createEmptyDiffFile("rename-pure")}
+          layout="split"
+          theme={theme}
+          width={72}
+          selectedHunkIndex={0}
+          scrollable={false}
+        />
+        <text>after-placeholder</text>
+      </box>,
+      76,
+      6,
+    );
+    const frameLines = frame.split("\n");
+    const messageLine = frameLines.findIndex((line) =>
+      line.includes("This change only renames the file."),
+    );
+    const sentinelLine = frameLines.findIndex((line) => line.includes("after-placeholder"));
+
+    expect(messageLine).toBeGreaterThanOrEqual(0);
+    expect(sentinelLine - messageLine).toBe(2);
+  });
+
   test("DiffSectionBody shows the expand chevron only when a source fetcher is attached", async () => {
     const { file: baseFile } = createExpandableContextDiffFile("expand-affordance", "expand.ts");
     const theme = resolveTheme("github-dark-default", null);
@@ -3927,64 +4208,6 @@ describe("UI components", () => {
     } finally {
       await act(async () => {
         secondSetup.renderer.destroy();
-      });
-    }
-  });
-
-  test("DiffPane prefetches highlight data for files approaching the viewport before they mount", async () => {
-    const files = createHighlightPrefetchWindowFiles();
-    const theme = resolveTheme("github-dark-default", null);
-    const setup = await testRender(
-      <DiffPane
-        {...createDiffPaneProps(files, theme, {
-          diffContentWidth: 92,
-          separatorWidth: 88,
-          width: 96,
-        })}
-      />,
-      { width: 100, height: 10 },
-    );
-    const thirdFileCheck = await testRender(
-      <DiffSectionBody
-        file={files[2]}
-        layout="split"
-        theme={theme}
-        width={180}
-        selectedHunkIndex={0}
-        shouldLoadHighlight={false}
-        scrollable={false}
-      />,
-      { width: 184, height: 10 },
-    );
-
-    try {
-      await settleDiffPane(setup);
-
-      const initialFrame = setup.captureCharFrame();
-      expect(initialFrame).not.toContain("prefetch-3.ts");
-
-      let prefetched = false;
-      for (let iteration = 0; iteration < 400; iteration += 1) {
-        await act(async () => {
-          await setup.renderOnce();
-          await thirdFileCheck.renderOnce();
-          await Bun.sleep(0);
-          await setup.renderOnce();
-          await thirdFileCheck.renderOnce();
-          await Bun.sleep(0);
-        });
-
-        if (frameHasHighlightedMarker(thirdFileCheck.captureSpans(), "prefetchMarker3")) {
-          prefetched = true;
-          break;
-        }
-      }
-
-      expect(prefetched).toBe(true);
-    } finally {
-      await act(async () => {
-        thirdFileCheck.renderer.destroy();
-        setup.renderer.destroy();
       });
     }
   });

--- a/src/ui/diff/DiffSectionBody.tsx
+++ b/src/ui/diff/DiffSectionBody.tsx
@@ -24,6 +24,7 @@ import { plannedReviewRowVisible } from "./reviewRowGeometry";
 import { buildDiffSectionRowPlan, type DiffSectionRowPlan } from "./diffSectionRowPlan";
 import { resolveVisiblePlannedRowWindow, type VisibleBodyBounds } from "./rowWindowing";
 import {
+  DIFF_MESSAGE_BODY_HEIGHT,
   diffMessage,
   DiffRowView,
   fitText,
@@ -363,7 +364,14 @@ export function DiffSectionBody({
 
   if (file.metadata.hunks.length === 0) {
     return (
-      <box style={{ width: "100%", paddingLeft: 1, paddingRight: 1, paddingBottom: 1 }}>
+      <box
+        style={{
+          width: "100%",
+          height: DIFF_MESSAGE_BODY_HEIGHT,
+          paddingLeft: 1,
+          paddingRight: 1,
+        }}
+      >
         <text fg={theme.muted}>{fitText(diffMessage(file), Math.max(1, width - 2))}</text>
       </box>
     );

--- a/src/ui/diff/diffSectionGeometry.test.ts
+++ b/src/ui/diff/diffSectionGeometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createVisibleAgentNote, type VisibleAgentNote } from "../lib/agentAnnotations";
 import { measureDiffSectionGeometry } from "./diffSectionGeometry";
+import { DIFF_MESSAGE_BODY_HEIGHT } from "./renderRows";
 import { resolveTheme } from "../themes";
 import {
   createTestDiffFile,
@@ -277,7 +278,7 @@ describe("measureDiffSectionGeometry", () => {
     );
   });
 
-  test("returns a one-row placeholder for files with no visible hunks", () => {
+  test("returns the shared message height for files with no visible hunks", () => {
     const file = createTestDiffFile({
       after: "const stable = true;\n",
       before: "const stable = true;\n",
@@ -288,7 +289,7 @@ describe("measureDiffSectionGeometry", () => {
     const metrics = measureDiffSectionGeometry(file, "split", true, theme);
 
     expect(file.metadata.hunks).toHaveLength(0);
-    expect(metrics.bodyHeight).toBe(1);
+    expect(metrics.bodyHeight).toBe(DIFF_MESSAGE_BODY_HEIGHT);
     expect(metrics.hunkBounds.size).toBe(0);
     expect(metrics.rowBounds).toEqual([]);
   });
@@ -506,4 +507,151 @@ describe("measureDiffSectionGeometry", () => {
 
     expect(longGeometry.bodyHeight).toBeGreaterThan(shortGeometry.bodyHeight);
   });
+});
+
+describe("measureDiffSectionGeometry note-guide width", () => {
+  const theme = resolveTheme("github-dark-default", null);
+  const width = 120;
+  const addNoteBadgeWidth = 3;
+
+  function createGuideFixture(side: "old" | "new", guidedLineLength: number) {
+    const annotatedLines = lines(
+      "const a = 1;",
+      "const anchor = 2;",
+      `const guided = "${"x".repeat(guidedLineLength)}";`,
+      "const tail = 4;",
+    );
+    const unannotatedLines = lines("const a = 1;");
+
+    return createTestDiffFile({
+      after: side === "new" ? annotatedLines : unannotatedLines,
+      before: side === "new" ? unannotatedLines : annotatedLines,
+      id: `guide-${side}-${guidedLineLength}`,
+      path: "guide.ts",
+    });
+  }
+
+  function guideNotes(
+    file: ReturnType<typeof createGuideFixture>,
+    side: "old" | "new",
+  ): VisibleAgentNote[] {
+    return [
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "annotation:guide:0",
+        annotation: {
+          ...(side === "new"
+            ? { newRange: [2, 3] as [number, number] }
+            : { oldRange: [2, 3] as [number, number] }),
+          rationale: "Guide every row the note covers.",
+          summary: "Guide",
+        },
+      }),
+    ];
+  }
+
+  function guidedRowHeight({
+    layout,
+    side,
+    guidedLineLength,
+    withGuide,
+    reserveAddNoteColumn = false,
+  }: {
+    layout: "split" | "stack";
+    side: "old" | "new";
+    guidedLineLength: number;
+    withGuide: boolean;
+    reserveAddNoteColumn?: boolean;
+  }) {
+    const file = createGuideFixture(side, guidedLineLength);
+    const measure = (notes: VisibleAgentNote[]) =>
+      measureDiffSectionGeometry(
+        file,
+        layout,
+        true,
+        theme,
+        notes,
+        width,
+        true,
+        true,
+        undefined,
+        undefined,
+        reserveAddNoteColumn,
+      );
+    const guided = measure(guideNotes(file, side));
+    const guidedRow = guided.plannedRows.find(
+      (row) => row.kind === "diff-row" && row.noteGuideSide === side,
+    );
+    expect(guidedRow).toBeDefined();
+
+    if (withGuide) {
+      return guided.rowBoundsByKey.get(guidedRow!.key)!.height;
+    }
+
+    return measure([]).rowBoundsByStableKey.get(guidedRow!.stableKey)!.height;
+  }
+
+  function exactSingleRowBoundary(measure: (guidedLineLength: number) => number) {
+    let low = 1;
+    let high = 400;
+    expect(measure(low)).toBe(1);
+    expect(measure(high)).toBeGreaterThan(1);
+
+    while (low < high) {
+      const middle = Math.ceil((low + high) / 2);
+      if (measure(middle) === 1) {
+        low = middle;
+      } else {
+        high = middle - 1;
+      }
+    }
+    return low;
+  }
+
+  for (const layout of ["split", "stack"] as const) {
+    test(`${layout} measurement reserves exactly one column for a new-side guide`, () => {
+      const boundary = exactSingleRowBoundary((guidedLineLength) =>
+        guidedRowHeight({
+          layout,
+          side: "new",
+          guidedLineLength,
+          withGuide: false,
+        }),
+      );
+
+      expect(
+        guidedRowHeight({
+          layout,
+          side: "new",
+          guidedLineLength: boundary,
+          withGuide: true,
+        }),
+      ).toBe(2);
+      expect(
+        guidedRowHeight({
+          layout,
+          side: "new",
+          guidedLineLength: boundary - 1,
+          withGuide: true,
+        }),
+      ).toBe(1);
+    });
+
+    test(`${layout} measurement combines guide and add-note reservations`, () => {
+      const boundaryFor = (withGuide: boolean, reserveAddNoteColumn: boolean) =>
+        exactSingleRowBoundary((guidedLineLength) =>
+          guidedRowHeight({
+            layout,
+            side: "new",
+            guidedLineLength,
+            withGuide,
+            reserveAddNoteColumn,
+          }),
+        );
+      const plain = boundaryFor(false, false);
+
+      expect(boundaryFor(true, false)).toBe(plain - 1);
+      expect(boundaryFor(false, true)).toBe(plain - addNoteBadgeWidth);
+      expect(boundaryFor(true, true)).toBe(plain - addNoteBadgeWidth - 1);
+    });
+  }
 });

--- a/src/ui/diff/diffSectionGeometry.ts
+++ b/src/ui/diff/diffSectionGeometry.ts
@@ -15,7 +15,7 @@ import {
 } from "./reviewRowGeometry";
 import type { PlannedFileViewRow } from "../fileViews/renderPlan";
 import type { PlannedReviewRow } from "./reviewRenderPlan";
-import { measureRenderedRowHeight } from "./renderRows";
+import { DIFF_MESSAGE_BODY_HEIGHT, measureRenderedRowHeight } from "./renderRows";
 
 const EMPTY_EXPANDED_GAP_KEYS: ReadonlySet<string> = new Set();
 const EMPTY_VISIBLE_AGENT_NOTES: VisibleAgentNote[] = [];
@@ -195,7 +195,6 @@ interface DiffSectionRowHeightOptions {
   showHunkHeaders: boolean;
   showLineNumbers: boolean;
   reserveAddNoteColumn: boolean;
-  theme: AppTheme;
   width: number;
   wrapLines: boolean;
 }
@@ -208,7 +207,6 @@ function buildDiffSectionRowHeightOptions(
     showHunkHeaders,
     showLineNumbers,
     reserveAddNoteColumn,
-    theme,
     width,
     wrapLines,
   }: Omit<DiffSectionRowHeightOptions, "lineNumberDigits">,
@@ -219,7 +217,6 @@ function buildDiffSectionRowHeightOptions(
     showHunkHeaders,
     reserveAddNoteColumn,
     showLineNumbers,
-    theme,
     width,
     wrapLines,
   };
@@ -234,7 +231,6 @@ function measurePlannedDiffSectionRowHeight(
     showHunkHeaders,
     reserveAddNoteColumn,
     showLineNumbers,
-    theme,
     width,
     wrapLines,
   }: DiffSectionRowHeightOptions,
@@ -248,16 +244,15 @@ function measurePlannedDiffSectionRowHeight(
     });
   }
 
-  return measureRenderedRowHeight(
-    row.row,
-    width,
+  return measureRenderedRowHeight(row.row, {
     lineNumberDigits,
-    showLineNumbers,
-    showHunkHeaders,
-    wrapLines,
-    theme,
+    noteGuideSide: row.noteGuideSide,
     reserveAddNoteColumn,
-  );
+    showHunkHeaders,
+    showLineNumbers,
+    width,
+    wrapLines,
+  });
 }
 
 /** Measure one file section from the same render plan used by DiffSectionBody. */
@@ -277,7 +272,7 @@ export function measureDiffSectionGeometry(
 ): DiffSectionGeometry {
   if (file.metadata.hunks.length === 0) {
     return {
-      bodyHeight: 1,
+      bodyHeight: DIFF_MESSAGE_BODY_HEIGHT,
       hunkAnchorRows: new Map(),
       hunkBounds: new Map(),
       lineNumberDigits: String(findMaxLineNumber(file)).length,
@@ -331,7 +326,6 @@ export function measureDiffSectionGeometry(
     showHunkHeaders,
     reserveAddNoteColumn,
     showLineNumbers,
-    theme,
     width,
     wrapLines,
   });

--- a/src/ui/diff/highlightPrefetch.test.ts
+++ b/src/ui/diff/highlightPrefetch.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, jest, mock, test } from "bun:test";
+import type { DiffFile } from "../../core/changeset/model";
+import { buildFileSectionLayouts } from "../lib/fileSectionLayout";
+import { resolveTheme } from "../themes";
+import {
+  buildHighlightPrefetchPlan,
+  prefetchImmediateHighlightedFiles,
+  scheduleSpeculativeHighlightedFiles,
+  type HighlightPrefetch,
+} from "./highlightPrefetch";
+
+/** Build file identities sufficient for highlight policy and scheduler tests. */
+function createFiles(count: number) {
+  return Array.from({ length: count }, (_, index) => ({ id: `file-${index}` })) as DiffFile[];
+}
+
+/** Build exact highlight sets for one selection and viewport without loading the real highlighter. */
+function createHighlightPlan({
+  files,
+  layouts,
+  scrollTop,
+  selectedFileId,
+  viewportHeight = 5,
+}: {
+  files: DiffFile[];
+  layouts: ReturnType<typeof buildFileSectionLayouts>;
+  scrollTop: number;
+  selectedFileId?: string;
+  viewportHeight?: number;
+}) {
+  return buildHighlightPrefetchPlan({
+    files,
+    fileSectionLayouts: layouts,
+    rapidScrollOverscanRows: 0,
+    scrollTop,
+    selectedFileId,
+    viewportHeight,
+  });
+}
+
+/** Resolve speculative calls in review-file dispatch order. */
+function expectedSpeculativeIds(files: DiffFile[], speculativeFileIds: ReadonlySet<string>) {
+  return files.filter((file) => speculativeFileIds.has(file.id)).map((file) => file.id);
+}
+
+/** Read file ids from one injected prefetch mock. */
+function prefetchedIds(prefetch: ReturnType<typeof mock<HighlightPrefetch>>) {
+  return prefetch.mock.calls.map(([options]) => options.file.id);
+}
+
+describe("highlight prefetch scheduling", () => {
+  test("dispatches selected and initially visible files immediately with worker offload", () => {
+    const files = createFiles(8);
+    const layouts = buildFileSectionLayouts(
+      files,
+      files.map(() => 10),
+    );
+    const theme = resolveTheme("github-dark-default", null);
+    const plan = createHighlightPlan({
+      files,
+      layouts,
+      scrollTop: 0,
+      selectedFileId: files[6]!.id,
+    });
+    const prefetch = mock<HighlightPrefetch>(() => undefined);
+
+    expect(
+      [...plan.immediateFileIds].filter((fileId) => plan.speculativeFileIds.has(fileId)),
+    ).toEqual([]);
+
+    prefetchImmediateHighlightedFiles({
+      files,
+      immediateFileIds: plan.immediateFileIds,
+      offloadLargeDiff: true,
+      prefetch,
+      theme,
+    });
+
+    expect(prefetchedIds(prefetch)).toEqual([files[0]!.id, files[6]!.id]);
+    expect(prefetch.mock.calls.every(([options]) => options.offloadLargeDiff)).toBe(true);
+  });
+
+  test("keeps speculative highlighting quiet until the 300 ms idle boundary", () => {
+    jest.useFakeTimers();
+    const files = createFiles(8);
+    const layouts = buildFileSectionLayouts(
+      files,
+      files.map(() => 10),
+    );
+    const theme = resolveTheme("github-dark-default", null);
+    const plan = createHighlightPlan({ files, layouts, scrollTop: 0 });
+    const prefetch = mock<HighlightPrefetch>(() => undefined);
+    let cancel = () => {};
+
+    try {
+      cancel = scheduleSpeculativeHighlightedFiles({
+        files,
+        offloadLargeDiff: true,
+        prefetch,
+        speculativeFileIds: plan.speculativeFileIds,
+        theme,
+      });
+
+      jest.advanceTimersByTime(299);
+      expect(prefetch).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      expect(prefetchedIds(prefetch)).toEqual(
+        expectedSpeculativeIds(files, plan.speculativeFileIds),
+      );
+      expect(prefetch.mock.calls.every(([options]) => options.offloadLargeDiff)).toBe(true);
+
+      cancel();
+      const completedCalls = prefetch.mock.calls.length;
+      jest.advanceTimersByTime(1_000);
+      expect(prefetch).toHaveBeenCalledTimes(completedCalls);
+    } finally {
+      cancel();
+      jest.useRealTimers();
+    }
+  });
+
+  test("does not allocate a timer when the plan has no speculative-only work", () => {
+    jest.useFakeTimers();
+    const files = createFiles(1);
+    const layouts = buildFileSectionLayouts(files, [10]);
+    const theme = resolveTheme("github-dark-default", null);
+    const plan = createHighlightPlan({
+      files,
+      layouts,
+      scrollTop: 0,
+      selectedFileId: files[0]!.id,
+      viewportHeight: 10,
+    });
+    const prefetch = mock<HighlightPrefetch>(() => undefined);
+    const initialTimerCount = jest.getTimerCount();
+    let cancel = () => {};
+
+    try {
+      expect(plan.speculativeFileIds.size).toBe(0);
+      cancel = scheduleSpeculativeHighlightedFiles({
+        files,
+        offloadLargeDiff: true,
+        prefetch,
+        speculativeFileIds: plan.speculativeFileIds,
+        theme,
+      });
+
+      expect(jest.getTimerCount()).toBe(initialTimerCount);
+      jest.advanceTimersByTime(301);
+      expect(prefetch).not.toHaveBeenCalled();
+      cancel();
+    } finally {
+      cancel();
+      jest.useRealTimers();
+    }
+  });
+
+  test("selection changes cancel the old halo and start a fresh 300 ms deadline", () => {
+    jest.useFakeTimers();
+    const files = createFiles(8);
+    const layouts = buildFileSectionLayouts(
+      files,
+      files.map(() => 10),
+    );
+    const theme = resolveTheme("github-dark-default", null);
+    const oldPlan = createHighlightPlan({
+      files,
+      layouts,
+      scrollTop: 0,
+      selectedFileId: files[1]!.id,
+    });
+    const newPlan = createHighlightPlan({
+      files,
+      layouts,
+      scrollTop: 0,
+      selectedFileId: files[6]!.id,
+    });
+    const expectedNewIds = expectedSpeculativeIds(files, newPlan.speculativeFileIds);
+    const prefetch = mock<HighlightPrefetch>(() => undefined);
+    let cancelOld = () => {};
+    let cancelNew = () => {};
+
+    try {
+      cancelOld = scheduleSpeculativeHighlightedFiles({
+        files,
+        offloadLargeDiff: true,
+        prefetch,
+        speculativeFileIds: oldPlan.speculativeFileIds,
+        theme,
+      });
+
+      jest.advanceTimersByTime(100);
+      cancelOld();
+      cancelNew = scheduleSpeculativeHighlightedFiles({
+        files,
+        offloadLargeDiff: true,
+        prefetch,
+        speculativeFileIds: newPlan.speculativeFileIds,
+        theme,
+      });
+
+      // Total t=300: the cancelled selection's original deadline must do no work.
+      jest.advanceTimersByTime(200);
+      expect(prefetch).not.toHaveBeenCalled();
+
+      // Total t=399: the new selection has been idle for only 299 ms.
+      jest.advanceTimersByTime(99);
+      expect(prefetch).not.toHaveBeenCalled();
+
+      // Total t=400: exactly 300 ms after the selection change, only the new halo starts.
+      jest.advanceTimersByTime(1);
+      expect(prefetchedIds(prefetch)).toEqual(expectedNewIds);
+      expect(prefetch.mock.calls.every(([options]) => options.offloadLargeDiff)).toBe(true);
+
+      cancelNew();
+      const completedCalls = prefetch.mock.calls.length;
+      jest.advanceTimersByTime(1_000);
+      expect(prefetch).toHaveBeenCalledTimes(completedCalls);
+    } finally {
+      cancelNew();
+      cancelOld();
+      jest.useRealTimers();
+    }
+  });
+
+  test("viewport changes cancel the old halo before scheduling the new viewport", () => {
+    jest.useFakeTimers();
+    const files = createFiles(12);
+    const layouts = buildFileSectionLayouts(
+      files,
+      files.map(() => 10),
+    );
+    const theme = resolveTheme("github-dark-default", null);
+    const oldPlan = createHighlightPlan({ files, layouts, scrollTop: 0 });
+    const newPlan = createHighlightPlan({
+      files,
+      layouts,
+      scrollTop: layouts[8]!.bodyTop,
+    });
+    const expectedNewIds = expectedSpeculativeIds(files, newPlan.speculativeFileIds);
+    const prefetch = mock<HighlightPrefetch>(() => undefined);
+    let cancelOld = () => {};
+    let cancelNew = () => {};
+
+    try {
+      cancelOld = scheduleSpeculativeHighlightedFiles({
+        files,
+        offloadLargeDiff: true,
+        prefetch,
+        speculativeFileIds: oldPlan.speculativeFileIds,
+        theme,
+      });
+
+      jest.advanceTimersByTime(100);
+      cancelOld();
+      cancelNew = scheduleSpeculativeHighlightedFiles({
+        files,
+        offloadLargeDiff: true,
+        prefetch,
+        speculativeFileIds: newPlan.speculativeFileIds,
+        theme,
+      });
+
+      jest.advanceTimersByTime(299);
+      expect(prefetch).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1);
+      expect(prefetchedIds(prefetch)).toEqual(expectedNewIds);
+
+      cancelNew();
+      const completedCalls = prefetch.mock.calls.length;
+      jest.advanceTimersByTime(1_000);
+      expect(prefetch).toHaveBeenCalledTimes(completedCalls);
+    } finally {
+      cancelNew();
+      cancelOld();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/ui/diff/highlightPrefetch.ts
+++ b/src/ui/diff/highlightPrefetch.ts
@@ -1,0 +1,141 @@
+import type { DiffFile } from "../../core/changeset/model";
+import type { AppTheme } from "../themes";
+import {
+  collectIntersectingFileSectionIds,
+  type FileSectionLayout,
+} from "../lib/fileSectionLayout";
+
+export const HIGHLIGHT_PREFETCH_IDLE_MS = 300;
+
+export interface HighlightPrefetchOptions {
+  file: DiffFile;
+  offloadLargeDiff: boolean;
+  theme: AppTheme;
+}
+
+export type HighlightPrefetch = (options: HighlightPrefetchOptions) => unknown;
+
+export interface HighlightPrefetchPlan {
+  immediateFileIds: ReadonlySet<string>;
+  speculativeFileIds: ReadonlySet<string>;
+}
+
+/** Plan disjoint immediate and speculative highlight work for the review stream. */
+export function buildHighlightPrefetchPlan({
+  files,
+  fileSectionLayouts,
+  rapidScrollOverscanRows,
+  scrollTop,
+  viewportHeight,
+  selectedFileId,
+}: {
+  files: DiffFile[];
+  fileSectionLayouts: FileSectionLayout[];
+  rapidScrollOverscanRows: number;
+  scrollTop: number;
+  viewportHeight: number;
+  selectedFileId?: string;
+}): HighlightPrefetchPlan {
+  const immediateFileIds = new Set<string>();
+  if (selectedFileId) {
+    immediateFileIds.add(selectedFileId);
+  }
+
+  for (const fileId of collectIntersectingFileSectionIds(
+    fileSectionLayouts,
+    Math.max(0, scrollTop),
+    scrollTop + Math.max(1, viewportHeight),
+  )) {
+    immediateFileIds.add(fileId);
+  }
+
+  const speculativeFileIds = new Set<string>();
+  if (selectedFileId) {
+    const selectedIndex = files.findIndex((file) => file.id === selectedFileId);
+    if (selectedIndex >= 0) {
+      const previousFile = files[selectedIndex - 1];
+      const nextFile = files[selectedIndex + 1];
+
+      if (previousFile) {
+        speculativeFileIds.add(previousFile.id);
+      }
+
+      if (nextFile) {
+        speculativeFileIds.add(nextFile.id);
+      }
+    }
+  }
+
+  const clampedViewportHeight = Math.max(1, viewportHeight);
+  const prefetchRows = Math.max(24, clampedViewportHeight * 3, rapidScrollOverscanRows);
+  const minPrefetchY = Math.max(0, scrollTop - prefetchRows);
+  const maxPrefetchY = scrollTop + viewportHeight + prefetchRows;
+
+  for (const fileId of collectIntersectingFileSectionIds(
+    fileSectionLayouts,
+    minPrefetchY,
+    maxPrefetchY,
+  )) {
+    speculativeFileIds.add(fileId);
+  }
+
+  for (const fileId of immediateFileIds) {
+    speculativeFileIds.delete(fileId);
+  }
+
+  return { immediateFileIds, speculativeFileIds };
+}
+
+/** Dispatch selected and visible highlight work synchronously from the owning effect. */
+export function prefetchImmediateHighlightedFiles({
+  files,
+  immediateFileIds,
+  offloadLargeDiff,
+  prefetch,
+  theme,
+}: {
+  files: DiffFile[];
+  immediateFileIds: ReadonlySet<string>;
+  offloadLargeDiff: boolean;
+  prefetch: HighlightPrefetch;
+  theme: AppTheme;
+}) {
+  for (const file of files) {
+    if (!immediateFileIds.has(file.id)) {
+      continue;
+    }
+
+    void prefetch({ file, offloadLargeDiff, theme });
+  }
+}
+
+/** Schedule cancellable speculative highlighting after the review stream has been idle. */
+export function scheduleSpeculativeHighlightedFiles({
+  files,
+  offloadLargeDiff,
+  prefetch,
+  speculativeFileIds,
+  theme,
+}: {
+  files: DiffFile[];
+  offloadLargeDiff: boolean;
+  prefetch: HighlightPrefetch;
+  speculativeFileIds: ReadonlySet<string>;
+  theme: AppTheme;
+}) {
+  if (speculativeFileIds.size === 0) {
+    return () => {};
+  }
+
+  const timer = setTimeout(() => {
+    for (const file of files) {
+      if (!speculativeFileIds.has(file.id)) {
+        continue;
+      }
+
+      void prefetch({ file, offloadLargeDiff, theme });
+    }
+  }, HIGHLIGHT_PREFETCH_IDLE_MS);
+
+  return () => clearTimeout(timer);
+}

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -235,6 +235,68 @@ const addNoteBadgeText = "[+]";
 const styledTextColorCache = new Map<string, ReturnType<typeof parseColor>>();
 const addNoteSpacerContentCache = new Map<string, StyledText>();
 
+interface RenderedRowWidthBudgetInput {
+  width: number;
+  wrapLines: boolean;
+  reserveAddNoteColumn?: boolean;
+  showAddNoteBadge?: boolean;
+  noteGuideSide?: "old" | "new";
+}
+
+interface RenderedSplitRowWidthBudget {
+  addNoteWidth: number;
+  leftWidth: number;
+  rightRenderWidth: number;
+}
+
+interface RenderedStackRowWidthBudget {
+  addNoteWidth: number;
+  contentWidth: number;
+}
+
+function resolveRenderedRowWidthBudget(
+  rowType: "split-line",
+  input: RenderedRowWidthBudgetInput,
+): RenderedSplitRowWidthBudget;
+function resolveRenderedRowWidthBudget(
+  rowType: "stack-line",
+  input: RenderedRowWidthBudgetInput,
+): RenderedStackRowWidthBudget;
+/**
+ * Resolve the exact widths used to render one diff row.
+ *
+ * Wrapped height depends on these widths, so measurement and rendering must reserve the note guide
+ * and add-note columns through the same path.
+ */
+function resolveRenderedRowWidthBudget(
+  rowType: "split-line" | "stack-line",
+  {
+    width,
+    wrapLines,
+    reserveAddNoteColumn = false,
+    showAddNoteBadge = false,
+    noteGuideSide,
+  }: RenderedRowWidthBudgetInput,
+): RenderedSplitRowWidthBudget | RenderedStackRowWidthBudget {
+  const addNoteWidth =
+    showAddNoteBadge || (wrapLines && reserveAddNoteColumn) ? addNoteBadgeText.length : 0;
+  const newSideGuideWidth = noteGuideSide === "new" ? 1 : 0;
+
+  if (rowType === "stack-line") {
+    return {
+      addNoteWidth,
+      contentWidth: Math.max(0, width - newSideGuideWidth - addNoteWidth),
+    };
+  }
+
+  const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
+  return {
+    addNoteWidth,
+    leftWidth,
+    rightRenderWidth: Math.max(0, rightWidth - newSideGuideWidth - addNoteWidth),
+  };
+}
+
 /** Resolve one OpenTUI color while reusing immutable parsed theme values. */
 function styledTextColor(value: string | undefined) {
   if (!value) {
@@ -498,11 +560,6 @@ function appendWrappedCellChunks(
     palette.contentBg,
     contentHighlightBg,
   );
-}
-
-/** Reserve the hover affordance column in wrapped rows so hover cannot reflow code. */
-function wrappedAddNoteReserveWidth(wrapLines: boolean, reserveAddNoteColumn = false) {
-  return wrapLines && reserveAddNoteColumn ? addNoteBadgeText.length : 0;
 }
 
 /** Render a fixed-width inline span sequence for one diff cell. */
@@ -1684,6 +1741,14 @@ function renderWrappedStackCellLine(
   );
 }
 
+/**
+ * Rows occupied by a no-hunk file body: one message row and one row of inter-section spacing.
+ *
+ * Keeping this aggregate height shared prevents an unmounted placeholder from changing the review
+ * stream extent when file-level windowing replaces it with a spacer.
+ */
+export const DIFF_MESSAGE_BODY_HEIGHT = 2;
+
 /** Review-stream wording for each shared reason a file renders no diff rows. */
 export const DIFF_MESSAGES: Record<ReviewEmptyDiffReason, string> = {
   "rename-only": "No textual hunks. This change only renames the file.",
@@ -1870,17 +1935,27 @@ function renderAddNoteSpacer(key: string, width: number, bg: string) {
   );
 }
 
+interface RenderedRowHeightOptions {
+  width: number;
+  lineNumberDigits: number;
+  showLineNumbers: boolean;
+  showHunkHeaders: boolean;
+  wrapLines: boolean;
+  reserveAddNoteColumn?: boolean;
+  noteGuideSide?: "old" | "new";
+}
+
 /** Measure how many terminal rows one rendered diff row occupies. */
-export function measureRenderedRowHeight(
-  row: DiffRow,
-  width: number,
-  lineNumberDigits: number,
-  showLineNumbers: boolean,
-  showHunkHeaders: boolean,
-  wrapLines: boolean,
-  _theme: AppTheme,
-  reserveAddNoteColumn = false,
-) {
+export function measureRenderedRowHeight(row: DiffRow, options: RenderedRowHeightOptions) {
+  const {
+    lineNumberDigits,
+    noteGuideSide,
+    reserveAddNoteColumn,
+    showHunkHeaders,
+    showLineNumbers,
+    width,
+    wrapLines,
+  } = options;
   if (row.type === "hunk-header") {
     return showHunkHeaders ? 1 : 0;
   }
@@ -1895,8 +1970,12 @@ export function measureRenderedRowHeight(
     }
 
     const markerWidth = 1;
-    const hoverReserveWidth = wrappedAddNoteReserveWidth(wrapLines, reserveAddNoteColumn);
-    const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
+    const { leftWidth, rightRenderWidth } = resolveRenderedRowWidthBudget("split-line", {
+      noteGuideSide,
+      reserveAddNoteColumn,
+      width,
+      wrapLines,
+    });
     const leftGeometry = resolveSplitCellGeometry(
       leftWidth,
       lineNumberDigits,
@@ -1904,7 +1983,7 @@ export function measureRenderedRowHeight(
       markerWidth,
     );
     const rightGeometry = resolveSplitCellGeometry(
-      Math.max(0, rightWidth - hoverReserveWidth),
+      rightRenderWidth,
       lineNumberDigits,
       showLineNumbers,
       markerWidth,
@@ -1924,8 +2003,14 @@ export function measureRenderedRowHeight(
     return 1;
   }
 
+  const { contentWidth } = resolveRenderedRowWidthBudget("stack-line", {
+    noteGuideSide,
+    reserveAddNoteColumn,
+    width,
+    wrapLines,
+  });
   const cellGeometry = resolveStackCellGeometry(
-    Math.max(0, width - wrappedAddNoteReserveWidth(wrapLines, reserveAddNoteColumn)),
+    contentWidth,
     lineNumberDigits,
     showLineNumbers,
     marker().length,
@@ -2111,11 +2196,18 @@ function renderRow(
           ? { side: "old", line: row.left.lineNumber }
           : undefined;
 
-    // Reserve fixed columns for the diff rails, center separator slot, and hover affordance.
-    const addBadgeWidth =
-      showAddNoteBadge || (wrapLines && reserveAddNoteColumn) ? addNoteBadgeText.length : 0;
-    const { leftWidth, rightWidth } = resolveSplitPaneWidths(width);
-    const rightRenderWidth = Math.max(0, rightWidth - (guideOnNewSide ? 1 : 0) - addBadgeWidth);
+    // Measurement reads this same budget, so a wrapped row cannot disagree by one reserved column.
+    const {
+      addNoteWidth: addBadgeWidth,
+      leftWidth,
+      rightRenderWidth,
+    } = resolveRenderedRowWidthBudget("split-line", {
+      noteGuideSide,
+      reserveAddNoteColumn,
+      showAddNoteBadge,
+      width,
+      wrapLines,
+    });
     const leftPrefix = {
       text: guideOnOldSide ? "│" : marker(),
       fg: guideOnOldSide
@@ -2372,9 +2464,16 @@ function renderRow(
         : row.cell.oldLineNumber !== undefined
           ? { side: "old", line: row.cell.oldLineNumber }
           : undefined;
-    const addBadgeWidth =
-      showAddNoteBadge || (wrapLines && reserveAddNoteColumn) ? addNoteBadgeText.length : 0;
-    const contentWidth = Math.max(0, width - (guideOnNewSide ? 1 : 0) - addBadgeWidth);
+    const { addNoteWidth: addBadgeWidth, contentWidth } = resolveRenderedRowWidthBudget(
+      "stack-line",
+      {
+        noteGuideSide,
+        reserveAddNoteColumn,
+        showAddNoteBadge,
+        width,
+        wrapLines,
+      },
+    );
     const prefix = {
       text: guideOnOldSide ? "│" : marker(),
       fg: guideOnOldSide

--- a/src/ui/lib/fileRenderWindow.test.ts
+++ b/src/ui/lib/fileRenderWindow.test.ts
@@ -5,13 +5,13 @@ import { buildFileRenderWindow, type FileRenderWindowItem } from "./fileRenderWi
 
 /** Build simple file-section layouts with realistic separator/header rows after the first file. */
 function createLayouts(count: number, bodyHeight = 10) {
-  const files = Array.from({ length: count }, (_, index) => ({
-    id: `file-${index}`,
-  })) as DiffFile[];
-  return buildFileSectionLayouts(
-    files,
-    Array.from({ length: count }, () => bodyHeight),
-  );
+  return createVariableLayouts(Array.from({ length: count }, () => bodyHeight));
+}
+
+/** Build layouts from explicit per-file body heights, as wrapped files are never uniform. */
+function createVariableLayouts(bodyHeights: number[]) {
+  const files = bodyHeights.map((_, index) => ({ id: `file-${index}` })) as DiffFile[];
+  return buildFileSectionLayouts(files, bodyHeights);
 }
 
 /** Sum exact rendered item heights using the source section layouts for file items. */
@@ -120,6 +120,29 @@ describe("buildFileRenderWindow", () => {
     expect(renderedHeight(plan.items, layouts)).toBe(layouts.at(-1)!.sectionBottom);
   });
 
+  test("keeps a distant selected file sparse without mounting its offscreen neighbors", () => {
+    const layouts = createLayouts(10);
+    const plan = buildFileRenderWindow({
+      fileSectionLayouts: layouts,
+      overscanFiles: 1,
+      scrollTop: 0,
+      selectedFileId: "file-8",
+      viewportHeight: 4,
+    });
+
+    expect(plan.mountedFileIndices).toEqual([0, 1, 8]);
+    expect(plan.mountedFileIndices).not.toContain(7);
+    expect(plan.mountedFileIndices).not.toContain(9);
+    expect(itemSummary(plan.items)).toEqual([
+      { kind: "file", sectionIndex: 0 },
+      { kind: "file", sectionIndex: 1 },
+      { kind: "spacer", height: 72, startIndex: 2, endIndex: 7 },
+      { kind: "file", sectionIndex: 8 },
+      { kind: "spacer", height: 12, startIndex: 9, endIndex: 9 },
+    ]);
+    expect(renderedHeight(plan.items, layouts)).toBe(layouts.at(-1)!.sectionBottom);
+  });
+
   test("mounts explicitly included prefetch files as sparse islands", () => {
     const layouts = createLayouts(6);
     const plan = buildFileRenderWindow({
@@ -173,5 +196,21 @@ describe("buildFileRenderWindow", () => {
     expect(plan.topSpacerHeight).toBe(22);
     expect(plan.bottomSpacerHeight).toBe(22);
     expect(renderedHeight(plan.items, layouts)).toBe(layouts.at(-1)!.sectionBottom);
+  });
+
+  test("preserves exact stream height across variable wrapped file bodies", () => {
+    const layouts = createVariableLayouts([3, 17, 5, 29, 2, 13]);
+    const scrollPositions = [0, 4, layouts[2]!.bodyTop, layouts[4]!.bodyTop, 999];
+
+    for (const scrollTop of scrollPositions) {
+      const plan = buildFileRenderWindow({
+        fileSectionLayouts: layouts,
+        overscanFiles: 1,
+        scrollTop,
+        viewportHeight: 7,
+      });
+
+      expect(renderedHeight(plan.items, layouts)).toBe(layouts.at(-1)!.sectionBottom);
+    }
   });
 });

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -688,6 +688,33 @@ end
     ]);
   }
 
+  /** Build a many-file stream whose changed lines wrap into tall sections at test widths. */
+  function createWrappedStreamRepoFixture(fileCount = 8) {
+    function markerLine(fileNumber: number, suffix: string) {
+      const filler = Array.from(
+        { length: 3 },
+        (_, part) => `segment${part}OfFile${fileNumber}PaddedWideEnoughToForceContinuationRows`,
+      ).join(" ");
+
+      return `export const marker${fileNumber} = "${filler} ${suffix}";`;
+    }
+
+    return createGitRepoFixture(
+      Array.from({ length: fileCount }, (_, index) => {
+        const fileNumber = index + 1;
+        return {
+          path: `wrapped-${String(fileNumber).padStart(2, "0")}.ts`,
+          before: `${markerLine(fileNumber, "before")}\n`,
+          after: [
+            markerLine(fileNumber, "after"),
+            `export const marker${fileNumber}Extra = ${fileNumber * 100};`,
+            "",
+          ].join("\n"),
+        };
+      }),
+    );
+  }
+
   function createPinnedHeaderRepoFixture() {
     return createGitRepoFixture([
       {
@@ -1051,6 +1078,7 @@ end
     createUnicodePathRepoFixture,
     createWatchFilePair,
     createWideCharacterFilePair,
+    createWrappedStreamRepoFixture,
     ensureKeyboardIsLive,
     launchHunk,
     launchHunkWithFileBackedStdin,

--- a/test/pty/nav.test.ts
+++ b/test/pty/nav.test.ts
@@ -254,4 +254,73 @@ describe("PTY navigation", () => {
       session.close();
     }
   });
+
+  test("wrapped hunk navigation crosses unmounted file ranges with exact key counts", async () => {
+    const fixture = harness.createWrappedStreamRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split", "--wrap"],
+      cwd: fixture.dir,
+      cols: 160,
+      rows: 10,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      expect(initial).toContain("marker1Extra = 100");
+      expect(initial).not.toContain("marker8Extra = 800");
+
+      await harness.ensureKeyboardIsLive(session);
+
+      // Observe every semantic destination after exactly one keypress. Requiring the intended
+      // marker while excluding the next one makes a double advance fail on file 2, not only at the
+      // endpoint. waitForSnapshot only observes redraws; it never adds navigation input or retries.
+      for (let fileNumber = 2; fileNumber <= 8; fileNumber += 1) {
+        const targetMarker = `marker${fileNumber}Extra = ${fileNumber * 100}`;
+        const beforePress = await session.text({ immediate: true });
+        expect(beforePress).not.toContain(targetMarker);
+
+        await session.press("]");
+        const skippedMarker =
+          fileNumber < 8 ? `marker${fileNumber + 1}Extra = ${(fileNumber + 1) * 100}` : null;
+        const snapshot = await harness.waitForSnapshot(
+          session,
+          (text) =>
+            text.includes(targetMarker) &&
+            (skippedMarker === null || !text.includes(skippedMarker)),
+          5_000,
+        );
+
+        expect(snapshot).toContain(targetMarker);
+        if (skippedMarker) {
+          expect(snapshot).not.toContain(skippedMarker);
+        }
+      }
+
+      for (let fileNumber = 7; fileNumber >= 1; fileNumber -= 1) {
+        const targetMarker = `marker${fileNumber}Extra = ${fileNumber * 100}`;
+        const beforePress = await session.text({ immediate: true });
+        expect(beforePress).not.toContain(targetMarker);
+
+        await session.press("[");
+        const skippedMarker =
+          fileNumber > 1 ? `marker${fileNumber - 1}Extra = ${(fileNumber - 1) * 100}` : null;
+        const snapshot = await harness.waitForSnapshot(
+          session,
+          (text) =>
+            text.includes(targetMarker) &&
+            (skippedMarker === null || !text.includes(skippedMarker)),
+          5_000,
+        );
+
+        expect(snapshot).toContain(targetMarker);
+        if (skippedMarker) {
+          expect(snapshot).not.toContain(skippedMarker);
+        }
+      }
+    } finally {
+      session.close();
+    }
+  });
 });


### PR DESCRIPTION
Fixes #600

## Summary

- Enable exact file-level windowing for wrapped reviews instead of mounting every file section.
- Highlight selected and visible files immediately, while deferring speculative neighbor/offscreen highlighting until navigation is idle.
- Share wrapped-row width budgets between rendering and geometry, including note-guide and add-note columns.
- Give no-hunk messages an explicit two-row body so window spacers and mounted content stay aligned.
- Add component, geometry, render-window, and PTY regressions for wrapped navigation and rapid scrolling.

## Why

Wrapping previously bypassed file-level windowing. On a large review this mounted the entire file stream and eagerly queued syntax highlighting on the main thread, producing a blank startup and high memory use. Exact precomputed section geometry now lets wrapped reviews mount only nearby files without changing scroll or hunk-navigation coordinates.

## Validation

- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run check:docs`
- `bun run changeset:status`
- 96 focused unit/component tests
- 15 targeted PTY tests, including wrapped cross-window hunk navigation and rapid scroll-to-edge recovery
- 64/64 PTY integration tests with an isolated Git/TMP environment
- Compiled binary build
- Frozen 142-file wrapped review (20,853 insertions / 1,480 deletions, 216x60 Kitty), 5/5 valid runs:
  - first paint median 1.403s, max 1.505s
  - peak RSS max 348,618,752 bytes
  - prior affected baseline did not paint within 30s and reached 1,242,595,328 bytes
- Literal local wrapper launch with the compiled candidate: paint, hunk navigation, and clean quit all passed

The broader macOS `bun run test` attempt reached 1,474 passing and 17 skipped tests; three pre-existing session E2E cases remained host-dependent because the harness assumes Linux `script` behavior and has daemon timing sensitivity. The changed surface and PTY integration suites pass, and upstream Linux CI remains authoritative for those session cases.
