### PR TITLE
feat(extensions): give command handlers guarded review navigation

### DIFF
--- a/.changeset/command-context-navigation.md
+++ b/.changeset/command-context-navigation.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Extension command handlers can now navigate the review stream: `ctx.navigation.selectFile(fileId)` and `ctx.navigation.selectHunk(fileId, hunkIndex)` carry the same guarded navigation a custom sidebar's `actions` do — validated against the currently visible files, hunk indexes clamped, failures reported as warnings — routed through the same review controller, so a "jump to the next flagged hunk" command no longer needs a mounted sidebar to move the selection. Unlike `ctx.selection`, which stays a snapshot from when the key fired, `navigation` is live: a handler that awaits a dialog and then navigates acts on the review as it is now.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -738,6 +738,16 @@ select. The values are captured when the command fires: a handler that awaits
 still sees the selection it was run from, not wherever the user navigated to
 meanwhile.
 
+`ctx.navigation` moves the review stream: `selectFile(fileId)` and
+`selectHunk(fileId, hunkIndex)`, the same guarded navigation a sidebar's
+`actions` carry, routed through the same review controller — the stream
+scrolls, selection updates, and `selection_changed` fires exactly as if the
+user had clicked a sidebar row. Unlike `selection` it is live, not a snapshot:
+a call acts on the review as it is at that moment, so a handler that awaits a
+dialog and then navigates still works. A file id the stream cannot currently
+show is refused with a warning rather than corrupting the selection, and a
+hunk index is clamped into the file's real range.
+
 A handler may be async; a failure (sync or rejected) becomes a warning naming
 your extension.
 
