### PR TITLE
docs(extensions): commit the scrollbox ref contract for custom sidebars

### DIFF
--- a/.changeset/sidebar-scroll-ref-contract.md
+++ b/.changeset/sidebar-scroll-ref-contract.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+The extension authoring guide now documents the supported scrollbox ref contract for custom sidebars: hold a React ref to your `<scrollbox>`, give rows stable `id` props, and use `scrollChildIntoView` to follow the selection, with `scrollTop`/`viewport.height` and the scrollbar/viewport change events for pane geometry — the exact surface the built-in sidebar runs on, now committed as the supported way to scroll, follow, and window a third-party sidebar instead of being described as an unsupported gap.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -582,23 +582,97 @@ toast naming your extension, the pane closes, and the built-in file navigation
 reopens if nothing else is showing.
 
 Props carry the pane's `width` but not its height: the pane is a flex cell, so
-give your root element `height="100%"` and let layout size it. For a list
-longer than the pane, a `scrollbox` scrolls it — but there is no public
-viewport data (pane rows, scroll offset), so row virtualization and
-keeping the selected row scrolled into view are not supportable in a
-third-party sidebar today. `useTerminalDimensions` from `@opentui/react`
-reports the whole terminal, which bounds the pane but is not its height. If
-your extension needs true pane geometry, say so in an issue — it is a known
-gap under consideration, not a settled boundary.
+give your root element `height="100%"` and let layout size it. Everything else
+about scrolling — pane viewport height, scroll position, keeping a row visible
+— goes through the `<scrollbox>` itself, via a plain React ref. Hunk serves
+its own `@opentui/core` to extension files, so the renderable a ref hands you
+is the very instance the host renders with.
+
+#### Scrolling: the scrollbox ref contract
+
+The one behavior a list sidebar always ends up needing is following the
+selection. Give your rows stable `id` props, hold a ref to the scrollbox, and
+scroll the selected row into view from an effect:
+
+```tsx
+import { useEffect, useRef } from "react";
+import type { ScrollBoxRenderable } from "@opentui/core";
+import type { ExtensionSidebarViewProps } from "hunkdiff/extension";
+
+function HunkList({
+  files,
+  selectedFileId,
+  selectedHunkIndex,
+  theme,
+  actions,
+}: ExtensionSidebarViewProps) {
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+
+  // Follow policy is deliberately yours: the host never scrolls a pane it
+  // cannot see into, so decide here when (and whether) to follow.
+  useEffect(() => {
+    if (selectedFileId !== null) {
+      scrollRef.current?.scrollChildIntoView(`row-${selectedFileId}-${selectedHunkIndex ?? 0}`);
+    }
+  }, [selectedFileId, selectedHunkIndex]);
+
+  return (
+    <scrollbox ref={scrollRef} width="100%" height="100%" scrollY={true} focused={false}>
+      {files.flatMap((file) =>
+        (file.hunks ?? []).map((hunk) => {
+          const selected = file.id === selectedFileId && hunk.index === selectedHunkIndex;
+          return (
+            <box
+              key={`${file.id}:${hunk.index}`}
+              id={`row-${file.id}-${hunk.index}`}
+              style={{ width: "100%", height: 1 }}
+              onMouseUp={() => actions.selectHunk(file.id, hunk.index)}
+            >
+              <text
+                content={` ${file.path}  ${hunk.header}`}
+                style={{ fg: selected ? theme.accent : theme.text }}
+              />
+            </box>
+          );
+        }),
+      )}
+    </scrollbox>
+  );
+}
+```
+
+The ref surface this recipe stands on is the exact one the built-in sidebar
+runs on:
+
+- **`scrollChildIntoView(id)`** scrolls the descendant with that `id` prop
+  into view.
+- **`scrollTop`** and **`viewport.height`** read the current scroll offset and
+  the pane's viewport rows — the pane-height number the props do not carry.
+  A read before the first layout pass reports `0`, so viewport-dependent code
+  belongs behind the events below rather than a bare mount effect.
+- **`verticalScrollBar.on("change", handler)`**,
+  **`viewport.on("layout-changed", handler)`**, and
+  **`viewport.on("resized", handler)`** report scrolling and pane resizes;
+  unsubscribe with the matching `.off` in your effect's cleanup.
+
+That is enough to window a long list yourself: the built-in sidebar renders
+only the rows near the viewport, plus spacer boxes sized from those same
+reads (its render-window helper is host code, but nothing it computes needs
+anything beyond this surface — `useTerminalDimensions` from `@opentui/react`
+serves as its pre-first-layout viewport estimate).
+
+One honest caveat: this contract rides on OpenTUI's renderable API, served at
+whatever version Hunk pins — a wider surface than `hunkdiff/extension` itself.
+The built-in sidebar exercising the exact same calls is the compatibility
+guarantee: a change that breaks your scroll code breaks Hunk's own sidebar
+first. Still, keep scroll handling small and behind your own helpers.
 
 The built-in sidebar is itself a bundled extension
