### PR TITLE
fix(ui): keep file navigation from losing the file it just jumped to

### DIFF
--- a/.changeset/steady-file-jump-align.md
+++ b/.changeset/steady-file-jump-align.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep file navigation from losing the file it just jumped to. On a loaded machine the scroll that aligns the new file to the top could land after the viewport-follow window closed, so the review stream adopted the file under the cursor again and the next "previous file" press did nothing.

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1169,6 +1169,11 @@ export function DiffPane({
       previousViewportTop === scrollViewport.top ||
       !onViewportCenteredHunkChange ||
       suppressViewportSelectionSyncRef.current ||
+      // A requested file-top align is still settling, so this viewport move is our own scroll
+      // rather than the user's. The timed suppression above can expire before the align lands on
+      // a loaded machine, and adopting the centered hunk there would silently undo the navigation
+      // that asked for the align in the first place.
+      pendingFileTopAlignFileIdRef.current !== null ||
       files.length === 0 ||
       scrollViewport.height <= 0
     ) {
@@ -1453,27 +1458,57 @@ export function DiffPane({
     pendingFileTopAlignFileIdRef.current = null;
   }, []);
 
-  /** Scroll one file so it immediately owns the viewport top using the latest planned geometry. */
-  const scrollFileHeaderToTop = useCallback(
+  /**
+   * Report whether the align has landed as far as the rest of this pane can observe it.
+   *
+   * `scrollViewport` is a coalesced read of the scroll box, so it trails `scrollBox.scrollTop` by at
+   * least one read interval and by much more on a loaded machine. Viewport-follow selection reacts
+   * to that trailing value, so an align counts as settled only once the trailing value agrees.
+   */
+  const isFileTopAlignSettled = useCallback(
+    (desiredTop: number) => Math.abs(scrollViewport.top - desiredTop) <= 0.5,
+    [scrollViewport.top],
+  );
+
+  /**
+   * Resolve the scroll top that makes one file own the viewport top, or null when the planned
+   * geometry is not measurable yet.
+   *
+   * The pinned header owns the top row, so align the review stream to the file body. Clamp the
+   * target so short trailing files still settle cleanly at the reachable bottom edge: the last
+   * short file often cannot actually own the viewport top near EOF, and treating that unreachable
+   * top as the target would keep snapping manual upward scrolling back down to the bottom edge.
+   */
+  const resolveFileTopAlignScrollTop = useCallback(
     (fileId: string) => {
       const targetSection = fileSectionLayouts.find((layout) => layout.fileId === fileId);
       if (!targetSection) {
-        return false;
+        return null;
       }
 
       const scrollBox = scrollRef.current;
       if (!scrollBox) {
-        return false;
+        return null;
       }
 
       const viewportHeight = Math.max(scrollViewport.height, scrollBox.viewport.height ?? 0);
-
-      // The pinned header owns the top row, so align the review stream to the file body. Clamp the
-      // request so short trailing files can still settle cleanly at the reachable bottom edge.
-      scrollBox.scrollTo(clampReviewScrollTop(targetSection.bodyTop, viewportHeight));
-      return true;
+      return clampReviewScrollTop(targetSection.bodyTop, viewportHeight);
     },
     [clampReviewScrollTop, fileSectionLayouts, scrollRef, scrollViewport.height],
+  );
+
+  /** Scroll one file so it immediately owns the viewport top using the latest planned geometry. */
+  const scrollFileHeaderToTop = useCallback(
+    (fileId: string) => {
+      const desiredTop = resolveFileTopAlignScrollTop(fileId);
+      if (desiredTop === null) {
+        return false;
+      }
+
+      scrollRef.current?.scrollTo(desiredTop);
+      return true;
+    },
+    [resolveFileTopAlignScrollTop, scrollRef],
   );
 
   useLayoutEffect(() => {
@@ -1629,10 +1664,18 @@ export function DiffPane({
 
     // Sidebar navigation should make the selected file immediately own the viewport top.
     suppressViewportSelectionSync();
-    pendingFileTopAlignFileIdRef.current = selectedFileId;
+    // Only track the align as pending while the stream still has to travel. Marking an
+    // already-aligned file pending would hold viewport-driven selection off until the next
+    // relayout happened to clear it.
+    const desiredTop = resolveFileTopAlignScrollTop(selectedFileId);
+    if (desiredTop === null || !isFileTopAlignSettled(desiredTop)) {
+      pendingFileTopAlignFileIdRef.current = selectedFileId;
+    }
     scrollFileHeaderToTop(selectedFileId);
   }, [
     clearPendingFileTopAlign,
+    isFileTopAlignSettled,
+    resolveFileTopAlignScrollTop,
     scrollFileHeaderToTop,
     selectedFileTopAlignRequestId,
     selectedFileId,
@@ -1653,33 +1696,31 @@ export function DiffPane({
       return;
     }
 
-    const targetSection = fileSectionLayouts.find((layout) => layout.fileId === pendingFileId);
-    if (!targetSection) {
+    const desiredTop = resolveFileTopAlignScrollTop(pendingFileId);
+    if (desiredTop === null) {
       return;
     }
 
-    const viewportHeight = Math.max(scrollViewport.height, scrollRef.current?.viewport.height ?? 0);
-    // Compare against the reachable target, not the raw file body top. The last short file often
-    // cannot actually own the viewport top near EOF, and treating that unreachable top as pending
-    // would keep snapping manual upward scrolling back down to the bottom edge.
-    const desiredTop = clampReviewScrollTop(targetSection.bodyTop, viewportHeight);
-
-    const currentTop = scrollRef.current?.scrollTop ?? scrollViewport.top;
-    if (Math.abs(currentTop - desiredTop) <= 0.5) {
+    if (isFileTopAlignSettled(desiredTop)) {
       clearPendingFileTopAlign();
+      return;
+    }
+
+    // The scroll box may already sit on target while the coalesced viewport read has not caught up
+    // yet. Stay pending in that window instead of re-issuing the same scroll.
+    if (Math.abs((scrollRef.current?.scrollTop ?? scrollViewport.top) - desiredTop) <= 0.5) {
       return;
     }
 
     suppressViewportSelectionSync();
     scrollFileHeaderToTop(pendingFileId);
   }, [
-    clampReviewScrollTop,
     clearPendingFileTopAlign,
-    fileSectionLayouts,
     files,
+    isFileTopAlignSettled,
+    resolveFileTopAlignScrollTop,
     scrollFileHeaderToTop,
     scrollRef,
-    scrollViewport.height,
     scrollViewport.top,
     suppressViewportSelectionSync,
   ]);

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1667,6 +1667,13 @@ export function DiffPane({
     // Only track the align as pending while the stream still has to travel. Marking an
     // already-aligned file pending would hold viewport-driven selection off until the next
     // relayout happened to clear it.
+    //
+    // Testing the coalesced read rather than the live scroll top is deliberate, and safe even
+    // when the two disagree. Skipping requires the coalesced read to already sit on the target,
+    // and the align below puts the live position on that same target synchronously — so the next
+    // coalesced read can only report the value viewport-follow selection last recorded. It never
+    // observes a move, so it cannot mistake this align for user scrolling. Where the live
+    // position sat when the request arrived does not enter into it.
     const desiredTop = resolveFileTopAlignScrollTop(selectedFileId);
     if (desiredTop === null || !isFileTopAlignSettled(desiredTop)) {
       pendingFileTopAlignFileIdRef.current = selectedFileId;

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1258,6 +1258,92 @@ describe("UI components", () => {
     }
   });
 
+  test("DiffPane releases viewport-follow selection after an align request that needs no scrolling", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const files = [
+      createTestDiffFile(
+        "first",
+        "first.ts",
+        lines("export const alpha = 1;"),
+        lines("export const alpha = 2;"),
+      ),
+      createWideTwoHunkDiffFile("second", "second.ts", 100),
+    ];
+    const scrollRef = createRef<ScrollBoxRenderable>();
+    let latestSelection = { fileId: files[0]!.id, hunkIndex: 0 };
+    let bumpAlignRequest = () => {};
+
+    function FileTopAlignHarness() {
+      const [selection, setSelection] = useState(latestSelection);
+      const [alignRequestId, setAlignRequestId] = useState(0);
+      bumpAlignRequest = () => setAlignRequestId((current) => current + 1);
+
+      return (
+        <DiffPane
+          {...createDiffPaneProps(files, theme, {
+            diffContentWidth: 96,
+            headerLabelWidth: 48,
+            scrollRef,
+            selectedFileId: selection.fileId,
+            selectedFileTopAlignRequestId: alignRequestId,
+            selectedHunkIndex: selection.hunkIndex,
+            selectedHunkRevealRequestId: 0,
+            separatorWidth: 92,
+            width: 100,
+          })}
+          onViewportCenteredHunkChange={(fileId, hunkIndex) => {
+            latestSelection = { fileId, hunkIndex };
+            setSelection(latestSelection);
+          }}
+        />
+      );
+    }
+
+    const setup = await testRender(<FileTopAlignHarness />, {
+      width: 104,
+      height: 12,
+    });
+
+    const sectionGeometry = files.map((file) =>
+      measureDiffSectionGeometry(file, "split", true, theme, [], 96, true, false),
+    );
+    const fileSectionLayouts = buildFileSectionLayouts(
+      files,
+      sectionGeometry.map((geometry) => geometry.bodyHeight),
+      buildInStreamFileHeaderHeights(files),
+    );
+
+    try {
+      await settleDiffPane(setup);
+
+      // Align the already-aligned first file: the stream has nowhere to travel, so the align is
+      // done the moment it is requested and must not keep owning the viewport afterwards.
+      await act(async () => {
+        bumpAlignRequest();
+      });
+      await settleDiffPane(setup);
+
+      const viewportHeight = scrollRef.current?.viewport.height ?? 0;
+      expect(viewportHeight).toBeGreaterThan(0);
+
+      const secondFileSecondHunkTop =
+        fileSectionLayouts[1]!.bodyTop + sectionGeometry[1]!.hunkBounds.get(1)!.top;
+      const targetScrollTop = scrollTopForCenter(secondFileSecondHunkTop, viewportHeight);
+
+      await act(async () => {
+        scrollRef.current?.scrollTo(targetScrollTop);
+      });
+      await settleDiffPane(setup);
+
+      expect(latestSelection).toEqual({ fileId: "second", hunkIndex: 1 });
+      expect(scrollRef.current?.scrollTop ?? 0).toBe(targetScrollTop);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("DiffPane keeps the sticky-header lane stable through the divider and next-header handoff", async () => {
     const theme = resolveTheme("github-dark-default", null);
     const firstFile = createTallDiffFile("first", "first.ts", 18);

--- a/test/pty/pager.test.ts
+++ b/test/pty/pager.test.ts
@@ -304,12 +304,7 @@ describe("PTY pager", () => {
     }
   });
 
-  // TODO(#650): re-enable once file navigation stops racing the align-to-top
-  // scroll. The `,` leg fails on CI far more often than it passes (4 of 5
-  // observed runs, including a re-run of main's own CI), while passing
-  // consistently on macOS locally. `moveToFile` requests the alignment through
-  // an effect keyed on `selectedFileTopAlignRequestId`, which this test races.
-  test.skip("general pager mode navigates between files in the review stream", async () => {
+  test("general pager mode navigates between files in the review stream", async () => {
     const fixture = harness.createMultiFilePagerPatchFixture();
     const session = await harness.launchHunkWithFileBackedStdin({
       stdinFile: fixture.patchFile,
@@ -325,24 +320,31 @@ describe("PTY pager", () => {
       expect(initial).toContain("line01 = 1;");
       expect(initial).not.toContain("secondValue = 2;");
 
-      await session.waitIdle({ timeout: 200 });
+      // The keypress handler is bound after the first paint, so proving one key landed keeps a
+      // slow start from being misread as broken file navigation.
+      await harness.ensureKeyboardIsLive(session);
       await session.press(".");
+      // second.ts is the last file and too short to own the viewport top, so the only correct
+      // landing spot is the bottom of the stream. Assert that exact position -- reaching it while
+      // first.ts's opening line is gone is what separates a real jump from an incidental redraw.
       const nextFile = await harness.waitForSnapshot(
         session,
-        (text) => text.includes("secondValue = 2;"),
+        (text) => text.includes("secondValue = 2;") && !text.includes("line01 = 1;"),
         5_000,
       );
 
       expect(nextFile).toContain("secondValue = 2;");
+      expect(nextFile).not.toContain("line01 = 1;");
 
       await session.press(",");
       const previousFile = await harness.waitForSnapshot(
         session,
-        (text) => text.includes("line01 = 1;"),
+        (text) => text.includes("line01 = 1;") && !text.includes("secondValue = 2;"),
         5_000,
       );
 
       expect(previousFile).toContain("line01 = 1;");
+      expect(previousFile).not.toContain("secondValue = 2;");
     } finally {
       session.close();
     }


### PR DESCRIPTION
Closes #650.

The flaky pager test turned out to be reporting a real bug, not racing one. Fixes the product race, then re-enables the test it was skipped behind.

## What was broken

Jumping to a file (`.`/`,`, or a sidebar click) asks the review stream to align that file to the viewport top, and viewport-follow selection is held off while the jump settles. That hold-off was a **160 ms wall-clock timer**, but what it has to outlive is a **coalesced read of the scroll box** — the pane only observes the align one read interval later, and under load that lag runs 300-470 ms.

When the timer lost that race, the pane read *its own align scroll* as user scrolling and adopted the hunk under the viewport center, silently reverting the selection it had just made. A short trailing file makes this worst: it can only clamp at the bottom edge with the previous file still centered, so the selection snapped straight back to where the jump started and the next "previous file" press had nowhere to go — it did nothing at all.

That is what CI kept catching: not a slow render, but navigation genuinely losing the file it had just jumped to.

## The fix

Gate viewport-follow selection on the same signal the align uses — the coalesced viewport read agreeing with the align target — instead of a timer. The two now key off one signal rather than racing.

Also stop registering no-travel align requests as pending. Those used to stay pending until an unrelated relayout cleared them, which yanked the next manual scroll back to the file top.

## Reproduction

Never reproduced on macOS (0/10 in isolation, 0/10 under 32 background spinners). Reproduces on Linux under constrained CPU:

```bash
docker run -d --name hunkci --cpuset-cpus=0,1 -v "$PWD":/repo -v hunk-node-modules:/repo/node_modules \
  -w /repo oven/bun:1.3.14-debian sleep infinity
docker exec hunkci bash -lc 'apt-get install -y git && cd /repo && bun install --frozen-lockfile --ignore-scripts'
# 4 spinning load generators, then run the test 30x
```

**18/30 failures (60%)**, matching CI's 4-of-5 rate, with the same failure snapshot.

## Measured stability

30 runs each, 2 CPUs, 4 spinners:

| test wait | product fix | failures |
| --- | --- | --- |
| `waitIdle(200)` | no | **18/30** |
| `waitIdle(200)` | yes | 0/30 |
| `ensureKeyboardIsLive` | no | 0/30 |
| `ensureKeyboardIsLive` | yes | 0/30 |

At 12 spinners: 50/50 green. Full `pager.test.ts` green 3x under load; full `./test/pty` 86/86 on Linux.

Note the third row: the test's own startup race could mask the product bug, which is why both are fixed rather than either alone.

## Test changes

Two separate problems, both addressed:

- **Startup race.** The test waited `waitIdle({timeout: 200})` before its first keypress, but the key handler is bound after first paint — on a slow start the `.` press was dropped outright. Now uses the harness's `ensureKeyboardIsLive`, like the rest of the PTY suite.
- **Assertions that passed for the wrong reason.** The `.` leg only checked that `second.ts` was on screen *somewhere*, which is true whether or not any alignment landed. Both legs now assert the exact landing position.

The short trailing file is deliberately kept. Making it tall enough to align properly makes the test pass 50/50 **even with the bug present** — that fixture shape is precisely what exercises the race.

## Deterministic coverage

`ui-components.test.tsx` gains a DiffPane case for the no-travel align path that does not depend on timing at all: it requests an align that needs no scrolling, then scrolls manually and asserts the scroll sticks. Red on pre-fix code (`scrollTop` 7 → 0), green after. Verified independently by running it against `main`'s DiffPane.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run format:check` clean.
- `bun run test:integration` on macOS: 74 pass / 12 fail, identical to a clean-worktree baseline (4 extensions, 1 file-views, 7 piped-stdin pager tests that time out on this machine); the previously-skipped test now passes.
- `bun test ./src/ui/components/ui-components.test.tsx`: 68/68.
- Real TTY smoke via tmux confirms `.`/`,` navigation and post-jump manual scrolling behave correctly. (`test:tty-smoke` itself can't run on macOS — BSD `script` rejects `-f`, unrelated to this change.)
