### PR TITLE
Support .tsx and .jsx extension entries in discovery

### DIFF
--- a/.changeset/discover-tsx-extension-entries.md
+++ b/.changeset/discover-tsx-extension-entries.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Extension discovery now recognizes `.tsx` and `.jsx` entry files everywhere `.ts` entries are found — standalone files in an extensions directory and `index.tsx`/`index.jsx` folder fallbacks — matching what the runtime loader already supported. A TSX sidebar extension no longer needs a `package.json` manifest just to name its entry file. The authoring guide also gains a recipe for feeding lifecycle-event state into sidebar components, documents the pane width/height contract, qualifies exactly which notes the `note_created`/`note_edited` events report, and fixes the "not contributable yet" list to say standalone keybindings rather than contradicting the remappable-command docs.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -41,12 +41,14 @@ The two repo-local sources share a group number because they are one group:
 both are repo-controlled, so they share a trust decision and their paths are
 sorted together rather than one source being loaded ahead of the other.
 
-A directory source matches `*.ts`, `*.js`, `*.mjs` directly inside it, plus one
-level of folder extensions, so a folder extension can keep helper modules beside
-its entry file.
+A directory source matches `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.mjs` directly
+inside it, plus one level of folder extensions, so a folder extension can keep
+helper modules beside its entry file.
 
 A folder is an extension if it declares its entry files in a `package.json`, or
