### PR TITLE
fix(release): include provenance in platform packages

### DIFF
--- a/.changeset/fix-prebuilt-provenance.md
+++ b/.changeset/fix-prebuilt-provenance.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fix trusted npm publishing metadata for prebuilt platform packages.

--- a/scripts/prebuilt-package-helpers.test.ts
+++ b/scripts/prebuilt-package-helpers.test.ts
@@ -84,11 +84,18 @@ describe("prebuilt package helpers", () => {
     );
   });
 
-  test("buildPlatformPackageManifest declares the native binary as a bin entry", () => {
+  test("buildPlatformPackageManifest carries provenance metadata without a native bin script", () => {
+    const repository = {
+      type: "git",
+      url: "git+https://github.com/modem-dev/hunk.git",
+    };
     const manifest = buildPlatformPackageManifest(
       {
         version: "1.2.3",
         description: "Desktop diff viewer",
+        repository,
+        homepage: "https://github.com/modem-dev/hunk#readme",
+        bugs: { url: "https://github.com/modem-dev/hunk/issues" },
         license: "MIT",
       },
       getPlatformPackageSpecForHost("linux", "x64"),
@@ -96,9 +103,10 @@ describe("prebuilt package helpers", () => {
 
     expect(manifest.name).toBe("hunkdiff-linux-x64");
     expect(manifest.version).toBe("1.2.3");
-    expect(manifest.bin).toEqual({
-      hunk: "./bin/hunk",
-    });
+    expect(manifest).not.toHaveProperty("bin");
+    expect(manifest.repository).toEqual(repository);
+    expect(manifest.homepage).toBe("https://github.com/modem-dev/hunk#readme");
+    expect(manifest.bugs).toEqual({ url: "https://github.com/modem-dev/hunk/issues" });
     expect(manifest.os).toEqual(["linux"]);
     expect(manifest.cpu).toEqual(["x64"]);
   });
@@ -114,9 +122,7 @@ describe("prebuilt package helpers", () => {
     );
 
     expect(manifest.name).toBe("hunkdiff-windows-x64");
-    expect(manifest.bin).toEqual({
-      hunk: "./bin/hunk.exe",
-    });
+    expect(manifest).not.toHaveProperty("bin");
     expect(manifest.os).toEqual(["win32"]);
     expect(manifest.cpu).toEqual(["x64"]);
   });

--- a/scripts/prebuilt-package-helpers.ts
+++ b/scripts/prebuilt-package-helpers.ts
@@ -127,29 +127,31 @@ export function binaryFilenameForSpec(spec: PlatformPackageSpec) {
 /**
  * Build the published manifest for one prebuilt platform package.
  *
- * Declaring the native binary in `bin` makes npm restore execute bits on install,
- * including root-owned global installs where the JS wrapper cannot chmod later.
+ * Platform packages are implementation dependencies, so their native executables
+ * stay out of `bin`; npm 11 rejects native files there as invalid scripts. The
+ * staged executable bit and top-level wrapper preserve direct execution instead.
  */
 export function buildPlatformPackageManifest(
   rootPackage: {
     version: string;
     description?: string;
+    repository?: unknown;
+    homepage?: string;
+    bugs?: unknown;
     license?: string;
   },
   spec: PlatformPackageSpec,
 ) {
-  const binaryName = binaryFilenameForSpec(spec);
-
   return {
     name: spec.packageName,
     version: rootPackage.version,
     description: `${rootPackage.description} (${spec.os} ${spec.cpu} binary)`,
     os: [spec.os === "windows" ? "win32" : spec.os],
     cpu: [spec.cpu],
-    bin: {
-      hunk: `./bin/${binaryName}`,
-    },
     files: ["bin", "LICENSE"],
+    repository: rootPackage.repository,
+    homepage: rootPackage.homepage,
+    bugs: rootPackage.bugs,
     license: rootPackage.license,
     publishConfig: {
       access: "public",


### PR DESCRIPTION
## Summary

- copy repository metadata into prebuilt platform package manifests so npm trusted provenance can verify them
- stop declaring native executables as npm `bin` scripts, avoiding npm 11’s invalid-script rewrite
- keep the executable bit in staged artifacts and the wrapper’s existing fallback

The first `0.18.0-beta.0` publish attempt failed before npm accepted any package. No GitHub release was created.

## Validation

- `bun test scripts/prebuilt-package-helpers.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- staged and checked the Linux x64 prebuilt package
- `npm@11.17.0 pack --dry-run` completed without manifest corrections or warnings
- release-note changeset validation

*This PR description was generated by Pi using OpenAI GPT-5.3 Codex*
