### PR TITLE
ci(release): switch npm publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -191,6 +191,9 @@ jobs:
       - stage-release
     if: github.event_name == 'push' || inputs.publish == true
     environment: npm
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -206,6 +209,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Use npm with trusted publishing support
+        run: npm install -g npm@11.17.0
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -218,14 +224,7 @@ jobs:
       - name: Show staged packages
         run: find dist/release/npm -maxdepth 3 -type f | sort
 
-      - name: Verify npm auth
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm whoami
-
       - name: Publish packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bun run publish:prebuilt:npm -- --tag "${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag || ((contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc')) && 'beta' || 'latest') }}"
 
   create-github-release:


### PR DESCRIPTION
Applies the same trusted-publishing migration as modem-dev/sideshow#241, plus the two pieces this workflow was missing to be OIDC-ready:

- Grant the `publish` job `permissions: contents: read, id-token: write` — the workflow had no permissions block, and the OIDC exchange requires `id-token: write`.
- Install `npm@11.17.0` in the publish job — trusted publishing needs npm ≥ 11.5.1, but Node 22 bundles npm 10.x. The publish script (`scripts/publish-prebuilt-npm.ts`) shells out to `npm publish` per package, so upgrading the global npm is sufficient.
- Remove the "Verify npm auth" (`npm whoami`) step and the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from the publish step. `npm whoami` cannot authenticate via the OIDC token, and a set `NODE_AUTH_TOKEN` makes npm use the legacy token instead of performing the OIDC exchange. Provenance is applied automatically by the OIDC flow.

The script's `npm view` already-published check is an unauthenticated read of the public registry, so it keeps working without a token.

**Prerequisite before merging/releasing:** trusted publishers must be configured on npmjs.com for all six published packages — `hunkdiff`, `hunkdiff-darwin-arm64`, `hunkdiff-darwin-x64`, `hunkdiff-linux-arm64`, `hunkdiff-linux-x64`, `hunkdiff-windows-x64` — each with:

- Owner: `modem-dev`
- Repository: `hunk`
- Workflow filename: `release-prebuilt-npm.yml`
- Environment: `npm`
- Allowed action: `npm publish`

After the first successful OIDC release, the `NPM_TOKEN` repo secret can be deleted — but only revoke the underlying npm token once sideshow has also migrated, if the two repos share it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BerkCKcoCgvaKozTXXv6D8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BerkCKcoCgvaKozTXXv6D8)_