### PR TITLE
Restyle community video cards as paused YouTube embeds

### DIFF
--- a/.changeset/video-cards-paused-embed.md
+++ b/.changeset/video-cards-paused-embed.md
@@ -1,0 +1,4 @@
+---
+---
+
+Restyle the landing page's community video cards as paused YouTube embeds — locally drawn scrim, red play button, duration badge, and channel monogram — so the walkthroughs read as real videos instead of marketing tiles. Website-only change with no published package bump.

--- a/website/MEDIA.md
+++ b/website/MEDIA.md
@@ -34,3 +34,11 @@ magick /tmp/thumb.jpg -resize '900x>' -strip -quality 80 public/video-<channel>.
 ```
 
 Durations in that component are hardcoded because they never change once a video is published. Verify them against the video before adding a new card.
+
+The cards render as paused embeds: the scrim, red play button, and duration badge are drawn locally so nothing loads from YouTube. Channel avatars are currently monogram circles (`initial` + `avatarColor` in the component data). To upgrade a card to the channel's real avatar, self-host it the same way as the thumbnails — save the channel page's avatar image, then:
+
+```bash
+magick avatar.jpg -resize 56x56 -strip -quality 80 public/avatar-<channel>.webp
+```
+
+and swap the component's monogram span for an `<img>` pointing at it. Keep avatars square at 56px; the CSS rounds them.

--- a/website/src/components/marketing/CommunityVideos.astro
+++ b/website/src/components/marketing/CommunityVideos.astro
@@ -1,47 +1,56 @@
 ---
 /**
- * Independent walkthroughs, linked out rather than embedded.
- * Self-hosted thumbnails keep the landing page free of third-party player scripts.
+ * Independent walkthroughs styled as paused YouTube embeds, linked out rather
+ * than embedded. Self-hosted thumbnails keep the landing page free of
+ * third-party player scripts; the player chrome (scrim, red play button,
+ * duration badge) is drawn locally so the cards read as real videos without
+ * loading anything from YouTube.
+ *
+ * Avatars are monogram fallbacks until a self-hosted channel avatar exists;
+ * see website/MEDIA.md for the swap ritual.
  */
 const videos = [
   {
     href: "https://www.youtube.com/watch?v=FFfz81XM57k",
     thumb: "/video-jilles.webp",
     channel: "Jilles",
+    initial: "J",
+    avatarColor: "#8a5a2b",
     length: "5:14",
     title: "Hunk changed the way I write and review code with my agent",
-    blurb: "Why the diff becomes the main artifact once an agent is writing the code.",
   },
   {
     href: "https://www.youtube.com/watch?v=-4fJbIF8WAs",
     thumb: "/video-devops-toolbox.webp",
     channel: "DevOps Toolbox",
+    initial: "D",
+    avatarColor: "#3b5bdb",
     length: "13:33",
     title: "I Was Definitely Using The Wrong Terminal Code Reviewer",
-    blurb: "A longer hands-on tour — layouts, themes, keyboard and mouse, and daily use.",
   },
 ] as const;
 ---
 
 <div class="vgrid">
   {
-    videos.map(({ href, thumb, channel, length, title, blurb }) => (
+    videos.map(({ href, thumb, channel, initial, avatarColor, length, title }) => (
       <a class="vcard" href={href} target="_blank" rel="noopener noreferrer">
-        <span class="vthumb">
+        <span class="vplayer">
           <img src={thumb} alt="" width="900" height="506" loading="lazy" draggable="false" />
+          <span class="vscrim">
+            <span class="vavatar" style={`background: ${avatarColor}`} aria-hidden="true">
+              {initial}
+            </span>
+            <span class="vtitle">{title}</span>
+          </span>
           <span class="vplay" aria-hidden="true">
             <svg viewBox="0 0 24 24" fill="currentColor">
               <path d="M8 5v14l11-7z" />
             </svg>
           </span>
+          <span class="vlength">{length}</span>
         </span>
-        <span class="vbody">
-          <span class="vmeta">
-            {channel} · {length}
-          </span>
-          <span class="vtitle">{title}</span>
-          <span class="vblurb">{blurb}</span>
-        </span>
+        <span class="vcaption">{channel} · watch on YouTube</span>
       </a>
     ))
   }

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -467,7 +467,13 @@ a:focus-visible {
 .marketing .vscrim,
 .marketing .vlength {
   font-family:
-    Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    Roboto,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Helvetica,
+    Arial,
+    sans-serif;
 }
 
 .marketing .vscrim {

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -499,6 +499,12 @@ a:focus-visible {
 }
 
 .marketing .vtitle {
+  /* Clamp like YouTube so a long title can't push the scrim into the centered play button. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
   color: #fff;
   font-size: 14px;
   font-weight: 500;

--- a/website/src/styles/marketing.css
+++ b/website/src/styles/marketing.css
@@ -433,39 +433,71 @@ a:focus-visible {
   line-height: 1.6;
 }
 
-/* Community videos: thumbnails link out, so no third-party player script loads. */
+/* Community videos: paused-embed cards that link out, so no third-party player script loads.
+   The player chrome (scrim, red play button, duration badge) always sits on the dark
+   thumbnail, so it stays fixed-color instead of following the site theme. */
 .marketing .vgrid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  border-top: 1.5px solid var(--ink);
-  border-left: 1.5px solid var(--ink);
+  gap: 28px;
 }
 
 .marketing .vcard {
   display: block;
-  border-right: 1.5px solid var(--ink);
-  border-bottom: 1.5px solid var(--ink);
-  background: var(--paper);
-  transition: 0.12s;
 }
 
-.marketing .vcard:hover {
-  background: var(--hunk-paper-hover);
-}
-
-.marketing .vthumb {
+.marketing .vplayer {
   position: relative;
   display: block;
-  border-bottom: 1.5px solid var(--ink);
+  overflow: hidden;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
   background: #0c0e10;
   aspect-ratio: 16 / 9;
 }
 
-.marketing .vthumb img {
+.marketing .vplayer img {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+/* Player UI mimics YouTube's own chrome, so it drops the site's mono face. */
+.marketing .vscrim,
+.marketing .vlength {
+  font-family:
+    Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
+
+.marketing .vscrim {
+  position: absolute;
+  inset: 0 0 auto 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px 26px;
+  background: linear-gradient(rgba(0, 0, 0, 0.65), rgba(0, 0, 0, 0));
+}
+
+.marketing .vavatar {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.marketing .vtitle {
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.3;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
 .marketing .vplay {
@@ -473,56 +505,51 @@ a:focus-visible {
   inset: 0;
   display: grid;
   place-items: center;
-  width: 46px;
-  height: 46px;
+  width: 62px;
+  height: 44px;
   margin: auto;
-  border: 1.5px solid var(--ink);
-  border-radius: 50%;
-  background: var(--acc);
-  box-shadow: 2px 2px 0 var(--ink);
-  color: var(--paper);
+  border-radius: 12px;
+  background: #f03;
+  color: #fff;
   transition: 0.12s;
 }
 
 .marketing .vcard:hover .vplay,
 .marketing .vcard:focus-visible .vplay {
-  transform: translate(1px, 1px);
-  box-shadow: 1px 1px 0 var(--ink);
+  transform: scale(1.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marketing .vcard:hover .vplay,
+  .marketing .vcard:focus-visible .vplay {
+    transform: none;
+  }
 }
 
 .marketing .vplay svg {
-  width: 16px;
-  height: 16px;
+  width: 22px;
+  height: 22px;
   margin-left: 2px;
 }
 
-.marketing .vbody {
-  display: block;
-  padding: 16px 20px 20px;
+.marketing .vlength {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.82);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
-.marketing .vmeta {
+.marketing .vcaption {
   display: block;
+  margin-top: 10px;
   color: var(--soft);
-  font-size: 11.5px;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.marketing .vtitle {
-  display: block;
-  margin: 8px 0 6px;
-  font-size: 14.5px;
-  font-weight: 700;
-  line-height: 1.35;
-  letter-spacing: -0.01em;
-}
-
-.marketing .vblurb {
-  display: block;
-  color: var(--hunk-body);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: 12.5px;
 }
 
 /* Agent section: the screenshot carries it, the commands just say who runs what. */

--- a/website/tests/marketing-smoke.spec.ts
+++ b/website/tests/marketing-smoke.spec.ts
@@ -92,6 +92,20 @@ test("community videos link out without embedding a third-party player", async (
   await expect(page.locator("iframe")).toHaveCount(0);
 });
 
+test("community video cards read as paused embeds, not marketing tiles", async ({ page }) => {
+  await page.goto("/");
+  const card = page.getByRole("link", { name: /Hunk changed the way I write/ });
+
+  // Player chrome drawn locally: duration badge on the thumbnail, quiet link-out caption.
+  await expect(card.locator(".vlength")).toHaveText("5:14");
+  await expect(card.locator(".vcaption")).toHaveText("Jilles · watch on YouTube");
+  // The old ad-copy blurb is gone on purpose; the title lives on the player scrim.
+  await expect(card.locator(".vscrim")).toContainText(
+    "Hunk changed the way I write and review code with my agent",
+  );
+  await expect(page.locator(".vblurb")).toHaveCount(0);
+});
+
 test("feature cards deep-link into the matching documentation page", async ({ page }) => {
   await page.goto("/");
 


### PR DESCRIPTION
Redesign the landing page's community video cards to visually read as paused YouTube embeds rather than marketing tiles. The player chrome (scrim with channel monogram, red play button, and duration badge) is now drawn locally, eliminating the need to load any third-party player scripts while maintaining visual fidelity to real video embeds.

## Changes

- **CSS redesign** (`marketing.css`):
  - Replaced grid borders with `gap` spacing for cleaner layout
  - Removed hover state background changes on the card container
  - Renamed `.vthumb` to `.vplayer` and added `border-radius` and `overflow: hidden` for embed-like appearance
  - Added `.vscrim` (gradient overlay) with channel monogram avatar and title text positioned on the thumbnail
  - Styled `.vavatar` as a circular monogram fallback (initial letter + color) until self-hosted channel avatars exist
  - Redesigned `.vplay` button to match YouTube's red (#f03) with rounded corners and scale-on-hover animation
  - Added `.vlength` duration badge in the bottom-right corner with YouTube-style typography
  - Replaced `.vbody`, `.vmeta`, `.vblurb` with minimal `.vcaption` showing channel name and "watch on YouTube" link text
  - Added `prefers-reduced-motion` support for the play button hover animation
  - Applied YouTube-compatible font stack (`Roboto` + system fallbacks) to player UI elements

- **Component update** (`CommunityVideos.astro`):
  - Added `initial` (monogram letter) and `avatarColor` fields to video data
  - Removed `blurb` field (marketing copy no longer needed)
  - Restructured markup: moved title into `.vscrim` overlay, duration into `.vlength` badge
  - Simplified caption to channel name + "watch on YouTube" call-to-action
  - Updated JSDoc to explain the paused-embed design and monogram fallback strategy

- **Test coverage** (`marketing-smoke.spec.ts`):
  - Added test verifying player chrome elements (duration badge, scrim title, caption) render correctly
  - Confirmed old `.vblurb` marketing copy is removed

- **Documentation** (`MEDIA.md`):
  - Added instructions for upgrading monogram avatars to self-hosted channel images
  - Clarified that player chrome is drawn locally to avoid third-party script loads

## Implementation notes

The redesign maintains the "no third-party scripts" constraint while improving visual hierarchy. Channel avatars currently use monogram circles; the component data structure supports easy migration to self-hosted images once available. The player UI uses a fixed color palette (YouTube red, white text, dark scrim) that does not follow the site theme, keeping it visually consistent with real YouTube embeds.

https://claude.ai/code/session_01G3SQ2GjQahhYyjyRVz46yY