### PR TITLE
fix(session): support IPv6 loopback broker URLs

### DIFF
--- a/.changeset/fix-ipv6-session-broker-origins.md
+++ b/.changeset/fix-ipv6-session-broker-origins.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix session commands when the local daemon uses the IPv6 loopback address.

--- a/src/session-broker/brokerConfig.test.ts
+++ b/src/session-broker/brokerConfig.test.ts
@@ -24,6 +24,20 @@ describe("Hunk session daemon config", () => {
     ).toMatchObject({ host: "localhost", port: 49000 });
   });
 
+  test("formats IPv6 literal origins with URL authority brackets", () => {
+    expect(
+      resolveSessionBrokerConfig({
+        [SESSION_BROKER_HOST_ENV]: "::1",
+        [SESSION_BROKER_PORT_ENV]: "49000",
+      }),
+    ).toMatchObject({
+      host: "::1",
+      port: 49000,
+      httpOrigin: "http://[::1]:49000",
+      wsOrigin: "ws://[::1]:49000",
+    });
+  });
+
   test("accepts loopback hosts without an unsafe override", () => {
     expect(isLoopbackHost("127.0.0.1")).toBe(true);
     expect(isLoopbackHost("127.1.2.3")).toBe(true);

--- a/src/session-broker/brokerConfig.ts
+++ b/src/session-broker/brokerConfig.ts
@@ -63,10 +63,13 @@ export function resolveSessionBrokerConfig(
     );
   }
 
+  // URL authorities require brackets around literal IPv6 addresses, unlike socket APIs.
+  const urlHost = isIP(host) === 6 ? `[${host}]` : host;
+
   return {
     host,
     port,
-    httpOrigin: `http://${host}:${port}`,
-    wsOrigin: `ws://${host}:${port}`,
+    httpOrigin: `http://${urlHost}:${port}`,
+    wsOrigin: `ws://${urlHost}:${port}`,
   };
 }


### PR DESCRIPTION
## Summary

- format literal IPv6 session-broker hosts as bracketed URL authorities
- cover IPv6 HTTP and WebSocket origin generation
- add a patch changeset

## Verification

- `bun test src/session-broker/brokerConfig.test.ts`
- `bun run typecheck`
- `bun run lint`

*This PR description was generated by Pi using GPT-5.2*