### PR TITLE
ci(release): verify generated prerelease notes

### DIFF
--- a/.changeset/validate-generated-prerelease-notes.md
+++ b/.changeset/validate-generated-prerelease-notes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Validate generated prerelease notes through a dedicated, base-aware CI check.

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -44,7 +44,10 @@ jobs:
           bun-version: 1.3.14
 
       - name: Verify release-note changeset
-        run: bun run changeset:status -- --since=origin/main
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: bun run ./scripts/verify-pr-release-notes.ts "$BASE_SHA" "$HEAD_SHA"
 
   windows-compat:
     name: Windows compatibility

--- a/scripts/verify-pr-release-notes.test.ts
+++ b/scripts/verify-pr-release-notes.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   isGeneratedPrereleasePreparation,
   isGeneratedReleasePath,
   validateGeneratedPrerelease,
+  verifyPrReleaseNotes,
 } from "./verify-pr-release-notes";
 
+const tempRoots: string[] = [];
 const generatedPaths = [
   ".changeset/pre.json",
   ".changeset/old-fix.md",
@@ -22,10 +27,72 @@ function validInput() {
       initialVersions: { hunkdiff: "0.17.7" },
       changesets: ["new-feature", "old-fix"],
     },
-    changelog: "# Changelog\n\n## 0.18.0-beta.0\n\n- Added a feature.\n",
+    changelog: "# Changelog\n\n## 0.18.0-beta.0\n\n- Added a feature.\n\n## 0.17.7\n",
     changesetIdsOnDisk: new Set(["new-feature", "old-fix"]),
   };
 }
