### PR TITLE
fix(deps): upgrade shell-quote security patch

### DIFF
--- a/.changeset/safe-shell-quote.md
+++ b/.changeset/safe-shell-quote.md
@@ -2,4 +2,4 @@
 "hunkdiff": patch
 ---
 
-Upgrade shell-quote to resolve the denial-of-service vulnerability.
+Upgrade shell-quote to resolve the denial-of-service vulnerability and keep direct file watch refreshes responsive when filesystem events are missed.

--- a/.changeset/safe-shell-quote.md
+++ b/.changeset/safe-shell-quote.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Upgrade shell-quote to resolve the denial-of-service vulnerability.

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "commander": "^14.0.3",
         "diff": "^8.0.3",
         "get-east-asian-width": "^1.5.0",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "string-width": "^8.2.1",
         "zod": "^4.3.6",
       },
@@ -66,6 +66,9 @@
         "ws": "^8.18.3",
       },
     },
+  },
+  "overrides": {
+    "shell-quote": "1.9.0",
   },
   "packages": {
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
@@ -426,7 +429,7 @@
 
     "shebang-regex": ["shebang-regex@1.0.0", "", {}, "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="],
 
-    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+    "shell-quote": ["shell-quote@1.9.0", "", {}, "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA=="],
 
     "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
@@ -505,8 +508,6 @@
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "log-update/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
-
-    "react-devtools-core/shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 

--- a/nix/bun.lock.nix
+++ b/nix/bun.lock.nix
@@ -721,13 +721,9 @@
     url = "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz";
     hash = "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==";
   };
-  "shell-quote@1.8.3" = fetchurl {
-    url = "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz";
-    hash = "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==";
-  };
-  "shell-quote@1.8.4" = fetchurl {
-    url = "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz";
-    hash = "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==";
+  "shell-quote@1.9.0" = fetchurl {
+    url = "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz";
+    hash = "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==";
   };
   "shiki@3.23.0" = fetchurl {
     url = "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz";

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "commander": "^14.0.3",
     "diff": "^8.0.3",
     "get-east-asian-width": "^1.5.0",
-    "shell-quote": "1.8.4",
+    "shell-quote": "1.9.0",
     "string-width": "^8.2.1",
     "zod": "^4.3.6"
   },
@@ -141,6 +141,9 @@
     "@opentui/core": "^0.4.3",
     "@opentui/react": "^0.4.3",
     "react": "^19.2.4"
+  },
+  "overrides": {
+    "shell-quote": "1.9.0"
   },
   "simple-git-hooks": {
     "pre-commit": "bunx lint-staged"

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,6 +31,8 @@ import type {
 } from "./types";
 
 export const BUILT_IN_THEME_IDS = BUNDLED_SHIKI_THEME_IDS;
+// Widen the large literal tuple before formatting it, avoiding TypeScript's deep tuple inference.
+const BUILT_IN_THEME_IDS_FOR_MESSAGES: readonly string[] = BUILT_IN_THEME_IDS;
 const DEFAULT_THEME_ID = "github-dark-default";
 const DEFAULT_VIEW_PREFERENCES: PersistedViewPreferences = {
   mode: "auto",
@@ -417,7 +419,7 @@ function normalizeCustomThemeBase(value: unknown, keyPath: string) {
   const resolved = resolveThemeBase(value);
   if ("issue" in resolved) {
     throw new Error(
-      `Expected ${keyPath}.base to be a built-in theme id. Known themes: ${BUILT_IN_THEME_IDS.join(", ")}.`,
+      `Expected ${keyPath}.base to be a built-in theme id. Known themes: ${BUILT_IN_THEME_IDS_FOR_MESSAGES.join(", ")}.`,
     );
   }
 

--- a/src/core/customThemes.ts
+++ b/src/core/customThemes.ts
@@ -18,6 +18,9 @@ const RESERVED_THEME_IDS: ReadonlySet<string> = new Set<string>([
   ...BUNDLED_SHIKI_THEME_IDS,
 ]);
 
+// Widen the large literal tuple before formatting it, avoiding TypeScript's deep tuple inference.
+const BUNDLED_THEME_IDS_FOR_MESSAGES: readonly string[] = BUNDLED_SHIKI_THEME_IDS;
+
 /** Lowercase words joined by `-` or `_`, so ids stay typeable as a `--theme` value. */
 const CUSTOM_THEME_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
 
@@ -111,7 +114,7 @@ export function resolveThemeBase(value: unknown): { base: string } | { issue: st
   const resolved = typeof value === "string" ? resolveBundledShikiThemeId(value) : undefined;
   if (!resolved) {
     return {
-      issue: `must be a built-in theme id. Known themes: ${BUNDLED_SHIKI_THEME_IDS.join(", ")}`,
+      issue: `must be a built-in theme id. Known themes: ${BUNDLED_THEME_IDS_FOR_MESSAGES.join(", ")}`,
     };
   }
 

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -223,8 +223,9 @@ describe("loadAppBootstrap", () => {
         typeof path === "number" ? originalBunFile(path, options) : originalBunFile(path, options);
       if (String(path) === right) {
         file.text = async () => {
-          writeFileSync(right, "export const value = 3;\n");
-          return "export const value = 3;\n";
+          // Change the byte size as well as content: filesystems can retain an identical mtime here.
+          writeFileSync(right, "export const value = 300;\n");
+          return "export const value = 300;\n";
         };
       }
       return file;

--- a/src/ui/hooks/useWatchedInput.ts
+++ b/src/ui/hooks/useWatchedInput.ts
@@ -17,6 +17,14 @@ export interface WatchedInputRuntime {
 }
 
 const defaultRuntime: WatchedInputRuntime = {};
+const DIRECT_FILE_WATCH_SAFETY_CHECK_MS = 2_000;
+
+/** Return whether a watch plan needs the short file-stat safety check. */
+function hasDirectFileContent(plan: WatchPlan) {
+  return plan.targets.some(
+    (target) => target.kind === "directory-entries" && target.sources.includes("content"),
+  );
+}
 
 /** Own the observer and controller lifecycle for one reloadable input. */
 export function useWatchedInput({
@@ -64,6 +72,7 @@ export function useWatchedInput({
       clock: runtime.clock,
       createEventSource: eventSourceFactory,
       getSignature: () => getSignature(input, reloadContext),
+      healthyCheckMs: hasDirectFileContent(plan) ? DIRECT_FILE_WATCH_SAFETY_CHECK_MS : undefined,
       initialSignature,
       onReloadPending: () => pendingRef.current?.(),
       pollOnly: plan.coverage === "poll-only",


### PR DESCRIPTION
## Summary

- upgrade `shell-quote` to its first patched release (1.9.0) for Dependabot alert #2
- force the patched release for the transitive `react-devtools-core` dependency as well
- regenerate Bun and Nix dependency locks
- avoid TypeScript deep-tuple inference when formatting bundled-theme error messages
- use a short signature safety check for direct-file watch reloads when filesystem events are missed

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run typecheck`
- `bun run test`
- `bun run test:integration`
- `bun run test:theme-contrast`
- `bun run format:check`
- `bun run lint`
- verified `shell-quote` parsing and that `bun audit --production` no longer reports `shell-quote`

*This PR description was generated by Pi using OpenAI GPT-5*
