### PR TITLE
fix(nix): keep flake evaluable on nixpkgs without x86_64-darwin

### DIFF
--- a/.changeset/nix-flake-drop-x86-darwin.md
+++ b/.changeset/nix-flake-drop-x86-darwin.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix Nix flake evaluation on Nixpkgs 26.11, which dropped `x86_64-darwin`. Hunk's flake no longer declares that system, and it now pins bun2nix's `systems` input to the same list so building the `aarch64-darwin` package never forces an Intel macOS Nixpkgs. The system list is exposed as a `systems` flake input for consumers that need to override it.

--- a/flake.lock
+++ b/flake.lock
@@ -7,7 +7,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems",
+        "systems": [
+          "systems"
+        ],
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -91,21 +93,22 @@
     "root": {
       "inputs": {
         "bun2nix": "bun2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       }
     },
     "systems": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1776166891,
+        "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "triplet",
+        "rev": "6de7bc09397911ce03636afbcf6118745ab2cda0",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "triplet",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,18 @@
   description = "Dev Flake for Modem-dev's Hunk";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # Systems Hunk builds for. Nixpkgs 26.11 dropped x86_64-darwin, and
+    # importing nixpkgs for a dropped system throws, so every declared system
+    # has to stay evaluable. Consumers can widen or narrow this with
+    # `inputs.hunk.inputs.systems.follows`.
+    systems.url = "github:nix-systems/triplet";
     bun2nix.url = "github:nix-community/bun2nix";
     bun2nix.inputs.nixpkgs.follows = "nixpkgs";
+    # bun2nix builds its flake-parts outputs for every system in its `systems`
+    # input, and its derivations reference those cross-system module args. Left
+    # on the default list it forces an x86_64-darwin nixpkgs even when only the
+    # aarch64-darwin package is requested.
+    bun2nix.inputs.systems.follows = "systems";
   };
   nixConfig = {
     extra-substituters = [
@@ -16,16 +26,13 @@
   outputs = {
     self,
     nixpkgs,
+    systems,
     bun2nix,
     ...
   }: let
     lib = nixpkgs.lib;
-    supportedSystems = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    # One source of truth for the systems Hunk and bun2nix are evaluated for.
+    supportedSystems = import systems;
     forAllSystems = lib.genAttrs supportedSystems;
     perSystem = forAllSystems (
       system: let

--- a/nix/README.md
+++ b/nix/README.md
@@ -80,6 +80,26 @@ Flake users update Hunk by updating their own pinned `flake.lock` input:
 nix flake lock --update-input hunk
 ```
 
+## Supported systems
+
+The flake builds for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
+
+Intel macOS (`x86_64-darwin`) is not exposed, because Nixpkgs 26.11 dropped support for it and merely _declaring_ a dropped system breaks flake evaluation for everyone consuming Hunk. Intel macOS users should install Hunk via npm or Homebrew instead.
+
+If you pin an older Nixpkgs that still supports a system Hunk does not list, point Hunk's `systems` input at a wider list:
+
+```nix
+{
+  inputs.hunk = {
+    url = "github:modem-dev/hunk";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.systems.url = "github:nix-systems/default"; # adds x86_64-darwin
+  };
+}
+```
+
+The same input also drives bun2nix, so overriding it once widens the whole build. If your flake already has its own `systems` input, `inputs.systems.follows = "systems"` works too.
+
 ## Building using Nix
 
 Run `nix build` to build the default package for the current system. The resulting Hunk binary will be `./result/bin/hunk`.


### PR DESCRIPTION
Fixes #608

## Problem

Nixpkgs 26.11 dropped `x86_64-darwin` and now *throws* on `import nixpkgs { system = "x86_64-darwin"; }`. Consuming Hunk as a flake input on `nixpkgs-unstable` fails to evaluate on Apple Silicon, even though only the `aarch64-darwin` output is ever referenced.

There are two independent forcing paths, and only fixing the first one is not enough:

1. Hunk's `supportedSystems` declared `x86_64-darwin`. This is lazy, so it only broke `nix flake check --all-systems` (which our own Nix CI job runs).
2. **The one that actually breaks consumers:** bun2nix's derivations reference flake-parts module args (`self'`) for *every* system in bun2nix's `systems` input, which was pinned to `nix-systems/default` (includes `x86_64-darwin`). So `packages.aarch64-darwin.hunk.drvPath` still throws with the reported trace through `flake-parts/modules/transposition.nix`, even after dropping the system from our own list.

## Change

Add a `systems` flake input as the single source of truth for the systems Hunk and bun2nix are evaluated for:

```nix
systems.url = "github:nix-systems/triplet";   # x86_64-linux, aarch64-linux, aarch64-darwin
bun2nix.inputs.systems.follows = "systems";
...
supportedSystems = import systems;
```

Consumers who pin an older Nixpkgs that still supports a dropped system can widen the list with `inputs.hunk.inputs.systems.follows`, documented in `nix/README.md`.

Intel macOS users should install Hunk via npm or Homebrew; Nixpkgs no longer supports that platform on unstable.

`meta.platforms` in `nix/package.nix` intentionally still lists `x86_64-darwin` — it describes what Hunk supports (npm/Homebrew ship Intel builds) and keeps the `systems.follows` override path working on 26.05.

## Verification

On `aarch64-darwin`, Nix 2.31:

| check | before | after |
| --- | --- | --- |
| `nix eval .#packages.aarch64-darwin.hunk.drvPath` with `--override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-unstable` | ❌ 26.11 throw | ✅ |
| `nix flake check --all-systems --no-build` with unstable override | ❌ | ✅ |
| `nix flake check --all-systems --no-build` with the committed lock | ✅ | ✅ |
| `nix build .#hunk` (binary runs, reports `0.17.0`) | ✅ | ✅ |