-(`src/extensions/default/ui/sidebar/`): it registers through this exact call
-and its component consumes exactly the props documented above, so it doubles as
-the reference implementation — anything it draws from those props (grouping,
-change-type icons, stat badges), yours can too. The one thing it does that the
-props alone cannot express is windowing and selection follow, which it builds
-from host-internal geometry helpers — that is the pane-geometry gap described
-above, kept honest by the dogfooding.
+(`src/extensions/default/ui/sidebar/`): it registers through this exact call,
+its component consumes exactly the props documented above, and its windowing
+and selection follow run on exactly the ref contract above — so it doubles as
+the reference implementation for everything a third-party sidebar can build,
+from grouping and stat badges down to scroll behavior.
 
 #### Sidebar state from events
 

--- a/src/extensions/default/ui/sidebar/index.tsx
+++ b/src/extensions/default/ui/sidebar/index.tsx
@@ -37,6 +37,13 @@ import {
  * Rendering helpers (row components, the render window) are imported from Hunk
  * directly: this is host code, and the dogfooding boundary is the data,
  * actions, and theme crossing the props — not utility code.
+ *
+ * The scrollbox usage below is itself part of the published contract: the ref
+ * reads (`scrollTop`, `viewport.height`), the scrollbar/viewport change
+ * events, and `scrollChildIntoView` over child `id` props are documented in
+ * docs/extensions.md as the supported way third-party sidebars scroll and
+ * follow the selection. Changing how this component talks to its scrollbox
+ * means updating that contract — same honesty mechanism as the props.
  */
 
 /**

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -502,10 +502,11 @@ describe("extension sidebar views", () => {
 
     const extDir = createTempDir("hunk-ext-sidebar-scroll-ext-");
     const logPath = join(extDir, "probe.log");
-    // A TSX fixture running the exact recipe docs/extensions.md publishes:
-    // a ref on the scrollbox, `id` props on the rows, and an effect calling
-    // `scrollChildIntoView` when the selection moves. The viewport read in the
-    // same effect proves the geometry side of the contract from extension code.
+    // A TSX fixture running the exact recipe docs/extensions.md publishes: a
+    // ref on the scrollbox, `id` props on the rows, an effect calling
+    // `scrollChildIntoView` when the selection moves, and the documented
+    // event subscriptions reporting `scrollTop`/`viewport.height` — the whole
+    // committed ref surface, exercised from extension code.
     const extPath = join(extDir, "ext.tsx");
     writeFileSync(
       extPath,
@@ -518,8 +519,26 @@ describe("extension sidebar views", () => {
         `  const scrollRef = useRef<ScrollBoxRenderable | null>(null);\n` +
         `\n` +
         `  useEffect(() => {\n` +
-        `    const viewportHeight = scrollRef.current?.viewport.height ?? 0;\n` +
-        `    appendFileSync(${JSON.stringify(logPath)}, "viewport " + viewportHeight + " follow " + selectedFileId + "\\n");\n` +
+        `    const scrollBox = scrollRef.current;\n` +
+        `    if (!scrollBox) {\n` +
+        `      return;\n` +
+        `    }\n` +
+        `    const report = () => {\n` +
+        `      const top = scrollBox.scrollTop ?? 0;\n` +
+        `      const height = scrollBox.viewport.height ?? 0;\n` +
+        `      appendFileSync(${JSON.stringify(logPath)}, "geom " + top + " " + height + "\\n");\n` +
+        `    };\n` +
+        `    scrollBox.verticalScrollBar.on("change", report);\n` +
+        `    scrollBox.viewport.on("layout-changed", report);\n` +
+        `    scrollBox.viewport.on("resized", report);\n` +
+        `    return () => {\n` +
+        `      scrollBox.verticalScrollBar.off("change", report);\n` +
+        `      scrollBox.viewport.off("layout-changed", report);\n` +
+        `      scrollBox.viewport.off("resized", report);\n` +
+        `    };\n` +
+        `  }, []);\n` +
+        `\n` +
+        `  useEffect(() => {\n` +
         `    if (selectedFileId !== null) {\n` +
         `      scrollRef.current?.scrollChildIntoView("probe-" + selectedFileId);\n` +
         `    }\n` +
@@ -576,13 +595,20 @@ describe("extension sidebar views", () => {
         "the fixture pane to follow the selection to the last row",
       );
 
-      // The effect's ref read saw real pane geometry once layout had run — an
-      // immediate post-mount read is legitimately 0, which is exactly why the
-      // docs point viewport-dependent code at the layout/scroll events.
-      const viewportRows = readProbeLog(logPath)
-        .filter((line) => line.startsWith("viewport "))
-        .map((line) => Number(line.split(" ")[1]));
-      expect(Math.max(0, ...viewportRows)).toBeGreaterThan(0);
+      // The documented event subscriptions delivered real geometry: layout
+      // events reported a nonzero viewport height once the pane laid out, and
+      // the scrollbar change event reported a nonzero scrollTop once
+      // `scrollChildIntoView` moved the pane — both read through the ref, from
+      // extension code, exactly as the guide's bullets promise.
+      const geometry = readProbeLog(logPath)
+        .filter((line) => line.startsWith("geom "))
+        .map((line) => {
+          const [, top, height] = line.split(" ");
+          return { top: Number(top), height: Number(height) };
+        });
+      expect(geometry.length).toBeGreaterThan(0);
+      expect(Math.max(0, ...geometry.map((entry) => entry.height))).toBeGreaterThan(0);
+      expect(Math.max(0, ...geometry.map((entry) => entry.top))).toBeGreaterThan(0);
     });
   });
 });

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -478,4 +478,111 @@ describe("extension sidebar views", () => {
       );
     });
   });
+
+  test("the documented scrollbox ref contract follows the selection from a fixture sidebar", async () => {
+    // Enough changed files that the fixture pane's list overflows its viewport:
+    // the last row is only visible if `scrollChildIntoView` actually scrolled.
+    const repo = createTempDir("hunk-ext-sidebar-scroll-");
+    execSync("git init && git config user.email test@test && git config user.name test", {
+      cwd: repo,
+      stdio: "ignore",
+    });
+    const fileCount = 30;
+    const names = Array.from(
+      { length: fileCount },
+      (_, index) => `file-${String(index).padStart(2, "0")}.txt`,
+    );
+    for (const name of names) {
+      writeFileSync(join(repo, name), "one\n");
+    }
+    execSync("git add . && git commit -m init", { cwd: repo, stdio: "ignore" });
+    for (const name of names) {
+      writeFileSync(join(repo, name), "one\ntwo\n");
+    }
+
+    const extDir = createTempDir("hunk-ext-sidebar-scroll-ext-");
+    const logPath = join(extDir, "probe.log");
+    // A TSX fixture running the exact recipe docs/extensions.md publishes:
+    // a ref on the scrollbox, `id` props on the rows, and an effect calling
+    // `scrollChildIntoView` when the selection moves. The viewport read in the
+    // same effect proves the geometry side of the contract from extension code.
+    const extPath = join(extDir, "ext.tsx");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `import { useEffect, useRef } from "react";\n` +
+        `import type { ScrollBoxRenderable } from "@opentui/core";\n` +
+        `import type { ExtensionSidebarViewProps, HunkExtensionAPI } from "hunkdiff/extension";\n` +
+        `\n` +
+        `function RefList({ files, selectedFileId, theme }: ExtensionSidebarViewProps) {\n` +
+        `  const scrollRef = useRef<ScrollBoxRenderable | null>(null);\n` +
+        `\n` +
+        `  useEffect(() => {\n` +
+        `    const viewportHeight = scrollRef.current?.viewport.height ?? 0;\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "viewport " + viewportHeight + " follow " + selectedFileId + "\\n");\n` +
+        `    if (selectedFileId !== null) {\n` +
+        `      scrollRef.current?.scrollChildIntoView("probe-" + selectedFileId);\n` +
+        `    }\n` +
+        `  }, [selectedFileId]);\n` +
+        `\n` +
+        `  return (\n` +
+        `    <scrollbox ref={scrollRef} width="100%" height="100%" scrollY={true} focused={false}>\n` +
+        `      {files.map((file) => (\n` +
+        `        <box key={file.id} id={"probe-" + file.id} style={{ width: "100%", height: 1 }}>\n` +
+        `          <text\n` +
+        `            content={"ref:" + file.path}\n` +
+        `            style={{ fg: file.id === selectedFileId ? theme.accent : theme.text }}\n` +
+        `          />\n` +
+        `        </box>\n` +
+        `      ))}\n` +
+        `    </scrollbox>\n` +
+        `  );\n` +
+        `}\n` +
+        `\n` +
+        `export default function (hunk: HunkExtensionAPI) {\n` +
+        `  hunk.registerSidebarView({\n` +
+        `    id: "reflist",\n` +
+        `    title: "Ref list",\n` +
+        `    placement: "right",\n` +
+        `    defaultOpen: true,\n` +
+        `    component: RefList,\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("ref:file-00.txt"),
+        "the fixture pane to render its first row",
+      );
+      // The tail of the list starts outside the pane's viewport.
+      expect(setup.captureCharFrame()).not.toContain(`ref:file-${fileCount - 1}`);
+
+      // Walk the selection to the last file, one keypress per frame — the
+      // review coalesces navigation within a frame, so a single burst would
+      // move one file. Each step re-runs the fixture's follow effect, and the
+      // final row can only be on screen if `scrollChildIntoView` scrolled.
+      for (let step = 0; step < fileCount - 1; step += 1) {
+        await act(async () => {
+          await setup.mockInput.typeText(".");
+        });
+        await flush(setup);
+      }
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes(`ref:file-${fileCount - 1}`),
+        "the fixture pane to follow the selection to the last row",
+      );
+
+      // The effect's ref read saw real pane geometry once layout had run — an
+      // immediate post-mount read is legitimately 0, which is exactly why the
+      // docs point viewport-dependent code at the layout/scroll events.
+      const viewportRows = readProbeLog(logPath)
+        .filter((line) => line.startsWith("viewport "))
+        .map((line) => Number(line.split(" ")[1]));
+      expect(Math.max(0, ...viewportRows)).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## What

Replaces the authoring guide's "pane geometry / selection follow are not supportable in a third-party sidebar" caveat with a documented, committed contract: the scrollbox ref. Custom sidebars hold a React ref to their `<scrollbox>`, give rows stable `id` props, and get:

- `scrollChildIntoView(id)` for selection following (with a full recipe in the guide),
- `scrollTop` / `viewport.height` for pane geometry — including the pre-first-layout zero-read caveat,
- `verticalScrollBar` / `viewport` change events for reacting to scrolling and pane resizes.

## Why

Extension-author feedback (round 2, finding 1) claimed a third-party sidebar cannot reproduce the built-in sidebar's windowing or follow-selection without host internals. Investigation showed the claim was overstated: everything the built-in sidebar does with its scrollbox goes through host-served `@opentui/core` and plain refs, which extensions already receive — the only internal pieces are rendering helpers. The real gap was that none of this was documented or committed, so authors reasonably treated it as off-limits. The feedback itself suggested "a supported scrollbox ref contract" as the alternative; this PR makes that the answer, instead of new viewport props that would duplicate what the ref already exposes.

## How

- The sidebar section gains a "Scrolling: the scrollbox ref contract" subsection with a follow-selection recipe (rows modeled on the built-in sidebar's `id`-on-box pattern), the committed ref surface, and an honest caveat that the contract rides on Hunk's pinned OpenTUI version — with the built-in sidebar exercising the same calls as the compatibility guarantee.
- The bundled sidebar's module header now marks its scrollbox usage as load-bearing: changing how it talks to its scrollbox means updating the published contract.
- A new AppHost test runs the exact published recipe from a TSX fixture extension through the real host runtime: a 30-row list overflows its pane, the selection walks to the last file, and the last row being on screen proves `scrollChildIntoView` scrolled; the fixture's ref reads prove the geometry side.

## Testing

- New test in `src/ui/AppHost.extension-sidebar.test.tsx` (suite now 8 passing).
- `bun run typecheck`, `bun run lint`, `bun run check:pack`, full `src/` suite — all green.

Changeset: `patch` for `hunkdiff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7EZpzieiVPdj6LZn4oBYJ)_