-failing that if it has an `index.{ts,js,mjs}`. The manifest field is `hunk`:
+failing that if it has an `index.{ts,tsx,js,jsx,mjs}` (in that preference
+order, so a folder shipping both a source and a built entry resolves the same
+everywhere). The manifest field is `hunk`:
 
 ```text
 ~/.config/hunk/extensions/my-ext/
@@ -571,11 +573,70 @@ costs you the pane, not the user the session: the failure is reported as a
 toast naming your extension, the pane closes, and the built-in file navigation
 reopens if nothing else is showing.
 
+Props carry the pane's `width` but not its height: the pane is a flex cell, so
+give your root element `height="100%"` and let layout size it. For a list
+longer than the pane, a `scrollbox` scrolls it — but there is no public
+viewport data (pane rows, scroll offset), so row virtualization and
+keeping the selected row scrolled into view are not supportable in a
+third-party sidebar today. `useTerminalDimensions` from `@opentui/react`
+reports the whole terminal, which bounds the pane but is not its height. If
+your extension needs true pane geometry, say so in an issue — it is a known
+gap under consideration, not a settled boundary.
+
 The built-in sidebar is itself a bundled extension
-(`src/extensions/default/ui/sidebar/`): it registers through this exact call and
-its component consumes exactly the props documented above, so it doubles as the
-reference implementation — anything it renders (grouping, change-type icons,
-stat badges, selection follow), yours can too.
+(`src/extensions/default/ui/sidebar/`): it registers through this exact call
+and its component consumes exactly the props documented above, so it doubles as
+the reference implementation — anything it draws from those props (grouping,
+change-type icons, stat badges), yours can too. The one thing it does that the
+props alone cannot express is windowing and selection follow, which it builds
+from host-internal geometry helpers — that is the pane-geometry gap described
+above, kept honest by the dogfooding.
+
+#### Sidebar state from events
+
+Lifecycle handlers run outside React, but a sidebar component only rerenders
+when React sees a change. The recipe that connects them is a module-local store
+read through `useSyncExternalStore`: the event handler updates the store, and
+any mounted component subscribed to it rerenders — while the store keeps
+accumulating even when the pane is closed.
+
+```tsx
+import { useSyncExternalStore } from "react";
+import type { HunkExtensionAPI } from "hunkdiff/extension";
+
+let viewedPaths: ReadonlySet<string> = new Set();
+const listeners = new Set<() => void>();
+
+function markViewed(path: string) {
+  if (viewedPaths.has(path)) return;
+  viewedPaths = new Set(viewedPaths).add(path); // new reference, so React sees the change
+  for (const listener of listeners) listener();
+}
+
+function useViewedPaths() {
+  return useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => viewedPaths,
+  );
+}
+
+function ViewedCount() {
+  const viewed = useViewedPaths();
+  return <text content={`${viewed.size} files viewed`} />;
+}
+
+export default function (hunk: HunkExtensionAPI) {
+  hunk.on("file_viewed", ({ file }) => markViewed(file.path));
+  hunk.registerSidebarView({ id: "progress", component: ViewedCount });
+}
+```
+
+Snapshots must be immutable — replace the set instead of mutating it, so
+`useSyncExternalStore` can compare references. Storing state in a hook inside
+the component instead would lose it every time the pane closes and unmounts.
 
 ### `hunk.registerCommand(command, handler)`
 
@@ -800,6 +861,13 @@ the selection many times a second, and handlers only care where the user landed.
 `"daemon"` (an agent command through the session broker), or `"manual"` (the
 refresh key, or the reload after granting extension trust).
 
+`note_created` and `note_edited` cover notes authored in Hunk's own UI, in this
+session. Review notes are session-local state, so there is no backlog to replay
+on startup — but comments added through agent session commands do not emit
+these events, and a `session_reload` may remap or drop notes without one
+either. A list accumulated from these events is therefore "notes the user saved
+here this session", not a complete review record; present it as such.
+
 `shutdown` handlers get a short window (250ms) to finish before Hunk exits
 anyway, so treat it as best-effort flushing rather than guaranteed cleanup.
 
@@ -952,9 +1020,11 @@ repo-controlled either way.
 
 ## Not contributable yet
 
-Menu entries, user-remappable keybindings, custom note renderers, session
-commands, and CLI subcommands are not contributable yet. Commands and their
-default key bindings landed with `registerCommand` — the named-command registry
-the rest build on; see
+Menu entries, standalone keybindings (a chord contributed without a command —
+commands registered through `registerCommand` **are** already user-remappable
+via `[keybindings]`), custom note renderers, session commands, and CLI
+subcommands are not contributable yet. Commands and their default key bindings
+landed with `registerCommand` — the named-command registry the rest build on;
+see
 [docs/extension-system-exploration.md](extension-system-exploration.md) for the
 design and phasing.

--- a/src/extensions/discovery.test.ts
+++ b/src/extensions/discovery.test.ts
@@ -66,6 +66,44 @@ describe("extension discovery", () => {
     expect(candidates.every((candidate) => candidate.origin === "global")).toBe(true);
   });
 
+  test("discovers .tsx and .jsx entries everywhere .ts entries are discovered", () => {
+    // The runtime transpiler has always accepted TSX; discovery used to be the
+    // only gap, forcing a manifest just to name an `index.tsx`.
+    const globalDir = createTempDir("hunk-ext-tsx-");
+    const standaloneTsx = writeExtensionFile(globalDir, "alpha.tsx");
+    const standaloneJsx = writeExtensionFile(globalDir, "beta.jsx");
+    const folderTsxIndex = writeExtensionFile(globalDir, "gamma", "index.tsx");
+
+    const candidates = discoverExtensions({
+      cwd: globalDir,
+      globalExtensionsDir: globalDir,
+      repoRoot: undefined,
+      env: {},
+    });
+
+    expect(candidates).toEqual([
+      { id: "alpha", path: standaloneTsx, origin: "global" },
+      { id: "beta", path: standaloneJsx, origin: "global" },
+      { id: "gamma", path: folderTsxIndex, origin: "global" },
+    ]);
+  });
+
+  test("prefers index.ts over index.tsx for a folder shipping both", () => {
+    const root = createTempDir("hunk-ext-tsx-index-order-");
+    const typescriptIndex = writeExtensionFile(root, "dual", "index.ts");
+    writeExtensionFile(root, "dual", "index.tsx");
+
+    const candidates = discoverExtensions({
+      cwd: root,
+      repoRoot: undefined,
+      globalExtensionsDir: undefined,
+      flagPaths: [join(root, "dual")],
+      env: {},
+    });
+
+    expect(candidates).toEqual([{ id: "dual", path: typescriptIndex, origin: "flag" }]);
+  });
+
   test("orders flag, user config, global, then repo-local sources", () => {
     const repo = createRepo("hunk-ext-repo-");
     const globalDir = join(repo, "global-extensions");

--- a/src/extensions/discovery.ts
+++ b/src/extensions/discovery.ts
@@ -6,7 +6,7 @@ import { findVcsRepoRootCandidate } from "../core/vcs";
 import { deriveExtensionId, type ExtensionCandidate, type ExtensionOrigin } from "./types";
 
 /** Entry-file suffixes Hunk will import directly, in preference order. */
-const EXTENSION_ENTRY_SUFFIXES = [".ts", ".js", ".mjs"] as const;
+const EXTENSION_ENTRY_SUFFIXES = [".ts", ".tsx", ".js", ".jsx", ".mjs"] as const;
 const EXTENSION_INDEX_BASENAMES = EXTENSION_ENTRY_SUFFIXES.map((suffix) => `index${suffix}`);
 /** `package.json` field a folder extension declares its entry files under. */
 const EXTENSION_MANIFEST_FIELD = "hunk";
@@ -146,8 +146,8 @@ function deriveManifestEntryIds(paths: readonly string[]) {
 /**
  * Resolve the entry files of one folder extension.
  *
- * A `package.json` manifest wins over the `index.{ts,js,mjs}` fallback, and may
- * declare several entries. A manifest that declares no usable entry is treated
+ * A `package.json` manifest wins over the `index.*` entry-suffix fallback, and
+ * may declare several entries. A manifest that declares no usable entry is treated
  * as no manifest at all, so such a folder still loads its index if it has one.
  *
  * A single-entry manifest keeps the folder's name as the extension id — the
@@ -181,10 +181,10 @@ function resolveFolderExtensionEntries(dir: string): DiscoveredExtensionEntry[] 
 /**
  * Scan one extensions directory for entry files.
  *
- * Matches `<dir>/*.{ts,js,mjs}` plus exactly one level of folder extensions —
- * either a `package.json` manifest or `<dir>/<name>/index.{ts,js,mjs}` — so
- * folder extensions can keep helper modules beside their entry file without
- * being scanned as entries themselves.
+ * Matches `<dir>/*.{ts,tsx,js,jsx,mjs}` plus exactly one level of folder
+ * extensions — either a `package.json` manifest or an `index.*` file with one
+ * of those suffixes — so folder extensions can keep helper modules beside
+ * their entry file without being scanned as entries themselves.
  */
 function scanExtensionsDir(dir: string): DiscoveredExtensionEntry[] {
   const entries: DiscoveredExtensionEntry[] = [];
@@ -230,7 +230,7 @@ function expandHomePath(path: string) {
  * Expand one explicit path into entry files.
  *
  * A directory that resolves as a folder extension — by `package.json` manifest
- * or by its own `index.{ts,js,mjs}` — expands to just those entries: its helper
+ * or by its own `index.*` entry file — expands to just those entries: its helper
  * modules sit beside the entry file and must not be loaded as separate
  * extensions. Only a directory that is not a folder extension is a container of
  * extensions and gets scanned. Anything else is taken as a literal entry file so

--- a/src/extensions/host.test.ts
+++ b/src/extensions/host.test.ts
@@ -209,6 +209,45 @@ export default function (hunk: { registerFileLanguage: (e: string, l: string) =>
     ]);
   });
 