+
+function runGit(root: string, args: string[]) {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(new TextDecoder().decode(result.stderr));
+  }
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
+function writeJson(filePath: string, value: unknown) {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createTestRepo() {
+  const root = mkdtempSync(path.join(os.tmpdir(), "hunk-pr-release-notes-"));
+  tempRoots.push(root);
+  mkdirSync(path.join(root, ".changeset"));
+  runGit(root, ["init", "--quiet"]);
+  runGit(root, ["config", "user.email", "test@example.com"]);
+  runGit(root, ["config", "user.name", "Hunk Test"]);
+
+  writeJson(path.join(root, "package.json"), {
+    name: "hunkdiff",
+    version: "0.17.7",
+    private: true,
+    scripts: { "changeset:status": "bun run ./record-status.ts" },
+  });
+  writeFileSync(path.join(root, "CHANGELOG.md"), "# Changelog\n");
+  writeFileSync(path.join(root, ".changeset", "new-feature.md"), "---\n---\n");
+  writeFileSync(
+    path.join(root, "record-status.ts"),
+    'await Bun.write("status-call.json", JSON.stringify(process.argv.slice(2)));\n',
+  );
+  runGit(root, ["add", "."]);
+  runGit(root, ["commit", "--quiet", "-m", "base"]);
+  return { root, base: runGit(root, ["rev-parse", "HEAD"]) };
+}
+
+function writeGeneratedPrerelease(root: string, initialVersion = "0.17.7") {
+  const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+  packageJson.version = "0.18.0-beta.0";
+  writeJson(path.join(root, "package.json"), packageJson);
+  writeJson(path.join(root, ".changeset", "pre.json"), {
+    mode: "pre",
+    tag: "beta",
+    initialVersions: { hunkdiff: initialVersion },
+    changesets: ["new-feature"],
+  });
+  writeFileSync(path.join(root, "CHANGELOG.md"), "# Changelog\n\n## 0.18.0-beta.0\n\n## 0.17.7\n");
+  runGit(root, ["add", "."]);
+  runGit(root, ["commit", "--quiet", "-m", "prepare prerelease"]);
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe("isGeneratedReleasePath", () => {
   test("accepts only generated prerelease metadata", () => {
@@ -75,6 +142,16 @@ describe("validateGeneratedPrerelease", () => {
     );
   });
 
+  test("requires the latest stable changelog version", () => {
+    const input = validInput();
+    input.pre.initialVersions.hunkdiff = "0.17.6";
+    input.changelog += "\n## 0.17.6\n";
+
+    expect(() => validateGeneratedPrerelease(input)).toThrow(
+      "Initial version 0.17.6 does not match latest stable release 0.17.7",
+    );
+  });
+
   test("requires every consumed changeset to remain on disk", () => {
     const input = validInput();
     input.changesetIdsOnDisk.delete("old-fix");
@@ -93,10 +170,41 @@ describe("validateGeneratedPrerelease", () => {
 
   test("requires the exact package version heading", () => {
     const input = validInput();
-    input.changelog = "# Changelog\n\n## 0.18.0-beta.1\n";
+    input.changelog = "# Changelog\n\n## 0.18.0-beta.1\n\n## 0.17.7\n";
 
     expect(() => validateGeneratedPrerelease(input)).toThrow(
       "Changelog is missing the 0.18.0-beta.0 release heading",
+    );
+  });
+});
+
+describe("verifyPrReleaseNotes", () => {
+  test("routes ordinary diffs through Changesets with the exact base revision", async () => {
+    const { root, base } = createTestRepo();
+    writeFileSync(path.join(root, "source.ts"), "export const changed = true;\n");
+    runGit(root, ["add", "."]);
+    runGit(root, ["commit", "--quiet", "-m", "ordinary change"]);
+
+    await expect(verifyPrReleaseNotes(base, "HEAD", root)).resolves.toBe("changeset-status");
+    expect(JSON.parse(readFileSync(path.join(root, "status-call.json"), "utf8"))).toEqual([
+      `--since=${base}`,
+    ]);
+  });
+
+  test("routes metadata-only prerelease output through generated-state validation", async () => {
+    const { root, base } = createTestRepo();
+    writeGeneratedPrerelease(root);
+
+    await expect(verifyPrReleaseNotes(base, "HEAD", root)).resolves.toBe("generated-prerelease");
+    expect(existsSync(path.join(root, "status-call.json"))).toBe(false);
+  });
+
+  test("rejects an initial version older than the carried stable changelog", async () => {
+    const { root, base } = createTestRepo();
+    writeGeneratedPrerelease(root, "0.17.6");
+
+    await expect(verifyPrReleaseNotes(base, "HEAD", root)).rejects.toThrow(
+      "Initial version 0.17.6 does not match latest stable release 0.17.7",
     );
   });
 });

--- a/scripts/verify-pr-release-notes.test.ts
+++ b/scripts/verify-pr-release-notes.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isGeneratedPrereleasePreparation,
+  isGeneratedReleasePath,
+  validateGeneratedPrerelease,
+} from "./verify-pr-release-notes";
+
+const generatedPaths = [
+  ".changeset/pre.json",
+  ".changeset/old-fix.md",
+  "CHANGELOG.md",
+  "package.json",
+  "benchmarks/release/bench-0.18.0-beta.0.json",
+];
+
+function validInput() {
+  return {
+    packageJson: { name: "hunkdiff", version: "0.18.0-beta.0" },
+    pre: {
+      mode: "pre",
+      tag: "beta",
+      initialVersions: { hunkdiff: "0.17.7" },
+      changesets: ["new-feature", "old-fix"],
+    },
+    changelog: "# Changelog\n\n## 0.18.0-beta.0\n\n- Added a feature.\n",
+    changesetIdsOnDisk: new Set(["new-feature", "old-fix"]),
+  };
+}
+
+describe("isGeneratedReleasePath", () => {
+  test("accepts only generated prerelease metadata", () => {
+    for (const filePath of generatedPaths) {
+      expect(isGeneratedReleasePath(filePath)).toBe(true);
+    }
+
+    expect(isGeneratedReleasePath("src/main.tsx")).toBe(false);
+    expect(isGeneratedReleasePath("benchmarks/run.ts")).toBe(false);
+    expect(isGeneratedReleasePath("bun.lock")).toBe(false);
+  });
+});
+
+describe("isGeneratedPrereleasePreparation", () => {
+  test("selects a metadata-only diff that changes prerelease state", () => {
+    expect(isGeneratedPrereleasePreparation(generatedPaths)).toBe(true);
+  });
+
+  test("keeps ordinary changesets on the standard status path", () => {
+    expect(isGeneratedPrereleasePreparation(["src/main.tsx", ".changeset/fix.md"])).toBe(false);
+    expect(isGeneratedPrereleasePreparation(["CHANGELOG.md", "package.json"])).toBe(false);
+  });
+
+  test("does not exempt release preparation mixed with source changes", () => {
+    expect(isGeneratedPrereleasePreparation([...generatedPaths, "src/main.tsx"])).toBe(false);
+  });
+});
+
+describe("validateGeneratedPrerelease", () => {
+  test("accepts coherent generated prerelease state", () => {
+    expect(() => validateGeneratedPrerelease(validInput())).not.toThrow();
+  });
+
+  test("requires package version and tag agreement", () => {
+    const input = validInput();
+    input.packageJson.version = "0.18.0-next.0";
+
+    expect(() => validateGeneratedPrerelease(input)).toThrow("does not match prerelease tag beta");
+  });
+
+  test("requires a stable initial package version", () => {
+    const input = validInput();
+    input.pre.initialVersions.hunkdiff = "0.17.7-beta.1";
+
+    expect(() => validateGeneratedPrerelease(input)).toThrow(
+      "Missing stable initial version for package hunkdiff",
+    );
+  });
+
+  test("requires every consumed changeset to remain on disk", () => {
+    const input = validInput();
+    input.changesetIdsOnDisk.delete("old-fix");
+
+    expect(() => validateGeneratedPrerelease(input)).toThrow(
+      "Missing consumed changeset files: old-fix",
+    );
+  });
+
+  test("rejects duplicate changeset IDs", () => {
+    const input = validInput();
+    input.pre.changesets = ["old-fix", "old-fix"];
+
+    expect(() => validateGeneratedPrerelease(input)).toThrow("invalid or duplicate changeset IDs");
+  });
+
+  test("requires the exact package version heading", () => {
+    const input = validInput();
+    input.changelog = "# Changelog\n\n## 0.18.0-beta.1\n";
+
+    expect(() => validateGeneratedPrerelease(input)).toThrow(
+      "Changelog is missing the 0.18.0-beta.0 release heading",
+    );
+  });
+});

--- a/scripts/verify-pr-release-notes.ts
+++ b/scripts/verify-pr-release-notes.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+interface PackageManifest {
+  name: string;
+  version: string;
+}
+
+interface PrereleaseState {
+  mode: string;
+  tag: unknown;
+  initialVersions: unknown;
+  changesets: unknown;
+}
+
+interface GeneratedPrereleaseInput {
+  packageJson: PackageManifest;
+  pre: PrereleaseState;
+  changelog: string;
+  changesetIdsOnDisk: ReadonlySet<string>;
+}
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+const RELEASE_BENCHMARK_PATTERN = /^benchmarks\/release\/bench-[^/]+\.json$/;
+const CHANGESET_PATTERN = /^\.changeset\/[^/]+\.md$/;
+
+/** Return whether a path is release metadata permitted in a generated prerelease PR. */
+export function isGeneratedReleasePath(filePath: string) {
+  return (
+    filePath === ".changeset/pre.json" ||
+    filePath === "CHANGELOG.md" ||
+    filePath === "package.json" ||
+    CHANGESET_PATTERN.test(filePath) ||
+    RELEASE_BENCHMARK_PATTERN.test(filePath)
+  );
+}
+
+/** Select generated-prerelease validation only for metadata-only release preparation diffs. */
+export function isGeneratedPrereleasePreparation(changedPaths: readonly string[]) {
+  return (
+    changedPaths.includes(".changeset/pre.json") &&
+    changedPaths.length > 0 &&
+    changedPaths.every(isGeneratedReleasePath)
+  );
+}
+
+/** Validate the coherent Changesets, package, and changelog state produced for a prerelease. */
+export function validateGeneratedPrerelease(input: GeneratedPrereleaseInput) {
+  const { packageJson, pre, changelog, changesetIdsOnDisk } = input;
+  if (pre.mode !== "pre") {
+    throw new Error(`Expected Changesets pre mode, received ${JSON.stringify(pre.mode)}`);
+  }
+
+  if (typeof pre.tag !== "string" || !/^[0-9A-Za-z-]+$/.test(pre.tag)) {
+    throw new Error("Changesets prerelease tag must be a non-empty npm tag");
+  }
+
+  if (!pre.initialVersions || typeof pre.initialVersions !== "object") {
+    throw new Error("Changesets prerelease state is missing initialVersions");
+  }
+
+  const initialVersion = (pre.initialVersions as Record<string, unknown>)[packageJson.name];
+  if (typeof initialVersion !== "string" || !/^\d+\.\d+\.\d+$/.test(initialVersion)) {
+    throw new Error(`Missing stable initial version for package ${packageJson.name}`);
+  }
+
+  const escapedTag = pre.tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (!new RegExp(`^\\d+\\.\\d+\\.\\d+-${escapedTag}\\.\\d+$`).test(packageJson.version)) {
+    throw new Error(
+      `Package version ${packageJson.version} does not match prerelease tag ${pre.tag}`,
+    );
+  }
+
+  if (!Array.isArray(pre.changesets) || pre.changesets.length === 0) {
+    throw new Error("Changesets prerelease state must record at least one consumed changeset");
+  }
+
+  const changesetIds = pre.changesets.filter(
+    (changesetId): changesetId is string =>
+      typeof changesetId === "string" && /^[0-9A-Za-z-]+$/.test(changesetId),
+  );
+  if (
+    changesetIds.length !== pre.changesets.length ||
+    new Set(changesetIds).size !== changesetIds.length
+  ) {
+    throw new Error("Changesets prerelease state contains invalid or duplicate changeset IDs");
+  }
+
+  const missingChangesets = changesetIds.filter(
+    (changesetId) => !changesetIdsOnDisk.has(changesetId),
+  );
+  if (missingChangesets.length > 0) {
+    throw new Error(`Missing consumed changeset files: ${missingChangesets.join(", ")}`);
+  }
+
+  if (!changelog.split(/\r?\n/).includes(`## ${packageJson.version}`)) {
+    throw new Error(`Changelog is missing the ${packageJson.version} release heading`);
+  }
+}
+
+/** Run Git and return its captured standard output or fail with its diagnostic. */
+function readGitOutput(args: string[]) {
+  const result = Bun.spawnSync(["git", ...args], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed with exit ${result.exitCode}`);
+  }
+  return result.stdout;
+}
+
+/** Read changed paths without relying on shell parsing or platform path separators. */
+function readChangedPaths(baseRevision: string, headRevision: string) {
+  const output = readGitOutput([
+    "diff",
+    "--name-only",
+    "--no-renames",
+    "-z",
+    baseRevision,
+    headRevision,
+    "--",
+  ]);
+  return new TextDecoder().decode(output).split("\0").filter(Boolean);
+}
+
+/** Run the normal Changesets status gate for a non-release-preparation pull request. */
+function runChangesetStatus(baseRevision: string) {
+  const result = Bun.spawnSync(
+    [process.execPath, "run", "changeset:status", "--", `--since=${baseRevision}`],
+    {
+      cwd: repoRoot,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    },
+  );
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}
+
+/** Verify ordinary changesets or the generated state of a metadata-only prerelease PR. */
+async function main(args = process.argv.slice(2)) {
+  const [baseRevision, headRevision = "HEAD"] = args;
+  if (!baseRevision || baseRevision.startsWith("-") || headRevision.startsWith("-")) {
+    throw new Error("Usage: verify-pr-release-notes.ts <base-revision> [head-revision]");
+  }
+
+  const changedPaths = readChangedPaths(baseRevision, headRevision);
+  if (!isGeneratedPrereleasePreparation(changedPaths)) {
+    runChangesetStatus(baseRevision);
+    return;
+  }
+
+  const prePath = path.join(repoRoot, ".changeset", "pre.json");
+  if (!existsSync(prePath)) {
+    throw new Error("Generated prerelease preparation removed .changeset/pre.json");
+  }
+
+  const [packageJson, pre, changelog] = await Promise.all([
+    Bun.file(path.join(repoRoot, "package.json")).json() as Promise<PackageManifest>,
+    Bun.file(prePath).json() as Promise<PrereleaseState>,
+    Bun.file(path.join(repoRoot, "CHANGELOG.md")).text(),
+  ]);
+  const changesetIdsOnDisk = new Set(
+    readdirSync(path.join(repoRoot, ".changeset"), { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+      .map((entry) => entry.name.slice(0, -3)),
+  );
+
+  validateGeneratedPrerelease({ packageJson, pre, changelog, changesetIdsOnDisk });
+  console.log(`Validated generated prerelease notes for ${packageJson.version}.`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/verify-pr-release-notes.ts
+++ b/scripts/verify-pr-release-notes.ts
@@ -46,6 +46,22 @@ export function isGeneratedPrereleasePreparation(changedPaths: readonly string[]
   );
 }
 
+/** Return the highest stable release heading carried in the generated changelog. */
+function findLatestStableRelease(changelog: string) {
+  const versions = [...changelog.matchAll(/^## (\d+)\.(\d+)\.(\d+)$/gm)].map((match) => ({
+    raw: match[0].slice(3),
+    parts: [Number(match[1]), Number(match[2]), Number(match[3])],
+  }));
+  versions.sort((left, right) => {
+    for (let index = 0; index < 3; index += 1) {
+      const difference = right.parts[index]! - left.parts[index]!;
+      if (difference !== 0) return difference;
+    }
+    return 0;
+  });
+  return versions[0]?.raw;
+}
+
 /** Validate the coherent Changesets, package, and changelog state produced for a prerelease. */
 export function validateGeneratedPrerelease(input: GeneratedPrereleaseInput) {
   const { packageJson, pre, changelog, changesetIdsOnDisk } = input;
@@ -64,6 +80,15 @@ export function validateGeneratedPrerelease(input: GeneratedPrereleaseInput) {
   const initialVersion = (pre.initialVersions as Record<string, unknown>)[packageJson.name];
   if (typeof initialVersion !== "string" || !/^\d+\.\d+\.\d+$/.test(initialVersion)) {
     throw new Error(`Missing stable initial version for package ${packageJson.name}`);
+  }
+  const latestStableRelease = findLatestStableRelease(changelog);
+  if (!latestStableRelease) {
+    throw new Error("Changelog does not contain a stable release heading");
+  }
+  if (initialVersion !== latestStableRelease) {
+    throw new Error(
+      `Initial version ${initialVersion} does not match latest stable release ${latestStableRelease}`,
+    );
   }
 
   const escapedTag = pre.tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -101,9 +126,9 @@ export function validateGeneratedPrerelease(input: GeneratedPrereleaseInput) {
 }
 
 /** Run Git and return its captured standard output or fail with its diagnostic. */
-function readGitOutput(args: string[]) {
+function readGitOutput(args: string[], root: string) {
   const result = Bun.spawnSync(["git", ...args], {
-    cwd: repoRoot,
+    cwd: root,
     stdout: "pipe",
     stderr: "inherit",
   });
@@ -114,66 +139,70 @@ function readGitOutput(args: string[]) {
 }
 
 /** Read changed paths without relying on shell parsing or platform path separators. */
-function readChangedPaths(baseRevision: string, headRevision: string) {
-  const output = readGitOutput([
-    "diff",
-    "--name-only",
-    "--no-renames",
-    "-z",
-    baseRevision,
-    headRevision,
-    "--",
-  ]);
+function readChangedPaths(baseRevision: string, headRevision: string, root: string) {
+  const output = readGitOutput(
+    ["diff", "--name-only", "--no-renames", "-z", baseRevision, headRevision, "--"],
+    root,
+  );
   return new TextDecoder().decode(output).split("\0").filter(Boolean);
 }
 
 /** Run the normal Changesets status gate for a non-release-preparation pull request. */
-function runChangesetStatus(baseRevision: string) {
+function runChangesetStatus(baseRevision: string, root: string) {
   const result = Bun.spawnSync(
     [process.execPath, "run", "changeset:status", "--", `--since=${baseRevision}`],
     {
-      cwd: repoRoot,
+      cwd: root,
       stdin: "inherit",
       stdout: "inherit",
       stderr: "inherit",
     },
   );
   if (result.exitCode !== 0) {
-    process.exit(result.exitCode);
+    throw new Error(`Changesets status failed with exit ${result.exitCode}`);
   }
 }
 
 /** Verify ordinary changesets or the generated state of a metadata-only prerelease PR. */
-async function main(args = process.argv.slice(2)) {
-  const [baseRevision, headRevision = "HEAD"] = args;
-  if (!baseRevision || baseRevision.startsWith("-") || headRevision.startsWith("-")) {
-    throw new Error("Usage: verify-pr-release-notes.ts <base-revision> [head-revision]");
-  }
-
-  const changedPaths = readChangedPaths(baseRevision, headRevision);
+export async function verifyPrReleaseNotes(
+  baseRevision: string,
+  headRevision = "HEAD",
+  root = repoRoot,
+) {
+  const changedPaths = readChangedPaths(baseRevision, headRevision, root);
   if (!isGeneratedPrereleasePreparation(changedPaths)) {
-    runChangesetStatus(baseRevision);
-    return;
+    runChangesetStatus(baseRevision, root);
+    return "changeset-status" as const;
   }
 
-  const prePath = path.join(repoRoot, ".changeset", "pre.json");
+  const prePath = path.join(root, ".changeset", "pre.json");
   if (!existsSync(prePath)) {
     throw new Error("Generated prerelease preparation removed .changeset/pre.json");
   }
 
   const [packageJson, pre, changelog] = await Promise.all([
-    Bun.file(path.join(repoRoot, "package.json")).json() as Promise<PackageManifest>,
+    Bun.file(path.join(root, "package.json")).json() as Promise<PackageManifest>,
     Bun.file(prePath).json() as Promise<PrereleaseState>,
-    Bun.file(path.join(repoRoot, "CHANGELOG.md")).text(),
+    Bun.file(path.join(root, "CHANGELOG.md")).text(),
   ]);
   const changesetIdsOnDisk = new Set(
-    readdirSync(path.join(repoRoot, ".changeset"), { withFileTypes: true })
+    readdirSync(path.join(root, ".changeset"), { withFileTypes: true })
       .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
       .map((entry) => entry.name.slice(0, -3)),
   );
 
   validateGeneratedPrerelease({ packageJson, pre, changelog, changesetIdsOnDisk });
   console.log(`Validated generated prerelease notes for ${packageJson.version}.`);
+  return "generated-prerelease" as const;
+}
+
+/** Parse command-line revisions before running pull-request release-note verification. */
+async function main(args = process.argv.slice(2)) {
+  const [baseRevision, headRevision = "HEAD"] = args;
+  if (!baseRevision || baseRevision.startsWith("-") || headRevision.startsWith("-")) {
+    throw new Error("Usage: verify-pr-release-notes.ts <base-revision> [head-revision]");
+  }
+  await verifyPrReleaseNotes(baseRevision, headRevision);
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Summary

- move PR release-note verification into a dedicated TypeScript script
- run ordinary Changesets status against the pull request's actual base SHA
- recognize generated prerelease output only when the diff contains release metadata and no source changes
- validate prerelease mode, package/tag agreement, initial versions, consumed changeset files, and the exact changelog heading

The implementation uses argument-array subprocesses and NUL-delimited Git output rather than shell parsing, keeping path and process handling portable.

## Validation

- `bun test scripts/verify-pr-release-notes.test.ts` — 14 passed
- ordinary maintenance changeset path against `origin/main`
- generated `0.18.0-beta.0` release-preparation path against its stacked base
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

*This PR description was generated by Pi using OpenAI GPT-5.3 Codex*