@@ -770,24 +780,24 @@ hunk.registerCommand(
 );
 ```
 
-`select` is the natural fit for acting on part of the selection — here, one hunk
-of the selected file:
+`select` is the natural fit for acting on part of the selection — here, asking
+which hunk of the selected file to jump to, then navigating there:
 
 ```ts
 hunk.registerCommand({ id: "pick-hunk", title: "Pick a hunk", key: "ctrl+k" }, async (ctx) => {
-  const hunks = ctx.selection.file?.hunks ?? [];
-  if (hunks.length === 0) {
+  const file = ctx.selection.file;
+  const hunks = file?.hunks ?? [];
+  if (!file || hunks.length === 0) {
     ctx.notify("Nothing to pick from", "warning");
     return;
   }
 
-  const picked = await ctx.dialogs.select({
-    title: "Which hunk?",
-    options: hunks.map((hunk) => hunk.header || `hunk ${hunk.index + 1}`),
-  });
+  const labels = hunks.map((hunk) => hunk.header || `hunk ${hunk.index + 1}`);
+  const picked = await ctx.dialogs.select({ title: "Which hunk?", options: labels });
 
+  // `navigation` is live, so the jump is valid even after awaiting the dialog.
   if (picked !== null) {
-    ctx.notify(`You picked ${picked}`);
+    ctx.navigation.selectHunk(file.id, labels.indexOf(picked));
   }
 });
 ```
@@ -943,7 +953,8 @@ const patterns = (hunk.config.patterns as string[] | undefined) ?? ["*.lock"];
 
 Every handler and transform receives a context object with `cwd` and `notify`.
 Event and bus handlers additionally receive `sidebars` and `events.emit`; command
-handlers receive `sidebars`. `notify` shows a single unobtrusive line at the bottom of the app that clears
+handlers receive `sidebars`, `selection`, `navigation`, and `dialogs`. `notify`
+shows a single unobtrusive line at the bottom of the app that clears
 itself after a few seconds; queued messages appear in turn. `type` is `"info"`
 (default), `"warning"`, or `"error"`, which selects the color. Notifications
 raised before the UI has mounted are buffered and flushed once it does, so a

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -60,6 +60,7 @@ export type {
   ExtensionNotifyType,
   ExtensionLayoutMode,
   ExtensionResolvedLayout,
+  ExtensionReviewNavigation,
   ExtensionReviewNote,
   ExtensionSidebarActions,
   ExtensionSidebarKeybindings,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -640,21 +640,31 @@ export interface ExtensionSidebarTheme {
 }
 
 /**
- * Navigation a custom sidebar can trigger, exactly as the built-in one does.
+ * Navigation any extension surface can trigger, exactly as the built-in
+ * sidebar does.
  *
- * Every action routes through the same review controller the built-in sidebar
+ * Every call routes through the same review controller the built-in sidebar
  * and keyboard shortcuts use, so the main review stream scrolls, selection
  * updates, and the `selection_changed` lifecycle event fires identically —
- * other extensions cannot tell a custom sidebar drove the navigation. Actions
- * stay valid for as long as the component is mounted; a failure inside one is
- * reported as a warning naming the extension instead of thrown back into the
- * component.
+ * other extensions cannot tell what drove the navigation. Targets are
+ * validated against the currently visible (filtered) files: an unknown or
+ * hidden file id is refused with a warning naming the extension, and a hunk
+ * index is clamped into the file's real hunk range. A failure inside a call is
+ * reported the same way instead of thrown back into the caller.
  */
-export interface ExtensionSidebarActions {
+export interface ExtensionReviewNavigation {
   /** Jump the review stream to one file, like clicking its sidebar row. */
   selectFile(fileId: string): void;
   /** Jump the review stream to one hunk of one file. */
   selectHunk(fileId: string, hunkIndex: number): void;
+}
+
+/**
+ * What a custom sidebar component can trigger: review navigation plus a toast.
+ *
+ * Actions stay valid for as long as the component is mounted.
+ */
+export interface ExtensionSidebarActions extends ExtensionReviewNavigation {
   /** Show one toast, attributed to the owning extension. */
   notify(message: string, type?: ExtensionNotifyType): void;
 }
@@ -905,6 +915,15 @@ export interface ExtensionCommandContext extends ExtensionContext {
    * still sees the selection the user ran the command from.
    */
   readonly selection: ExtensionReviewSelection;
+  /**
+   * Navigate the review stream, exactly as a sidebar's actions do.
+   *
+   * Live rather than snapshot, the opposite of `selection`: a call acts on the
+   * review as it is at that moment, validated against the currently visible
+   * files — so a handler that awaits a dialog and then navigates still works,
+   * and one racing a reload gets a warning instead of a stale jump.
+   */
+  readonly navigation: ExtensionReviewNavigation;
   /**
    * Ask the user a question and await the answer.
    *

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -371,6 +371,18 @@ export function App({
     onSelectFile: (_fileId: string) => {},
     onSelectHunk: (_fileId: string, _hunkIndex: number) => {},
   });
+  // A hard session reload (`resetApp`) remounts App under an in-flight async
+  // command handler, whose `ctx.navigation` closes over *this* instance's
+  // refs. Flipping this on unmount lets those closures refuse with an accurate
+  // warning instead of validating against the dead instance's file list or
+  // driving a controller whose state updates no longer render.
+  const appAliveForNavigationRef = useRef(true);
+  useEffect(
+    () => () => {
+      appAliveForNavigationRef.current = false;
+    },
+    [],
+  );
 
   /** Build the selection snapshot a command handler receives, at invocation. */
   const getExtensionSelection = useCallback(() => {
@@ -652,6 +664,9 @@ export function App({
         navigation: createGuardedReviewNavigation({
           extensionId: registered.extensionId,
           getFiles: () => extensionSelectionInputsRef.current.filteredFiles,
+          // Extensions outlive App remounts, so the notify sink stays valid
+          // even after this instance dies and `isLive` starts refusing calls.
+          isLive: () => appAliveForNavigationRef.current,
           notify: (message, type) => extensions?.context.notify(message, type),
           onSelectFile: (fileId) => extensionCommandNavigationRef.current.onSelectFile(fileId),
           onSelectHunk: (fileId, hunkIndex) =>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -79,6 +79,7 @@ import {
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
 import { createExtensionDialogQueue } from "./lib/extensionDialogs";
+import { createGuardedReviewNavigation } from "./lib/extensionNavigation";
 import { buildExtensionReviewSelection } from "./lib/extensionSelection";
 import { createExtensionSidebarKeybindings, resolveCommandKeys } from "./lib/keymap";
 import {
@@ -362,6 +363,15 @@ export function App({
     extensionViewsCacheRef.current = { source, views };
     return views;
   }, []);
+  // Navigation callbacks for extension command handlers. The focus and jump
+  // helpers they delegate to are defined further down the component, so the
+  // callbacks are assigned there each render and only ever read at command
+  // invocation, keeping the dispatch table free of their identities.
+  const extensionCommandNavigationRef = useRef({
+    onSelectFile: (_fileId: string) => {},
+    onSelectHunk: (_fileId: string, _hunkIndex: number) => {},
+  });
+
   /** Build the selection snapshot a command handler receives, at invocation. */
   const getExtensionSelection = useCallback(() => {
     const { selectedFileId: fileId, selectedHunkIndex: hunkIndex } =
@@ -635,6 +645,18 @@ export function App({
         // whole life of the handler's promise — a handler may ask several
         // questions in sequence with work between them.
         dialogs: extensionDialogQueue.createDialogs(registered.extensionId),
+        // Live, unlike `selection`: reads the visible files and delegates to
+        // the same focus/jump callbacks a sidebar row click runs, so a handler
+        // that awaits a dialog before navigating still acts on the current
+        // review — validated, clamped, and warned exactly like sidebar actions.
+        navigation: createGuardedReviewNavigation({
+          extensionId: registered.extensionId,
+          getFiles: () => extensionSelectionInputsRef.current.filteredFiles,
+          notify: (message, type) => extensions?.context.notify(message, type),
+          onSelectFile: (fileId) => extensionCommandNavigationRef.current.onSelectFile(fileId),
+          onSelectHunk: (fileId, hunkIndex) =>
+            extensionCommandNavigationRef.current.onSelectHunk(fileId, hunkIndex),
+        }),
       };
 
       try {
@@ -1378,6 +1400,22 @@ export function App({
   const focusFilter = useCallback(() => {
     setFocusArea("filter");
   }, []);
+
+  // Command-handler navigation lands here each render: the same focus and jump
+  // semantics the sidebar's onSelect handlers use, so a command's navigation is
+  // indistinguishable from a sidebar row click. Read through a ref because the
+  // command dispatch table is built above these helpers and must stay
+  // identity-stable while the review moves.
+  extensionCommandNavigationRef.current = {
+    onSelectFile: (fileId) => {
+      focusFiles();
+      jumpToFile(fileId, 0, { alignFileHeaderTop: true });
+    },
+    onSelectHunk: (fileId, hunkIndex) => {
+      focusFiles();
+      review.selectHunk(fileId, hunkIndex);
+    },
+  };
 
   /** Toggle keyboard focus between the file list and the file filter. */
   const toggleFocusArea = useCallback(() => {

--- a/src/ui/AppHost.extension-navigation.test.tsx
+++ b/src/ui/AppHost.extension-navigation.test.tsx
@@ -1,0 +1,217 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
+import { loadAppBootstrap } from "../core/loaders";
+import type { AppBootstrap } from "../core/types";
+import { loadStartupExtensions } from "../extensions/startup";
+import { AppHost } from "./AppHost";
+
+/**
+ * `ctx.navigation`, driven through the real app: a fixture extension's command
+ * jumps the review stream, and the `selection_changed` event that comes back is
+ * the proof the navigation ran through the same controller as a sidebar click.
+ * The guard semantics themselves are unit-tested in `lib/extensionNavigation.test.ts`.
+ */
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createTempDir(prefix: string) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Create a Git checkout with two committed files carrying working-tree changes. */
+function createTestRepo(prefix: string) {
+  const repo = createTempDir(prefix);
+  execSync("git init && git config user.email test@test && git config user.name test", {
+    cwd: repo,
+    stdio: "ignore",
+  });
+  writeFileSync(join(repo, "alpha.txt"), "one\n");
+  writeFileSync(join(repo, "beta.txt"), "one\n");
+  execSync("git add . && git commit -m init", { cwd: repo, stdio: "ignore" });
+  writeFileSync(join(repo, "alpha.txt"), "one\ntwo\n");
+  writeFileSync(join(repo, "beta.txt"), "one\ntwo\n");
+  return repo;
+}
+
+function readProbeLog(logPath: string) {
+  try {
+    return readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
+  await act(async () => {
+    await setup.renderOnce();
+    await Bun.sleep(0);
+    await setup.renderOnce();
+  });
+}
+
+/** Render frames until a condition holds, and fail loudly when it never does. */
+async function flushUntil(
+  setup: Awaited<ReturnType<typeof testRender>>,
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 4_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for ${description}.`);
+    }
+
+    await flush(setup);
+    await act(async () => {
+      await Bun.sleep(20);
+    });
+  }
+}
+
+/** Launch a bootstrap whose extensions come from one `--extension` fixture path. */
+async function launchWithExtension(repo: string, extPath: string): Promise<AppBootstrap> {
+  const bootstrap = await loadAppBootstrap(
+    { kind: "vcs", staged: false, options: { mode: "stack", extensionPaths: [extPath] } },
+    { cwd: repo },
+  );
+  bootstrap.extensions = await loadStartupExtensions({
+    extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+    cwd: repo,
+    cliExtensionPaths: [extPath],
+  });
+  expect(bootstrap.extensions.issues).toEqual([]);
+  return bootstrap;
+}
+
+/** Mount one AppHost, run the body, and tear down. */
+async function withAppHost(
+  bootstrap: AppBootstrap,
+  body: (setup: Awaited<ReturnType<typeof testRender>>) => Promise<void>,
+) {
+  const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={() => {}} />, {
+    width: 140,
+    height: 30,
+  });
+
+  try {
+    await flush(setup);
+    await body(setup);
+  } finally {
+    await act(async () => {
+      setup.renderer.destroy();
+    });
+  }
+}
+
+describe("extension command navigation", () => {
+  test("a command handler jumps the review stream through ctx.navigation", async () => {
+    const repo = createTestRepo("hunk-ext-nav-jump-");
+    // Outside the repo, so the fixture and its log never join the review.
+    const extDir = createTempDir("hunk-ext-nav-jump-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `let fileIds = [];\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.on("changeset_loaded", ({ changeset }) => {\n` +
+        `    fileIds = changeset.files.map((file) => file.id);\n` +
+        `  });\n` +
+        `  hunk.on("selection_changed", ({ fileId, hunkIndex }) => {\n` +
+        `    const label = fileId === fileIds[1] ? "second" : "other";\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "selected " + label + " " + hunkIndex + "\\n");\n` +
+        `  });\n` +
+        // An out-of-range index on purpose: the guard clamps it into the
+        // file's real hunk range before it reaches the review controller.
+        `  hunk.registerCommand({ id: "jump", title: "Jump", key: "y" }, (ctx) => {\n` +
+        `    ctx.navigation.selectHunk(fileIds[1], 99);\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("beta.txt"),
+        "the review to render",
+      );
+
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+
+      // `selection_changed` firing for the second file is the whole proof:
+      // the command's jump ran through the same review controller a sidebar
+      // row click uses, debounce and all, with the index clamped to 0.
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).some((line) => line === "selected second 0"),
+        "the selection to land on the second file's only hunk",
+      );
+    });
+  });
+
+  test("navigation to a file the stream cannot show warns instead of jumping", async () => {
+    const repo = createTestRepo("hunk-ext-nav-unknown-");
+    const extDir = createTempDir("hunk-ext-nav-unknown-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.on("selection_changed", ({ fileId }) => {\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "selected " + fileId + "\\n");\n` +
+        `  });\n` +
+        `  hunk.registerCommand({ id: "bogus", title: "Bogus", key: "y" }, (ctx) => {\n` +
+        `    ctx.navigation.selectFile("no-such-file");\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "handler-finished\\n");\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("alpha.txt"),
+        "the review to render",
+      );
+
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("handler-finished"),
+        "the command handler to finish",
+      );
+
+      // The refusal surfaces as a toast naming the extension, and the
+      // selection never moved to the phantom id.
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes('targeted unknown file id "no-such-file"'),
+        "the warning toast to render",
+      );
+      expect(readProbeLog(logPath)).not.toContain("selected no-such-file");
+    });
+  });
+});

--- a/src/ui/components/panes/ExtensionSidebarPane.tsx
+++ b/src/ui/components/panes/ExtensionSidebarPane.tsx
@@ -10,6 +10,7 @@ import type {
 import { BuiltInSidebarView } from "../../../extensions/default/ui/sidebar";
 import type { ExtensionNotifySink, RegisteredSidebarView } from "../../../extensions/types";
 import type { DiffFile } from "../../../core/types";
+import { createGuardedReviewNavigation } from "../../lib/extensionNavigation";
 import type { AppTheme } from "../../themes";
 
 /** Read an error's message without assuming extension components throw `Error` instances. */
@@ -155,65 +156,24 @@ export function ExtensionSidebarPane({
   const { extensionId } = registered;
   const publicTheme = useMemo(() => Object.freeze(toSidebarTheme(theme)), [theme]);
 
-  const actions = useMemo<ExtensionSidebarActions>(() => {
-    /** Resolve a navigation target, or report one the review stream cannot show. */
-    const resolveVisibleFile = (method: string, fileId: string) => {
-      const file = files.find((candidate) => candidate.id === fileId);
-      if (!file) {
-        notify(
-          `Extension ${extensionId} ${method} targeted unknown file id "${fileId}"`,
-          "warning",
-        );
-      }
-
-      return file;
-    };
-
-    /** Turn one action failure into a warning naming the extension. */
-    const guard = (method: string, run: () => void) => {
-      try {
-        run();
-      } catch (error) {
-        notify(`Extension ${extensionId} failed ${method} • ${describeError(error)}`, "warning");
-      }
-    };
-
-    return Object.freeze({
-      selectFile(fileId: string) {
-        guard("selectFile", () => {
-          if (resolveVisibleFile("selectFile", fileId)) {
-            onSelectFile(fileId);
-          }
-        });
-      },
-      selectHunk(fileId: string, hunkIndex: number) {
-        guard("selectHunk", () => {
-          const file = resolveVisibleFile("selectHunk", fileId);
-          if (!file) {
-            return;
-          }
-
-          // Selection state, reveal scrolling, and `selection_changed` all
-          // carry this index, so an out-of-range or non-numeric value must not
-          // reach the controller: refuse garbage, clamp the rest into the
-          // file's real hunk range.
-          if (typeof hunkIndex !== "number" || !Number.isFinite(hunkIndex)) {
-            notify(
-              `Extension ${extensionId} selectHunk received an invalid hunk index for "${fileId}"`,
-              "warning",
-            );
-            return;
-          }
-
-          const maxHunkIndex = Math.max(0, file.metadata.hunks.length - 1);
-          onSelectHunk(fileId, Math.min(Math.max(0, Math.floor(hunkIndex)), maxHunkIndex));
-        });
-      },
-      notify(message: string, type: ExtensionNotifyType = "info") {
-        notify(`${extensionId}: ${message}`, type);
-      },
-    });
-  }, [extensionId, files, notify, onSelectFile, onSelectHunk]);
+  const actions = useMemo<ExtensionSidebarActions>(
+    () =>
+      Object.freeze({
+        // The same guarded navigation a command handler's `navigation` uses,
+        // so a sidebar row click and a command jump enforce one contract.
+        ...createGuardedReviewNavigation({
+          extensionId,
+          getFiles: () => files,
+          notify,
+          onSelectFile,
+          onSelectHunk,
+        }),
+        notify(message: string, type: ExtensionNotifyType = "info") {
+          notify(`${extensionId}: ${message}`, type);
+        },
+      }),
+    [extensionId, files, notify, onSelectFile, onSelectHunk],
+  );
 
   // The published contract types the component's return opaquely (`unknown`)
   // because the contract module carries no React types; inside the host it is

--- a/src/ui/lib/extensionNavigation.test.ts
+++ b/src/ui/lib/extensionNavigation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { createGuardedReviewNavigation } from "./extensionNavigation";
+
+/** One navigable file with the given number of parsed hunks. */
+function createTestNavigableFile(id: string, hunkCount: number) {
+  return { id, metadata: { hunks: Array.from({ length: hunkCount }, () => ({})) } };
+}
+
+function createTestNavigation(options?: {
+  files?: ReturnType<typeof createTestNavigableFile>[];
+  onSelectFile?: (fileId: string) => void;
+  onSelectHunk?: (fileId: string, hunkIndex: number) => void;
+}) {
+  const warnings: string[] = [];
+  const selectedFiles: string[] = [];
+  const selectedHunks: Array<[string, number]> = [];
+  let files = options?.files ?? [createTestNavigableFile("a", 3)];
+
+  const navigation = createGuardedReviewNavigation({
+    extensionId: "triage",
+    getFiles: () => files,
+    notify: (message, type) => {
+      if (type === "warning") {
+        warnings.push(message);
+      }
+    },
+    onSelectFile: options?.onSelectFile ?? ((fileId) => selectedFiles.push(fileId)),
+    onSelectHunk:
+      options?.onSelectHunk ?? ((fileId, hunkIndex) => selectedHunks.push([fileId, hunkIndex])),
+  });
+
+  return {
+    navigation,
+    warnings,
+    selectedFiles,
+    selectedHunks,
+    setFiles(next: ReturnType<typeof createTestNavigableFile>[]) {
+      files = next;
+    },
+  };
+}
+
+describe("createGuardedReviewNavigation", () => {
+  test("routes a visible-file selection through to the host callback", () => {
+    const { navigation, selectedFiles, warnings } = createTestNavigation();
+
+    navigation.selectFile("a");
+
+    expect(selectedFiles).toEqual(["a"]);
+    expect(warnings).toEqual([]);
+  });
+
+  test("refuses a file id the review stream cannot show, with a warning", () => {
+    const { navigation, selectedFiles, warnings } = createTestNavigation();
+
+    navigation.selectFile("hidden");
+
+    expect(selectedFiles).toEqual([]);
+    expect(warnings).toEqual(['Extension triage selectFile targeted unknown file id "hidden"']);
+  });
+
+  test("clamps a hunk index into the file's real range and floors fractions", () => {
+    const { navigation, selectedHunks } = createTestNavigation();
+
+    navigation.selectHunk("a", 99);
+    navigation.selectHunk("a", -5);
+    navigation.selectHunk("a", 1.7);
+
+    expect(selectedHunks).toEqual([
+      ["a", 2],
+      ["a", 0],
+      ["a", 1],
+    ]);
+  });
+
+  test("refuses a non-numeric hunk index instead of passing garbage through", () => {
+    const { navigation, selectedHunks, warnings } = createTestNavigation();
+
+    navigation.selectHunk("a", Number.NaN);
+    navigation.selectHunk("a", "2" as unknown as number);
+
+    expect(selectedHunks).toEqual([]);
+    expect(warnings).toEqual([
+      'Extension triage selectHunk received an invalid hunk index for "a"',
+      'Extension triage selectHunk received an invalid hunk index for "a"',
+    ]);
+  });
+
+  test("turns a host-callback failure into a warning naming the extension", () => {
+    const { navigation, warnings } = createTestNavigation({
+      onSelectFile: () => {
+        throw new Error("controller unavailable");
+      },
+    });
+
+    navigation.selectFile("a");
+
+    expect(warnings).toEqual(["Extension triage failed selectFile • controller unavailable"]);
+  });
+
+  test("validates against the files visible at call time, not at creation", () => {
+    // A command handler may await a dialog while a reload or filter changes
+    // the review; navigation must judge the target against the current list.
+    const { navigation, selectedFiles, warnings, setFiles } = createTestNavigation();
+
+    setFiles([createTestNavigableFile("b", 1)]);
+    navigation.selectFile("a");
+    navigation.selectFile("b");
+
+    expect(selectedFiles).toEqual(["b"]);
+    expect(warnings).toEqual(['Extension triage selectFile targeted unknown file id "a"']);
+  });
+});

--- a/src/ui/lib/extensionNavigation.test.ts
+++ b/src/ui/lib/extensionNavigation.test.ts
@@ -98,6 +98,38 @@ describe("createGuardedReviewNavigation", () => {
     expect(warnings).toEqual(["Extension triage failed selectFile • controller unavailable"]);
   });
 
+  test("refuses every call once the review surface it was minted for is gone", () => {
+    // A hard session reload (`resetApp`) remounts the app under an in-flight
+    // handler; its navigation must say so rather than silently no-op against
+    // the dead instance or judge targets by the old review's file list.
+    let alive = true;
+    const warnings: string[] = [];
+    const selectedFiles: string[] = [];
+    const navigation = createGuardedReviewNavigation({
+      extensionId: "triage",
+      getFiles: () => [createTestNavigableFile("a", 1)],
+      isLive: () => alive,
+      notify: (message, type) => {
+        if (type === "warning") {
+          warnings.push(message);
+        }
+      },
+      onSelectFile: (fileId) => selectedFiles.push(fileId),
+      onSelectHunk: () => {},
+    });
+
+    navigation.selectFile("a");
+    alive = false;
+    navigation.selectFile("a");
+    navigation.selectHunk("a", 0);
+
+    expect(selectedFiles).toEqual(["a"]);
+    expect(warnings).toEqual([
+      "Extension triage selectFile ignored — the review session was reloaded",
+      "Extension triage selectHunk ignored — the review session was reloaded",
+    ]);
+  });
+
   test("validates against the files visible at call time, not at creation", () => {
     // A command handler may await a dialog while a reload or filter changes
     // the review; navigation must judge the target against the current list.

--- a/src/ui/lib/extensionNavigation.ts
+++ b/src/ui/lib/extensionNavigation.ts
@@ -1,0 +1,107 @@
+import type { ExtensionReviewNavigation } from "../../extension-api/types";
+import type { ExtensionNotifySink } from "../../extensions/types";
+
+/**
+ * The file fields navigation guarding reads: identity to validate a target,
+ * parsed hunks to clamp an index. Structural so the sidebar pane's `files`
+ * prop and App's live visible-files ref both satisfy it without conversion.
+ */
+interface NavigableFile {
+  id: string;
+  metadata: { hunks: readonly unknown[] };
+}
+
+/** Read an error's message without assuming extension code throws `Error` instances. */
+function describeError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message || error.name;
+  }
+
+  return String(error);
+}
+
+export interface CreateGuardedReviewNavigationOptions {
+  extensionId: string;
+  /**
+   * The currently visible review-stream files, read per call.
+   *
+   * A getter rather than a list so one navigation object can stay
+   * identity-stable while the review moves underneath it — a command handler
+   * that awaits a dialog and then navigates must be validated against the
+   * files visible *now*, not the ones visible when its key fired.
+   */
+  getFiles: () => readonly NavigableFile[];
+  notify: ExtensionNotifySink;
+  onSelectFile: (fileId: string) => void;
+  onSelectHunk: (fileId: string, hunkIndex: number) => void;
+}
+
+/**
+ * Build the guarded review navigation extension surfaces share.
+ *
+ * One builder behind both a sidebar's `actions` and a command handler's
+ * `navigation`, so every extension-driven jump enforces the same contract: a
+ * target is refused (with a warning naming the extension) unless it is a
+ * currently visible file, a hunk index is clamped into the file's real hunk
+ * range, and a failure inside the host callback becomes a warning instead of
+ * unwinding into extension code.
+ */
+export function createGuardedReviewNavigation({
+  extensionId,
+  getFiles,
+  notify,
+  onSelectFile,
+  onSelectHunk,
+}: CreateGuardedReviewNavigationOptions): ExtensionReviewNavigation {
+  /** Resolve a navigation target, or report one the review stream cannot show. */
+  const resolveVisibleFile = (method: string, fileId: string) => {
+    const file = getFiles().find((candidate) => candidate.id === fileId);
+    if (!file) {
+      notify(`Extension ${extensionId} ${method} targeted unknown file id "${fileId}"`, "warning");
+    }
+
+    return file;
+  };
+
+  /** Turn one action failure into a warning naming the extension. */
+  const guard = (method: string, run: () => void) => {
+    try {
+      run();
+    } catch (error) {
+      notify(`Extension ${extensionId} failed ${method} • ${describeError(error)}`, "warning");
+    }
+  };
+
+  return Object.freeze({
+    selectFile(fileId: string) {
+      guard("selectFile", () => {
+        if (resolveVisibleFile("selectFile", fileId)) {
+          onSelectFile(fileId);
+        }
+      });
+    },
+    selectHunk(fileId: string, hunkIndex: number) {
+      guard("selectHunk", () => {
+        const file = resolveVisibleFile("selectHunk", fileId);
+        if (!file) {
+          return;
+        }
+
+        // Selection state, reveal scrolling, and `selection_changed` all
+        // carry this index, so an out-of-range or non-numeric value must not
+        // reach the controller: refuse garbage, clamp the rest into the
+        // file's real hunk range.
+        if (typeof hunkIndex !== "number" || !Number.isFinite(hunkIndex)) {
+          notify(
+            `Extension ${extensionId} selectHunk received an invalid hunk index for "${fileId}"`,
+            "warning",
+          );
+          return;
+        }
+
+        const maxHunkIndex = Math.max(0, file.metadata.hunks.length - 1);
+        onSelectHunk(fileId, Math.min(Math.max(0, Math.floor(hunkIndex)), maxHunkIndex));
+      });
+    },
+  });
+}

--- a/src/ui/lib/extensionNavigation.ts
+++ b/src/ui/lib/extensionNavigation.ts
@@ -31,6 +31,18 @@ export interface CreateGuardedReviewNavigationOptions {
    * files visible *now*, not the ones visible when its key fired.
    */
   getFiles: () => readonly NavigableFile[];
+  /**
+   * Whether the review surface this navigation was minted for still exists.
+   *
+   * A session reload may remount the whole app (`resetApp`), and a command
+   * handler still in flight across that remount holds navigation closing over
+   * the unmounted instance — its file list frozen at the old review, its
+   * callbacks driving a controller whose state updates no longer render.
+   * Checked per call, so such a handler gets an accurate refusal instead of a
+   * stale validation or a silent no-op. Omitted means always live, which is
+   * right for a sidebar's actions: the pane unmounts with the instance.
+   */
+  isLive?: () => boolean;
   notify: ExtensionNotifySink;
   onSelectFile: (fileId: string) => void;
   onSelectHunk: (fileId: string, hunkIndex: number) => void;
@@ -49,6 +61,7 @@ export interface CreateGuardedReviewNavigationOptions {
 export function createGuardedReviewNavigation({
   extensionId,
   getFiles,
+  isLive,
   notify,
   onSelectFile,
   onSelectHunk,
@@ -65,6 +78,14 @@ export function createGuardedReviewNavigation({
 
   /** Turn one action failure into a warning naming the extension. */
   const guard = (method: string, run: () => void) => {
+    if (isLive && !isLive()) {
+      notify(
+        `Extension ${extensionId} ${method} ignored — the review session was reloaded`,
+        "warning",
+      );
+      return;
+    }
+
     try {
       run();
     } catch (error) {


### PR DESCRIPTION
## What

Adds `ctx.navigation` to extension command handlers: `selectFile(fileId)` and `selectHunk(fileId, hunkIndex)`, the same guarded review navigation a custom sidebar's `actions` carry, routed through the same review controller — the stream scrolls, selection updates, and `selection_changed` fires exactly as if the user clicked a sidebar row.

## Why

Extension-author feedback (round 2, finding 3): commands receive a selection snapshot, dialogs, and sidebar open/close controls, but no way to move the review. A "next blocked hunk" command had to rely on a mounted sidebar to navigate — indirect, and unreliable on a narrow terminal where the pane may not fit.

## How

- The guarded navigation logic (visible-file validation, hunk-index clamping, callback-failure-to-warning) moves out of `ExtensionSidebarPane` into one shared builder, `src/ui/lib/extensionNavigation.ts`, so a sidebar row click and a command jump enforce one contract. Warning strings are unchanged.
- App mints `navigation` per command invocation, delegating to the same focus + jump callbacks the sidebar's `onSelect` handlers use, read through render-assigned refs so the command dispatch table keeps its identity-stability (no new memo deps).
- `navigation` is deliberately **live** where `selection` is a snapshot: the file list is read per call, so a handler that awaits a dialog and then navigates acts on the current review, and one racing a reload gets a warning instead of a stale jump. New public type `ExtensionReviewNavigation`; `ExtensionSidebarActions` now extends it.
- The guide documents `ctx.navigation`, and the pick-hunk example now ends by jumping to the chosen hunk instead of just naming it.

## Testing

- New `src/ui/lib/extensionNavigation.test.ts` (6 tests: pass-through, unknown-id refusal, clamping/flooring, non-numeric refusal, throw-to-warning, call-time validation).
- New `src/ui/AppHost.extension-navigation.test.tsx` end-to-end through the real app: a fixture extension's `y` command jumps to the second file's hunk with an out-of-range index and the clamped `selection_changed` event proves the controller path; a phantom-id jump surfaces the warning toast and never moves the selection.
- `bun run typecheck`, `bun run lint`, `bun run check:pack` (docs examples typecheck), full `src/` suite (1595 pass), extensions PTY suite — all green.

Changeset: `minor` for `hunkdiff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ)_