+  test("loads a discovered standalone .tsx entry with JSX in it", async () => {
+    // The docs' sidebar example is a bare `flat-sidebar.tsx` in the global
+    // extensions directory; discovery finding it and the host importing its
+    // JSX is the whole contract that example depends on.
+    const globalDir = createTempDir("hunk-host-tsx-");
+    const entryPath = writeTestFile(
+      globalDir,
+      "flat-sidebar.tsx",
+      `function FlatSidebar() {
+  return <text content="flat" />;
+}
+
+export default function (hunk: { registerSidebarView: (view: unknown) => void }) {
+  hunk.registerSidebarView({ id: "flat", component: FlatSidebar });
+}
+`,
+    );
+
+    const candidates = discoverExtensions({
+      cwd: globalDir,
+      repoRoot: undefined,
+      globalExtensionsDir: globalDir,
+      env: {},
+    });
+    const result = await loadExtensions({ candidates, cwd: globalDir });
+
+    expect(candidates).toEqual([{ id: "flat-sidebar", path: entryPath, origin: "global" }]);
+    expect(result.issues).toEqual([]);
+    expect(result.loaded).toEqual([
+      { id: "flat-sidebar", sourcePath: entryPath, origin: "global" },
+    ]);
+    expect(
+      result.registry.sidebarViews.map((entry) => ({
+        extensionId: entry.extensionId,
+        viewId: entry.view.id,
+      })),
+    ).toEqual([{ extensionId: "flat-sidebar", viewId: "flat" }]);
+  });
+
   test("awaits an async factory before sealing the API", async () => {
     const dir = createTempDir("hunk-host-async-");
     const candidate = createTestExtension(


### PR DESCRIPTION
Extension discovery now recognizes `.tsx` and `.jsx` entry files everywhere `.ts` entries are found — both as standalone files in extensions directories and as `index.tsx`/`index.jsx` folder fallbacks. This closes a gap where the runtime loader already supported TSX/JSX, but discovery required a `package.json` manifest to name a `.tsx` entry file.

## Changes

- **Discovery**: Updated `EXTENSION_ENTRY_SUFFIXES` to include `.tsx` and `.jsx` in preference order (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`), matching the runtime loader's capabilities
- **Tests**: Added coverage for discovering standalone `.tsx`/`.jsx` files and folder `index.tsx`/`index.jsx` entries, plus a test verifying preference order when both `.ts` and `.tsx` exist
- **Host loader**: Added test confirming a discovered `.tsx` entry with JSX can be loaded and registered
- **Documentation**: 
  - Updated `docs/extensions.md` to document the full set of supported suffixes and their preference order
  - Added a sidebar state recipe using `useSyncExternalStore` to connect lifecycle events to React component state
  - Documented the pane width/height contract and known geometry limitations
  - Clarified which notes `note_created`/`note_edited` events report (session-local, not backlog)
  - Fixed "not contributable yet" section to distinguish standalone keybindings from user-remappable commands

The preference order ensures consistent resolution: a folder shipping both `index.ts` and `index.tsx` will always load the `.ts` version, so the same extension resolves identically across different environments.

https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