### PR TITLE
feat(ui): drive menus and help from the command table, and add an Extensions menu

### DIFF
--- a/.changeset/menus-from-command-table.md
+++ b/.changeset/menus-from-command-table.md
@@ -1,0 +1,9 @@
+---
+"hunkdiff": minor
+---
+
+Menus and the controls help dialog now show the keys your commands are actually on. Both are built from the same command table the keyboard dispatches through, so a shortcut remapped in `[keybindings]` is advertised under its new key everywhere instead of only in the config file, and a command you unbind stops claiming a key it no longer answers to.
+
+Extensions get a menu of their own: registered commands are listed in a new **Extensions** menu with their titles and current keys, grouped per extension. A command whose chord was already taken — or that never declared one — is still reachable there with the mouse. The menu appears only when an extension registered a command.
+
+Four actions that were previously menu-only are now named commands, so they can be bound to keys: `hunk.view.toggleCopyDecorations`, `hunk.app.openAgentSkill`, `hunk.review.nextAnnotatedFile`, and `hunk.review.previousAnnotatedFile`.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -100,6 +100,19 @@ held it by default gives it up. The chord grammar itself lives in
 that need internal keys; `src/lib/commandKeys.ts` re-exports it inward and
 keeps the host-only pieces.
 
+The table is also the only description of what each action is called and which
+key runs it, so the mouse surfaces read from it rather than restating it: the
+dropdown menus (`src/ui/lib/appMenus.ts`) declare items as command ids plus
+menu-specific wording and checkbox state, and the controls help dialog
+(`src/ui/lib/helpContent.ts`) declares curated rows the same way — both render
+their key text from resolved `keyLabels` and run entries through
+`executeAppCommand`. A few commands ship with `defaultKeys: []` because they
+exist for a menu item; they never match a key but remain bindable by id. The
+**Extensions** menu is generated from the registered extension commands, one
+item per command grouped by extension, and is absent entirely when there are
+none — which is why the visible menu list is derived from the menus record
+(`buildMenuSpecs` in `src/ui/components/chrome/menu.ts`) rather than fixed.
+
 ## VCS adapters
 
 `src/core/vcs/index.ts` is the single assembly point ordering bundled + user

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -617,6 +617,13 @@ and friends. See [docs/keybindings.md](keybindings.md) for the rules; the
 practical consequence is that a chord you declare may not be the chord your
 command ends up on.
 
+Every registered command is also listed in the menu bar's **Extensions** menu,
+under its `title`, showing whichever key it currently answers to. The menu
+appears only when something registered a command, entries are grouped by
+extension in load order, and running one from the menu is the same dispatch the
+key would have done — so a command with no `key`, or one whose chord was
+refused, is still reachable with the mouse.
+
 The handler fires when the key is pressed outside modal UI — dialogs, menus,
 and focused text inputs own their keys first, and pager mode does not dispatch
 extension commands. It receives the standard context plus `ctx.sidebars`, the

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -44,6 +44,7 @@ The built-in commands and the keys they ship with:
 | `hunk.app.refresh`                  | Refresh the review                       | `r`                          |
 | `hunk.app.toggleHelp`               | Toggle help                              | `?`                          |
 | `hunk.app.toggleFocusArea`          | Switch focus between files and filter    | `tab`                        |
+| `hunk.app.openAgentSkill`           | Show agent skill                         | _(none)_                     |
 | `hunk.review.focusFilter`           | Focus the file filter                    | `/`                          |
 | `hunk.review.startNote`             | Add a review note                        | `c`                          |
 | `hunk.review.editSelectedFile`      | Open the selected file in your editor    | `e`                          |
@@ -53,6 +54,8 @@ The built-in commands and the keys they ship with:
 | `hunk.review.previousFile`          | Previous file                            | `,`                          |
 | `hunk.review.nextAnnotatedHunk`     | Next annotated hunk                      | `}`                          |
 | `hunk.review.previousAnnotatedHunk` | Previous annotated hunk                  | `{`                          |
+| `hunk.review.nextAnnotatedFile`     | Next annotated file                      | _(none)_                     |
+| `hunk.review.previousAnnotatedFile` | Previous annotated file                  | _(none)_                     |
 | `hunk.review.toggleHunkGap`         | Expand or collapse the selected context  | `z`                          |
 | `hunk.review.pageDown`              | Scroll down one page                     | `pagedown`, `space`, `f`     |
 | `hunk.review.pageUp`                | Scroll up one page                       | `pageup`, `b`, `shift+space` |
@@ -70,10 +73,18 @@ The built-in commands and the keys they ship with:
 | `hunk.view.toggleLineNumbers`       | Toggle line numbers                      | `l`                          |
 | `hunk.view.toggleLineWrap`          | Toggle line wrapping                     | `w`                          |
 | `hunk.view.toggleAgentNotes`        | Toggle agent notes                       | `a`                          |
+| `hunk.view.toggleCopyDecorations`   | Toggle copy decorations                  | _(none)_                     |
 | `hunk.view.openThemeSelector`       | Choose theme                             | `t`                          |
 | `hunk.view.layoutSplit`             | Split layout                             | `1`                          |
 | `hunk.view.layoutStack`             | Stack layout                             | `2`                          |
 | `hunk.view.layoutAuto`              | Auto layout                              | `0`                          |
