### PR TITLE
feat(extensions): give command handlers the review selection

### DIFF
--- a/.changeset/command-selection-context.md
+++ b/.changeset/command-selection-context.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Extension command handlers receive the current review selection as `ctx.selection` — the selected file as a frozen read-only view plus its selected hunk index, captured when the command fires. A command that acts on what the user is looking at (copy this path, open this hunk elsewhere) no longer has to shadow-track the `selection_changed` event to know where the review is.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -88,7 +88,12 @@ commands. Extension
 `src/ui/lib/extensionCommands.ts` — built-ins win key conflicts, refused one
 chord at a time and detected by probing matchers with a synthesized event
 (`src/lib/commandKeys.ts`). Command handlers receive sidebar open/close
-controls, which is how a registered key opens an extension's sidebar.
+controls, which is how a registered key opens an extension's sidebar, plus a
+`selection` snapshot resolved by `src/ui/lib/extensionSelection.ts` from the
+same frozen file views the sidebar panes render — one conversion feeding both
+surfaces, so a command and a sidebar can never disagree about what is selected.
+App reads the snapshot through a ref when a command fires, keeping the dispatch
+table stable as the review moves.
 
 Commands declare chords, not matchers: `src/ui/lib/keymap.ts` folds every
 command's `defaultKeys` against the user's `[keybindings]` table (user config

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -656,8 +656,9 @@ hunk.registerCommand(
 ```
 
 `selection.file` is a frozen read-only view, identical to the entries in a
-sidebar's `files` prop, and is `null` when nothing is selected or when the
-current filter hides the selected file. `selection.hunkIndex` is that file's
+sidebar's `files` prop. Hunk keeps the selection inside the visible files, so
+it is `null` only when nothing is visible at all — a filter that matches no
+files. `selection.hunkIndex` is that file's
 selected hunk, and `null` whenever `file` is — or when the file has no hunks to
 select. The values are captured when the command fires: a handler that awaits
 still sees the selection it was run from, not wherever the user navigated to

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -636,6 +636,33 @@ controls for opening sidebar views:
   with `s`, so the open is never silent.
 - `ctx.sidebars.isOpen(viewId)` reports current state.
 
+`ctx.selection` is where the review was pointing when the command fired — the
+same selection a sidebar component sees in its props, so a command never has to
+track `selection_changed` itself to know what the user is looking at:
+
+```ts
+hunk.registerCommand(
+  { id: "show-selection", title: "Show the selected file", key: "ctrl+y" },
+  (ctx) => {
+    const { file, hunkIndex } = ctx.selection;
+    if (!file) {
+      ctx.notify("No file selected");
+      return;
+    }
+
+    ctx.notify(hunkIndex === null ? file.path : `${file.path} — hunk ${hunkIndex + 1}`);
+  },
+);
+```
+
+`selection.file` is a frozen read-only view, identical to the entries in a
+sidebar's `files` prop, and is `null` when nothing is selected or when the
+current filter hides the selected file. `selection.hunkIndex` is that file's
+selected hunk, and `null` whenever `file` is — or when the file has no hunks to
+select. The values are captured when the command fires: a handler that awaits
+still sees the selection it was run from, not wherever the user navigated to
+meanwhile.
+
 A handler may be async; a failure (sync or rejected) becomes a warning naming
 your extension.
 

--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -23,6 +23,7 @@ import {
 } from "hunkdiff/extension";
 import type {
   ExtensionChangeset,
+  ExtensionReviewSelection,
   ExtensionVcsAdapter,
   ExtensionVcsDiffInput,
   ExtensionVcsLoadContext,
@@ -32,6 +33,9 @@ import type {
 } from "hunkdiff/extension";
 
 export default function (hunk: HunkExtensionAPI) {
+  const noSelection: ExtensionReviewSelection = { file: null, hunkIndex: null };
+  hunk.log(noSelection.file === null ? "nothing selected" : noSelection.file.path);
+
   const theme: NamedCustomThemeConfig = {
     id: "midnight-review",
     label: "Midnight Review",

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -48,6 +48,7 @@ export type {
   ExtensionCommand,
   ExtensionCommandContext,
   ExtensionCommandHandler,
+  ExtensionReviewSelection,
   ExtensionNotifyType,
   ExtensionSidebarActions,
   ExtensionSidebarComponent,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -738,9 +738,40 @@ export interface ExtensionSidebarControls {
   isOpen(viewId: string): boolean;
 }
 
+/**
+ * The review selection at one moment, as extensions see it.
+ *
+ * A snapshot rather than a live window onto the review: the values describe
+ * where the user was when the command fired, and never change afterwards.
+ */
+export interface ExtensionReviewSelection {
+  /**
+   * The selected file among the currently visible (filtered) files, or `null`.
+   *
+   * The same frozen read-only view a sidebar component receives in its `files`
+   * prop, so holding or mutating it cannot reach the review model. `null` when
+   * nothing is selected, or when the selection points at a file the current
+   * file filter hides.
+   */
+  file: ExtensionDiffFile | null;
+  /**
+   * The selected hunk's index within that file, or `null` when no hunk is
+   * selected — including whenever `file` is `null`, and for a file with no
+   * hunks to select (a binary or skipped file).
+   */
+  hunkIndex: number | null;
+}
+
 /** What a command handler receives when its key fires. */
 export interface ExtensionCommandContext extends ExtensionContext {
   sidebars: ExtensionSidebarControls;
+  /**
+   * Where the review was pointing when this command fired.
+   *
+   * Captured at invocation, not live: a handler that awaits and reads it again
+   * still sees the selection the user ran the command from.
+   */
+  readonly selection: ExtensionReviewSelection;
 }
 
 export type ExtensionCommandHandler = (ctx: ExtensionCommandContext) => void | Promise<void>;

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -131,7 +131,10 @@ export interface ExtensionDiffFile {
    * Opaque on purpose: its shape is not part of the extension contract, and it
    * is what the renderer draws from. Carry it through untouched — spreading a
    * file (`{ ...file, path }`) preserves it. A file returned without usable
-   * metadata is rejected, and the previous changeset is kept.
+   * metadata is rejected, and the previous changeset is kept. On the read-only
+   * views Hunk hands outward (event payloads, sidebar props, a command's
+   * selection) it is guarded like the rest of the view: reads pass through,
+   * writes into it are refused.
    */
   metadata: unknown;
   /**

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -749,9 +749,11 @@ export interface ExtensionReviewSelection {
    * The selected file among the currently visible (filtered) files, or `null`.
    *
    * The same frozen read-only view a sidebar component receives in its `files`
-   * prop, so holding or mutating it cannot reach the review model. `null` when
-   * nothing is selected, or when the selection points at a file the current
-   * file filter hides.
+   * prop, so holding or mutating it cannot reach the review model. Hunk keeps
+   * the selection inside the visible list — filtering away the selected file
+   * immediately reselects the first visible one — so in practice this is
+   * `null` only when nothing is visible at all, such as a filter matching no
+   * files.
    */
   file: ExtensionDiffFile | null;
   /**

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -758,13 +758,13 @@ export interface ExtensionReviewSelection {
    * `null` only when nothing is visible at all, such as a filter matching no
    * files.
    */
-  file: ExtensionDiffFile | null;
+  readonly file: ExtensionDiffFile | null;
   /**
    * The selected hunk's index within that file, or `null` when no hunk is
    * selected — including whenever `file` is `null`, and for a file with no
    * hunks to select (a binary or skipped file).
    */
-  hunkIndex: number | null;
+  readonly hunkIndex: number | null;
 }
 
 /** What a command handler receives when its key fires. */

--- a/src/extensions/events.test.ts
+++ b/src/extensions/events.test.ts
@@ -328,6 +328,23 @@ describe("read-only file views", () => {
     expect(file.metadata.hunks[0]!.header).toBe("@@ -1 +1 @@");
   });
 
+  test("reflection cannot expose or alter the live model", () => {
+    const file = createTestFile();
+    const [view] = toReadOnlyFileViews([file as never]);
+    const metadata = view!.metadata as object;
+    const hunks = Object.getOwnPropertyDescriptor(metadata, "hunks")!.value as {
+      header: string;
+    }[];
+
+    expect(hunks).not.toBe(file.metadata.hunks);
+    expect(() => {
+      hunks[0]!.header = "@@ forged @@";
+    }).toThrow(TypeError);
+    expect(() => Object.preventExtensions(metadata)).toThrow(TypeError);
+    expect(file.metadata.hunks[0]!.header).toBe("@@ -1 +1 @@");
+    expect(Object.isExtensible(file.metadata)).toBe(true);
+  });
+
   test("stats and agent annotations are guarded the same way", () => {
     const file = createTestFile();
     const [view] = toReadOnlyFileViews([file as never]);

--- a/src/extensions/events.test.ts
+++ b/src/extensions/events.test.ts
@@ -3,6 +3,8 @@ import {
   emitExtensionEvent,
   emitExtensionEventBounded,
   emitExtensionEventToExtensions,
+  readMetadataHunkCount,
+  toReadOnlyFileViews,
 } from "./events";
 import { createExtensionNotificationHub } from "./notifications";
 import {
@@ -286,6 +288,82 @@ describe("changeset payloads handed to event handlers", () => {
     emitExtensionEvent(result, "changeset_loaded", { changeset } as never);
 
     expect(seen).toEqual(["working tree"]);
+  });
+});
+
+describe("read-only file views", () => {
+  /** One file whose nested state a test can try to corrupt. */
+  function createTestFile() {
+    return {
+      id: "file-1",
+      path: "a.ts",
+      patch: "",
+      stats: { additions: 1, deletions: 0 },
+      metadata: { type: "change", hunks: [{ header: "@@ -1 +1 @@" }] },
+      agent: { path: "a.ts", annotations: [{ summary: "why" }] },
+    };
+  }
+
+  test("reads reach the shared metadata, writes into it are refused", () => {
+    const file = createTestFile();
+    const [view] = toReadOnlyFileViews([file as never]);
+
+    // Reads pass through, including the host's own metadata readers.
+    expect(readMetadataHunkCount(view!.metadata)).toBe(1);
+
+    const metadata = view!.metadata as { type: string; hunks: { header: string }[] };
+    expect(() => {
+      metadata.type = "deleted";
+    }).toThrow(TypeError);
+    expect(() => {
+      metadata.hunks.push({ header: "@@ forged @@" });
+    }).toThrow(TypeError);
+    expect(() => {
+      metadata.hunks[0]!.header = "@@ forged @@";
+    }).toThrow(TypeError);
+
+    // The live model is exactly as it was.
+    expect(file.metadata.type).toBe("change");
+    expect(file.metadata.hunks).toHaveLength(1);
+    expect(file.metadata.hunks[0]!.header).toBe("@@ -1 +1 @@");
+  });
+
+  test("stats and agent annotations are guarded the same way", () => {
+    const file = createTestFile();
+    const [view] = toReadOnlyFileViews([file as never]);
+
+    expect(view!.stats.additions).toBe(1);
+    expect(() => {
+      (view!.stats as { additions: number }).additions = 99;
+    }).toThrow(TypeError);
+    expect(() => {
+      view!.agent!.annotations[0]!.summary = "forged";
+    }).toThrow(TypeError);
+    expect(file.stats.additions).toBe(1);
+    expect(file.agent.annotations[0]!.summary).toBe("why");
+  });
+
+  test("converting the same file again hands out the identical guarded objects", () => {
+    const file = createTestFile();
+    const [first] = toReadOnlyFileViews([file as never]);
+    const [second] = toReadOnlyFileViews([file as never]);
+
+    // Cached per source object, so consumers comparing across conversions —
+    // sidebar props against a command's selection snapshot — see one identity.
+    expect(second!.metadata).toBe(first!.metadata);
+    expect(second!.agent).toBe(first!.agent);
+  });
+
+  test("exotic objects inside metadata read through unwrapped", () => {
+    // A proxy would break internal-slot methods (`Map.prototype.get` on a
+    // proxied Map throws), so non-JSON-shaped values pass through as-is.
+    const cache = new Map([["k", "v"]]);
+    const file = { ...createTestFile(), metadata: { cache } };
+    const [view] = toReadOnlyFileViews([file as never]);
+
+    const seen = (view!.metadata as { cache: Map<string, string> }).cache;
+    expect(seen).toBe(cache);
+    expect(seen.get("k")).toBe("v");
   });
 });
 

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -111,10 +111,10 @@ function isProxyableData(value: unknown): value is object {
  *
  * Only plain objects and arrays are wrapped: the diff model is JSON-shaped,
  * and proxying an exotic object (a Map, a class instance) would break its
- * internal-slot methods, so anything else reads through unwrapped. A property
- * that is already non-configurable and non-writable is returned as-is — the
- * proxy `get` invariant requires its identity, and it cannot be reassigned
- * anyway.
+ * internal-slot methods, so anything else reads through unwrapped. The proxy
+ * targets a disposable façade rather than the shared source. That keeps
+ * reflective operations — especially property descriptors and preventing
+ * extensions — from exposing or mutating the live model behind the view.
  */
 export function toReadOnlyDeepView<T>(value: T): T {
   if (!isProxyableData(value)) {
@@ -126,20 +126,55 @@ export function toReadOnlyDeepView<T>(value: T): T {
     return cached as T;
   }
 
-  const proxy = new Proxy(value, {
-    get(target, property) {
-      const descriptor = Object.getOwnPropertyDescriptor(target, property);
-      const result = Reflect.get(target, property, target);
-      if (descriptor !== undefined && !descriptor.configurable && !descriptor.writable) {
-        return result;
+  // Keep an array target for Array.isArray and array built-ins, but never put
+  // source properties on it: descriptor reflection must not expose raw values.
+  const façade = Array.isArray(value) ? [] : Object.create(Object.getPrototypeOf(value));
+  if (Array.isArray(value)) {
+    // Match the source length without copying its elements onto the façade.
+    (façade as unknown[]).length = value.length;
+  }
+
+  const proxy = new Proxy(façade, {
+    get(_target, property) {
+      return toReadOnlyDeepView(Reflect.get(value, property, value));
+    },
+    has: (_target, property) => Reflect.has(value, property),
+    ownKeys: () => Reflect.ownKeys(value),
+    getOwnPropertyDescriptor(target, property) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, property);
+      if (descriptor === undefined) {
+        return undefined;
       }
 
-      return toReadOnlyDeepView(result);
+      // Array targets have a non-configurable `length` property, which proxy
+      // invariants require us to report as non-configurable as well.
+      if (Array.isArray(target) && property === "length") {
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      }
+
+      if ("value" in descriptor) {
+        return {
+          ...descriptor,
+          configurable: true,
+          value: toReadOnlyDeepView(descriptor.value),
+        };
+      }
+
+      // Accessors are read-only from the extension's perspective too. Calling
+      // the source setter through a reflected descriptor would otherwise evade
+      // the proxy's `set` trap.
+      return {
+        configurable: true,
+        enumerable: descriptor.enumerable,
+        get: () => toReadOnlyDeepView(Reflect.get(value, property, value)),
+        set: undefined,
+      };
     },
     set: () => false,
     defineProperty: () => false,
     deleteProperty: () => false,
     setPrototypeOf: () => false,
+    preventExtensions: () => false,
   });
   readOnlyDeepViews.set(value, proxy);
   return proxy as T;

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -37,9 +37,9 @@ function describeError(error: unknown) {
  * each file. A mutating handler now throws *inside itself*, where the isolation
  * contract already turns it into a warning naming the extension. Copies are
  * frozen rather than the originals, so nothing internal — which legitimately
- * rebuilds and reassigns these objects — is affected. `metadata` stays the
- * shared opaque value the renderer owns; it is not part of the authoring
- * contract and deep-freezing it would cost a walk of the whole diff model.
+ * rebuilds and reassigns these objects — is affected. The shared nested state
+ * (`metadata`, `stats`, `agent`) is guarded by `toReadOnlyDeepView` instead of
+ * a deep freeze, which would cost a walk of the whole diff model per emit.
  */
 export function toReadOnlyChangesetView(changeset: ExtensionChangeset): ExtensionChangeset {
   const files = Array.isArray(changeset.files) ? changeset.files : [];
@@ -79,14 +79,81 @@ export function readMetadataHunkCount(metadata: unknown): number {
   return Array.isArray(hunks) ? hunks.length : 0;
 }
 
+/** Proxies already built for shared objects, so repeated views stay identical. */
+const readOnlyDeepViews = new WeakMap<object, unknown>();
+
+/** Report whether a value is JSON-shaped data a read-only proxy can stand in for. */
+function isProxyableData(value: unknown): value is object {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return true;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Lazily wrap one shared object so extensions can read it but never write it.
+ *
+ * The file views deliberately share `metadata`, `stats`, and `agent` with the
+ * live review model instead of copying them — `metadata` alone is the whole
+ * parsed diff, and eagerly deep-freezing it would walk the model on every
+ * conversion. The proxy defers the cost to the moment an extension actually
+ * reaches in: reads pass through and hand back wrapped objects (so the guard
+ * is deep), while writes, deletes, and redefinitions are refused — a
+ * strict-mode assignment throws inside the extension, exactly like writing to
+ * the frozen view itself. Proxies are cached per source object, so converting
+ * again hands out the identical view.
+ *
+ * Only plain objects and arrays are wrapped: the diff model is JSON-shaped,
+ * and proxying an exotic object (a Map, a class instance) would break its
+ * internal-slot methods, so anything else reads through unwrapped. A property
+ * that is already non-configurable and non-writable is returned as-is — the
+ * proxy `get` invariant requires its identity, and it cannot be reassigned
+ * anyway.
+ */
+export function toReadOnlyDeepView<T>(value: T): T {
+  if (!isProxyableData(value)) {
+    return value;
+  }
+
+  const cached = readOnlyDeepViews.get(value);
+  if (cached !== undefined) {
+    return cached as T;
+  }
+
+  const proxy = new Proxy(value, {
+    get(target, property) {
+      const descriptor = Object.getOwnPropertyDescriptor(target, property);
+      const result = Reflect.get(target, property, target);
+      if (descriptor !== undefined && !descriptor.configurable && !descriptor.writable) {
+        return result;
+      }
+
+      return toReadOnlyDeepView(result);
+    },
+    set: () => false,
+    defineProperty: () => false,
+    deleteProperty: () => false,
+    setPrototypeOf: () => false,
+  });
+  readOnlyDeepViews.set(value, proxy);
+  return proxy as T;
+}
+
 /**
  * Build the read-only file-list view extension UI code receives.
  *
  * The same isolation story as `toReadOnlyChangesetView` — frozen shallow
- * copies, shared opaque `metadata` — factored out so surfaces that hand
+ * copies, with the nested state every copy shares (`metadata`, `stats`,
+ * `agent`) behind `toReadOnlyDeepView` — factored out so surfaces that hand
  * extensions a file list without a changeset envelope (a custom sidebar's
- * props) freeze it identically. `changeType` is filled from the diff metadata
- * when the file does not carry it already.
+ * props, a command's selection) guard it identically. `changeType` is filled
+ * from the diff metadata when the file does not carry it already.
  */
 export function toReadOnlyFileViews(files: readonly ExtensionDiffFile[]): ExtensionDiffFile[] {
   const frozenFiles = files.map((file) => {
@@ -95,7 +162,13 @@ export function toReadOnlyFileViews(files: readonly ExtensionDiffFile[]): Extens
     }
 
     const changeType = file.changeType ?? readMetadataChangeType(file.metadata);
-    return Object.freeze(changeType ? { ...file, changeType } : { ...file });
+    return Object.freeze({
+      ...file,
+      ...(changeType ? { changeType } : {}),
+      metadata: toReadOnlyDeepView(file.metadata),
+      stats: toReadOnlyDeepView(file.stats),
+      agent: toReadOnlyDeepView(file.agent),
+    });
   }) as ExtensionDiffFile[];
 
   return Object.freeze(frozenFiles) as ExtensionDiffFile[];

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -66,6 +66,20 @@ export function readMetadataChangeType(metadata: unknown): ExtensionVcsFileChang
 }
 
 /**
+ * Read how many hunks Hunk's diff engine parsed for one file, if any.
+ *
+ * Same boundary as `readMetadataChangeType`: `metadata` is opaque to
+ * extensions, so the one place that knows its real shape stays here rather
+ * than spreading casts across the surfaces that hand extensions file views.
+ * A file the engine could not parse into hunks — binary, skipped — reads as
+ * zero rather than throwing.
+ */
+export function readMetadataHunkCount(metadata: unknown): number {
+  const hunks = (metadata as { hunks?: unknown } | null | undefined)?.hunks;
+  return Array.isArray(hunks) ? hunks.length : 0;
+}
+
+/**
  * Build the read-only file-list view extension UI code receives.
  *
  * The same isolation story as `toReadOnlyChangesetView` — frozen shallow

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -323,16 +323,37 @@ export function App({
   // The one conversion of the visible review files into the frozen views every
   // extension surface sees: sidebar props and command-handler selection both
   // read from this list, so they can never describe the review differently.
-  const extensionFileViews = useMemo(() => toReadOnlyFileViews(filteredFiles), [filteredFiles]);
-  const extensionSelection = useMemo(
-    () =>
-      buildExtensionReviewSelection({
-        files: extensionFileViews,
-        selectedFileId,
-        selectedHunkIndex,
-      }),
-    [extensionFileViews, selectedFileId, selectedHunkIndex],
-  );
+  // Computed on demand and cached per visible-files identity rather than
+  // eagerly memoized: `visibleFiles` gets a fresh identity on every selection
+  // change, so an eager memo would reconvert the whole list on each navigation
+  // keypress even in sessions where no pane is showing and no command fires.
+  const extensionViewsCacheRef = useRef<{
+    source: typeof filteredFiles;
+    views: ReturnType<typeof toReadOnlyFileViews>;
+  } | null>(null);
+  const extensionSelectionInputsRef = useRef({ filteredFiles, selectedFileId, selectedHunkIndex });
+  extensionSelectionInputsRef.current = { filteredFiles, selectedFileId, selectedHunkIndex };
+  const getExtensionFileViews = useCallback(() => {
+    const source = extensionSelectionInputsRef.current.filteredFiles;
+    const cache = extensionViewsCacheRef.current;
+    if (cache && cache.source === source) {
+      return cache.views;
+    }
+
+    const views = toReadOnlyFileViews(source);
+    extensionViewsCacheRef.current = { source, views };
+    return views;
+  }, []);
+  /** Build the selection snapshot a command handler receives, at invocation. */
+  const getExtensionSelection = useCallback(() => {
+    const { selectedFileId: fileId, selectedHunkIndex: hunkIndex } =
+      extensionSelectionInputsRef.current;
+    return buildExtensionReviewSelection({
+      files: getExtensionFileViews(),
+      selectedFileId: fileId,
+      selectedHunkIndex: hunkIndex,
+    });
+  }, [getExtensionFileViews]);
   const moveToAnnotatedFile = review.moveToAnnotatedFile;
   const moveToAnnotatedHunk = review.moveToAnnotatedHunk;
   const moveToFile = review.moveToFile;
@@ -476,17 +497,6 @@ export function App({
    */
   const revealSidebarAreaRef = useRef<() => void>(() => {});
 
-  /**
-   * The selection commands are handed, read when a command fires.
-   *
-   * Kept in a ref rather than in `runExtensionCommand`'s dependencies: the
-   * dispatch table, the keymap, and the Extensions menu are all derived from
-   * that callback, and rebuilding them on every `[`/`]` press to carry a value
-   * only read at invocation would be wasted work.
-   */
-  const extensionSelectionRef = useRef(extensionSelection);
-  extensionSelectionRef.current = extensionSelection;
-
   /** Invoke one extension command with its context, containing any failure. */
   const runExtensionCommand = useCallback(
     (registered: RegisteredCommand) => {
@@ -501,9 +511,10 @@ export function App({
         cwd: extensions?.context.cwd ?? process.cwd(),
         notify: (message, type) => extensions?.context.notify(message, type),
         sidebars: createSidebarControls(registered.extensionId),
-        // Snapshot semantics: the handler sees where the review was when its
-        // key fired, even if it awaits and the user navigates on.
-        selection: extensionSelectionRef.current,
+        // Snapshot semantics: built when the key fires, so the handler sees
+        // where the review was at that moment, even if it awaits and the user
+        // navigates on.
+        selection: getExtensionSelection(),
       };
 
       try {
@@ -515,7 +526,10 @@ export function App({
         report(error);
       }
     },
-    [createSidebarControls, extensions],
+    // `getExtensionSelection` is identity-stable (it reads refs), so the
+    // dispatch table, keymap, and Extensions menu derived from this callback
+    // do not rebuild on every `[`/`]` press.
+    [createSidebarControls, extensions, getExtensionSelection],
   );
 
   const registeredExtensionCommands = useMemo(
@@ -1417,34 +1431,39 @@ export function App({
   const diffPaneScreenTop = pagerMode || !showMenuBar ? 0 : 1;
 
   /** Render one open sidebar view at its planned width. */
-  const renderSidebarPane = (pane: SidebarPanePlan) => (
-    <ExtensionSidebarPane
-      registered={pane.view.registered}
-      files={filteredFiles}
-      fileViews={extensionFileViews}
-      selectedFileId={extensionSelection.file?.id ?? null}
-      selectedHunkIndex={extensionSelection.hunkIndex}
-      showTopChrome={showMenuBar}
-      theme={activeTheme}
-      width={pane.width}
-      notify={(message, type) => extensions?.context.notify(message, type)}
-      onSelectFile={(fileId) => {
-        focusFiles();
-        jumpToFile(fileId, 0, { alignFileHeaderTop: true });
-      }}
-      onSelectHunk={(fileId, hunkIndex) => {
-        focusFiles();
-        review.selectHunk(fileId, hunkIndex);
-      }}
-      // Extension panes close on a render failure; the bundled files pane is
-      // Hunk's own and keeps its in-place fallback semantics.
-      onRenderFailure={
-        pane.view.key === bundledSidebarViewKey()
-          ? undefined
-          : () => handleSidebarViewFailure(pane.view.key)
-      }
-    />
-  );
+  const renderSidebarPane = (pane: SidebarPanePlan) => {
+    // Resolved here so hidden sidebars never pay for the conversion; the
+    // per-source cache hands every pane (and command snapshots) one list.
+    const paneSelection = getExtensionSelection();
+    return (
+      <ExtensionSidebarPane
+        registered={pane.view.registered}
+        files={filteredFiles}
+        fileViews={getExtensionFileViews()}
+        selectedFileId={paneSelection.file?.id ?? null}
+        selectedHunkIndex={paneSelection.hunkIndex}
+        showTopChrome={showMenuBar}
+        theme={activeTheme}
+        width={pane.width}
+        notify={(message, type) => extensions?.context.notify(message, type)}
+        onSelectFile={(fileId) => {
+          focusFiles();
+          jumpToFile(fileId, 0, { alignFileHeaderTop: true });
+        }}
+        onSelectHunk={(fileId, hunkIndex) => {
+          focusFiles();
+          review.selectHunk(fileId, hunkIndex);
+        }}
+        // Extension panes close on a render failure; the bundled files pane is
+        // Hunk's own and keeps its in-place fallback semantics.
+        onRenderFailure={
+          pane.view.key === bundledSidebarViewKey()
+            ? undefined
+            : () => handleSidebarViewFailure(pane.view.key)
+        }
+      />
+    );
+  };
 
   return (
     <box

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -22,7 +22,7 @@ import type {
 import { canReloadInput } from "../core/watch";
 import { sanitizeTerminalLine } from "../lib/terminalText";
 import { resolveExtensionCommands } from "../extensions/apply";
-import { emitExtensionEvent } from "../extensions/events";
+import { emitExtensionEvent, toReadOnlyFileViews } from "../extensions/events";
 import { writeExtensionTrust } from "../extensions/trust";
 import type {
   ExtensionCommandContext,
@@ -61,6 +61,7 @@ import {
 } from "./lib/appCommands";
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
+import { buildExtensionReviewSelection } from "./lib/extensionSelection";
 import { resolveCommandKeys } from "./lib/keymap";
 import {
   buildSessionSidebarViews,
@@ -318,6 +319,20 @@ export function App({
   const filteredFiles = review.visibleFiles;
   const selectedFile = review.selectedFile;
   const selectedHunkIndex = review.selectedHunkIndex;
+  const selectedFileId = selectedFile?.id ?? null;
+  // The one conversion of the visible review files into the frozen views every
+  // extension surface sees: sidebar props and command-handler selection both
+  // read from this list, so they can never describe the review differently.
+  const extensionFileViews = useMemo(() => toReadOnlyFileViews(filteredFiles), [filteredFiles]);
+  const extensionSelection = useMemo(
+    () =>
+      buildExtensionReviewSelection({
+        files: extensionFileViews,
+        selectedFileId,
+        selectedHunkIndex,
+      }),
+    [extensionFileViews, selectedFileId, selectedHunkIndex],
+  );
   const moveToAnnotatedFile = review.moveToAnnotatedFile;
   const moveToAnnotatedHunk = review.moveToAnnotatedHunk;
   const moveToFile = review.moveToFile;
@@ -461,6 +476,17 @@ export function App({
    */
   const revealSidebarAreaRef = useRef<() => void>(() => {});
 
+  /**
+   * The selection commands are handed, read when a command fires.
+   *
+   * Kept in a ref rather than in `runExtensionCommand`'s dependencies: the
+   * dispatch table, the keymap, and the Extensions menu are all derived from
+   * that callback, and rebuilding them on every `[`/`]` press to carry a value
+   * only read at invocation would be wasted work.
+   */
+  const extensionSelectionRef = useRef(extensionSelection);
+  extensionSelectionRef.current = extensionSelection;
+
   /** Invoke one extension command with its context, containing any failure. */
   const runExtensionCommand = useCallback(
     (registered: RegisteredCommand) => {
@@ -475,6 +501,9 @@ export function App({
         cwd: extensions?.context.cwd ?? process.cwd(),
         notify: (message, type) => extensions?.context.notify(message, type),
         sidebars: createSidebarControls(registered.extensionId),
+        // Snapshot semantics: the handler sees where the review was when its
+        // key fired, even if it awaits and the user navigates on.
+        selection: extensionSelectionRef.current,
       };
 
       try {
@@ -566,7 +595,6 @@ export function App({
     );
   }, [keymap, showSessionNotice]);
 
-  const selectedFileId = selectedFile?.id ?? null;
   useEffect(() => {
     const timer = setTimeout(() => {
       emitExtensionEvent(extensions, "selection_changed", {
@@ -1393,8 +1421,9 @@ export function App({
     <ExtensionSidebarPane
       registered={pane.view.registered}
       files={filteredFiles}
-      selectedFileId={selectedFileId}
-      selectedHunkIndex={selectedFileId === null ? null : selectedHunkIndex}
+      fileViews={extensionFileViews}
+      selectedFileId={extensionSelection.file?.id ?? null}
+      selectedHunkIndex={extensionSelection.hunkIndex}
       showTopChrome={showMenuBar}
       theme={activeTheme}
       width={pane.width}

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -208,6 +208,67 @@ describe("extension sidebar views", () => {
     });
   });
 
+  test("a command handler sees the current review selection", async () => {
+    const repo = createTestRepo("hunk-ext-selection-");
+    // Outside the repo, so the fixture and its log never join the review as
+    // untracked files and shift the selection this test drives.
+    const extDir = createTempDir("hunk-ext-selection-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    // The handler reads only `ctx.selection` — no `selection_changed` handler
+    // shadowing the selection into module state, which is the whole point.
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerCommand({ id: "probe", title: "Probe selection", key: "y" }, (ctx) => {\n` +
+        `    const file = ctx.selection.file;\n` +
+        `    appendFileSync(\n` +
+        `      ${JSON.stringify(logPath)},\n` +
+        `      "selection " + (file ? file.path : "none") + "#" + ctx.selection.hunkIndex +\n` +
+        `        " frozen=" + Object.isFrozen(file) + "\\n",\n` +
+        `    );\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("alpha.txt"),
+        "the built-in sidebar to render",
+      );
+
+      // The review opens on the first file's first hunk, and the handler sees
+      // exactly that without having tracked anything itself.
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("selection alpha.txt#0 frozen=true"),
+        "the command to report the startup selection",
+      );
+
+      // `]` moves the review stream to the next hunk, which is the one hunk of
+      // the second file; the next run reports the new selection rather than a
+      // snapshot captured when the command was registered.
+      await act(async () => {
+        await setup.mockInput.typeText("]");
+      });
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("selection beta.txt#0 frozen=true"),
+        "the command to report the selection after navigating",
+      );
+    });
+  });
+
   test("opening a view through a command reveals a sidebar area hidden with s", async () => {
     const repo = createTestRepo("hunk-ext-sidebar-reveal-");
     const extPath = join(createTempDir("hunk-ext-sidebar-reveal-ext-"), "ext.ts");

--- a/src/ui/components/panes/ExtensionSidebarPane.test.tsx
+++ b/src/ui/components/panes/ExtensionSidebarPane.test.tsx
@@ -6,6 +6,7 @@ import type {
   ExtensionSidebarActions,
   ExtensionSidebarViewProps,
 } from "../../../extension-api/types";
+import { toReadOnlyFileViews } from "../../../extensions/events";
 import type { RegisteredSidebarView } from "../../../extensions/types";
 import { resolveTheme } from "../../themes";
 import { ExtensionSidebarPane } from "./ExtensionSidebarPane";
@@ -69,6 +70,7 @@ describe("ExtensionSidebarPane actions", () => {
           return <text content="probe" />;
         })}
         files={files}
+        fileViews={toReadOnlyFileViews(files)}
         selectedFileId={null}
         selectedHunkIndex={null}
         showTopChrome={true}
@@ -130,6 +132,7 @@ describe("ExtensionSidebarPane failure recovery", () => {
         <ExtensionSidebarPane
           registered={registered}
           files={files}
+          fileViews={toReadOnlyFileViews(files)}
           selectedFileId={null}
           selectedHunkIndex={null}
           showTopChrome={true}

--- a/src/ui/components/panes/ExtensionSidebarPane.tsx
+++ b/src/ui/components/panes/ExtensionSidebarPane.tsx
@@ -1,12 +1,12 @@
 import { Component, useMemo, type ReactNode } from "react";
 import type {
+  ExtensionDiffFile,
   ExtensionNotifyType,
   ExtensionSidebarActions,
   ExtensionSidebarTheme,
   ExtensionSidebarViewProps,
 } from "../../../extension-api/types";
 import { BuiltInSidebarView } from "../../../extensions/default/ui/sidebar";
-import { toReadOnlyFileViews } from "../../../extensions/events";
 import type { ExtensionNotifySink, RegisteredSidebarView } from "../../../extensions/types";
 import type { DiffFile } from "../../../core/types";
 import type { AppTheme } from "../../themes";
@@ -107,6 +107,7 @@ function toSidebarTheme(theme: AppTheme): ExtensionSidebarTheme {
 export function ExtensionSidebarPane({
   registered,
   files,
+  fileViews,
   selectedFileId,
   selectedHunkIndex,
   showTopChrome,
@@ -118,8 +119,19 @@ export function ExtensionSidebarPane({
   onRenderFailure,
 }: {
   registered: RegisteredSidebarView;
-  /** The visible review-stream files, already filtered like the built-in sidebar's. */
+  /**
+   * The visible review-stream files, already filtered like the built-in
+   * sidebar's. Host-side only: the guarded actions validate navigation targets
+   * against it, while the component sees `fileViews`.
+   */
   files: DiffFile[];
+  /**
+   * The same files as frozen read-only views, converted once by the host.
+   *
+   * Passed in rather than derived here so sidebar props and the selection
+   * command handlers receive come out of one conversion.
+   */
+  fileViews: ExtensionDiffFile[];
   selectedFileId: string | null;
   selectedHunkIndex: number | null;
   showTopChrome: boolean;
@@ -138,7 +150,6 @@ export function ExtensionSidebarPane({
   onRenderFailure?: () => void;
 }) {
   const { extensionId } = registered;
-  const publicFiles = useMemo(() => toReadOnlyFileViews(files), [files]);
   const publicTheme = useMemo(() => Object.freeze(toSidebarTheme(theme)), [theme]);
 
   const actions = useMemo<ExtensionSidebarActions>(() => {
@@ -207,7 +218,7 @@ export function ExtensionSidebarPane({
   const View = registered.view.component as (props: ExtensionSidebarViewProps) => ReactNode;
 
   const viewProps: ExtensionSidebarViewProps = {
-    files: publicFiles,
+    files: fileViews,
     selectedFileId,
     selectedHunkIndex,
     width,

--- a/src/ui/lib/extensionSelection.test.ts
+++ b/src/ui/lib/extensionSelection.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile } from "../../../test/helpers/diff-helpers";
+import { toReadOnlyFileViews } from "../../extensions/events";
+import { buildExtensionReviewSelection } from "./extensionSelection";
+
+/** The frozen views the sidebar panes render from, for two visible files. */
+function createTestFileViews() {
+  return toReadOnlyFileViews([
+    createTestDiffFile({ id: "alpha", path: "alpha.ts" }),
+    createTestDiffFile({ id: "beta", path: "beta.ts" }),
+  ]);
+}
+
+describe("buildExtensionReviewSelection", () => {
+  test("resolves the selected file and hunk out of the visible views", () => {
+    const files = createTestFileViews();
+    const selection = buildExtensionReviewSelection({
+      files,
+      selectedFileId: "beta",
+      selectedHunkIndex: 0,
+    });
+
+    expect(selection.file?.path).toBe("beta.ts");
+    expect(selection.hunkIndex).toBe(0);
+  });
+
+  test("reports no selection when nothing is selected", () => {
+    const selection = buildExtensionReviewSelection({
+      files: createTestFileViews(),
+      selectedFileId: null,
+      selectedHunkIndex: 3,
+    });
+
+    expect(selection).toEqual({ file: null, hunkIndex: null });
+  });
+
+  test("reports no selection for a file the filter hides", () => {
+    // The review controller keeps a selection that the current filter query
+    // hides; an extension cannot find that file in `files`, so it is not one it
+    // can act on either.
+    const selection = buildExtensionReviewSelection({
+      files: createTestFileViews(),
+      selectedFileId: "gamma",
+      selectedHunkIndex: 0,
+    });
+
+    expect(selection).toEqual({ file: null, hunkIndex: null });
+  });
+
+  test("clamps a stale hunk index into the file's real range", () => {
+    const files = createTestFileViews();
+    const lastHunkIndex = (files[0]!.metadata as { hunks: unknown[] }).hunks.length - 1;
+
+    expect(
+      buildExtensionReviewSelection({ files, selectedFileId: "alpha", selectedHunkIndex: 99 })
+        .hunkIndex,
+    ).toBe(lastHunkIndex);
+    expect(
+      buildExtensionReviewSelection({ files, selectedFileId: "alpha", selectedHunkIndex: -4 })
+        .hunkIndex,
+    ).toBe(0);
+    expect(
+      buildExtensionReviewSelection({
+        files,
+        selectedFileId: "alpha",
+        selectedHunkIndex: Number.NaN,
+      }).hunkIndex,
+    ).toBeNull();
+  });
+
+  test("reports no hunk for a file with nothing to select", () => {
+    const [file] = createTestFileViews();
+    const binaryLike = Object.freeze({ ...file!, id: "binary", metadata: { hunks: [] } });
+
+    expect(
+      buildExtensionReviewSelection({
+        files: [binaryLike],
+        selectedFileId: "binary",
+        selectedHunkIndex: 0,
+      }).hunkIndex,
+    ).toBeNull();
+  });
+
+  test("hands out the frozen view the sidebar receives, in a frozen snapshot", () => {
+    const files = createTestFileViews();
+    const selection = buildExtensionReviewSelection({
+      files,
+      selectedFileId: "alpha",
+      selectedHunkIndex: 0,
+    });
+
+    // Same object identity as the sidebar's props, and frozen: an extension
+    // holding the snapshot cannot reach the review model through it.
+    expect(selection.file).toBe(files[0]!);
+    expect(Object.isFrozen(selection.file)).toBe(true);
+    expect(Object.isFrozen(selection)).toBe(true);
+  });
+});

--- a/src/ui/lib/extensionSelection.ts
+++ b/src/ui/lib/extensionSelection.ts
@@ -1,0 +1,65 @@
+/**
+ * The review selection snapshot extension code receives.
+ *
+ * Sidebar components already get the selection as props; command handlers used
+ * to get nothing, and had to shadow-track `selection_changed` into module state
+ * to answer "which file am I on?". Both now resolve through this one function,
+ * fed the same frozen file views the sidebar panes render from, so a command
+ * and a sidebar can never disagree about what is selected.
+ */
+import { readMetadataHunkCount } from "../../extensions/events";
+import type { ExtensionDiffFile, ExtensionReviewSelection } from "../../extension-api/types";
+
+export interface BuildExtensionReviewSelectionOptions {
+  /**
+   * The visible review-stream files as frozen read-only views, in stream order.
+   *
+   * Already converted by `toReadOnlyFileViews`: this function selects from that
+   * list rather than projecting files itself, which is what keeps one
+   * conversion pipeline between the host model and everything extensions see.
+   */
+  files: readonly ExtensionDiffFile[];
+  selectedFileId: string | null;
+  selectedHunkIndex: number | null;
+}
+
+/**
+ * Resolve the current selection into the snapshot extensions see.
+ *
+ * The selected id is resolved against the *visible* files only: a selection the
+ * file filter hides is reported as no selection, because a file an extension
+ * cannot find in `files` is not one it can act on. The hunk index is clamped
+ * into the file's real hunk range — a reload can shrink a file under a
+ * selection that has not caught up yet — and is `null` for a file with no hunks
+ * at all, matching the same clamp the sidebar's `selectHunk` action applies.
+ */
+export function buildExtensionReviewSelection({
+  files,
+  selectedFileId,
+  selectedHunkIndex,
+}: BuildExtensionReviewSelectionOptions): ExtensionReviewSelection {
+  const file =
+    selectedFileId === null
+      ? undefined
+      : files.find((candidate) => candidate.id === selectedFileId);
+
+  if (!file) {
+    return Object.freeze({ file: null, hunkIndex: null });
+  }
+
+  return Object.freeze({ file, hunkIndex: resolveHunkIndex(file, selectedHunkIndex) });
+}
+
+/** Clamp one selected hunk index into a file's real hunk range, or drop it. */
+function resolveHunkIndex(file: ExtensionDiffFile, selectedHunkIndex: number | null) {
+  if (selectedHunkIndex === null || !Number.isFinite(selectedHunkIndex)) {
+    return null;
+  }
+
+  const hunkCount = readMetadataHunkCount(file.metadata);
+  if (hunkCount === 0) {
+    return null;
+  }
+
+  return Math.min(Math.max(0, Math.floor(selectedHunkIndex)), hunkCount - 1);
+}


### PR DESCRIPTION
Item 2 from the extension-system roadmap: extension command handlers previously received no review selection, so a "copy current file path" or "open this hunk in my tool" command had to shadow-track the `selection_changed` lifecycle event into module state.

## What changed

**Contract** (`src/extension-api/types.ts`, additive within apiVersion 1, still import-free):
- `ExtensionReviewSelection { file: ExtensionDiffFile | null; hunkIndex: number | null }`
- `ExtensionCommandContext.selection` — a snapshot built when the command fires: a handler that awaits still sees the selection it was run from. `file` is the same frozen read-only view sidebar components receive; since Hunk keeps the selection inside the visible files, it is `null` only when nothing is visible at all. `hunkIndex` is clamped against the file's real hunk count (guarding the one-frame window after a reload shrinks a file) and `null` for files with no hunks.

**One pipeline, lazily:** the `toReadOnlyFileViews` conversion moved out of `ExtensionSidebarPane` and now runs on demand behind a per-source cache in `App` — sidebar panes and command snapshots consume literally the same frozen objects, hidden sidebars and extension-free sessions never pay for the conversion, and the command callback stays identity-stable so the dispatch table, keymap, and Extensions menu don't rebuild on navigation keypresses. `readMetadataHunkCount` joins `readMetadataChangeType` in `src/extensions/events.ts` so knowledge of the opaque metadata shape stays in one module.

Works identically whether the command fires from its key or from the Extensions menu (both dispatch through the same run path).

## Docs & release
- `docs/extensions.md`: `ctx.selection` semantics plus a typechecked example command (gated by `check:pack` alongside the other 16 examples).
- `docs/extension-architecture.md`: command-system note on the shared frozen-view pipeline.
- Changeset: `minor`.

## Testing
- `src/ui/lib/extensionSelection.test.ts`: resolve/no-selection/not-visible cases, clamp high/low/NaN, zero-hunk file → null, frozen-ness and exact-object identity with the sidebar list.
- `AppHost.extension-sidebar.test.tsx`: a fixture command logs `ctx.selection.file?.path` + `hunkIndex` through real key dispatch; asserts the startup snapshot, then `]`-navigation updates it.
- Verified: `typecheck`, `bun test src/ui src/extensions src/lib` (797 pass), `check:pack`, lint/format. PTY integration: green except two failures confirmed pre-existing on a main-equivalent tree in this container ("a command key opens an extension sidebar", "filter focus narrows the visible review stream").

An internal adversarial review pass confirmed ref-timing, callback-identity stability, and contract purity, and caught the eager-conversion perf regression fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JML2m7oy2sUbFftN7QoHhi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JML2m7oy2sUbFftN7QoHhi)_