### PR TITLE
feat(extensions): expose public hunk summaries on file views

### DIFF
--- a/.changeset/public-hunk-summaries.md
+++ b/.changeset/public-hunk-summaries.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+The extension API now exposes public hunk summaries: every read-only file view Hunk hands outward (event payloads, sidebar props, a command's selection) carries a `hunks` list of `ExtensionDiffHunk` records — `index`, the `@@` header, and inclusive old/new line spans, in render order. The index is the same one `selectedHunkIndex` reports and `actions.selectHunk` accepts, so hunk checklists, per-hunk progress views, and agent-annotation navigators no longer need to cast into the opaque `metadata`. The summaries derive through the same helper the agent session surface reports hunks with, so the two external views of a review cannot drift apart.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -74,7 +74,10 @@ model — session view list, open-state reconciliation across reloads, and the
 layout plan deciding which open panes fit at what width.
 `src/ui/components/panes/ExtensionSidebarPane.tsx` mounts one view: frozen
 file views in, guarded actions out, error boundary scoped to the
-registration identity.
+registration identity. The frozen views fill `changeType` and the public
+`hunks` summaries from the opaque metadata at the view boundary
+(`src/extensions/events.ts`, deriving through `src/core/hunkSummary.ts` — the
+same helper the agent session surface reports hunks with).
 
 ## Command system
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -519,15 +519,15 @@ elements and need no import.
 
 The component receives fresh props as the app changes:
 
-| Prop                | What it is                                                                                                                                            |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `files`             | the visible reviewed files, review-stream order, filtered, frozen views (each carries `changeType` and `statsTruncated` beside the usual file fields) |
-| `selectedFileId`    | the selected file, or `null`                                                                                                                          |
-| `selectedHunkIndex` | the selected hunk within that file, or `null`                                                                                                         |
-| `width`             | terminal columns the sidebar pane occupies                                                                                                            |
-| `theme`             | hex color tokens from the active theme, updated on theme switch                                                                                       |
-| `keybindings`       | the current command bindings, resolved from defaults and the user's `[keybindings]` table                                                             |
-| `actions`           | navigation the sidebar may trigger                                                                                                                    |
+| Prop                | What it is                                                                                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `files`             | the visible reviewed files, review-stream order, filtered, frozen views (each carries `changeType`, `statsTruncated`, and `hunks` summaries beside the usual file fields) |
+| `selectedFileId`    | the selected file, or `null`                                                                                                                                              |
+| `selectedHunkIndex` | the selected hunk within that file, or `null`                                                                                                                             |
+| `width`             | terminal columns the sidebar pane occupies                                                                                                                                |
+| `theme`             | hex color tokens from the active theme, updated on theme switch                                                                                                           |
+| `keybindings`       | the current command bindings, resolved from defaults and the user's `[keybindings]` table                                                                                 |
+| `actions`           | navigation the sidebar may trigger                                                                                                                                        |
 
 `actions.selectFile(fileId)` and `actions.selectHunk(fileId, hunkIndex)` route
 through the same review controller as the built-in sidebar and the keyboard
@@ -536,6 +536,14 @@ shortcuts, so the review stream scrolls, selection updates, and the
 row. `actions.notify(message, type?)` shows a toast attributed to your
 extension. An action given a file id that is not currently visible is refused
 with a warning rather than corrupting the selection.
+
+The three hunk surfaces line up by design: each file's `hunks` lists public
+`ExtensionDiffHunk` summaries (`index`, the `@@` header, inclusive old/new
+line spans) in render order, `selectedHunkIndex` reports the same index, and
+`actions.selectHunk(fileId, hunkIndex)` accepts it. That is everything a hunk
+checklist, a per-hunk progress view, or an agent-annotation navigator needs —
+match an annotation's `oldRange`/`newRange` against the summaries' spans to
+find its hunk — without touching the opaque `metadata`.
 
 A component that owns a key event should ask the injected `keybindings`
 manager about a **command id**, rather than hard-coding the command's default
@@ -706,8 +714,7 @@ of the selected file:
 
 ```ts
 hunk.registerCommand({ id: "pick-hunk", title: "Pick a hunk", key: "ctrl+k" }, async (ctx) => {
-  const file = ctx.selection.file;
-  const hunks = (file?.metadata as { hunks?: { header?: string }[] } | undefined)?.hunks ?? [];
+  const hunks = ctx.selection.file?.hunks ?? [];
   if (hunks.length === 0) {
     ctx.notify("Nothing to pick from", "warning");
     return;
@@ -715,7 +722,7 @@ hunk.registerCommand({ id: "pick-hunk", title: "Pick a hunk", key: "ctrl+k" }, a
 
   const picked = await ctx.dialogs.select({
     title: "Which hunk?",
-    options: hunks.map((hunk, index) => hunk.header ?? `hunk ${index + 1}`),
+    options: hunks.map((hunk) => hunk.header || `hunk ${hunk.index + 1}`),
   });
 
   if (picked !== null) {
@@ -768,6 +775,14 @@ returns something the review UI could not draw — not a changeset with a `files
 array, a file missing `metadata.hunks` or `stats`, two files sharing an `id` —
 is skipped: the previous changeset carries forward and you get a warning naming
 your extension and the problem.
+
+You never need to reach into `metadata` to know what a file's hunks are: the
+read-only views Hunk hands outward (event payloads, sidebar props, a command's
+selection) carry a `hunks` list of public summaries — `index`, the `@@` header,
+and the inclusive old/new line spans, in render order. Like `changeType`, it is
+derived from the metadata at that boundary, so a transform neither receives nor
+produces it, and a stale value spread through a transform is replaced with what
+the metadata actually parses to.
 
 ### `hunk.on(event, handler)`
 

--- a/src/core/hunkSummary.test.ts
+++ b/src/core/hunkSummary.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import type { Hunk } from "@pierre/diffs";
+import { createTestDiffFile } from "../../test/helpers/diff-helpers";
+import { formatHunkHeader } from "./hunkHeader";
+import { summarizeHunk } from "./hunkSummary";
+import { hunkLineRange } from "./liveComments";
+
+describe("summarizeHunk", () => {
+  test("summarizes every hunk Pierre parses with its header and inclusive spans", () => {
+    // Two separated changes with zero context parse into two hunks.
+    const file = createTestDiffFile({
+      before: "const alpha = 1;\nconst beta = 2;\nconst gamma = 3;\nconst stable = true;\n",
+      after: "const alpha = 10;\nconst beta = 2;\nconst gamma = 30;\nconst stable = true;\n",
+      context: 0,
+    });
+    expect(file.metadata.hunks.length).toBeGreaterThan(1);
+
+    const summaries = file.metadata.hunks.map((hunk, index) => summarizeHunk(hunk, index));
+
+    for (const [index, hunk] of file.metadata.hunks.entries()) {
+      // The header and spans come from the same helpers every review surface
+      // uses, so a summary can never disagree with rendering or navigation.
+      expect(summaries[index]).toEqual({
+        index,
+        header: formatHunkHeader(hunk),
+        ...hunkLineRange(hunk),
+      });
+      expect(summaries[index]!.header).toMatch(/^@@ -\d/);
+      expect(summaries[index]!.oldRange).toBeDefined();
+      expect(summaries[index]!.newRange).toBeDefined();
+    }
+  });
+
+  test("gives a synthesized hunk without line numbers no ranges instead of NaN spans", () => {
+    // Transform validation only requires `hunkContent`, so this is the least
+    // hunk an extension can legally put in front of the review UI.
+    const bare = { hunkContent: [] } as unknown as Hunk;
+
+    expect(summarizeHunk(bare, 3)).toEqual({ index: 3, header: "" });
+  });
+
+  test("keeps a synthesized hunk's declared header text when it has one", () => {
+    const declared = { hunkContent: [], hunkSpecs: "@@ synthesized @@" } as unknown as Hunk;
+
+    expect(summarizeHunk(declared, 0)).toEqual({ index: 0, header: "@@ synthesized @@" });
+  });
+});

--- a/src/core/hunkSummary.ts
+++ b/src/core/hunkSummary.ts
@@ -1,0 +1,36 @@
+import type { Hunk } from "@pierre/diffs";
+import type { ExtensionDiffHunk } from "../extension-api/types";
+import { formatHunkHeader } from "./hunkHeader";
+import { hunkLineRange } from "./liveComments";
+
+/** Report whether one hunk carries the numeric header fields ranges derive from. */
+function hasLineNumbers(hunk: Hunk) {
+  return (
+    Number.isFinite(hunk.additionStart) &&
+    Number.isFinite(hunk.additionCount) &&
+    Number.isFinite(hunk.deletionStart) &&
+    Number.isFinite(hunk.deletionCount)
+  );
+}
+
+/**
+ * Summarize one parsed hunk into the stable index/header/range record.
+ *
+ * This is the one derivation behind every external view of a hunk — the agent
+ * session surface (`SessionReviewHunk`) and the extension API
+ * (`ExtensionDiffHunk`) — so the two can never drift apart on what a hunk's
+ * header or line spans are.
+ *
+ * Pierre always parses full numeric headers, but a changeset transform may
+ * synthesize a hunk, and validation only requires it to carry `hunkContent`.
+ * Such a hunk gets whatever `hunkSpecs` text it declared (or an empty header)
+ * and no ranges, rather than `NaN` spans an extension would have to guard.
+ */
+export function summarizeHunk(hunk: Hunk, index: number): ExtensionDiffHunk {
+  const rangesDerivable = hasLineNumbers(hunk);
+  return {
+    index,
+    header: hunk.hunkSpecs != null || rangesDerivable ? formatHunkHeader(hunk) : "",
+    ...(rangesDerivable ? hunkLineRange(hunk) : {}),
+  };
+}

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -41,6 +41,7 @@ export type {
   ExtensionChangeset,
   ExtensionContext,
   ExtensionDiffFile,
+  ExtensionDiffHunk,
   ExtensionCustomEventHandler,
   ExtensionEventBus,
   ExtensionEventContext,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -109,6 +109,36 @@ export interface AgentFileContext {
 /* -------------------------------------------------------------------------- */
 
 /**
+ * One hunk of a reviewed file, summarized for extensions.
+ *
+ * A stable public view of the parsed diff: enough to build a hunk list, a
+ * progress checklist, or an annotation navigator without reaching into the
+ * opaque `metadata`. The shape matches what the agent session surface reports
+ * for hunks, so the two external views of a review never disagree.
+ */
+export interface ExtensionDiffHunk {
+  /**
+   * The hunk's position within its file, in review-stream render order.
+   *
+   * This is the same index `selectedHunkIndex` reports and
+   * `actions.selectHunk(fileId, hunkIndex)` accepts, so a hunk list built from
+   * these summaries can highlight and drive the selection directly.
+   */
+  index: number;
+  /** The unified-diff `@@` header, including any trailing context text. */
+  header: string;
+  /**
+   * Inclusive old-side line span the hunk covers, context lines included.
+   *
+   * Omitted when the hunk carries no usable line numbers — which real parsed
+   * diffs always do; only a transform-synthesized hunk can lack them.
+   */
+  oldRange?: [number, number];
+  /** Inclusive new-side line span the hunk covers, context lines included. */
+  newRange?: [number, number];
+}
+
+/**
  * One reviewed file, as extensions see it.
  *
  * Structurally a subset of Hunk's internal `DiffFile`, so the internal value
@@ -147,6 +177,17 @@ export interface ExtensionDiffFile {
   changeType?: ExtensionVcsFileChangeType;
   /** True when `stats` were counted from a partial read and undercount the file. */
   statsTruncated?: boolean;
+  /**
+   * Summaries of the hunks the diff engine parsed from this file, in render
+   * order — empty for a file with nothing to select (binary, skipped).
+   *
+   * Like `changeType`, this is filled on the read-only views Hunk hands
+   * outward (event payloads, sidebar props, a command's selection). It is
+   * derived from `metadata` at that boundary, so a transform neither receives
+   * nor needs to produce it — a `hunks` value on a transform's returned file
+   * is ignored in favor of what the metadata actually parses to.
+   */
+  hunks?: readonly ExtensionDiffHunk[];
   agent: AgentFileContext | null;
   isUntracked?: boolean;
   isBinary?: boolean;

--- a/src/extensions/events.test.ts
+++ b/src/extensions/events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createTestDiffFile } from "../../test/helpers/diff-helpers";
 import {
   bindExtensionEventBus,
   emitExtensionCustomEvent,
@@ -6,6 +7,7 @@ import {
   emitExtensionEventBounded,
   emitExtensionEventToExtensions,
   readMetadataHunkCount,
+  readMetadataHunkSummaries,
   toReadOnlyFileViews,
 } from "./events";
 import { createExtensionNotificationHub } from "./notifications";
@@ -442,6 +444,57 @@ describe("read-only file views", () => {
     const seen = (view!.metadata as { cache: Map<string, string> }).cache;
     expect(seen).toBe(cache);
     expect(seen.get("k")).toBe("v");
+  });
+
+  test("fills hunk summaries from the parsed metadata", () => {
+    const file = createTestDiffFile({ context: 0 });
+    const [view] = toReadOnlyFileViews([file as never]);
+
+    expect(view!.hunks).toHaveLength(file.metadata.hunks.length);
+    expect(view!.hunks!.length).toBeGreaterThan(0);
+    for (const [index, summary] of view!.hunks!.entries()) {
+      expect(summary.index).toBe(index);
+      expect(summary.header).toMatch(/^@@ -\d/);
+      expect(summary.oldRange).toBeDefined();
+      expect(summary.newRange).toBeDefined();
+    }
+  });
+
+  test("hunk summaries are frozen and identical across conversions", () => {
+    const file = createTestDiffFile();
+    const [first] = toReadOnlyFileViews([file as never]);
+    const [second] = toReadOnlyFileViews([file as never]);
+
+    // Derived once per parsed diff: views are rebuilt on every emit, so the
+    // summaries are keyed by the metadata behind them, like the deep views.
+    expect(second!.hunks).toBe(first!.hunks);
+    expect(readMetadataHunkSummaries(file.metadata)).toBe(first!.hunks!);
+
+    expect(Object.isFrozen(first!.hunks)).toBe(true);
+    expect(Object.isFrozen(first!.hunks![0])).toBe(true);
+    expect(() => {
+      (first!.hunks as unknown as { header: string }[])[0]!.header = "@@ forged @@";
+    }).toThrow(TypeError);
+  });
+
+  test("hunk summaries always come from metadata, not from a stale field on the file", () => {
+    // A transform that spreads a frozen view carries an old `hunks` list along;
+    // the parsed diff is authoritative, so the boundary replaces it.
+    const file = { ...createTestFile(), hunks: [{ index: 9, header: "@@ stale @@" }] };
+    const [view] = toReadOnlyFileViews([file as never]);
+
+    expect(view!.hunks).toHaveLength(1);
+    expect(view!.hunks![0]!.index).toBe(0);
+    expect(view!.hunks![0]!.header).not.toBe("@@ stale @@");
+  });
+
+  test("files with no parsable hunks share one empty summary list", () => {
+    const binary = { ...createTestFile(), id: "bin", metadata: { type: "change" } };
+    const skipped = { ...createTestFile(), id: "skip", metadata: null };
+    const views = toReadOnlyFileViews([binary as never, skipped as never]);
+
+    expect(views[0]!.hunks).toEqual([]);
+    expect(views[1]!.hunks).toBe(views[0]!.hunks);
   });
 });
 

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -5,11 +5,14 @@ import type {
   ExtensionEventPayloads,
   ExtensionLoadResult,
 } from "./types";
+import type { Hunk } from "@pierre/diffs";
 import type {
+  ExtensionDiffHunk,
   ExtensionEventContext,
   ExtensionSidebarControls,
   ExtensionVcsFileChangeType,
 } from "../extension-api/types";
+import { summarizeHunk } from "../core/hunkSummary";
 
 /**
  * How long `shutdown` handlers may run before Hunk exits anyway.
@@ -81,6 +84,44 @@ export function readMetadataChangeType(metadata: unknown): ExtensionVcsFileChang
 export function readMetadataHunkCount(metadata: unknown): number {
   const hunks = (metadata as { hunks?: unknown } | null | undefined)?.hunks;
   return Array.isArray(hunks) ? hunks.length : 0;
+}
+
+/** The one frozen empty summary list, shared by every file with nothing to summarize. */
+const NO_HUNK_SUMMARIES: readonly ExtensionDiffHunk[] = Object.freeze([]);
+
+/** Summary lists already derived, keyed by the metadata that produced them. */
+const metadataHunkSummaries = new WeakMap<object, readonly ExtensionDiffHunk[]>();
+
+/**
+ * Summarize the hunks Hunk's diff engine parsed for one file.
+ *
+ * Same boundary as `readMetadataChangeType`: the parsed hunks live inside the
+ * opaque `metadata`, so the public views surface them as first-class
+ * `ExtensionDiffHunk` records instead of asking extensions to cast into an
+ * object Hunk promised not to describe. Derivation runs once per parsed diff —
+ * file views are rebuilt on every emit while the metadata behind them is
+ * stable, so summaries are cached by metadata object, and repeated views hand
+ * back the identical frozen list. A file whose metadata has no hunk array
+ * (binary, skipped) reads as the shared empty list rather than throwing.
+ */
+export function readMetadataHunkSummaries(metadata: unknown): readonly ExtensionDiffHunk[] {
+  if (metadata === null || typeof metadata !== "object") {
+    return NO_HUNK_SUMMARIES;
+  }
+
+  const cached = metadataHunkSummaries.get(metadata);
+  if (cached) {
+    return cached;
+  }
+
+  const hunks = (metadata as { hunks?: unknown }).hunks;
+  const summaries = Array.isArray(hunks)
+    ? Object.freeze(
+        (hunks as Hunk[]).map((hunk, index) => Object.freeze(summarizeHunk(hunk, index))),
+      )
+    : NO_HUNK_SUMMARIES;
+  metadataHunkSummaries.set(metadata, summaries);
+  return summaries;
 }
 
 /** Proxies already built for shared objects, so repeated views stay identical. */
@@ -192,7 +233,10 @@ export function toReadOnlyDeepView<T>(value: T): T {
  * `agent`) behind `toReadOnlyDeepView` — factored out so surfaces that hand
  * extensions a file list without a changeset envelope (a custom sidebar's
  * props, a command's selection) guard it identically. `changeType` is filled
- * from the diff metadata when the file does not carry it already.
+ * from the diff metadata when the file does not carry it already, and `hunks`
+ * always from the metadata — the parsed diff is authoritative, so a `hunks`
+ * value already on the file (say, spread through a transform) is replaced
+ * rather than trusted.
  */
 export function toReadOnlyFileViews(files: readonly ExtensionDiffFile[]): ExtensionDiffFile[] {
   const frozenFiles = files.map((file) => {
@@ -204,6 +248,7 @@ export function toReadOnlyFileViews(files: readonly ExtensionDiffFile[]): Extens
     return Object.freeze({
       ...file,
       ...(changeType ? { changeType } : {}),
+      hunks: readMetadataHunkSummaries(file.metadata),
       metadata: toReadOnlyDeepView(file.metadata),
       stats: toReadOnlyDeepView(file.stats),
       agent: toReadOnlyDeepView(file.agent),

--- a/src/hunk-session/sessionRegistration.ts
+++ b/src/hunk-session/sessionRegistration.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { resolveExperimentalFeatures } from "../core/experimental";
-import { formatHunkHeader } from "../core/hunkHeader";
+import { summarizeHunk } from "../core/hunkSummary";
 import { hunkLineRange } from "../core/liveComments";
 import type { AppBootstrap } from "../core/types";
 import {
@@ -44,11 +44,9 @@ function buildSessionFiles(bootstrap: AppBootstrap): SessionReviewFile[] {
     deletions: file.stats.deletions,
     hunkCount: file.metadata.hunks.length,
     patch: file.patch,
-    hunks: file.metadata.hunks.map((hunk, index) => ({
-      index,
-      header: formatHunkHeader(hunk),
-      ...hunkLineRange(hunk),
-    })),
+    // The same derivation the extension API's file views use, so the two
+    // external views of a review never disagree on a hunk's header or spans.
+    hunks: file.metadata.hunks.map((hunk, index) => summarizeHunk(hunk, index)),
   }));
 }
 


### PR DESCRIPTION
## What

Adds `ExtensionDiffHunk` to the public extension API and fills a `hunks` list on every read-only file view Hunk hands outward — event payloads, sidebar props, and a command's `selection`.

Each summary carries `index`, the `@@` header, and inclusive old/new line spans, in render order. The index is the same one `selectedHunkIndex` reports and `actions.selectHunk` accepts, so the three hunk surfaces line up by design.

## Why

Extension-author feedback (follow-up 2 of the report addressed by #625): `selectedHunkIndex` is public, but hunk headers, ranges, and counts lived inside the opaque `file.metadata`. That limited a progress view to *files viewed* and made a hunk checklist or agent-annotation navigator impossible without casting into an object the contract promises not to describe — the authoring guide's own pick-hunk example did exactly that cast.

## How

- `ExtensionDiffHunk` is declared in `src/extension-api/types.ts` (which stays import-free; `check:pack` passes) and exported from the barrel.
- Summaries are derived from `metadata` at the view boundary in `toReadOnlyFileViews` — like `changeType`, transforms neither receive nor produce them, and a stale `hunks` value spread through a transform is replaced by what the metadata actually parses to. Derivation is cached per parsed-diff metadata object (views are rebuilt on every emit), and repeated conversions hand back the identical frozen list.
- The derivation lives in one core helper, `src/core/hunkSummary.ts`, now shared with the agent session surface (`buildSessionFiles`), so the two external views of a review cannot drift apart. A transform-synthesized hunk without numeric line data gets its declared header text (or an empty one) and no ranges, instead of `NaN` spans.
- The guide's pick-hunk example now uses `ctx.selection.file.hunks` instead of casting into `metadata`, the sidebar props docs describe the checklist/navigator recipe, and the transform docs state the derived-at-boundary contract.

## Testing

- New colocated `src/core/hunkSummary.test.ts` (real Pierre-parsed hunks plus synthesized-hunk edge cases).
- New `toReadOnlyFileViews` coverage in `src/extensions/events.test.ts`: derivation, frozen/cached identity, metadata-authoritative replacement, shared empty list for binary/skipped files.
- `bun run typecheck`, `bun run lint`, `bun run check:pack` (typechecks all 20 docs examples for nodenext + bundler consumers), full `src/` suite (1583 pass), `test/cli` + `test/session`, and the extensions PTY integration tests all green.

Changeset: `minor` for `hunkdiff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ)_