+
+Commands marked _(none)_ ship without a key: they are menu items today, and
+binding one gives it a shortcut like any other.
+
+The menus and the controls help dialog (`?`) show the keys each command is
+currently on, so remapping something changes what they advertise. A command you
+unbind keeps its menu item and simply stops showing a key.
 
 Extension commands are named `<extensionId>.<commandId>` and remap the same way
 (see [docs/extensions.md](extensions.md)). Keys that belong to a dialog,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -697,7 +697,13 @@ export interface ExtensionCommand {
    * cannot shadow one of Hunk's, whichever id an extension is installed under.
    */
   id: string;
-  /** Human-readable name, for diagnostics and future menu listings. */
+  /**
+   * Human-readable name, shown as the command's item in the Extensions menu.
+   *
+   * Every registered command is listed there with the key it currently answers
+   * to, so a command is reachable by mouse even when it ships without a chord
+   * or the one it wanted was already taken.
+   */
   title: string;
   /**
    * Default key chord, e.g. `"ctrl+m"`, `"F2"`, `"G"`, `"y"`, or an array of

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1217,71 +1217,59 @@ export function App({
     setFocusArea("files");
   }, [review.cancelDraftNote]);
 
-  const menus = useMemo(
-    () =>
-      buildAppMenus({
-        canRefreshCurrentInput,
-        focusFilter,
-        layoutMode,
-        moveToAnnotatedFile,
-        moveToAnnotatedHunk,
-        moveToHunk: review.moveToHunk,
-        refreshCurrentInput: triggerRefreshCurrentInput,
-        requestQuit,
-        selectLayoutMode,
-        openThemeSelector,
-        copyDecorations,
-        showAgentNotes,
-        showHelp,
-        showHunkHeaders,
-        showLineNumbers,
-        showMenuBar,
-        renderSidebar,
-        toggleCopyDecorations,
-        toggleAgentNotes,
-        toggleFocusArea,
-        openAgentSkill,
-        toggleHelp,
-        toggleHunkHeaders,
-        toggleLineNumbers,
-        toggleMenuBar,
-        toggleLineWrap,
-        toggleSidebar,
-        triggerEditSelectedFile,
-        wrapLines,
-      }),
-    [
+  // One dispatch table for every app-level shortcut: the built-in commands
+  // over App's live callbacks, then extension commands, so built-ins always
+  // win a key and extension order follows load order.
+  const appCommands = [
+    ...buildAppCommands({
       canRefreshCurrentInput,
-      copyDecorations,
       focusFilter,
-      layoutMode,
       moveToAnnotatedFile,
       moveToAnnotatedHunk,
-      requestQuit,
-      review.moveToHunk,
+      moveToFile,
+      moveToHunk: review.moveToHunk,
       openAgentSkill,
-      selectLayoutMode,
       openThemeSelector,
-      triggerRefreshCurrentInput,
-      toggleCopyDecorations,
-      showAgentNotes,
-      showHelp,
-      showHunkHeaders,
-      showLineNumbers,
-      showMenuBar,
-      renderSidebar,
+      requestQuit,
+      resolvedKeys: resolvedCommandKeys,
+      scrollCodeHorizontally,
+      scrollDiff,
+      selectLayoutMode,
+      startUserNote: () => startUserNote(),
       toggleAgentNotes,
+      toggleCopyDecorations,
       toggleFocusArea,
+      toggleGapForSelectedHunk: review.toggleSelectedHunkGap,
       toggleHelp,
       toggleHunkHeaders,
       toggleLineNumbers,
-      toggleMenuBar,
       toggleLineWrap,
+      toggleMenuBar,
       toggleSidebar,
       triggerEditSelectedFile,
-      wrapLines,
-    ],
-  );
+      triggerRefreshCurrentInput,
+    }),
+    ...extensionAppCommands.commands,
+  ];
+
+  // Menus name commands rather than repeating them: every item's key hint and
+  // action come from the table above, so a remapped shortcut shows its new key
+  // and a menu item can never drift from the command it claims to run. Built
+  // fresh each render — construction is a handful of lookups, and both the
+  // hints and the checkbox state have to stay live.
+  const menus = buildAppMenus({
+    commands: appCommands,
+    extensionCommands: extensionAppCommands.commands,
+    copyDecorations,
+    layoutMode,
+    renderSidebar,
+    showAgentNotes,
+    showHelp,
+    showHunkHeaders,
+    showLineNumbers,
+    showMenuBar,
+    wrapLines,
+  });
 
   const {
     activeMenuEntries,
@@ -1298,38 +1286,6 @@ export function App({
     switchMenu,
     toggleMenu,
   } = useMenuController(menus);
-
-  // One dispatch table for every app-level shortcut: the built-in commands
-  // over App's live callbacks, then extension commands, so built-ins always
-  // win a key and extension order follows load order.
-  const appCommands = [
-    ...buildAppCommands({
-      canRefreshCurrentInput,
-      focusFilter,
-      moveToAnnotatedHunk,
-      moveToFile,
-      moveToHunk: review.moveToHunk,
-      openThemeSelector,
-      requestQuit,
-      resolvedKeys: resolvedCommandKeys,
-      scrollCodeHorizontally,
-      scrollDiff,
-      selectLayoutMode,
-      startUserNote: () => startUserNote(),
-      toggleAgentNotes,
-      toggleFocusArea,
-      toggleGapForSelectedHunk: review.toggleSelectedHunkGap,
-      toggleHelp,
-      toggleHunkHeaders,
-      toggleLineNumbers,
-      toggleLineWrap,
-      toggleMenuBar,
-      toggleSidebar,
-      triggerEditSelectedFile,
-      triggerRefreshCurrentInput,
-    }),
-    ...extensionAppCommands.commands,
-  ];
 
   useAppKeyboardShortcuts({
     activeMenuId,
@@ -1681,7 +1637,7 @@ export function App({
       {!pagerMode && showHelp ? (
         <Suspense fallback={null}>
           <LazyHelpDialog
-            canRefresh={canRefreshCurrentInput}
+            commands={appCommands}
             terminalHeight={terminal.height}
             terminalWidth={terminal.width}
             theme={baseTheme}

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -260,6 +260,68 @@ describe("extension sidebar views", () => {
     });
   });
 
+  test("the Extensions menu lists a registered command and runs it", async () => {
+    const repo = createTestRepo("hunk-ext-sidebar-menu-");
+    const extPath = join(createTempDir("hunk-ext-sidebar-menu-ext-"), "ext.ts");
+    // The command ships without a key on purpose: the menu is the only way to
+    // reach it, which is exactly the mouse/keyboard parity the menu restores.
+    writeFileSync(
+      extPath,
+      `import { createElement } from "react";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerSidebarView({\n` +
+        `    id: "probe",\n` +
+        `    component: () => createElement("text", { content: "EXTSIDEBAR" }),\n` +
+        `  });\n` +
+        `  hunk.registerCommand({ id: "open-probe", title: "Open the probe pane" }, (ctx) => {\n` +
+        `    ctx.sidebars.open("probe");\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("alpha.txt"),
+        "the built-in sidebar to render",
+      );
+      expect(setup.captureCharFrame()).toContain("Extensions");
+
+      // F10 opens the File menu; four steps right lands on Extensions, which
+      // only exists because the extension registered a command.
+      await act(async () => {
+        await setup.mockInput.pressKey("F10");
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("Toggle files/filter focus"),
+        "the menu bar to open",
+      );
+
+      for (let step = 0; step < 4; step += 1) {
+        await act(async () => {
+          await setup.mockInput.pressArrow("right");
+        });
+        await flush(setup);
+      }
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("Open the probe pane"),
+        "the Extensions menu to list the registered command",
+      );
+
+      await act(async () => {
+        await setup.mockInput.pressEnter();
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("EXTSIDEBAR"),
+        "the menu entry to run the extension's handler",
+      );
+    });
+  });
+
   test("a replacesDefault view stands in for the built-in file navigation", async () => {
     const repo = createTestRepo("hunk-ext-sidebar-replace-");
     const extPath = join(createTempDir("hunk-ext-sidebar-replace-ext-"), "ext.ts");

--- a/src/ui/components/chrome/HelpDialog.tsx
+++ b/src/ui/components/chrome/HelpDialog.tsx
@@ -1,75 +1,43 @@
+import type { AppCommand } from "../../lib/appCommands";
+import { buildHelpSections } from "../../lib/helpContent";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
 import { ModalFrame } from "./ModalFrame";
 
-/** Render the in-app controls help modal. */
+/**
+ * Render the in-app controls help modal.
+ *
+ * The rows come from the command table, so what the dialog shows is what the
+ * session's keys actually do, remapped or not.
+ */
 export function HelpDialog({
-  canRefresh = false,
+  commands,
   terminalHeight,
   terminalWidth,
   theme,
   onClose,
 }: {
-  canRefresh?: boolean;
+  commands: readonly AppCommand[];
   terminalHeight: number;
   terminalWidth: number;
   theme: AppTheme;
   onClose: () => void;
 }) {
-  const sections = [
-    {
-      title: "Navigation",
-      items: [
-        ["↑ / ↓", "move line-by-line"],
-        ["Space / f", "page down (alt: f)"],
-        ["b", "page up"],
-        ["Shift+Space", "page up (alt)"],
-        ["d / u", "half page down / up"],
-        ["[ / ]", "previous / next hunk"],
-        [", / .", "previous / next file"],
-        ["{ / }", "previous / next comment"],
-        ["← / →", "scroll code left / right (Shift = faster)"],
-        ["Home / End", "jump to top / bottom"],
-        ["g / G", "jump to top / bottom (less-style)"],
-      ],
-    },
-    {
-      title: "Mouse",
-      items: [
-        ["Wheel", "scroll vertically"],
-        ["Shift+Wheel", "scroll code horizontally"],
-      ],
-    },
-    {
-      title: "View",
-      items: [
-        ["1 / 2 / 0", "split / stack / auto"],
-        ["s / t", "sidebar / theme selector"],
-        ["a", "toggle AI notes"],
-        ["z", "toggle unchanged context"],
-        ["l / w / m / M", "lines / wrap / metadata / menu"],
-        ["e", "open file in $EDITOR"],
-      ],
-    },
-    {
-      title: "Review",
-      items: [
-        ["/", "focus file filter"],
-        ["c", "create review note"],
-        ["Tab", "toggle files/filter focus"],
-        ["F10", "open menus"],
-        [canRefresh ? "r / q" : "q", canRefresh ? "reload / quit" : "quit"],
-      ],
-    },
-  ] as const;
+  const sections = buildHelpSections(commands);
 
   const width = Math.min(74, Math.max(56, terminalWidth - 8));
   const bodyWidth = Math.max(1, width - 4);
-  const keyWidth = Math.min(16, Math.max(12, Math.floor(bodyWidth * 0.28)));
+  const rows = sections.flatMap((section) => section.rows);
+  const longestKeys = Math.max(0, ...rows.map((row) => row.keys.length));
+  const longestDescription = Math.max(0, ...rows.map((row) => row.description.length));
+  // Key text is user-controlled once bindings are, so the column is measured
+  // rather than guessed — but descriptions are given the room they need first,
+  // since a truncated key is still recognizable and a truncated sentence is not.
+  const keyWidth = Math.max(12, Math.min(longestKeys + 1, bodyWidth - longestDescription));
   const descriptionWidth = Math.max(1, bodyWidth - keyWidth);
   const sectionSpacerRowCount = Math.max(0, sections.length - 1);
   const contentRowCount =
-    sections.reduce((rowCount, section) => rowCount + 1 + section.items.length, 0) +
+    sections.reduce((rowCount, section) => rowCount + 1 + section.rows.length, 0) +
     sectionSpacerRowCount;
   // ModalFrame contributes the border rows, title row, padding, and one blank spacer row.
   const modalFrameChromeRowCount = 6;
@@ -83,13 +51,13 @@ export function HelpDialog({
           <box style={{ width: "100%", height: 1 }}>
             <text fg={theme.badgeNeutral}>{section.title}</text>
           </box>
-          {section.items.map(([keys, description]) => (
+          {section.rows.map((row) => (
             <box
-              key={`${section.title}:${keys}`}
+              key={`${section.title}:${row.description}`}
               style={{ width: "100%", height: 1, flexDirection: "row" }}
             >
-              <text fg={theme.accent}>{padText(fitText(keys, keyWidth), keyWidth)}</text>
-              <text fg={theme.muted}>{fitText(description, descriptionWidth)}</text>
+              <text fg={theme.accent}>{padText(fitText(row.keys, keyWidth), keyWidth)}</text>
+              <text fg={theme.muted}>{fitText(row.description, descriptionWidth)}</text>
             </box>
           ))}
           {sectionIndex < sections.length - 1 ? <box style={{ width: "100%", height: 1 }} /> : null}

--- a/src/ui/components/chrome/MenuBar.tsx
+++ b/src/ui/components/chrome/MenuBar.tsx
@@ -1,6 +1,6 @@
 import type { AppTheme } from "../../themes";
 import { fitText } from "../../lib/text";
-import type { MenuId, MenuSpec } from "./menu";
+import { menuBarTitleWidth, type MenuId, type MenuSpec } from "./menu";
 
 /** Render the top menu bar and the current changeset title. */
 export function MenuBar({
@@ -50,7 +50,9 @@ export function MenuBar({
       })}
 
       <box style={{ flexGrow: 1, height: 1, alignItems: "center", justifyContent: "flex-end" }}>
-        <text fg={theme.muted}>{` ${fitText(topTitle, Math.max(0, terminalWidth - 41))}`}</text>
+        <text
+          fg={theme.muted}
+        >{` ${fitText(topTitle, menuBarTitleWidth(menuSpecs, terminalWidth))}`}</text>
       </box>
     </box>
   );

--- a/src/ui/components/chrome/MenuDropdown.tsx
+++ b/src/ui/components/chrome/MenuDropdown.tsx
@@ -1,5 +1,5 @@
 import type { AppTheme } from "../../themes";
-import { padText } from "../../lib/text";
+import { measureTextWidth, padText } from "../../lib/text";
 import type { MenuEntry, MenuId, MenuSpec } from "./menu";
 
 /** Render one actionable menu line with an optional keyboard hint. */
@@ -14,7 +14,9 @@ function renderMenuLine(
       ? `  ${entry.label}`
       : `${entry.checked ? "[x]" : "[ ]"} ${entry.label}`;
   const hint = entry.hint ? entry.hint : "";
-  const leftWidth = Math.max(0, width - hint.length - (hint.length > 0 ? 1 : 0));
+  // Terminal cells, not code units: a shifted-character chord can be any glyph.
+  const hintWidth = measureTextWidth(hint);
+  const leftWidth = Math.max(0, width - hintWidth - (hintWidth > 0 ? 1 : 0));
 
   return (
     <box
@@ -24,7 +26,7 @@ function renderMenuLine(
         <text fg={theme.text}>{padText(text, leftWidth)}</text>
       </box>
       {hint ? (
-        <box style={{ width: hint.length, height: 1 }}>
+        <box style={{ width: hintWidth, height: 1 }}>
           <text fg={selected ? theme.text : theme.muted}>{hint}</text>
         </box>
       ) : null}
@@ -84,7 +86,9 @@ export function MenuDropdown({
           </box>
         ) : (
           <box
-            key={`${activeMenuId}:${entry.label}`}
+            // Command ids are unique where labels need not be: two extensions
+            // may both title a command "Refresh".
+            key={`${activeMenuId}:${entry.commandId ?? `item-${index}`}`}
             style={{
               height: 1,
               paddingLeft: 1,

--- a/src/ui/components/chrome/menu.ts
+++ b/src/ui/components/chrome/menu.ts
@@ -1,4 +1,4 @@
-export type MenuId = "file" | "view" | "navigate" | "agent" | "help";
+export type MenuId = "file" | "view" | "navigate" | "agent" | "extensions" | "help";
 
 export type MenuEntry =
   | {
@@ -19,31 +19,55 @@ export interface MenuSpec {
   label: string;
 }
 
+/**
+ * The dropdown menus one session shows.
+ *
+ * Every id is optional because not all menus always exist: Extensions is there
+ * only when an extension registered a command, and a menu bar with an empty
+ * dropdown on it would be worse than no menu.
+ */
+export type AppMenus = Partial<Record<MenuId, MenuEntry[]>>;
+
 const MENU_LABELS: Record<MenuId, string> = {
   file: "File",
   view: "View",
   navigate: "Navigate",
   agent: "Agent",
+  extensions: "Extensions",
   help: "Help",
 };
 
 export const MENU_ORDER = Object.keys(MENU_LABELS) as MenuId[];
 
-/** Compute menu-bar positions from the fixed top-level menu order. */
-export function buildMenuSpecs() {
-  return MENU_ORDER.reduce<MenuSpec[]>((items, id) => {
-    const previous = items.at(-1);
-    // Each menu label already includes its own leading/trailing padding inside the fixed-width box,
-    // so adjacent menu boxes are packed directly next to each other without an extra inter-box gap.
-    const left = previous ? previous.left + previous.width : 1;
-    items.push({
-      id,
-      left,
-      width: MENU_LABELS[id].length + 2,
-      label: MENU_LABELS[id],
-    });
-    return items;
-  }, []);
+/** The entries of one menu, or none when the session does not show it. */
+export function menuEntries(menus: AppMenus, id: MenuId): MenuEntry[] {
+  return menus[id] ?? [];
+}
+
+/**
+ * Compute menu-bar positions for the menus this session actually has.
+ *
+ * Positions follow `MENU_ORDER`, but a menu with nothing in it takes no space
+ * and no label: what the bar shows and what the keyboard cycles through are the
+ * same derived list, so neither can point at a menu that is not there.
+ */
+export function buildMenuSpecs(menus: AppMenus) {
+  return MENU_ORDER.filter((id) => menuEntries(menus, id).length > 0).reduce<MenuSpec[]>(
+    (items, id) => {
+      const previous = items.at(-1);
+      // Each menu label already includes its own leading/trailing padding inside the fixed-width
+      // box, so adjacent menu boxes are packed directly next to each other without an extra gap.
+      const left = previous ? previous.left + previous.width : 1;
+      items.push({
+        id,
+        left,
+        width: MENU_LABELS[id].length + 2,
+        label: MENU_LABELS[id],
+      });
+      return items;
+    },
+    [],
+  );
 }
 
 /** Find the next selectable menu item, skipping separators. */

--- a/src/ui/components/chrome/menu.ts
+++ b/src/ui/components/chrome/menu.ts
@@ -1,9 +1,13 @@
+import { measureTextWidth } from "../../lib/text";
+
 export type MenuId = "file" | "view" | "navigate" | "agent" | "extensions" | "help";
 
 export type MenuEntry =
   | {
       kind: "item";
       label: string;
+      /** The command this item runs; a stable render identity, since labels may repeat. */
+      commandId?: string;
       hint?: string;
       checked?: boolean;
       action: () => void;
@@ -99,8 +103,25 @@ function menuEntryText(entry: Extract<MenuEntry, { kind: "item" }>) {
 export function menuWidth(entries: MenuEntry[]) {
   return Math.max(
     20,
-    ...entries.map((entry) => (entry.kind === "separator" ? 6 : menuEntryText(entry).length + 2)),
+    // Terminal cells, not code units: extension command titles can carry CJK or
+    // emoji, which render two cells wide and would otherwise be clipped.
+    ...entries.map((entry) =>
+      entry.kind === "separator" ? 6 : measureTextWidth(menuEntryText(entry)) + 2,
+    ),
   );
+}
+
+/**
+ * Cells available for the changeset title beside the menus on the top bar.
+ *
+ * Derived from the specs the bar actually renders, so a session that shows the
+ * Extensions menu cedes its width to the menus instead of overdrawing the row.
+ * The constant covers the bar's own padding, the title's leading space, and a
+ * little breathing room between the last menu and the title.
+ */
+export function menuBarTitleWidth(menuSpecs: readonly MenuSpec[], terminalWidth: number) {
+  const menusWidth = menuSpecs.reduce((total, spec) => total + spec.width, 0);
+  return Math.max(0, terminalWidth - menusWidth - 6);
 }
 
 /** Return the border-inclusive height of a dropdown menu. */

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -15,6 +15,8 @@ import { RAPID_SCROLL_OVERSCAN_IDLE_MS } from "../lib/adaptiveScrollOverscan";
 import { resolveTheme } from "../themes";
 import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts, buildInStreamFileHeaderHeights } from "../lib/fileSectionLayout";
+import { builtinCommandKeyDefaults, builtinCommandMatchProbes } from "../lib/appCommands";
+import { resolveCommandKeys } from "../lib/keymap";
 
 const { AppHost } = await import("../AppHost");
 const { toReadOnlyFileViews } = await import("../../extensions/events");
@@ -2577,7 +2579,7 @@ describe("UI components", () => {
     const theme = resolveTheme("github-dark-default", null);
     const frame = await captureFrame(
       <HelpDialog
-        canRefresh={true}
+        commands={builtinCommandMatchProbes()}
         terminalHeight={39}
         terminalWidth={76}
         theme={theme}
@@ -2591,33 +2593,33 @@ describe("UI components", () => {
       "Controls help",
       "[Esc]",
       "Navigation",
-      "↑ / ↓           move line-by-line",
-      "Space / f       page down (alt: f)",
-      "b               page up",
-      "Shift+Space     page up (alt)",
-      "d / u           half page down / up",
-      "[ / ]           previous / next hunk",
-      ", / .           previous / next file",
-      "{ / }           previous / next comment",
-      "← / →           scroll code left / right (Shift = faster)",
-      "Home / End      jump to top / bottom",
-      "g / G           jump to top / bottom (less-style)",
+      "Up / Down                move line-by-line",
+      "PageDown / Space / f     page down",
+      "PageUp / b / Shift+Space page up",
+      "d / u                    half page down / up",
+      "[ / ]                    previous / next hunk",
+      ", / .                    previous / next file",
+      "{ / }                    previous / next comment",
+      "Left / Right             scroll code sideways (Shift = faster)",
+      "g / Home                 jump to start",
+      "G / End                  jump to end",
       "Mouse",
-      "Wheel           scroll vertically",
-      "Shift+Wheel     scroll code horizontally",
+      "Wheel                    scroll vertically",
+      "Shift+Wheel              scroll code horizontally",
       "View",
-      "1 / 2 / 0       split / stack / auto",
-      "s / t           sidebar / theme",
-      "a               toggle AI notes",
-      "z               toggle unchanged context",
-      "l / w / m / M   lines / wrap / metadata / menu",
-      "e               open file in $EDITOR",
+      "1 / 2 / 0                split / stack / auto",
+      "s / t                    sidebar / theme selector",
+      "a                        toggle AI notes",
+      "z                        toggle unchanged context",
+      "l / w / m / M            lines / wrap / metadata / menu",
+      "e                        open file in $EDITOR",
       "Review",
-      "/               focus file filter",
-      "c               create review note",
-      "Tab             toggle files/filter focus",
-      "F10             open menus",
-      "r / q           reload / quit",
+      "/                        focus file filter",
+      "c                        create review note",
+      "Tab                      toggle files/filter focus",
+      "F10                      open menus",
+      "r                        reload the review",
+      "q                        quit",
     ] as const;
 
     for (const expectedRow of expectedRows) {
@@ -2634,7 +2636,28 @@ describe("UI components", () => {
     expect(lines[viewHeaderIndex - 1]).toMatch(blankModalRow);
     expect(lines[reviewHeaderIndex - 1]).toMatch(blankModalRow);
     expect(frame).not.toContain("linese/Awrapt/smetadata");
-    expect(frame).not.toContain("reloade/uquit");
+  });
+
+  test("HelpDialog shows the keys a remapped command actually answers to", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const { keys } = resolveCommandKeys({
+      defaults: builtinCommandKeyDefaults(),
+      userBindings: { "hunk.app.quit": "ctrl+x" },
+    });
+    const frame = await captureFrame(
+      <HelpDialog
+        commands={builtinCommandMatchProbes(keys)}
+        terminalHeight={39}
+        terminalWidth={76}
+        theme={theme}
+        onClose={() => {}}
+      />,
+      76,
+      39,
+    );
+
+    expect(frame).toContain("Ctrl+X");
+    expect(frame).not.toMatch(/q\s+quit/);
   });
 
   test("DiffPane renders an empty-state message when no files are visible", async () => {

--- a/src/ui/hooks/useMenuController.test.tsx
+++ b/src/ui/hooks/useMenuController.test.tsx
@@ -85,6 +85,80 @@ describe("useMenuController", () => {
     }
   });
 
+  test("re-anchors the highlight when an open menu's entries change", async () => {
+    let controller!: ReturnType<typeof useMenuController>;
+    let setMenus!: (menus: AppMenus) => void;
+    const ran: string[] = [];
+    const runItem = (label: string): MenuEntry => ({
+      kind: "item",
+      label,
+      action: () => ran.push(label),
+    });
+
+    const longFileMenu: AppMenus = {
+      file: [runItem("Focus"), runItem("Reload"), runItem("Quit")],
+    };
+    // "Reload" drops out and a separator lands where "Quit" used to sit.
+    const shrunkFileMenu: AppMenus = {
+      file: [runItem("Focus"), { kind: "separator" }, runItem("Quit")],
+    };
+
+    function Probe({ initial }: { initial: AppMenus }) {
+      const [menus, set] = useState(initial);
+      setMenus = set;
+      controller = useMenuController(menus);
+      return null;
+    }
+
+    const setup = await testRender(<Probe initial={longFileMenu} />, { width: 80, height: 24 });
+
+    try {
+      await act(async () => {
+        await setup.renderOnce();
+      });
+
+      await act(async () => {
+        controller.openMenu("file");
+      });
+      await act(async () => {
+        controller.moveMenuItem(1);
+      });
+      expect(controller.activeMenuItemIndex).toBe(1);
+
+      // The stored index now points at the separator; the highlight resolves
+      // to the nearest selectable item and Enter runs it instead of no-oping.
+      await act(async () => {
+        setMenus(shrunkFileMenu);
+      });
+      expect(controller.activeMenuItemIndex).toBe(2);
+      await act(async () => {
+        controller.activateCurrentMenuItem();
+      });
+      expect(ran).toEqual(["Quit"]);
+
+      // An index past a shrunken list resolves back inside it.
+      await act(async () => {
+        controller.openMenu("file");
+      });
+      await act(async () => {
+        controller.moveMenuItem(1);
+      });
+      expect(controller.activeMenuItemIndex).toBe(2);
+      await act(async () => {
+        setMenus({ file: [runItem("Focus")] });
+      });
+      expect(controller.activeMenuItemIndex).toBe(0);
+      await act(async () => {
+        controller.activateCurrentMenuItem();
+      });
+      expect(ran).toEqual(["Quit", "Focus"]);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("cycling skips menus the session does not show", async () => {
     let controller!: ReturnType<typeof useMenuController>;
 

--- a/src/ui/hooks/useMenuController.test.tsx
+++ b/src/ui/hooks/useMenuController.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act, useState } from "react";
+import type { AppMenus, MenuEntry } from "../components/chrome/menu";
+import { useMenuController } from "./useMenuController";
+
+/**
+ * The controller's behavior when the menus record changes under an open menu —
+ * the Extensions menu vanishes when a session reload drops the last registered
+ * extension command, and the bar must not keep an invisible menu "open".
+ */
+
+function menuItem(label: string): MenuEntry {
+  return { kind: "item", label, action: () => {} };
+}
+
+const BASE_MENUS: AppMenus = {
+  file: [menuItem("Quit")],
+  view: [menuItem("Sidebar")],
+};
+
+const MENUS_WITH_EXTENSIONS: AppMenus = {
+  ...BASE_MENUS,
+  extensions: [menuItem("Open the probe pane")],
+};
+
+describe("useMenuController", () => {
+  test("treats an open menu as closed when its spec vanishes, without reopening on return", async () => {
+    let controller!: ReturnType<typeof useMenuController>;
+    let setMenus!: (menus: AppMenus) => void;
+
+    function Probe({ initial }: { initial: AppMenus }) {
+      const [menus, set] = useState(initial);
+      setMenus = set;
+      controller = useMenuController(menus);
+      return null;
+    }
+
+    const setup = await testRender(<Probe initial={MENUS_WITH_EXTENSIONS} />, {
+      width: 80,
+      height: 24,
+    });
+
+    try {
+      await act(async () => {
+        await setup.renderOnce();
+      });
+
+      await act(async () => {
+        controller.openMenu("extensions");
+      });
+      expect(controller.activeMenuId).toBe("extensions");
+      expect(controller.activeMenuSpec?.id).toBe("extensions");
+
+      // The registry reload drops the extension commands: the open menu's spec
+      // is gone, and the controller reports it closed rather than invisible.
+      await act(async () => {
+        setMenus(BASE_MENUS);
+      });
+      expect(controller.activeMenuId).toBeNull();
+      expect(controller.activeMenuSpec).toBeUndefined();
+      expect(controller.activeMenuEntries).toEqual([]);
+
+      // Closed means really closed: the next toggle opens the menu it names
+      // instead of dismissing a phantom, exactly what an F10 press goes through.
+      await act(async () => {
+        controller.toggleMenu("file");
+      });
+      expect(controller.activeMenuId).toBe("file");
+
+      await act(async () => {
+        controller.closeMenu();
+      });
+
+      // The Extensions menu coming back does not spring the dropdown back open:
+      // the stale id was cleared, not merely masked.
+      await act(async () => {
+        setMenus(MENUS_WITH_EXTENSIONS);
+      });
+      expect(controller.activeMenuId).toBeNull();
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("cycling skips menus the session does not show", async () => {
+    let controller!: ReturnType<typeof useMenuController>;
+
+    function Probe() {
+      controller = useMenuController(BASE_MENUS);
+      return null;
+    }
+
+    const setup = await testRender(<Probe />, { width: 80, height: 24 });
+
+    try {
+      await act(async () => {
+        await setup.renderOnce();
+      });
+
+      await act(async () => {
+        controller.openMenu("file");
+      });
+      await act(async () => {
+        controller.switchMenu(1);
+      });
+      expect(controller.activeMenuId).toBe("view");
+
+      // Wrapping from the last visible menu lands on the first visible one —
+      // never on extensions or help, which this session does not show.
+      await act(async () => {
+        controller.switchMenu(1);
+      });
+      expect(controller.activeMenuId).toBe("file");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+});

--- a/src/ui/hooks/useMenuController.ts
+++ b/src/ui/hooks/useMenuController.ts
@@ -1,15 +1,15 @@
 import { useMemo, useState } from "react";
 import {
-  MENU_ORDER,
   buildMenuSpecs,
+  menuEntries,
   menuWidth,
   nextMenuItemIndex,
-  type MenuEntry,
+  type AppMenus,
   type MenuId,
 } from "../components/chrome/menu";
 
 /** Drive menu selection/open state for the desktop-style top menu bar. */
-export function useMenuController(menus: Record<MenuId, MenuEntry[]>) {
+export function useMenuController(menus: AppMenus) {
   const [activeMenuId, setActiveMenuId] = useState<MenuId | null>(null);
   const [activeMenuItemIndex, setActiveMenuItemIndex] = useState(0);
 
@@ -19,7 +19,7 @@ export function useMenuController(menus: Record<MenuId, MenuEntry[]>) {
 
   const openMenu = (menuId: MenuId) => {
     setActiveMenuId(menuId);
-    setActiveMenuItemIndex(nextMenuItemIndex(menus[menuId], -1, 1));
+    setActiveMenuItemIndex(nextMenuItemIndex(menuEntries(menus, menuId), -1, 1));
   };
 
   const toggleMenu = (menuId: MenuId) => {
@@ -31,14 +31,25 @@ export function useMenuController(menus: Record<MenuId, MenuEntry[]>) {
     openMenu(menuId);
   };
 
+  const menuSpecs = useMemo(() => buildMenuSpecs(menus), [menus]);
+
+  // Cycling walks the menus the bar actually shows, so a session without an
+  // Extensions menu never lands on one that is not there.
   const switchMenu = (delta: number) => {
-    const currentIndex = Math.max(0, activeMenuId ? MENU_ORDER.indexOf(activeMenuId) : 0);
-    const nextIndex = (currentIndex + delta + MENU_ORDER.length) % MENU_ORDER.length;
-    openMenu(MENU_ORDER[nextIndex]!);
+    if (menuSpecs.length === 0) {
+      return;
+    }
+
+    const currentIndex = Math.max(
+      0,
+      activeMenuId ? menuSpecs.findIndex((menu) => menu.id === activeMenuId) : 0,
+    );
+    const nextIndex = (currentIndex + delta + menuSpecs.length) % menuSpecs.length;
+    openMenu(menuSpecs[nextIndex]!.id);
   };
 
   const moveMenuItem = (delta: number) => {
-    const entries = activeMenuId ? menus[activeMenuId] : [];
+    const entries = activeMenuId ? menuEntries(menus, activeMenuId) : [];
     setActiveMenuItemIndex((current) => nextMenuItemIndex(entries, current, delta));
   };
 
@@ -47,7 +58,7 @@ export function useMenuController(menus: Record<MenuId, MenuEntry[]>) {
       return;
     }
 
-    const entry = menus[activeMenuId][activeMenuItemIndex];
+    const entry = menuEntries(menus, activeMenuId)[activeMenuItemIndex];
     if (!entry || entry.kind !== "item") {
       return;
     }
@@ -56,8 +67,7 @@ export function useMenuController(menus: Record<MenuId, MenuEntry[]>) {
     closeMenu();
   };
 
-  const menuSpecs = useMemo(() => buildMenuSpecs(), []);
-  const activeMenuEntries = activeMenuId ? menus[activeMenuId] : [];
+  const activeMenuEntries = activeMenuId ? menuEntries(menus, activeMenuId) : [];
   const activeMenuSpec = menuSpecs.find((menu) => menu.id === activeMenuId);
   const activeMenuWidth = menuWidth(activeMenuEntries) + 2;
 

--- a/src/ui/hooks/useMenuController.ts
+++ b/src/ui/hooks/useMenuController.ts
@@ -67,17 +67,38 @@ export function useMenuController(menus: AppMenus) {
     openMenu(menuSpecs[nextIndex]!.id);
   };
 
+  const activeMenuEntries = openMenuId ? menuEntries(menus, openMenuId) : [];
+
+  // An open menu's entries can also change under the highlight — a watch
+  // reload adds "Reload", extension commands re-register — leaving the stored
+  // positional index on a separator, a shifted row, or past the end. Resolve
+  // a stored index to the nearest selectable item of the list as it is now,
+  // so the visible highlight and Enter always agree on a real entry.
+  const resolveItemIndex = (index: number) => {
+    const entry = activeMenuEntries[index];
+    return entry?.kind === "item"
+      ? index
+      : nextMenuItemIndex(activeMenuEntries, Math.min(index, activeMenuEntries.length) - 1, 1);
+  };
+
+  const openMenuItemIndex = resolveItemIndex(activeMenuItemIndex);
+
+  // Write the resolved index back so later steps start from where the
+  // highlight visibly is, not from the stale position.
+  useEffect(() => {
+    if (openMenuId !== null && openMenuItemIndex !== activeMenuItemIndex) {
+      setActiveMenuItemIndex(openMenuItemIndex);
+    }
+  }, [openMenuId, openMenuItemIndex, activeMenuItemIndex]);
+
   const moveMenuItem = (delta: number) => {
-    const entries = openMenuId ? menuEntries(menus, openMenuId) : [];
-    setActiveMenuItemIndex((current) => nextMenuItemIndex(entries, current, delta));
+    setActiveMenuItemIndex((current) =>
+      nextMenuItemIndex(activeMenuEntries, resolveItemIndex(current), delta),
+    );
   };
 
   const activateCurrentMenuItem = () => {
-    if (!openMenuId) {
-      return;
-    }
-
-    const entry = menuEntries(menus, openMenuId)[activeMenuItemIndex];
+    const entry = activeMenuEntries[openMenuItemIndex];
     if (!entry || entry.kind !== "item") {
       return;
     }
@@ -86,14 +107,13 @@ export function useMenuController(menus: AppMenus) {
     closeMenu();
   };
 
-  const activeMenuEntries = openMenuId ? menuEntries(menus, openMenuId) : [];
   const activeMenuSpec = menuSpecs.find((menu) => menu.id === openMenuId);
   const activeMenuWidth = menuWidth(activeMenuEntries) + 2;
 
   return {
     activeMenuEntries,
     activeMenuId: openMenuId,
-    activeMenuItemIndex,
+    activeMenuItemIndex: openMenuItemIndex,
     activeMenuSpec,
     activeMenuWidth,
     activateCurrentMenuItem,

--- a/src/ui/hooks/useMenuController.ts
+++ b/src/ui/hooks/useMenuController.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   buildMenuSpecs,
   menuEntries,
@@ -13,6 +13,27 @@ export function useMenuController(menus: AppMenus) {
   const [activeMenuId, setActiveMenuId] = useState<MenuId | null>(null);
   const [activeMenuItemIndex, setActiveMenuItemIndex] = useState(0);
 
+  // Plain derivation, not a memo: `menus` is rebuilt every render on purpose
+  // (hints and checked marks must stay live), so a memo keyed on it never hits.
+  const menuSpecs = buildMenuSpecs(menus);
+
+  // A menu can vanish while open — the Extensions menu disappears when a
+  // session reload drops the last registered extension command. The stored id
+  // counts as closed the moment its spec is gone, so the bar never holds an
+  // invisible "open" menu that swallows the next F10 press.
+  const openMenuId =
+    activeMenuId !== null && menuSpecs.some((menu) => menu.id === activeMenuId)
+      ? activeMenuId
+      : null;
+
+  // Also clear the stale id, so the menu does not spring back open if a later
+  // reload re-registers the commands that bring its spec back.
+  useEffect(() => {
+    if (activeMenuId !== null && openMenuId === null) {
+      setActiveMenuId(null);
+    }
+  }, [activeMenuId, openMenuId]);
+
   const closeMenu = () => {
     setActiveMenuId(null);
   };
@@ -23,15 +44,13 @@ export function useMenuController(menus: AppMenus) {
   };
 
   const toggleMenu = (menuId: MenuId) => {
-    if (activeMenuId === menuId) {
+    if (openMenuId === menuId) {
       closeMenu();
       return;
     }
 
     openMenu(menuId);
   };
-
-  const menuSpecs = useMemo(() => buildMenuSpecs(menus), [menus]);
 
   // Cycling walks the menus the bar actually shows, so a session without an
   // Extensions menu never lands on one that is not there.
@@ -42,23 +61,23 @@ export function useMenuController(menus: AppMenus) {
 
     const currentIndex = Math.max(
       0,
-      activeMenuId ? menuSpecs.findIndex((menu) => menu.id === activeMenuId) : 0,
+      openMenuId ? menuSpecs.findIndex((menu) => menu.id === openMenuId) : 0,
     );
     const nextIndex = (currentIndex + delta + menuSpecs.length) % menuSpecs.length;
     openMenu(menuSpecs[nextIndex]!.id);
   };
 
   const moveMenuItem = (delta: number) => {
-    const entries = activeMenuId ? menuEntries(menus, activeMenuId) : [];
+    const entries = openMenuId ? menuEntries(menus, openMenuId) : [];
     setActiveMenuItemIndex((current) => nextMenuItemIndex(entries, current, delta));
   };
 
   const activateCurrentMenuItem = () => {
-    if (!activeMenuId) {
+    if (!openMenuId) {
       return;
     }
 
-    const entry = menuEntries(menus, activeMenuId)[activeMenuItemIndex];
+    const entry = menuEntries(menus, openMenuId)[activeMenuItemIndex];
     if (!entry || entry.kind !== "item") {
       return;
     }
@@ -67,13 +86,13 @@ export function useMenuController(menus: AppMenus) {
     closeMenu();
   };
 
-  const activeMenuEntries = activeMenuId ? menuEntries(menus, activeMenuId) : [];
-  const activeMenuSpec = menuSpecs.find((menu) => menu.id === activeMenuId);
+  const activeMenuEntries = openMenuId ? menuEntries(menus, openMenuId) : [];
+  const activeMenuSpec = menuSpecs.find((menu) => menu.id === openMenuId);
   const activeMenuWidth = menuWidth(activeMenuEntries) + 2;
 
   return {
     activeMenuEntries,
-    activeMenuId,
+    activeMenuId: openMenuId,
     activeMenuItemIndex,
     activeMenuSpec,
     activeMenuWidth,

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -4,6 +4,7 @@ import {
   buildAppCommands,
   builtinCommandKeyDefaults,
   dispatchAppCommand,
+  executeAppCommand,
   type BuildAppCommandsOptions,
   type ResolvedCommandKeys,
 } from "./appCommands";
@@ -34,9 +35,11 @@ function createTestCommands(resolvedKeys?: ResolvedCommandKeys) {
   const options: BuildAppCommandsOptions = {
     canRefreshCurrentInput: true,
     focusFilter: record("focusFilter"),
+    moveToAnnotatedFile: record("moveToAnnotatedFile"),
     moveToAnnotatedHunk: record("moveToAnnotatedHunk"),
     moveToFile: record("moveToFile"),
     moveToHunk: record("moveToHunk"),
+    openAgentSkill: record("openAgentSkill"),
     openThemeSelector: record("openThemeSelector"),
     requestQuit: record("requestQuit"),
     resolvedKeys,
@@ -45,6 +48,7 @@ function createTestCommands(resolvedKeys?: ResolvedCommandKeys) {
     selectLayoutMode: record("selectLayoutMode"),
     startUserNote: record("startUserNote"),
     toggleAgentNotes: record("toggleAgentNotes"),
+    toggleCopyDecorations: record("toggleCopyDecorations"),
     toggleFocusArea: record("toggleFocusArea"),
     toggleGapForSelectedHunk: record("toggleGapForSelectedHunk"),
     toggleHelp: record("toggleHelp"),
@@ -184,11 +188,80 @@ describe("builtinCommandKeyDefaults", () => {
     const { commands } = createTestCommands();
 
     expect(defaults.map((entry) => entry.id)).toEqual(commands.map((command) => command.id));
-    expect(defaults.every((entry) => entry.defaultKeys.length > 0)).toBe(true);
     expect(defaults.find((entry) => entry.id === "hunk.review.pageDown")?.defaultKeys).toEqual([
       "pagedown",
       "space",
       "f",
     ]);
+    // The menu-only commands ship unbound, and are reported so users can bind them.
+    expect(
+      defaults
+        .filter((entry) => entry.defaultKeys.length === 0)
+        .map((entry) => entry.id)
+        .sort(),
+    ).toEqual([
+      "hunk.app.openAgentSkill",
+      "hunk.review.nextAnnotatedFile",
+      "hunk.review.previousAnnotatedFile",
+      "hunk.view.toggleCopyDecorations",
+    ]);
+  });
+});
+
+describe("commands that ship unbound", () => {
+  test("match no key but stay in the table with no labels", () => {
+    const { commands } = createTestCommands();
+    const unbound = commands.find((command) => command.id === "hunk.view.toggleCopyDecorations");
+
+    expect(unbound?.keyLabels).toEqual([]);
+    expect(unbound?.keys).toEqual([]);
+    // A neutral event is what an empty-chord matcher is asked about most often.
+    expect(unbound?.match(keyEvent({}))).toBe(false);
+  });
+
+  test("become dispatchable once the user binds a key to them", () => {
+    const { keys } = resolveCommandKeys({
+      defaults: builtinCommandKeyDefaults(),
+      userBindings: { "hunk.review.nextAnnotatedFile": "ctrl+n" },
+    });
+    const { commands, ran } = createTestCommands(keys);
+
+    expect(dispatchAppCommand(commands, "review", keyEvent({ name: "n", ctrl: true }))?.id).toBe(
+      "hunk.review.nextAnnotatedFile",
+    );
+    expect(ran).toEqual(["moveToAnnotatedFile:1"]);
+    expect(
+      commands.find((command) => command.id === "hunk.review.nextAnnotatedFile")?.keyLabels,
+    ).toEqual(["Ctrl+N"]);
+  });
+});
+
+describe("executeAppCommand", () => {
+  test("runs a command by id whatever key it is on", () => {
+    const { commands, ran } = createTestCommands();
+
+    expect(executeAppCommand(commands, "hunk.app.quit")).toBe(true);
+    // Unbound commands are reachable only this way, which is why menus use it.
+    expect(executeAppCommand(commands, "hunk.app.openAgentSkill")).toBe(true);
+    expect(ran).toEqual(["requestQuit", "openAgentSkill"]);
+  });
+
+  test("passes the command's own first chord to handlers that read the event", () => {
+    const { commands, ran } = createTestCommands();
+
+    // The shifted arrow scrolls further; invoked by name it takes the plain form.
+    expect(executeAppCommand(commands, "hunk.review.scrollCodeLeft")).toBe(true);
+    expect(ran).toEqual(["scrollCodeHorizontally:-1"]);
+  });
+
+  test("refuses a disabled command and an id nobody registered", () => {
+    const { commands, ran } = createTestCommands();
+    const disabled = commands.map((command) =>
+      command.id === "hunk.app.refresh" ? { ...command, isEnabled: () => false } : command,
+    );
+
+    expect(executeAppCommand(disabled, "hunk.app.refresh")).toBe(false);
+    expect(executeAppCommand(commands, "nobody.registered.this")).toBe(false);
+    expect(ran).toEqual([]);
   });
 });

--- a/src/ui/lib/appCommands.ts
+++ b/src/ui/lib/appCommands.ts
@@ -1,6 +1,10 @@
 import type { KeyEvent } from "@opentui/core";
 import type { LayoutMode } from "../../core/types";
-import { matchesAnyKeyChord } from "../../lib/commandKeys";
+import {
+  matchesAnyKeyChord,
+  parseKeyChordOrUndefined,
+  synthesizeKeyEvent,
+} from "../../lib/commandKeys";
 import { formatKeyChord, type CommandKeyDefaults } from "./keymap";
 
 type ScrollUnit = "step" | "viewport" | "content" | "half";
@@ -37,7 +41,14 @@ export interface AppCommand {
   id: string;
   title: string;
   scopes: readonly AppCommandScope[];
-  /** Human-readable key labels for menus, help, and conflict messages. */
+  /**
+   * The chords this command currently answers to, after user keybindings.
+   *
+   * Empty means the command is unbound: it never matches a key, and is reached
+   * only by name through `executeAppCommand` (a menu entry, say).
+   */
+  keys: readonly string[];
+  /** Display form of `keys`, for menus, help, and conflict messages. */
   keyLabels: readonly string[];
   /**
    * The chords this command ships with, before user keybindings.
@@ -72,9 +83,11 @@ interface BuiltinCommandSpec {
 export interface BuildAppCommandsOptions {
   canRefreshCurrentInput: boolean;
   focusFilter: () => void;
+  moveToAnnotatedFile: (delta: number) => void;
   moveToAnnotatedHunk: (delta: number) => void;
   moveToFile: (delta: number) => void;
   moveToHunk: (delta: number) => void;
+  openAgentSkill: () => void;
   openThemeSelector: () => void;
   requestQuit: () => void;
   /** Chords resolved against the user's `[keybindings]`; defaults apply where absent. */
@@ -84,6 +97,7 @@ export interface BuildAppCommandsOptions {
   selectLayoutMode: (mode: LayoutMode) => void;
   startUserNote: () => void;
   toggleAgentNotes: () => void;
+  toggleCopyDecorations: () => void;
   toggleFocusArea: () => void;
   toggleGapForSelectedHunk: () => void;
   toggleHelp: () => void;
@@ -109,6 +123,10 @@ const REVIEW_AND_PAGER: readonly AppCommandScope[] = ["review", "pager"];
  * Order is the tiebreaker when several commands could match one key, exactly
  * as the old cascade of if-statements was, so entries keep the old cascade's
  * relative order where it mattered (uppercase before lowercase forms).
+ *
+ * A few commands ship with no chords at all. They exist because the menus name
+ * them: an action reachable by mouse is a command like any other, and declaring
+ * it here is what makes it bindable from `[keybindings]` and dispatchable by id.
  */
 function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSpec[] {
   return [
@@ -139,6 +157,14 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       scopes: REVIEW,
       defaultKeys: ["?"],
       run: () => options.toggleHelp(),
+      closesMenu: true,
+    },
+    {
+      id: "hunk.app.openAgentSkill",
+      title: "Show agent skill",
+      scopes: REVIEW,
+      defaultKeys: [],
+      run: () => options.openAgentSkill(),
       closesMenu: true,
     },
     {
@@ -313,6 +339,14 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       closesMenu: true,
     },
     {
+      id: "hunk.view.toggleCopyDecorations",
+      title: "Toggle copy decorations",
+      scopes: REVIEW,
+      defaultKeys: [],
+      run: () => options.toggleCopyDecorations(),
+      closesMenu: true,
+    },
+    {
       id: "hunk.review.toggleHunkGap",
       title: "Expand or collapse context for the selected hunk",
       scopes: REVIEW,
@@ -376,6 +410,22 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       run: () => options.moveToAnnotatedHunk(1),
       closesMenu: true,
     },
+    {
+      id: "hunk.review.previousAnnotatedFile",
+      title: "Previous annotated file",
+      scopes: REVIEW,
+      defaultKeys: [],
+      run: () => options.moveToAnnotatedFile(-1),
+      closesMenu: true,
+    },
+    {
+      id: "hunk.review.nextAnnotatedFile",
+      title: "Next annotated file",
+      scopes: REVIEW,
+      defaultKeys: [],
+      run: () => options.moveToAnnotatedFile(1),
+      closesMenu: true,
+    },
   ];
 }
 
@@ -394,6 +444,7 @@ function toAppCommand(spec: BuiltinCommandSpec, resolvedKeys?: ResolvedCommandKe
     title: spec.title,
     scopes: spec.scopes,
     defaultKeys: spec.defaultKeys,
+    keys,
     keyLabels: keys.map(formatKeyChord),
     isEnabled: spec.isEnabled,
     match: matchesAnyKeyChord(keys),
@@ -412,9 +463,11 @@ const NOOP_COMMAND_OPTIONS: BuildAppCommandsOptions = (() => {
   return {
     canRefreshCurrentInput: true,
     focusFilter: noop,
+    moveToAnnotatedFile: noop,
     moveToAnnotatedHunk: noop,
     moveToFile: noop,
     moveToHunk: noop,
+    openAgentSkill: noop,
     openThemeSelector: noop,
     requestQuit: noop,
     scrollCodeHorizontally: noop,
@@ -422,6 +475,7 @@ const NOOP_COMMAND_OPTIONS: BuildAppCommandsOptions = (() => {
     selectLayoutMode: noop,
     startUserNote: noop,
     toggleAgentNotes: noop,
+    toggleCopyDecorations: noop,
     toggleFocusArea: noop,
     toggleGapForSelectedHunk: noop,
     toggleHelp: noop,
@@ -508,4 +562,38 @@ export function dispatchAppCommand(
   }
 
   return undefined;
+}
+
+/**
+ * A key event standing in for "the user asked for this command by name".
+ *
+ * Commands reached without a keypress still take one, because `run` is written
+ * against the event a chord produced. Synthesizing the command's own first
+ * chord keeps the two paths identical for the handful of commands that read the
+ * event (the shifted arrow scrolls further); an unbound command has no chord to
+ * synthesize, so it gets a neutral event with no modifiers set.
+ */
+function commandInvocationEvent(command: AppCommand): KeyEvent {
+  const parsed = command.keys.map(parseKeyChordOrUndefined).find((chord) => chord !== undefined);
+  return parsed
+    ? synthesizeKeyEvent(parsed)
+    : synthesizeKeyEvent({ base: "", ctrl: false, meta: false, option: false, shift: false });
+}
+
+/**
+ * Run one command by id, whatever key it is on.
+ *
+ * This is the programmatic path into the command table: dropdown menu entries
+ * name the command they run rather than closing over a copy of its callback, so
+ * a menu item and its shortcut can never drift apart. Reports whether a command
+ * ran — an id nobody registered, or one whose `isEnabled` says no, does nothing.
+ */
+export function executeAppCommand(commands: readonly AppCommand[], id: string): boolean {
+  const command = commands.find((candidate) => candidate.id === id);
+  if (!command || (command.isEnabled && !command.isEnabled())) {
+    return false;
+  }
+
+  command.run(commandInvocationEvent(command));
+  return true;
 }

--- a/src/ui/lib/appCommands.ts
+++ b/src/ui/lib/appCommands.ts
@@ -533,6 +533,16 @@ export function builtinCommandKeyDefaults(): readonly CommandKeyDefaults[] {
 }
 
 /**
+ * Report whether one command may run right now.
+ *
+ * The single answer key dispatch, programmatic execution, menu entries, and
+ * help rows all consult — a command without a gate is always runnable.
+ */
+export function isCommandEnabled(command: AppCommand): boolean {
+  return !command.isEnabled || command.isEnabled();
+}
+
+/**
  * Run the first enabled command matching one key in one scope.
  *
  * First match wins, exactly as the old if-cascade did. The matched command is
@@ -549,7 +559,7 @@ export function dispatchAppCommand(
       continue;
     }
 
-    if (command.isEnabled && !command.isEnabled()) {
+    if (!isCommandEnabled(command)) {
       continue;
     }
 
@@ -590,7 +600,7 @@ function commandInvocationEvent(command: AppCommand): KeyEvent {
  */
 export function executeAppCommand(commands: readonly AppCommand[], id: string): boolean {
   const command = commands.find((candidate) => candidate.id === id);
-  if (!command || (command.isEnabled && !command.isEnabled())) {
+  if (!command || !isCommandEnabled(command)) {
     return false;
   }
 

--- a/src/ui/lib/appMenus.test.ts
+++ b/src/ui/lib/appMenus.test.ts
@@ -129,13 +129,19 @@ describe("buildAppMenus", () => {
       "Next annotated file",
       "Previous annotated file",
     ]);
-    expect(items(menus.navigate).map((item) => item.hint)).toEqual([
-      "[",
-      "]",
-      "{",
-      "}",
-      "/",
-      undefined,
+    expect(items(menus.navigate).map((item) => item.hint)).toEqual(["[", "]", "{", "}", "/"]);
+  });
+
+  test("every item carries the id of the command it runs", () => {
+    const { commands } = createTestCommands();
+    const menus = buildAppMenus({ commands, ...MENU_STATE });
+
+    expect(items(menus.file).map((item) => item.commandId)).toEqual([
+      "hunk.app.toggleFocusArea",
+      "hunk.review.focusFilter",
+      "hunk.review.editSelectedFile",
+      "hunk.app.refresh",
+      "hunk.app.quit",
     ]);
   });
 
@@ -246,5 +252,26 @@ describe("the Extensions menu", () => {
     entry(menus, "extensions", "Quiet mode").action();
 
     expect(ran).toEqual(["sync", "quiet"]);
+  });
+
+  test("commands sharing a title stay distinct entries with their own ids", () => {
+    // Titles only need to be non-empty, so two extensions can both say
+    // "Refresh"; the command id is what keeps the rows and handlers apart.
+    const ran: string[] = [];
+    const menus = menusWithExtensions([
+      registeredCommand("notes", "refresh", "Refresh", "y", () => ran.push("notes")),
+      registeredCommand("blame", "refresh", "Refresh", undefined, () => ran.push("blame")),
+    ]);
+
+    const rows = items(menus.extensions);
+    expect(rows.map((item) => [item.label, item.commandId])).toEqual([
+      ["Refresh", "notes.refresh"],
+      ["Refresh", "blame.refresh"],
+    ]);
+
+    for (const row of rows) {
+      row.action();
+    }
+    expect(ran).toEqual(["notes", "blame"]);
   });
 });

--- a/src/ui/lib/appMenus.test.ts
+++ b/src/ui/lib/appMenus.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "bun:test";
+import type { RegisteredCommand } from "../../extensions/types";
+import type { MenuEntry, MenuId } from "../components/chrome/menu";
+import {
+  buildAppCommands,
+  builtinCommandKeyDefaults,
+  builtinCommandMatchProbes,
+  type AppCommand,
+  type BuildAppCommandsOptions,
+  type ResolvedCommandKeys,
+} from "./appCommands";
+import { buildAppMenus, type BuildAppMenusOptions } from "./appMenus";
+import { buildExtensionAppCommands } from "./extensionCommands";
+import { resolveCommandKeys } from "./keymap";
+
+/** The app-state half of the menu options, so tests only state what they exercise. */
+const MENU_STATE: Omit<BuildAppMenusOptions, "commands" | "extensionCommands"> = {
+  copyDecorations: true,
+  layoutMode: "stack",
+  renderSidebar: false,
+  showAgentNotes: true,
+  showHelp: false,
+  showHunkHeaders: false,
+  showLineNumbers: true,
+  showMenuBar: true,
+  wrapLines: true,
+};
+
+/** Build the built-in command table over recording callbacks, plus the log it writes. */
+function createTestCommands(overrides: Partial<BuildAppCommandsOptions> = {}) {
+  const ran: string[] = [];
+  const record =
+    (name: string) =>
+    (...args: unknown[]) => {
+      ran.push(args.length > 0 ? `${name}:${args.join(",")}` : name);
+    };
+  const noop = () => {};
+  const commands = buildAppCommands({
+    canRefreshCurrentInput: true,
+    focusFilter: noop,
+    moveToAnnotatedFile: record("moveToAnnotatedFile"),
+    moveToAnnotatedHunk: noop,
+    moveToFile: noop,
+    moveToHunk: noop,
+    openAgentSkill: record("openAgentSkill"),
+    openThemeSelector: noop,
+    requestQuit: record("requestQuit"),
+    scrollCodeHorizontally: noop,
+    scrollDiff: noop,
+    selectLayoutMode: noop,
+    startUserNote: noop,
+    toggleAgentNotes: noop,
+    toggleCopyDecorations: record("toggleCopyDecorations"),
+    toggleFocusArea: noop,
+    toggleGapForSelectedHunk: noop,
+    toggleHelp: noop,
+    toggleHunkHeaders: noop,
+    toggleLineNumbers: noop,
+    toggleLineWrap: noop,
+    toggleMenuBar: noop,
+    toggleSidebar: record("toggleSidebar"),
+    triggerEditSelectedFile: noop,
+    triggerRefreshCurrentInput: noop,
+    ...overrides,
+  });
+
+  return { commands, ran };
+}
+
+function items(entries: MenuEntry[] | undefined) {
+  return (entries ?? []).filter(
+    (entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item",
+  );
+}
+
+function entry(menus: Partial<Record<MenuId, MenuEntry[]>>, menuId: MenuId, label: string) {
+  const found = items(menus[menuId]).find((item) => item.label === label);
+  if (!found) {
+    throw new Error(`No "${label}" item in the ${menuId} menu.`);
+  }
+
+  return found;
+}
+
+/** Register one extension command, as the extension registry would report it. */
+function registeredCommand(
+  extensionId: string,
+  id: string,
+  title: string,
+  key?: string,
+  handler: () => void = () => {},
+): RegisteredCommand {
+  return { extensionId, command: { id, title, key }, handler };
+}
+
+describe("buildAppMenus", () => {
+  test("labels, hints, and checked state come from the commands and app state", () => {
+    const { commands } = createTestCommands();
+    const menus = buildAppMenus({ commands, ...MENU_STATE });
+
+    expect(items(menus.file).map((item) => item.label)).toEqual([
+      "Toggle files/filter focus",
+      "Focus filter",
+      "Open file in editor",
+      "Reload",
+      "Quit",
+    ]);
+    expect(menus.file?.[0]).toMatchObject({
+      kind: "item",
+      label: "Toggle files/filter focus",
+      hint: "Tab",
+    });
+    expect(
+      items(menus.view)
+        .filter((item) => item.checked)
+        .map((item) => item.label),
+    ).toEqual([
+      "Stacked view",
+      "Menu bar",
+      "Agent notes",
+      "Line numbers",
+      "Line wrapping",
+      "Copy decorations",
+    ]);
+    expect(items(menus.view).map((item) => item.label)).toContain("Themes…");
+    expect(items(menus.agent).map((item) => item.label)).toEqual([
+      "Agent notes",
+      "Agent skill",
+      "Next annotated file",
+      "Previous annotated file",
+    ]);
+    expect(items(menus.navigate).map((item) => item.hint)).toEqual([
+      "[",
+      "]",
+      "{",
+      "}",
+      "/",
+      undefined,
+    ]);
+  });
+
+  test("a remapped command re-labels the menu item that runs it", () => {
+    const { keys } = resolveCommandKeys({
+      defaults: builtinCommandKeyDefaults(),
+      userBindings: { "hunk.view.toggleSidebar": "ctrl+b", "hunk.app.quit": false },
+    });
+    const { commands } = createTestCommands({ resolvedKeys: keys as ResolvedCommandKeys });
+    const menus = buildAppMenus({ commands, ...MENU_STATE });
+
+    expect(entry(menus, "view", "Sidebar").hint).toBe("Ctrl+B");
+    // Unbound by the user, and unbound by declaration: neither advertises a key.
+    expect(entry(menus, "file", "Quit").hint).toBeUndefined();
+    expect(entry(menus, "view", "Copy decorations").hint).toBeUndefined();
+  });
+
+  test("menu items dispatch the command they name", () => {
+    const { commands, ran } = createTestCommands();
+    const menus = buildAppMenus({ commands, ...MENU_STATE });
+
+    entry(menus, "view", "Sidebar").action();
+    entry(menus, "view", "Copy decorations").action();
+    entry(menus, "agent", "Agent skill").action();
+    entry(menus, "agent", "Next annotated file").action();
+    entry(menus, "agent", "Previous annotated file").action();
+
+    expect(ran).toEqual([
+      "toggleSidebar",
+      "toggleCopyDecorations",
+      "openAgentSkill",
+      "moveToAnnotatedFile:1",
+      "moveToAnnotatedFile:-1",
+    ]);
+  });
+
+  test("Reload disappears when the current input cannot be reloaded", () => {
+    const { commands } = createTestCommands({ canRefreshCurrentInput: false });
+    const menus = buildAppMenus({ commands, ...MENU_STATE });
+
+    expect(items(menus.file).map((item) => item.label)).toEqual([
+      "Toggle files/filter focus",
+      "Focus filter",
+      "Open file in editor",
+      "Quit",
+    ]);
+  });
+});
+
+describe("the Extensions menu", () => {
+  /** Build the menus for a session whose extensions registered these commands. */
+  function menusWithExtensions(registered: readonly RegisteredCommand[]) {
+    const { commands: builtins } = createTestCommands();
+    const { commands: extensionCommands } = buildExtensionAppCommands({
+      registered,
+      builtins: builtinCommandMatchProbes(),
+      runCommand: (command) => command.handler({} as never),
+    });
+    const commands: AppCommand[] = [...builtins, ...extensionCommands];
+    return buildAppMenus({ commands, extensionCommands, ...MENU_STATE });
+  }
+
+  test("is absent when no extension registered a command", () => {
+    const { commands } = createTestCommands();
+
+    expect(buildAppMenus({ commands, ...MENU_STATE }).extensions).toBeUndefined();
+    expect(menusWithExtensions([]).extensions).toBeUndefined();
+  });
+
+  test("lists every registered command with its title and current key", () => {
+    const menus = menusWithExtensions([
+      registeredCommand("notes", "sync", "Sync notes", "y"),
+      // Refused: "s" already toggles the sidebar, so the command is listed
+      // without a key rather than dropped from the menu.
+      registeredCommand("notes", "stash", "Stash notes", "s"),
+      registeredCommand("notes", "quiet", "Quiet mode"),
+    ]);
+
+    expect(items(menus.extensions).map((item) => [item.label, item.hint])).toEqual([
+      ["Sync notes", "y"],
+      ["Stash notes", undefined],
+      ["Quiet mode", undefined],
+    ]);
+  });
+
+  test("separates one extension's commands from the next", () => {
+    const menus = menusWithExtensions([
+      registeredCommand("notes", "sync", "Sync notes", "y"),
+      registeredCommand("blame", "show", "Show blame", "ctrl+g"),
+    ]);
+
+    expect(menus.extensions).toMatchObject([
+      { kind: "item", label: "Sync notes" },
+      { kind: "separator" },
+      { kind: "item", label: "Show blame" },
+    ]);
+  });
+
+  test("an entry runs the extension's handler", () => {
+    const ran: string[] = [];
+    const menus = menusWithExtensions([
+      registeredCommand("notes", "sync", "Sync notes", "y", () => ran.push("sync")),
+      registeredCommand("notes", "quiet", "Quiet mode", undefined, () => ran.push("quiet")),
+    ]);
+
+    entry(menus, "extensions", "Sync notes").action();
+    // An unbound command has no key to reach it by; the menu still runs it.
+    entry(menus, "extensions", "Quiet mode").action();
+
+    expect(ran).toEqual(["sync", "quiet"]);
+  });
+});

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -1,259 +1,195 @@
 import type { LayoutMode } from "../../core/types";
-import type { MenuEntry, MenuId } from "../components/chrome/menu";
+import type { AppMenus, MenuEntry, MenuId } from "../components/chrome/menu";
+import { executeAppCommand, type AppCommand } from "./appCommands";
 
+/**
+ * The dropdown menus, expressed as references into the command table.
+ *
+ * A menu item is a command plus presentation: nothing here re-implements an
+ * action or re-states which key runs it. Labels and checkbox state are the two
+ * things the menu genuinely owns — a menu reads "Sidebar" under "View" where
+ * the command is titled "Toggle sidebar", and only App knows whether the
+ * sidebar is currently showing — so those are declared per entry and everything
+ * else is derived from the command the entry names.
+ */
+
+/** One dropdown item, named by the command it runs. */
+interface MenuCommandSpec {
+  commandId: string;
+  /** Short menu wording; defaults to the command's title. */
+  label?: string;
+  /** Checkbox state, supplied by the caller from live app state. */
+  checked?: boolean;
+}
+
+type MenuEntrySpec = MenuCommandSpec | { separator: true };
+
+const SEPARATOR: MenuEntrySpec = { separator: true };
+
+/** The app state menu items reflect, beyond what the command table already knows. */
 export interface BuildAppMenusOptions {
-  canRefreshCurrentInput: boolean;
-  focusFilter: () => void;
-  layoutMode: LayoutMode;
-  moveToAnnotatedFile: (delta: number) => void;
-  moveToAnnotatedHunk: (delta: number) => void;
-  moveToHunk: (delta: number) => void;
-  refreshCurrentInput: () => void;
-  requestQuit: () => void;
-  selectLayoutMode: (mode: LayoutMode) => void;
-  openThemeSelector: () => void;
+  /** Every dispatchable command, built-ins first, then extension commands. */
+  commands: readonly AppCommand[];
+  /** The extension-contributed subset, in registration order, for the Extensions menu. */
+  extensionCommands?: readonly AppCommand[];
   copyDecorations: boolean;
+  layoutMode: LayoutMode;
+  renderSidebar: boolean;
   showAgentNotes: boolean;
   showHelp: boolean;
   showHunkHeaders: boolean;
   showLineNumbers: boolean;
   showMenuBar: boolean;
-  renderSidebar: boolean;
-  toggleCopyDecorations: () => void;
-  toggleAgentNotes: () => void;
-  toggleFocusArea: () => void;
-  openAgentSkill: () => void;
-  toggleHelp: () => void;
-  toggleHunkHeaders: () => void;
-  toggleLineNumbers: () => void;
-  toggleMenuBar: () => void;
-  toggleLineWrap: () => void;
-  toggleSidebar: () => void;
-  triggerEditSelectedFile: () => void;
   wrapLines: boolean;
 }
 
-/** Build the top-level app menus from the current app state and actions. */
+/**
+ * Resolve one menu's specs against the command table.
+ *
+ * An item whose command is missing or currently disabled is dropped rather than
+ * shown dead: "Reload" only appears when the current input can be reloaded, and
+ * that answer lives on the command's `isEnabled`, not in a second flag here.
+ */
+function toMenuEntries(
+  commands: readonly AppCommand[],
+  specs: readonly MenuEntrySpec[],
+): MenuEntry[] {
+  const entries: MenuEntry[] = [];
+
+  for (const spec of specs) {
+    if ("separator" in spec) {
+      entries.push({ kind: "separator" });
+      continue;
+    }
+
+    const command = commands.find((candidate) => candidate.id === spec.commandId);
+    if (!command || (command.isEnabled && !command.isEnabled())) {
+      continue;
+    }
+
+    entries.push({
+      kind: "item",
+      label: spec.label ?? command.title,
+      // The first resolved chord is the one the menu advertises; a command the
+      // user unbound (or that ships unbound) simply shows no key.
+      hint: command.keyLabels[0],
+      checked: spec.checked,
+      action: () => {
+        executeAppCommand(commands, spec.commandId);
+      },
+    });
+  }
+
+  return entries;
+}
+
+/**
+ * The Extensions menu's items, grouped by the extension that registered them.
+ *
+ * Order follows the command table — extension load order, then registration
+ * order within one extension — and a rule between two extensions' groups keeps
+ * it readable when several contribute commands.
+ */
+function toExtensionMenuEntries(
+  commands: readonly AppCommand[],
+  extensionCommands: readonly AppCommand[],
+): MenuEntry[] {
+  const specs: MenuEntrySpec[] = [];
+  let previousOwner: string | undefined;
+
+  for (const command of extensionCommands) {
+    // Extension command ids are `<extensionId>.<commandId>`.
+    const owner = command.id.slice(0, command.id.indexOf("."));
+    if (previousOwner !== undefined && owner !== previousOwner) {
+      specs.push(SEPARATOR);
+    }
+
+    previousOwner = owner;
+    specs.push({ commandId: command.id });
+  }
+
+  return toMenuEntries(commands, specs);
+}
+
+/** Build the top-level app menus from the command table and the current app state. */
 export function buildAppMenus({
-  canRefreshCurrentInput,
-  focusFilter,
-  layoutMode,
-  moveToAnnotatedFile,
-  moveToAnnotatedHunk,
-  moveToHunk,
-  refreshCurrentInput,
-  requestQuit,
-  selectLayoutMode,
-  openThemeSelector,
+  commands,
+  extensionCommands = [],
   copyDecorations,
+  layoutMode,
+  renderSidebar,
   showAgentNotes,
   showHelp,
   showHunkHeaders,
   showLineNumbers,
   showMenuBar,
-  renderSidebar,
-  toggleCopyDecorations,
-  toggleAgentNotes,
-  toggleFocusArea,
-  openAgentSkill,
-  toggleHelp,
-  toggleHunkHeaders,
-  toggleLineNumbers,
-  toggleMenuBar,
-  toggleLineWrap,
-  toggleSidebar,
-  triggerEditSelectedFile,
   wrapLines,
-}: BuildAppMenusOptions): Record<MenuId, MenuEntry[]> {
-  const fileMenuEntries: MenuEntry[] = [
-    {
-      kind: "item",
-      label: "Toggle files/filter focus",
-      hint: "Tab",
-      action: toggleFocusArea,
-    },
-    {
-      kind: "item",
-      label: "Focus filter",
-      hint: "/",
-      action: focusFilter,
-    },
-    {
-      kind: "item",
-      label: "Open file in editor",
-      hint: "e",
-      action: triggerEditSelectedFile,
-    },
-  ];
-
-  if (canRefreshCurrentInput) {
-    fileMenuEntries.push({
-      kind: "item",
-      label: "Reload",
-      hint: "r",
-      action: refreshCurrentInput,
-    });
-  }
-
-  fileMenuEntries.push(
-    { kind: "separator" },
-    {
-      kind: "item",
-      label: "Quit",
-      hint: "q",
-      action: requestQuit,
-    },
-  );
-
-  return {
-    file: fileMenuEntries,
+}: BuildAppMenusOptions): AppMenus {
+  const specs: Record<Exclude<MenuId, "extensions">, MenuEntrySpec[]> = {
+    file: [
+      { commandId: "hunk.app.toggleFocusArea", label: "Toggle files/filter focus" },
+      { commandId: "hunk.review.focusFilter", label: "Focus filter" },
+      { commandId: "hunk.review.editSelectedFile", label: "Open file in editor" },
+      { commandId: "hunk.app.refresh", label: "Reload" },
+      SEPARATOR,
+      { commandId: "hunk.app.quit" },
+    ],
     view: [
+      { commandId: "hunk.view.layoutSplit", label: "Split view", checked: layoutMode === "split" },
       {
-        kind: "item",
-        label: "Split view",
-        hint: "1",
-        checked: layoutMode === "split",
-        action: () => selectLayoutMode("split"),
-      },
-      {
-        kind: "item",
+        commandId: "hunk.view.layoutStack",
         label: "Stacked view",
-        hint: "2",
         checked: layoutMode === "stack",
-        action: () => selectLayoutMode("stack"),
       },
+      { commandId: "hunk.view.layoutAuto", checked: layoutMode === "auto" },
+      SEPARATOR,
+      { commandId: "hunk.view.toggleSidebar", label: "Sidebar", checked: renderSidebar },
+      { commandId: "hunk.view.toggleMenuBar", label: "Menu bar", checked: showMenuBar },
+      SEPARATOR,
+      { commandId: "hunk.view.openThemeSelector", label: "Themes…" },
+      SEPARATOR,
+      { commandId: "hunk.view.toggleAgentNotes", label: "Agent notes", checked: showAgentNotes },
+      { commandId: "hunk.view.toggleLineNumbers", label: "Line numbers", checked: showLineNumbers },
+      { commandId: "hunk.view.toggleLineWrap", label: "Line wrapping", checked: wrapLines },
       {
-        kind: "item",
-        label: "Auto layout",
-        hint: "0",
-        checked: layoutMode === "auto",
-        action: () => selectLayoutMode("auto"),
-      },
-      { kind: "separator" },
-      {
-        kind: "item",
-        label: "Sidebar",
-        hint: "s",
-        checked: renderSidebar,
-        action: toggleSidebar,
-      },
-      {
-        kind: "item",
-        label: "Menu bar",
-        hint: "M",
-        checked: showMenuBar,
-        action: toggleMenuBar,
-      },
-      { kind: "separator" },
-      {
-        kind: "item",
-        label: "Themes…",
-        hint: "t",
-        action: openThemeSelector,
-      },
-      { kind: "separator" },
-      {
-        kind: "item",
-        label: "Agent notes",
-        hint: "a",
-        checked: showAgentNotes,
-        action: toggleAgentNotes,
-      },
-      {
-        kind: "item",
-        label: "Line numbers",
-        hint: "l",
-        checked: showLineNumbers,
-        action: toggleLineNumbers,
-      },
-      {
-        kind: "item",
-        label: "Line wrapping",
-        hint: "w",
-        checked: wrapLines,
-        action: toggleLineWrap,
-      },
-      {
-        kind: "item",
+        commandId: "hunk.view.toggleHunkHeaders",
         label: "Hunk metadata",
-        hint: "m",
         checked: showHunkHeaders,
-        action: toggleHunkHeaders,
       },
       {
-        kind: "item",
+        commandId: "hunk.view.toggleCopyDecorations",
         label: "Copy decorations",
         checked: copyDecorations,
-        action: toggleCopyDecorations,
       },
     ],
     navigate: [
-      {
-        kind: "item",
-        label: "Previous hunk",
-        hint: "[",
-        action: () => moveToHunk(-1),
-      },
-      {
-        kind: "item",
-        label: "Next hunk",
-        hint: "]",
-        action: () => moveToHunk(1),
-      },
-      { kind: "separator" },
-      {
-        kind: "item",
-        label: "Previous comment",
-        hint: "{",
-        action: () => moveToAnnotatedHunk(-1),
-      },
-      {
-        kind: "item",
-        label: "Next comment",
-        hint: "}",
-        action: () => moveToAnnotatedHunk(1),
-      },
-      { kind: "separator" },
-      {
-        kind: "item",
-        label: "Focus filter",
-        hint: "/",
-        action: focusFilter,
-      },
+      { commandId: "hunk.review.previousHunk" },
+      { commandId: "hunk.review.nextHunk" },
+      SEPARATOR,
+      { commandId: "hunk.review.previousAnnotatedHunk", label: "Previous comment" },
+      { commandId: "hunk.review.nextAnnotatedHunk", label: "Next comment" },
+      SEPARATOR,
+      { commandId: "hunk.review.focusFilter", label: "Focus filter" },
     ],
     agent: [
-      {
-        kind: "item",
-        label: "Agent notes",
-        hint: "a",
-        checked: showAgentNotes,
-        action: toggleAgentNotes,
-      },
-      {
-        kind: "item",
-        label: "Agent skill",
-        action: openAgentSkill,
-      },
-      { kind: "separator" },
-      {
-        kind: "item",
-        label: "Next annotated file",
-        action: () => moveToAnnotatedFile(1),
-      },
-      {
-        kind: "item",
-        label: "Previous annotated file",
-        action: () => moveToAnnotatedFile(-1),
-      },
+      { commandId: "hunk.view.toggleAgentNotes", label: "Agent notes", checked: showAgentNotes },
+      { commandId: "hunk.app.openAgentSkill", label: "Agent skill" },
+      SEPARATOR,
+      { commandId: "hunk.review.nextAnnotatedFile" },
+      { commandId: "hunk.review.previousAnnotatedFile" },
     ],
-    help: [
-      {
-        kind: "item",
-        label: "Controls help",
-        hint: "?",
-        checked: showHelp,
-        action: toggleHelp,
-      },
-    ],
+    help: [{ commandId: "hunk.app.toggleHelp", label: "Controls help", checked: showHelp }],
+  };
+
+  const extensions = toExtensionMenuEntries(commands, extensionCommands);
+
+  return {
+    file: toMenuEntries(commands, specs.file),
+    view: toMenuEntries(commands, specs.view),
+    navigate: toMenuEntries(commands, specs.navigate),
+    agent: toMenuEntries(commands, specs.agent),
+    // No extension commands means no menu at all, rather than an empty dropdown.
+    ...(extensions.length > 0 ? { extensions } : {}),
+    help: toMenuEntries(commands, specs.help),
   };
 }

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -1,6 +1,6 @@
 import type { LayoutMode } from "../../core/types";
 import type { AppMenus, MenuEntry, MenuId } from "../components/chrome/menu";
-import { executeAppCommand, type AppCommand } from "./appCommands";
+import { executeAppCommand, isCommandEnabled, type AppCommand } from "./appCommands";
 
 /**
  * The dropdown menus, expressed as references into the command table.
@@ -63,7 +63,7 @@ function toMenuEntries(
     }
 
     const command = commands.find((candidate) => candidate.id === spec.commandId);
-    if (!command || (command.isEnabled && !command.isEnabled())) {
+    if (!command || !isCommandEnabled(command)) {
       continue;
     }
 

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -70,6 +70,7 @@ function toMenuEntries(
     entries.push({
       kind: "item",
       label: spec.label ?? command.title,
+      commandId: spec.commandId,
       // The first resolved chord is the one the menu advertises; a command the
       // user unbound (or that ships unbound) simply shows no key.
       hint: command.keyLabels[0],
@@ -98,7 +99,9 @@ function toExtensionMenuEntries(
   let previousOwner: string | undefined;
 
   for (const command of extensionCommands) {
-    // Extension command ids are `<extensionId>.<commandId>`.
+    // Extension command ids are `<extensionId>.<commandId>`, and the host
+    // refuses extension ids containing dots at load, so the first dot always
+    // splits off the owning extension exactly — whatever the command half holds.
     const owner = command.id.slice(0, command.id.indexOf("."));
     if (previousOwner !== undefined && owner !== previousOwner) {
       specs.push(SEPARATOR);

--- a/src/ui/lib/extensionCommands.test.ts
+++ b/src/ui/lib/extensionCommands.test.ts
@@ -31,8 +31,9 @@ describe("buildExtensionAppCommands", () => {
     });
 
     expect(conflicts).toEqual([]);
-    // The unbound command has nothing to dispatch; the bound one runs on its key.
-    expect(commands.map((command) => command.id)).toEqual(["meta.toggle"]);
+    // Both are listed for the Extensions menu; only the bound one has a key.
+    expect(commands.map((command) => command.id)).toEqual(["meta.toggle", "meta.silent"]);
+    expect(commands.map((command) => command.keyLabels)).toEqual([["y"], []]);
     expect(dispatchAppCommand(commands, "review", chordEvent("y"))?.id).toBe("meta.toggle");
     expect(ran).toEqual(["meta.toggle"]);
   });
@@ -45,7 +46,9 @@ describe("buildExtensionAppCommands", () => {
       runCommand: () => {},
     });
 
-    expect(commands.map((command) => command.id)).toEqual(["meta.ok"]);
+    // The refused command stays in the table, just without the key it wanted.
+    expect(commands.map((command) => command.id)).toEqual(["meta.steal-s", "meta.ok"]);
+    expect(commands.map((command) => command.keyLabels)).toEqual([[], ["y"]]);
     expect(conflicts).toEqual([
       {
         extensionId: "meta",
@@ -66,7 +69,8 @@ describe("buildExtensionAppCommands", () => {
       runCommand: () => {},
     });
 
-    expect(commands.map((command) => command.id)).toEqual(["first.mine"]);
+    expect(commands.map((command) => command.id)).toEqual(["first.mine", "second.mine"]);
+    expect(commands.map((command) => command.keyLabels)).toEqual([["y"], []]);
     expect(conflicts.map((conflict) => conflict.fullId)).toEqual(["second.mine"]);
     expect(conflicts[0]?.conflictingId).toBe("first.mine");
   });

--- a/src/ui/lib/extensionCommands.ts
+++ b/src/ui/lib/extensionCommands.ts
@@ -61,6 +61,10 @@ interface ClaimedChord {
  * keeps the other two and reports the one it lost. Extension commands run in
  * the review scope only: pager mode is a pager, and modal surfaces own their
  * keys outright.
+ *
+ * Every registered command becomes a table entry, including one left with no
+ * chord at all: it never matches a key, but it is still listed in the
+ * Extensions menu and still runnable by id from there.
  */
 export function buildExtensionAppCommands(
   options: BuildExtensionAppCommandsOptions,
@@ -74,11 +78,6 @@ export function buildExtensionAppCommands(
     const { command } = registered;
     const fullId = `${registered.extensionId}.${command.id}`;
     const declared = options.resolvedKeys?.get(fullId) ?? toKeyChordList(command.key);
-    // A command without a binding stays registered but has nothing to dispatch.
-    if (declared.length === 0) {
-      continue;
-    }
-
     const bound: Array<{ chord: string; match: (key: KeyEvent) => boolean }> = [];
     for (const chord of declared) {
       // Registration already validated the chord; an error here is unreachable
@@ -108,15 +107,11 @@ export function buildExtensionAppCommands(
       bound.push({ chord, match });
     }
 
-    // Every chord was taken: the command stays registered, just unbound.
-    if (bound.length === 0) {
-      continue;
-    }
-
     commands.push({
       id: fullId,
       title: command.title,
       scopes: ["review"],
+      keys: bound.map((binding) => binding.chord),
       keyLabels: bound.map((binding) => formatKeyChord(binding.chord)),
       match: (key) => bound.some((binding) => binding.match(key)),
       run: () => options.runCommand(registered),

--- a/src/ui/lib/helpContent.test.ts
+++ b/src/ui/lib/helpContent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  builtinCommandKeyDefaults,
+  builtinCommandMatchProbes,
+  type AppCommand,
+} from "./appCommands";
+import { buildHelpSections, type HelpSection } from "./helpContent";
+import { resolveCommandKeys } from "./keymap";
+
+/** The help rows for a session with the given `[keybindings]` entries. */
+function helpSections(userBindings?: Record<string, string | false>): HelpSection[] {
+  const { keys } = resolveCommandKeys({ defaults: builtinCommandKeyDefaults(), userBindings });
+  return buildHelpSections(builtinCommandMatchProbes(keys));
+}
+
+/** The key column of the row documenting one description. */
+function keysFor(sections: HelpSection[], description: string) {
+  return sections.flatMap((section) => section.rows).find((row) => row.description === description)
+    ?.keys;
+}
+
+describe("buildHelpSections", () => {
+  test("renders paired rows from each command's primary key", () => {
+    const sections = helpSections();
+
+    expect(sections.map((section) => section.title)).toEqual([
+      "Navigation",
+      "Mouse",
+      "View",
+      "Review",
+    ]);
+    expect(keysFor(sections, "previous / next hunk")).toBe("[ / ]");
+    expect(keysFor(sections, "half page down / up")).toBe("d / u");
+    expect(keysFor(sections, "move line-by-line")).toBe("Up / Down");
+    expect(keysFor(sections, "split / stack / auto")).toBe("1 / 2 / 0");
+    expect(keysFor(sections, "lines / wrap / metadata / menu")).toBe("l / w / m / M");
+  });
+
+  test("a row about one command lists every chord it answers to", () => {
+    const sections = helpSections();
+
+    expect(keysFor(sections, "page down")).toBe("PageDown / Space / f");
+    expect(keysFor(sections, "page up")).toBe("PageUp / b / Shift+Space");
+    expect(keysFor(sections, "jump to start")).toBe("g / Home");
+  });
+
+  test("keeps the rows that are not commands at all", () => {
+    const sections = helpSections();
+
+    expect(keysFor(sections, "scroll vertically")).toBe("Wheel");
+    expect(keysFor(sections, "open menus")).toBe("F10");
+  });
+
+  test("a remapped command changes what help advertises", () => {
+    const sections = helpSections({
+      "hunk.review.nextHunk": "ctrl+n",
+      "hunk.app.quit": "ctrl+x",
+    });
+
+    expect(keysFor(sections, "previous / next hunk")).toBe("[ / Ctrl+N");
+    expect(keysFor(sections, "quit")).toBe("Ctrl+X");
+  });
+
+  test("an unbound command drops out of its row, and an empty row drops out entirely", () => {
+    const sections = helpSections({
+      "hunk.review.previousHunk": false,
+      "hunk.review.startNote": false,
+    });
+
+    // The pair survives on the half that still has a key.
+    expect(keysFor(sections, "previous / next hunk")).toBe("]");
+    // Nothing left to document, so the row is gone rather than blank.
+    expect(keysFor(sections, "create review note")).toBeUndefined();
+  });
+
+  test("a disabled command is documented only while it can run", () => {
+    const enabled = builtinCommandMatchProbes();
+    const disabled: AppCommand[] = enabled.map((command) =>
+      command.id === "hunk.app.refresh" ? { ...command, isEnabled: () => false } : command,
+    );
+
+    expect(keysFor(buildHelpSections(enabled), "reload the review")).toBe("r");
+    expect(keysFor(buildHelpSections(disabled), "reload the review")).toBeUndefined();
+  });
+});

--- a/src/ui/lib/helpContent.ts
+++ b/src/ui/lib/helpContent.ts
@@ -1,0 +1,153 @@
+import type { AppCommand } from "./appCommands";
+
+/**
+ * The curated content of the controls help dialog.
+ *
+ * The rows are hand-written — grouped, ordered, and worded for someone learning
+ * the app — but the keys in them are not: each row names the commands it
+ * documents and the key column is rendered from whatever chords those commands
+ * currently answer to. Remap a command and help says so; unbind it and its row
+ * disappears rather than advertising a key that does nothing.
+ *
+ * A few rows document behavior that is not a command at all (the mouse wheel,
+ * F10 opening the menus, which belong to the widgets that own them). Those
+ * carry literal key text, and are the only place a key is written by hand.
+ */
+
+/** One documented row, as declared. */
+type HelpEntrySpec = {
+  description: string;
+} & ({ keys: string } | { commandIds: readonly string[] });
+
+interface HelpSectionSpec {
+  title: string;
+  entries: readonly HelpEntrySpec[];
+}
+
+/** One rendered row: the key column text and what it does. */
+export interface HelpRow {
+  keys: string;
+  description: string;
+}
+
+/** One rendered section of the dialog. */
+export interface HelpSection {
+  title: string;
+  rows: HelpRow[];
+}
+
+const HELP_SECTIONS: readonly HelpSectionSpec[] = [
+  {
+    title: "Navigation",
+    entries: [
+      {
+        commandIds: ["hunk.review.stepUp", "hunk.review.stepDown"],
+        description: "move line-by-line",
+      },
+      { commandIds: ["hunk.review.pageDown"], description: "page down" },
+      { commandIds: ["hunk.review.pageUp"], description: "page up" },
+      {
+        commandIds: ["hunk.review.halfPageDown", "hunk.review.halfPageUp"],
+        description: "half page down / up",
+      },
+      {
+        commandIds: ["hunk.review.previousHunk", "hunk.review.nextHunk"],
+        description: "previous / next hunk",
+      },
+      {
+        commandIds: ["hunk.review.previousFile", "hunk.review.nextFile"],
+        description: "previous / next file",
+      },
+      {
+        commandIds: ["hunk.review.previousAnnotatedHunk", "hunk.review.nextAnnotatedHunk"],
+        description: "previous / next comment",
+      },
+      {
+        commandIds: ["hunk.review.scrollCodeLeft", "hunk.review.scrollCodeRight"],
+        description: "scroll code sideways (Shift = faster)",
+      },
+      { commandIds: ["hunk.review.jumpToTop"], description: "jump to start" },
+      { commandIds: ["hunk.review.jumpToBottom"], description: "jump to end" },
+    ],
+  },
+  {
+    title: "Mouse",
+    entries: [
+      { keys: "Wheel", description: "scroll vertically" },
+      { keys: "Shift+Wheel", description: "scroll code horizontally" },
+    ],
+  },
+  {
+    title: "View",
+    entries: [
+      {
+        commandIds: ["hunk.view.layoutSplit", "hunk.view.layoutStack", "hunk.view.layoutAuto"],
+        description: "split / stack / auto",
+      },
+      {
+        commandIds: ["hunk.view.toggleSidebar", "hunk.view.openThemeSelector"],
+        description: "sidebar / theme selector",
+      },
+      { commandIds: ["hunk.view.toggleAgentNotes"], description: "toggle AI notes" },
+      { commandIds: ["hunk.review.toggleHunkGap"], description: "toggle unchanged context" },
+      {
+        commandIds: [
+          "hunk.view.toggleLineNumbers",
+          "hunk.view.toggleLineWrap",
+          "hunk.view.toggleHunkHeaders",
+          "hunk.view.toggleMenuBar",
+        ],
+        description: "lines / wrap / metadata / menu",
+      },
+      { commandIds: ["hunk.review.editSelectedFile"], description: "open file in $EDITOR" },
+    ],
+  },
+  {
+    title: "Review",
+    entries: [
+      { commandIds: ["hunk.review.focusFilter"], description: "focus file filter" },
+      { commandIds: ["hunk.review.startNote"], description: "create review note" },
+      { commandIds: ["hunk.app.toggleFocusArea"], description: "toggle files/filter focus" },
+      { keys: "F10", description: "open menus" },
+      { commandIds: ["hunk.app.refresh"], description: "reload the review" },
+      { commandIds: ["hunk.app.quit"], description: "quit" },
+    ],
+  },
+];
+
+/**
+ * Render one entry's key column, or nothing when it documents no live key.
+ *
+ * A row about one command lists every chord it answers to, since there is room
+ * for the alternates; a row covering several commands shows each one's primary
+ * chord instead, so the column stays readable. Either way a command that is
+ * disabled or unbound contributes nothing, and a row left with no keys at all
+ * is dropped by the caller.
+ */
+function helpEntryKeys(commands: readonly AppCommand[], spec: HelpEntrySpec): string | undefined {
+  if ("keys" in spec) {
+    return spec.keys;
+  }
+
+  const labels = spec.commandIds.flatMap((id) => {
+    const command = commands.find((candidate) => candidate.id === id);
+    if (!command || (command.isEnabled && !command.isEnabled())) {
+      return [];
+    }
+
+    return spec.commandIds.length === 1 ? [...command.keyLabels] : command.keyLabels.slice(0, 1);
+  });
+
+  return labels.length > 0 ? labels.join(" / ") : undefined;
+}
+
+/** Build the help dialog's sections against the session's live command table. */
+export function buildHelpSections(commands: readonly AppCommand[]): HelpSection[] {
+  return HELP_SECTIONS.map((section) => ({
+    title: section.title,
+    rows: section.entries.flatMap((spec) => {
+      const keys = helpEntryKeys(commands, spec);
+      return keys === undefined ? [] : [{ keys, description: spec.description }];
+    }),
+  })).filter((section) => section.rows.length > 0);
+}

--- a/src/ui/lib/helpContent.ts
+++ b/src/ui/lib/helpContent.ts
@@ -1,4 +1,4 @@
-import type { AppCommand } from "./appCommands";
+import { isCommandEnabled, type AppCommand } from "./appCommands";
 
 /**
  * The curated content of the controls help dialog.
@@ -131,7 +131,7 @@ function helpEntryKeys(commands: readonly AppCommand[], spec: HelpEntrySpec): st
 
   const labels = spec.commandIds.flatMap((id) => {
     const command = commands.find((candidate) => candidate.id === id);
-    if (!command || (command.isEnabled && !command.isEnabled())) {
+    if (!command || !isCommandEnabled(command)) {
       return [];
     }
 

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -5,6 +5,7 @@ import stringWidth from "string-width";
 import type { DiffFile } from "../../core/types";
 import {
   buildMenuSpecs,
+  menuBarTitleWidth,
   menuBoxHeight,
   menuWidth,
   nextMenuItemIndex,
@@ -153,6 +154,33 @@ describe("ui helpers", () => {
 
     expect(menuWidth(entries)).toBeGreaterThanOrEqual(18);
     expect(menuBoxHeight(entries)).toBe(5);
+  });
+
+  test("menuWidth measures terminal cells, so wide characters are not clipped", () => {
+    const ascii: MenuEntry[] = [{ kind: "item", label: "12345678901234567890", action: () => {} }];
+    // Same count of user-visible characters, but CJK renders two cells each.
+    const wide: MenuEntry[] = [
+      { kind: "item", label: "拡張機能のコマンドを実行します", action: () => {} },
+    ];
+
+    expect(menuWidth(wide)).toBe(menuWidth(ascii) + 10);
+  });
+
+  test("menuBarTitleWidth cedes title space to the menus the bar shows", () => {
+    const item: MenuEntry = { kind: "item", label: "One", action: () => {} };
+    const base = { file: [item], view: [item], navigate: [item], agent: [item], help: [item] };
+    const withoutExtensions = buildMenuSpecs(base);
+    const withExtensions = buildMenuSpecs({ ...base, extensions: [item] });
+
+    // Parity with the bar before the Extensions menu existed: five menus over
+    // 35 columns left 39 title cells at 80 columns wide.
+    expect(menuBarTitleWidth(withoutExtensions, 80)).toBe(39);
+    // The Extensions menu's 12 columns come out of the title, not the row.
+    expect(menuBarTitleWidth(withExtensions, 80)).toBe(27);
+    const menusWidth = withExtensions.reduce((total, spec) => total + spec.width, 0);
+    expect(menusWidth + menuBarTitleWidth(withExtensions, 80)).toBeLessThanOrEqual(80 - 3);
+    // A terminal narrower than the menus still never yields a negative width.
+    expect(menuBarTitleWidth(withExtensions, 40)).toBe(0);
   });
 
   test("escape aliases normalize across terminal input paths", () => {

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -11,7 +11,6 @@ import {
   type MenuEntry,
 } from "../components/chrome/menu";
 import { buildAgentPopoverContent, resolveAgentPopoverPlacement, wrapText } from "./agentPopover";
-import { buildAppMenus } from "./appMenus";
 import { isEscapeKey, isSaveDraftNoteKey } from "./keyboard";
 import {
   cellRangeToCharRange,
@@ -77,8 +76,15 @@ function createDiffFile(
 }
 
 describe("ui helpers", () => {
-  test("buildMenuSpecs lays out the fixed top-level order", () => {
-    const specs = buildMenuSpecs();
+  test("buildMenuSpecs lays out the menus a session has", () => {
+    const item: MenuEntry = { kind: "item", label: "One", action: () => {} };
+    const specs = buildMenuSpecs({
+      file: [item],
+      view: [item],
+      navigate: [item],
+      agent: [item],
+      help: [item],
+    });
 
     expect(specs.map((spec) => spec.id)).toEqual(["file", "view", "navigate", "agent", "help"]);
     expect(specs).toMatchObject([
@@ -87,6 +93,28 @@ describe("ui helpers", () => {
       { id: "navigate", left: 13, width: 10, label: "Navigate" },
       { id: "agent", left: 23, width: 7, label: "Agent" },
       { id: "help", left: 30, width: 6, label: "Help" },
+    ]);
+  });
+
+  test("buildMenuSpecs seats an Extensions menu before Help and skips it when empty", () => {
+    const item: MenuEntry = { kind: "item", label: "One", action: () => {} };
+    const base = { file: [item], view: [item], navigate: [item], agent: [item], help: [item] };
+
+    expect(buildMenuSpecs({ ...base, extensions: [item] })).toMatchObject([
+      { id: "file", left: 1 },
+      { id: "view", left: 7 },
+      { id: "navigate", left: 13 },
+      { id: "agent", left: 23 },
+      { id: "extensions", left: 30, width: 12, label: "Extensions" },
+      { id: "help", left: 42, width: 6, label: "Help" },
+    ]);
+    // An id with no entries takes neither a slot nor a label on the bar.
+    expect(buildMenuSpecs({ ...base, extensions: [] }).map((spec) => spec.id)).toEqual([
+      "file",
+      "view",
+      "navigate",
+      "agent",
+      "help",
     ]);
   });
 
@@ -125,82 +153,6 @@ describe("ui helpers", () => {
 
     expect(menuWidth(entries)).toBeGreaterThanOrEqual(18);
     expect(menuBoxHeight(entries)).toBe(5);
-  });
-
-  test("buildAppMenus creates checked entries from the current app state", () => {
-    const menus = buildAppMenus({
-      canRefreshCurrentInput: true,
-      focusFilter: () => {},
-      layoutMode: "stack",
-      moveToAnnotatedFile: () => {},
-      moveToAnnotatedHunk: () => {},
-      moveToHunk: () => {},
-      refreshCurrentInput: () => {},
-      requestQuit: () => {},
-      selectLayoutMode: () => {},
-      openThemeSelector: () => {},
-      copyDecorations: true,
-      showAgentNotes: true,
-      showHelp: false,
-      showHunkHeaders: false,
-      showLineNumbers: true,
-      showMenuBar: true,
-      renderSidebar: false,
-      toggleCopyDecorations: () => {},
-      toggleAgentNotes: () => {},
-      toggleFocusArea: () => {},
-      openAgentSkill: () => {},
-      toggleHelp: () => {},
-      toggleHunkHeaders: () => {},
-      toggleLineNumbers: () => {},
-      toggleMenuBar: () => {},
-      toggleLineWrap: () => {},
-      toggleSidebar: () => {},
-      triggerEditSelectedFile: () => {},
-      wrapLines: true,
-    });
-
-    expect(
-      menus.file
-        .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
-        .map((entry) => entry.label),
-    ).toEqual([
-      "Toggle files/filter focus",
-      "Focus filter",
-      "Open file in editor",
-      "Reload",
-      "Quit",
-    ]);
-    expect(menus.file[0]).toMatchObject({
-      kind: "item",
-      label: "Toggle files/filter focus",
-      hint: "Tab",
-    });
-    expect(
-      menus.view
-        .filter(
-          (entry): entry is Extract<MenuEntry, { kind: "item" }> =>
-            entry.kind === "item" && Boolean(entry.checked),
-        )
-        .map((entry) => entry.label),
-    ).toEqual([
-      "Stacked view",
-      "Menu bar",
-      "Agent notes",
-      "Line numbers",
-      "Line wrapping",
-      "Copy decorations",
-    ]);
-    expect(
-      menus.view
-        .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
-        .map((entry) => entry.label),
-    ).toContain("Themes…");
-    expect(
-      menus.agent
-        .filter((entry): entry is Extract<MenuEntry, { kind: "item" }> => entry.kind === "item")
-        .map((entry) => entry.label),
-    ).toEqual(["Agent notes", "Agent skill", "Next annotated file", "Previous annotated file"]);
   });
 
   test("escape aliases normalize across terminal input paths", () => {

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -73,7 +73,8 @@ describe("PTY chrome", () => {
       await session.click(/Controls help/);
       const helpDialog = await session.waitForText(/Navigation/, { timeout: 5_000 });
 
-      expect(helpDialog).toContain("g / G");
+      // The key column is rendered from the commands' resolved chords.
+      expect(helpDialog).toContain("g / Home");
     } finally {
       session.close();
     }

--- a/test/pty/extensions-integration.test.ts
+++ b/test/pty/extensions-integration.test.ts
@@ -191,6 +191,47 @@ describe("PTY extensions", () => {
     }
   });
 
+  test("the Extensions menu runs a registered command by mouse", async () => {
+    const configHome = harness.createIsolatedConfigHome();
+    const fixture = harness.createRepoExtensionFixture(SIDEBAR_EXTENSION_SOURCE);
+    const session = await harness.launchHunk({
+      args: [
+        "diff",
+        "--mode",
+        "stack",
+        "--extension",
+        join(fixture.dir, ".hunk", "extensions", "fixture.ts"),
+      ],
+      cwd: fixture.dir,
+      // The sidebar only renders on a "full" viewport, which starts at 220 columns.
+      cols: 240,
+      rows: 24,
+      env: { XDG_CONFIG_HOME: configHome },
+    });
+
+    try {
+      const before = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("alpha.ts") && !text.includes("Run this repository's extensions?"),
+        20_000,
+      );
+      // The menu exists because an extension registered a command.
+      expect(before).toContain("Extensions");
+      expect(before).not.toContain("EXTSIDEBAR");
+
+      await session.click(/Extensions/);
+      // The dropdown names the command by its title and advertises its key.
+      const menu = await session.waitForText(/Toggle fixture/, { timeout: 20_000 });
+      expect(menu).toMatch(/Toggle fixture\s+y/);
+
+      await session.click(/Toggle fixture/);
+      const opened = await session.waitForText(/EXTSIDEBAR 2 FILES/, { timeout: 20_000 });
+      expect(opened).toContain("alpha.ts");
+    } finally {
+      session.close();
+    }
+  });
+
   test("a command key opens an extension sidebar beside the built-in pane", async () => {
     const configHome = harness.createIsolatedConfigHome();
     const fixture = harness.createRepoExtensionFixture(SIDEBAR_EXTENSION_SOURCE);


### PR DESCRIPTION
Follow-up to #611. The dropdown menu bar and the help dialog previously bypassed the named-command system: menu items closed over raw callbacks and hard-coded their key hints, and the help dialog's entire key column was string literals. Remap a command in `[keybindings]` and both kept advertising the old key. Extension commands were also keyboard-only, with no menu presence at all.

## What changed

**Menus and help derive from the command table**
- Menu items now name the command they run (`{commandId, label?, checked?}`): the hint is the command's first *resolved* key label, and selecting the item dispatches through a new `executeAppCommand(commands, id)` — the same table the keyboard uses, so a menu item and its shortcut can never drift apart. A user remap shows its new key in the dropdowns; an unbound command shows no hint.
- The help dialog is rebuilt on a curated content model (`src/ui/lib/helpContent.ts`) whose key cells render from resolved chords. Remapped commands show their new keys; fully unbound commands drop their row instead of advertising a dead key.
- "Reload" menu visibility now derives from `hunk.app.refresh`'s `isEnabled` instead of a parallel flag.

**Four menu-only actions became real commands**, shipped unbound but bindable by id in `[keybindings]`: `hunk.view.toggleCopyDecorations`, `hunk.app.openAgentSkill`, `hunk.review.previousAnnotatedFile`, `hunk.review.nextAnnotatedFile`.

**Automatic Extensions menu**
- A new menu between Agent and Help that exists only when at least one extension registered a command. Entries list each command by title with its current key label, grouped per extension with separators, and dispatch by full id through the shared table — so even a command whose chord was refused (or that never declared one) is still reachable by mouse, restoring the mouse/keyboard parity rule for extension contributions.
- `buildExtensionAppCommands` now keeps unbound/refused commands in the table with never-matching matchers instead of dropping them.
- The menu bar and F10/arrow cycling derive from the same visible-menu list, so a hidden Extensions menu is skipped; a menu that vanishes *while open* (a reload dropping the last extension command) is treated as closed and its state cleared.

## Docs & contract
- `docs/keybindings.md`: the new bindable ids, plus a note that menus/help display resolved keys.
- `docs/extensions.md` / `docs/extension-architecture.md`: the Extensions menu and command-table derivation.
- `src/extension-api/types.ts`: comment-only JSDoc update (`title` now really is shown in a menu); `check:pack` verified the contract stays import-free.
- Changeset: `minor`.

## Testing
- New unit suites: `appMenus.test.ts`, `helpContent.test.ts`, `useMenuController.test.tsx`; extended `appCommands.test.ts`, `extensionCommands.test.ts`, `ui-lib.test.ts`, `ui-components.test.tsx` — covering remapped hints, unbound degradation, `executeAppCommand`, Extensions-menu visibility/grouping, and the vanished-open-menu edge.
- AppHost test: a keyless extension command is reachable through the Extensions menu by keyboard and runs its handler.
- New PTY test: the Extensions menu runs a registered command by mouse click.
- Verified: `typecheck`, targeted `bun test` (782 pass), `check:pack`, `test:integration`, `test:tty-smoke`, lint/format, plus a real TTY smoke run.

Note: the pre-existing PTY flake "a command key opens an extension sidebar" reproduces identically on `main` in the CI container (verified 5/5 on a clean `origin/main` worktree — when it fails, no key events reach the app at all, pointing at PTY stdin delivery in the test harness). It is unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JML2m7oy2sUbFftN7QoHhi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JML2m7oy2sUbFftN7QoHhi)_