### PR TITLE
fix(ui): step keys scrolling multiple lines after a review-stream click

### DIFF
--- a/.changeset/steady-step-scrolling.md
+++ b/.changeset/steady-step-scrolling.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep scrolling one line at a time after a click in the review stream, instead of jumping several lines once the click handed keyboard focus to the scroll box.

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { KeyEvent } from "@opentui/core";
+import { KeyEvent, type ParsedKey } from "@opentui/core";
 import {
   buildAppCommands,
   builtinCommandKeyDefaults,
@@ -11,8 +11,8 @@ import {
 import { resolveCommandKeys } from "./keymap";
 
 /** Build a key event with the fields command matching reads. */
-function keyEvent(fields: Partial<KeyEvent>): KeyEvent {
-  return {
+function keyEvent(fields: Partial<ParsedKey>): KeyEvent {
+  return new KeyEvent({
     name: "",
     sequence: "",
     raw: "",
@@ -20,8 +20,11 @@ function keyEvent(fields: Partial<KeyEvent>): KeyEvent {
     meta: false,
     option: false,
     shift: false,
+    number: false,
+    eventType: "press",
+    source: "raw",
     ...fields,
-  } as KeyEvent;
+  });
 }
 
 /** Build the built-in table over recording callbacks, plus the log it writes. */
@@ -67,7 +70,7 @@ function createTestCommands(resolvedKeys?: ResolvedCommandKeys) {
 describe("built-in command chords", () => {
   test("every alias of the scroll shortcuts still dispatches", () => {
     const { commands, ran } = createTestCommands();
-    const press = (fields: Partial<KeyEvent>) =>
+    const press = (fields: Partial<ParsedKey>) =>
       dispatchAppCommand(commands, "review", keyEvent(fields))?.id;
 
     expect(press({ name: "pagedown" })).toBe("hunk.review.pageDown");
@@ -101,7 +104,7 @@ describe("built-in command chords", () => {
 
   test("shifted and unshifted forms stay separate commands", () => {
     const { commands } = createTestCommands();
-    const press = (fields: Partial<KeyEvent>) =>
+    const press = (fields: Partial<ParsedKey>) =>
       dispatchAppCommand(commands, "review", keyEvent(fields))?.id;
 
     expect(press({ name: "g", sequence: "g" })).toBe("hunk.review.jumpToTop");
@@ -119,6 +122,20 @@ describe("built-in command chords", () => {
     dispatchAppCommand(commands, "review", keyEvent({ name: "left" }));
     dispatchAppCommand(commands, "review", keyEvent({ name: "left", shift: true }));
     expect(ran).toEqual(["scrollCodeHorizontally:-1", "scrollCodeHorizontally:-8"]);
+  });
+
+  test("a matched key is claimed so focused OpenTUI widgets cannot scroll it too", () => {
+    const { commands } = createTestCommands();
+    const press = (fields: Partial<ParsedKey>) => {
+      const key = keyEvent(fields);
+      dispatchAppCommand(commands, "review", key);
+      return key.defaultPrevented;
+    };
+
+    expect(press({ name: "j", sequence: "j" })).toBe(true);
+    expect(press({ name: "up" })).toBe(true);
+    expect(press({ name: "pagedown" })).toBe(true);
+    expect(press({ name: "f9" })).toBe(false);
   });
 
   test("key labels are derived from the chords the command answers to", () => {
@@ -158,7 +175,7 @@ describe("built-in commands under user keybindings", () => {
       userBindings: { "hunk.review.focusFilter": ["f", "/"] },
     });
     const { commands } = createTestCommands(keys);
-    const press = (fields: Partial<KeyEvent>) =>
+    const press = (fields: Partial<ParsedKey>) =>
       dispatchAppCommand(commands, "review", keyEvent(fields))?.id;
 
     expect(press({ name: "f", sequence: "f" })).toBe("hunk.review.focusFilter");

--- a/src/ui/lib/appCommands.ts
+++ b/src/ui/lib/appCommands.ts
@@ -567,6 +567,7 @@ export function dispatchAppCommand(
       continue;
     }
 
+    key.preventDefault();
     command.run(key);
     return command;
   }

--- a/test/pty/scroll.test.ts
+++ b/test/pty/scroll.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { createPtyHarness, dragMouse } from "./harness";
+import type { Key, Session } from "tuistory";
+import { createPtyHarness, dragMouse, lineIndexOf } from "./harness";
 
 const harness = createPtyHarness();
 
@@ -9,6 +10,25 @@ setDefaultTimeout(20_000);
 afterEach(() => {
   harness.cleanup();
 });
+
+/**
+ * Count how many rows one keypress moved the stream by following the text that
+ * sat on a fixed screen row.
+ */
+async function measureKeyScroll(session: Session, key: Key, anchorRow: number) {
+  const before = (await session.text({ immediate: true })).split("\n");
+  const anchor = before[anchorRow]?.trim() ?? "";
+  expect(anchor.length).toBeGreaterThan(0);
+
+  await session.press(key);
+  await session.waitIdle({ timeout: 400 });
+
+  const after = (await session.text({ immediate: true })).split("\n");
+  const movedTo = after.findIndex((line) => line.trim() === anchor);
+  expect(movedTo).toBeGreaterThanOrEqual(0);
+
+  return anchorRow - movedTo;
+}
 
 describe("PTY scrolling", () => {
   test("a short last file does not trap upward scrolling at the bottom edge", async () => {
@@ -46,6 +66,58 @@ describe("PTY scrolling", () => {
       );
 
       expect(movedUp).toContain("line30 = 130");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("step keys move one row in pager mode, where the scroll box holds focus", async () => {
+    const fixture = harness.createPagerPatchFixture(60);
+    const session = await harness.launchHunkWithFileBackedStdin({
+      stdinFile: fixture.patchFile,
+      args: ["pager"],
+      cols: 140,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/scroll\.ts/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "k", 12)).toBe(-1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("step keys still move one row after a click in the review stream", async () => {
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      await session.waitIdle({ timeout: 300 });
+
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "k", 12)).toBe(-1);
+
+      const codeRow = lineIndexOf(initial, "line16 = 16;");
+      expect(codeRow).toBeGreaterThan(0);
+      await session.clickAt(60, codeRow);
+      await session.waitIdle({ timeout: 400 });
+
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "k", 12)).toBe(-1);
     } finally {
       session.close();
     }


### PR DESCRIPTION
OpenTUI offers each keypress to the focused renderable after Hunk's global handler returns, and its scroll boxes answer arrows and j/k with a fraction-of-a-viewport scroll of their own. A click in the review stream that Hunk does not consume hands the scroll box focus, so from then on every step key scrolled twice: Hunk's one row plus a fifth of the viewport. Pager mode, which focuses the scroll box deliberately, jumped that way from the first keypress.

Claiming a key when a command matches it leaves Hunk as the only thing that scrolls, whatever holds focus.