### PR TITLE
perf(ui): skip inactive file-view preparation

### DIFF
--- a/.changeset/skip-inactive-file-view-preparation.md
+++ b/.changeset/skip-inactive-file-view-preparation.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Skip inactive custom file-view preparation so ordinary raw-diff reviews avoid unnecessary rerenders and retain less memory during navigation.

--- a/src/ui/fileViews/availability.test.ts
+++ b/src/ui/fileViews/availability.test.ts
@@ -18,6 +18,17 @@ describe("file-view availability", () => {
     );
   });
 
+  test("preserves selection identity when no host constraint masks a view", () => {
+    const selections = { readme: "preview:rendered" };
+    expect(availableFileViewSelections(selections, new Map())).toBe(selections);
+    expect(
+      availableFileViewSelections(
+        selections,
+        new Map([["other", FILE_VIEW_DRAFT_UNAVAILABLE_REASON]]),
+      ),
+    ).toBe(selections);
+  });
+
   test("masks unavailable selections without discarding stored choices", () => {
     const selections = { readme: "preview:rendered", other: "ext:view" };
     expect(

--- a/src/ui/fileViews/availability.ts
+++ b/src/ui/fileViews/availability.ts
@@ -11,9 +11,16 @@ export function availableFileViewSelections(
   selections: Readonly<Record<string, string>>,
   unavailableReasons: ReadonlyMap<string, string>,
 ) {
+  if (unavailableReasons.size === 0) return selections;
+
   const available: Record<string, string> = {};
+  let masked = false;
   for (const [fileId, viewKey] of Object.entries(selections)) {
-    if (!unavailableReasons.has(fileId)) available[fileId] = viewKey;
+    if (unavailableReasons.has(fileId)) {
+      masked = true;
+    } else {
+      available[fileId] = viewKey;
+    }
   }
-  return available;
+  return masked ? available : selections;
 }

--- a/src/ui/fileViews/state.test.ts
+++ b/src/ui/fileViews/state.test.ts
@@ -25,6 +25,15 @@ describe("file-view selection state", () => {
     ).toEqual({ readme: "preview:rendered" });
   });
 
+  test("preserves selection identity when reconciliation removes nothing", () => {
+    const current = { readme: "preview:rendered" };
+    expect(reconcileFileViewSelections(current, ["readme"], new Set(["preview:rendered"]))).toBe(
+      current,
+    );
+    const empty = {};
+    expect(reconcileFileViewSelections(empty, [], new Set())).toBe(empty);
+  });
+
   test("stores raw implicitly and avoids needless state changes", () => {
     const active = selectFileView({}, "readme", "preview:rendered");
     expect(active).toEqual({ readme: "preview:rendered" });

--- a/src/ui/fileViews/state.ts
+++ b/src/ui/fileViews/state.ts
@@ -29,12 +29,15 @@ export function reconcileFileViewSelections(
 ): FileViewSelectionState {
   const validFileIds = new Set(fileIds);
   const next: Record<string, string> = {};
+  let changed = false;
   for (const [fileId, viewKey] of Object.entries(current)) {
     if (validFileIds.has(fileId) && viewKeys.has(viewKey)) {
       next[fileId] = viewKey;
+    } else {
+      changed = true;
     }
   }
-  return next;
+  return changed ? next : current;
 }
 
 /** Select raw or a named view for one file without retaining a redundant raw entry. */

--- a/src/ui/fileViews/useFileViews.test.tsx
+++ b/src/ui/fileViews/useFileViews.test.tsx
@@ -159,6 +159,48 @@ describe("file-view layout request lifetime", () => {
   });
 });
 
+describe("inactive file-view preparation", () => {
+  test("does not schedule empty-map renders while every file uses raw diff", async () => {
+    let renderCount = 0;
+    let replaceFiles = () => {};
+    let latest: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
+
+    function Harness() {
+      const [visibleFiles, setVisibleFiles] = useState(files);
+      replaceFiles = () => setVisibleFiles([...files]);
+      renderCount += 1;
+      latest = useFileViewLayouts({
+        files: visibleFiles,
+        selections: {},
+        views: [],
+        width: 80,
+        onIssue: ignoreIssue,
+      });
+      return null;
+    }
+
+    const setup = await testRender(createElement(Harness), { width: 10, height: 2 });
+    try {
+      await act(async () => {
+        await Promise.resolve();
+        await setup.renderOnce();
+      });
+      expect(renderCount).toBe(1);
+      expect(latest.size).toBe(0);
+
+      await act(async () => {
+        replaceFiles();
+        await setup.renderOnce();
+        await Promise.resolve();
+      });
+      expect(renderCount).toBe(2);
+      expect(latest.size).toBe(0);
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+});
+
 describe("file-view layout cache identity", () => {
   test("retains exact unaffected files while suppressing another file's changed selection", async () => {
     const secondFile = createTestDiffFile({

--- a/src/ui/fileViews/useFileViews.ts
+++ b/src/ui/fileViews/useFileViews.ts
@@ -190,6 +190,14 @@ export async function runFileViewLayoutRequest(
   }
 }
 
+/** Return whether this render has any alternate file-view work to prepare. */
+function hasSelectedFileViews(
+  selections: Readonly<Record<string, string>>,
+  views: readonly RegisteredFileView[],
+) {
+  return views.length > 0 && Object.keys(selections).length > 0;
+}
+
 /**
  * Run selected file-view layouts outside render and retain only validated results.
  *
@@ -217,8 +225,16 @@ export function useFileViewLayouts({
   const previousWidth = useRef<number | undefined>(undefined);
   const reportedIssues = useRef(new Set<string>());
   const [resolved, setResolved] = useState<ReadonlyMap<string, ResolvedEntry>>(new Map());
+  const hasSelectedViews = hasSelectedFileViews(selections, views);
 
   useEffect(() => {
+    if (!hasSelectedViews) {
+      // Raw diff is implicit. Avoid traversing every file through async workers and committing an
+      // empty map after each selection-only render when no alternate presentation is selected.
+      if (resolved.size > 0) setResolved(new Map());
+      return;
+    }
+
     const controller = new AbortController();
     const next = new Map<string, ResolvedEntry>();
     const widthChanged = previousWidth.current !== undefined && previousWidth.current !== width;
@@ -327,7 +343,9 @@ export function useFileViewLayouts({
       void Promise.all(
         Array.from({ length: Math.min(FILE_VIEW_LAYOUT_CONCURRENCY, files.length) }, worker),
       ).then(() => {
-        if (active) setResolved(next);
+        if (active) {
+          setResolved((current) => (current.size === 0 && next.size === 0 ? current : next));
+        }
       });
     };
 
@@ -342,9 +360,11 @@ export function useFileViewLayouts({
       if (startTimer) clearTimeout(startTimer);
       controller.abort();
     };
-  }, [files, onIssue, selections, views, width]);
+  }, [files, hasSelectedViews, onIssue, selections, views, width]);
 
   return useMemo(() => {
+    if (!hasSelectedViews) return EMPTY_RESOLVED_FILE_VIEW_LAYOUTS;
+
     const current = new Map<string, ResolvedFileViewLayout>();
     const byKey = new Map(views.map((view) => [registeredFileViewKey(view), view]));
     for (const file of files) {
@@ -363,5 +383,5 @@ export function useFileViewLayouts({
     // Effects clean up after render. Exact per-file filtering synchronously declines stale geometry
     // while preserving unaffected files across filtering and another file's selection change.
     return current.size > 0 ? current : EMPTY_RESOLVED_FILE_VIEW_LAYOUTS;
-  }, [files, resolved, selections, views, width]);
+  }, [files, hasSelectedViews, resolved, selections, views, width]);
 }

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -81,12 +81,13 @@ describe("PTY chrome", () => {
   });
 
   test("quit prompt shows the config diff and saves preferences on mouse click", async () => {
-    // Own the config home instead of the shared harness one so the test can
-    // assert what the save action wrote.
+    // Own both config scopes so the test can assert what the save action wrote without an
+    // ambient repository `.hunk/config.toml` changing the starting preferences.
     const configHome = mkdtempSync(join(tmpdir(), "hunk-tuistory-save-view-"));
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({
       args: ["diff", fixture.before, fixture.after],
+      cwd: fixture.dir,
       cols: 120,
       rows: 24,
       env: { XDG_CONFIG_HOME: configHome },


### PR DESCRIPTION
## Summary

- skip custom file-view layout workers and empty state commits while every file uses raw diff
- preserve file-view selection identity when reconciliation and availability masking make no changes
- isolate the saved-view PTY fixture from ambient repository configuration

## Performance

The 0.18 release benchmark initially reported seven material regressions against 0.17.7. Commit-level isolation traced the jump to inactive file-view preparation introduced with custom previews. After this fix, the release benchmark gate passes without accepted regressions; hunk-navigation median returned from 88.45 ms to 70.55 ms and retained navigation heap from 160.9 MB to 134.1 MB.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` — 1,741 passed
- `bun run test:integration` — 79 passed
- `bun run test:tty-smoke` — 9 passed
- real-TTY smoke run
- `bun run bench:release:compare`

*This PR description was generated by Pi using OpenAI GPT-5.3 Codex*
