### PR TITLE
feat(review): mark the current line and anchor notes to it

### DIFF
--- a/.changeset/current-line-cursor.md
+++ b/.changeset/current-line-cursor.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Highlight the current line and move it with `j`/`k`, so `c` adds a note exactly where the cursor sits. Set `cursor_line` to `number` for a quieter line-number marker, or `off` to restore plain row scrolling.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -78,6 +78,9 @@ The built-in commands and the keys they ship with:
 | `hunk.view.layoutSplit`             | Split layout                             | `1`                          |
 | `hunk.view.layoutStack`             | Stack layout                             | `2`                          |
 | `hunk.view.layoutAuto`              | Auto layout                              | `0`                          |
+| `hunk.view.cursorLineRow`           | Highlight the current row                | _(none)_                     |
+| `hunk.view.cursorLineNumber`        | Mark the current line number             | _(none)_                     |
+| `hunk.view.cursorLineOff`           | Hide the current-line marker             | _(none)_                     |
 
 Commands marked _(none)_ ship without a key: they are menu items today, and
 binding one gives it a shortcut like any other.

--- a/src/core/cli.test.ts
+++ b/src/core/cli.test.ts
@@ -151,6 +151,19 @@ describe("parseCli", () => {
     });
   });
 
+  test("parses the current-line style and rejects an unknown one", async () => {
+    const parsed = await parseCli(["bun", "hunk", "diff", "--cursor-line", "number"]);
+
+    expect(parsed).toMatchObject({
+      kind: "vcs",
+      options: { cursorLine: "number" },
+    });
+
+    await expect(parseCli(["bun", "hunk", "diff", "--cursor-line", "sparkles"])).rejects.toThrow(
+      "Invalid cursor line style: sparkles",
+    );
+  });
+
   test("accepts --experimental before the review command", async () => {
     const parsed = await parseCli(["bun", "hunk", "--experimental", "diff"]);
 

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -4,6 +4,7 @@ import { Command, Option } from "commander";
 import type {
   CliInput,
   CommonOptions,
+  CursorLine,
   HelpCommandInput,
   LayoutMode,
   PagerCommandInput,
@@ -38,7 +39,7 @@ import { resolveCliVersion } from "./version";
 export interface CliReferenceOption {
   readonly flag: string;
   readonly description: string;
-  readonly parse?: "layout" | "positiveInt" | "tabWidth" | "collect";
+  readonly parse?: "layout" | "cursorLine" | "positiveInt" | "tabWidth" | "collect";
   readonly defaultValue?: string;
   /** Default applied directly by Commander (as opposed to a config-resolved default). */
   readonly commanderDefault?: string;
@@ -59,6 +60,11 @@ export interface CliReferenceCommand {
 /** Review flags registered on every full-screen review command. */
 export const COMMON_REVIEW_OPTIONS = [
   { flag: "--mode <mode>", description: "layout mode: auto, split, stack", parse: "layout" },
+  {
+    flag: "--cursor-line <style>",
+    description: "current-line marker: row, number, off",
+    parse: "cursorLine",
+  },
   { flag: "--theme <theme>", description: "named theme override" },
   AUXILIARY_AGENT_OPTIONS.agentContext,
   { flag: "--pager", description: "use pager-style chrome" },
@@ -195,6 +201,15 @@ function parseLayoutMode(value: string): LayoutMode {
   throw new Error(`Invalid layout mode: ${value}`);
 }
 
+/** Validate one requested current-line style from CLI input. */
+function parseCursorLine(value: string): CursorLine {
+  if (value === "row" || value === "number" || value === "off") {
+    return value;
+  }
+
+  throw new Error(`Invalid cursor line style: ${value}`);
+}
+
 /** Parse one required positive integer CLI value. */
 function parsePositiveInt(value: string) {
   if (!/^[1-9]\d*$/.test(value)) {
@@ -236,6 +251,7 @@ function collectRepeatedValue(value: string, previous: string[] = []) {
 function buildCommonOptions(
   options: {
     mode?: LayoutMode;
+    cursorLine?: CursorLine;
     theme?: string;
     agentContext?: string;
     pager?: boolean;
@@ -249,6 +265,7 @@ function buildCommonOptions(
 ): CommonOptions {
   return {
     mode: options.mode,
+    cursorLine: options.cursorLine,
     theme: options.theme,
     agentContext: options.agentContext,
     pager: options.pager ? true : undefined,
@@ -281,6 +298,8 @@ function applyReferenceOption(command: Command, option: CliReferenceOption) {
   const commanderOption = new Option(option.flag, option.description);
   if (option.parse === "layout") {
     commanderOption.argParser(parseLayoutMode);
+  } else if (option.parse === "cursorLine") {
+    commanderOption.argParser(parseCursorLine);
   } else if (option.parse === "positiveInt") {
     commanderOption.argParser(parsePositiveInt);
   } else if (option.parse === "tabWidth") {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -79,6 +79,7 @@ describe("config persistence", () => {
         showMenuBar: false,
         showAgentNotes: true,
         copyDecorations: true,
+        cursorLine: "row",
       },
       { env: { HOME: home } },
     );
@@ -95,6 +96,7 @@ describe("config persistence", () => {
         "menu_bar = false",
         "agent_notes = true",
         "copy_decorations = true",
+        'cursor_line = "row"',
         "",
         "[custom_theme]",
         'label = "Keep me"',
@@ -133,6 +135,7 @@ describe("config persistence", () => {
       showMenuBar: true,
       showAgentNotes: true,
       copyDecorations: false,
+      cursorLine: "row",
     } as const;
 
     expect(diffPersistedViewPreferences(initial, { ...initial })).toEqual([]);
@@ -217,6 +220,43 @@ describe("config resolution", () => {
       transparentBackground: true,
       colorMoved: true,
     });
+  });
+
+  test("reads the current-line style from config and lets CLI flags outrank it", () => {
+    const home = createTempDir("hunk-config-home-");
+    const repo = createTempDir("hunk-config-repo-");
+    createRepo(repo);
+
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(join(home, ".config", "hunk", "config.toml"), 'cursor_line = "number"');
+
+    const fromConfig = resolveConfiguredCliInput(createPatchPagerInput(), {
+      cwd: repo,
+      env: { HOME: home },
+    });
+    expect(fromConfig.input.options.cursorLine).toBe("number");
+
+    const fromFlag = resolveConfiguredCliInput(createPatchPagerInput({ cursorLine: "off" }), {
+      cwd: repo,
+      env: { HOME: home },
+    });
+    expect(fromFlag.input.options.cursorLine).toBe("off");
+  });
+
+  test("falls back to the built-in current-line style when config names an unknown one", () => {
+    const home = createTempDir("hunk-config-home-");
+    const repo = createTempDir("hunk-config-repo-");
+    createRepo(repo);
+
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(join(home, ".config", "hunk", "config.toml"), 'cursor_line = "sparkles"');
+
+    const resolved = resolveConfiguredCliInput(createPatchPagerInput(), {
+      cwd: repo,
+      env: { HOME: home },
+    });
+
+    expect(resolved.input.options.cursorLine).toBe("row");
   });
 
   test("starts pager mode with the menu bar hidden unless a later layer asks for it", () => {

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -20,6 +20,7 @@ import { detectVcs, findVcsRepoRootCandidate, getDefaultVcsAdapter } from "./vcs
 import type {
   CliInput,
   CommonOptions,
+  CursorLine,
   CustomSyntaxColorsConfig,
   CustomSyntaxScopesConfig,
   ExtensionsConfig,
@@ -42,6 +43,7 @@ const DEFAULT_VIEW_PREFERENCES: PersistedViewPreferences = {
   showMenuBar: true,
   showAgentNotes: false,
   copyDecorations: false,
+  cursorLine: "row",
 };
 
 const VIEW_PREFERENCES_PROMPT_CONFIG_KEY = "prompt_save_view_preferences";
@@ -57,6 +59,7 @@ const PERSISTED_VIEW_PREFERENCE_KEYS: Array<{
   { configKey: "menu_bar", value: (preferences) => preferences.showMenuBar },
   { configKey: "agent_notes", value: (preferences) => preferences.showAgentNotes },
   { configKey: "copy_decorations", value: (preferences) => preferences.copyDecorations },
+  { configKey: "cursor_line", value: (preferences) => preferences.cursorLine },
 ];
 
 interface ConfigResolutionOptions {
@@ -142,6 +145,11 @@ function normalizeLayoutMode(value: unknown): LayoutMode | undefined {
   return value === "auto" || value === "split" || value === "stack" ? value : undefined;
 }
 
+/** Accept only the current-line styles the review stream can draw. */
+function normalizeCursorLine(value: unknown): CursorLine | undefined {
+  return value === "row" || value === "number" || value === "off" ? value : undefined;
+}
+
 /**
  * Accept any backend id a config layer names, provisionally.
  *
@@ -210,6 +218,15 @@ export const CONFIG_REFERENCE_OPTIONS: readonly ConfigReferenceOption[] = [
     accepted: "`auto`, `split`, or `stack`",
     runtimeDefault: DEFAULT_VIEW_PREFERENCES.mode,
     description: "Choose responsive, side-by-side, or stacked diff layout.",
+  },
+  {
+    key: "cursor_line",
+    property: "cursorLine",
+    type: "string",
+    accepted: "`row`, `number`, or `off`",
+    runtimeDefault: DEFAULT_VIEW_PREFERENCES.cursorLine,
+    description:
+      "Mark the current line as a full-row highlight or on its line number. `off` restores plain `j`/`k` scrolling.",
   },
   {
     key: "vcs",
@@ -802,6 +819,8 @@ function normalizeConfigReferenceValue(property: keyof CommonOptions, value: unk
   switch (property) {
     case "mode":
       return normalizeLayoutMode(value);
+    case "cursorLine":
+      return normalizeCursorLine(value);
     case "vcs":
       return normalizeVcsMode(value);
     case "theme":
@@ -853,6 +872,7 @@ function mergeOptions(base: CommonOptions, overrides: CommonOptions): CommonOpti
   return {
     ...base,
     mode: overrides.mode ?? base.mode,
+    cursorLine: overrides.cursorLine ?? base.cursorLine,
     vcs: overrides.vcs ?? base.vcs,
     theme: overrides.theme ?? base.theme,
     agentContext: overrides.agentContext ?? base.agentContext,

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -513,5 +513,6 @@ export async function loadAppBootstrap(
     initialShowMenuBar: input.options.menuBar ?? true,
     initialShowAgentNotes: input.options.agentNotes ?? false,
     initialCopyDecorations: input.options.copyDecorations ?? false,
+    initialCursorLine: input.options.cursorLine ?? "row",
   };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -29,6 +29,7 @@ export type {
 } from "../extension-api/types";
 
 export type LayoutMode = "auto" | "split" | "stack";
+export type CursorLine = "row" | "number" | "off";
 export type VcsMode = string;
 export type TerminalThemeMode = "light" | "dark";
 
@@ -86,6 +87,7 @@ export interface Changeset {
 
 export interface CommonOptions {
   mode?: LayoutMode;
+  cursorLine?: CursorLine;
   vcs?: VcsMode;
   theme?: string;
   agentContext?: string;
@@ -147,6 +149,7 @@ export interface PersistedViewPreferences {
   showMenuBar: boolean;
   showAgentNotes: boolean;
   copyDecorations: boolean;
+  cursorLine: CursorLine;
 }
 
 export interface HelpCommandInput {
@@ -390,6 +393,7 @@ export interface AppBootstrap {
   initialShowMenuBar?: boolean;
   initialShowAgentNotes?: boolean;
   initialCopyDecorations?: boolean;
+  initialCursorLine?: CursorLine;
   startupNotices?: readonly StartupNotice[];
   viewPreferencesConfigPath?: string;
   /** The user's `[keybindings]` table, resolved against command defaults in App. */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -102,7 +102,6 @@ type ThemeSelectorState = {
 };
 
 const FAST_CODE_HORIZONTAL_SCROLL_COLUMNS = 8;
-const EMPTY_LINE_CURSORS: LineCursor[] = [];
 
 /**
  * Trailing debounce before one `selection_changed` event is emitted.
@@ -329,8 +328,7 @@ export function App({
   // App computes layout geometry below this hook call, so the controller reads
   // the current values through a ref instead of a render-time parameter.
   const noteGeometryRef = useRef<AgentNoteGeometrySnapshot | null>(null);
-  // The diff pane measures the review stream, so it is the one that can enumerate navigable lines.
-  const [lineCursors, setLineCursors] = useState<LineCursor[]>(EMPTY_LINE_CURSORS);
+  const [lineCursors, setLineCursors] = useState<LineCursor[]>([]);
   const review = useReviewController({
     files: reviewFiles,
     lineCursors,
@@ -920,7 +918,6 @@ export function App({
 
   /** Step one line: move the current line, or scroll the viewport when there is no marker. */
   const stepDiffLine = (delta: number) => {
-    // Changesets with no navigable lines, such as binary-only reviews, still have to scroll.
     if (cursorLine === "off" || !review.lineCursor) {
       scrollDiff(delta, "step");
       return;
@@ -960,11 +957,6 @@ export function App({
     },
     [maxCodeHorizontalOffset, wrapLines],
   );
-
-  /** Choose how the review stream marks the line the reviewer is on. */
-  const selectCursorLine = useCallback((style: CursorLine) => {
-    setCursorLine(style);
-  }, []);
 
   /** Preserve the current review position before changing the active diff layout. */
   const selectLayoutMode = useCallback((mode: LayoutMode) => {
@@ -1436,15 +1428,13 @@ export function App({
   /** Start a user-authored inline note and move keyboard focus into it. */
   const startUserNote = useCallback(
     (fileId?: string, hunkIndex?: number, target?: UserNoteLineTarget) => {
-      // A live hover is the more recent intent, so it outranks the resting current line.
-      const restingTarget = cursorLine === "off" ? null : review.lineCursor;
       const hoverTarget = fileId === undefined ? activeAddNoteTarget : null;
-      const keyboardTarget = fileId === undefined ? (hoverTarget ?? restingTarget) : null;
+      const keyboardTarget =
+        hoverTarget ?? (fileId === undefined && cursorLine !== "off" ? review.lineCursor : null);
       const draft = review.startUserNote(
         fileId ?? keyboardTarget?.fileId,
         hunkIndex ?? keyboardTarget?.hunkIndex,
         target ?? keyboardTarget?.target,
-        // A pointer-placed note is already on screen; one placed from the current line may not be.
         { preserveViewport: fileId !== undefined || hoverTarget !== null },
       );
       if (draft) {
@@ -1544,7 +1534,7 @@ export function App({
       scrollCodeHorizontally,
       scrollDiff,
       stepDiffLine,
-      selectCursorLine,
+      selectCursorLine: setCursorLine,
       selectLayoutMode,
       startUserNote: () => startUserNote(),
       toggleAgentNotes,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,6 +15,7 @@ import { DEFAULT_TAB_WIDTH } from "../core/tabWidth";
 import type {
   AppBootstrap,
   CliInput,
+  CursorLine,
   LayoutMode,
   PersistedViewPreferences,
   UserNoteLineTarget,
@@ -213,6 +214,7 @@ export function App({
   const [wrapLines, setWrapLines] = useState(bootstrap.initialWrapLines ?? false);
   const [copyDecorations, setCopyDecorations] = useState(bootstrap.initialCopyDecorations ?? false);
   const [codeHorizontalOffset, setCodeHorizontalOffset] = useState(0);
+  const [cursorLine, setCursorLine] = useState<CursorLine>(bootstrap.initialCursorLine ?? "row");
   const [showHunkHeaders, setShowHunkHeaders] = useState(bootstrap.initialShowHunkHeaders ?? true);
   const [showMenuBar, setShowMenuBar] = useState(bootstrap.initialShowMenuBar ?? true);
   const [themeSelectorState, setThemeSelectorState] = useState<ThemeSelectorState>({
@@ -284,9 +286,11 @@ export function App({
       showMenuBar,
       showAgentNotes,
       copyDecorations,
+      cursorLine,
     }),
     [
       copyDecorations,
+      cursorLine,
       layoutMode,
       showAgentNotes,
       showHunkHeaders,
@@ -323,8 +327,11 @@ export function App({
   // App computes layout geometry below this hook call, so the controller reads
   // the current values through a ref instead of a render-time parameter.
   const noteGeometryRef = useRef<AgentNoteGeometrySnapshot | null>(null);
+  const responsiveLayout = resolveResponsiveLayout(layoutMode, terminal.width);
+  const resolvedLayout = responsiveLayout.layout;
   const review = useReviewController({
     files: reviewFiles,
+    layout: resolvedLayout,
     noteGeometry: noteGeometryRef,
     stmlEnabled,
   });
@@ -759,11 +766,9 @@ export function App({
 
   const bodyPadding = pagerMode ? 0 : BODY_PADDING;
   const bodyWidth = Math.max(0, terminal.width - bodyPadding);
-  const responsiveLayout = resolveResponsiveLayout(layoutMode, terminal.width);
   const canForceShowSidebar = bodyWidth >= SIDEBAR_MIN_WIDTH + DIVIDER_WIDTH + DIFF_MIN_WIDTH;
   const sidebarAreaVisible =
     sidebarVisible && (responsiveLayout.showSidebar || (forceSidebarOpen && canForceShowSidebar));
-  const resolvedLayout = responsiveLayout.layout;
   const reportedLayoutRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const signature = `${layoutMode}:${resolvedLayout}`;
@@ -909,6 +914,17 @@ export function App({
     diffScrollRef.current?.scrollBy(delta, unit);
   };
 
+  /** Step one line: move the current line, or scroll the viewport when there is no marker. */
+  const stepDiffLine = (delta: number) => {
+    // Changesets with no navigable lines, such as binary-only reviews, still have to scroll.
+    if (cursorLine === "off" || !review.lineCursor) {
+      scrollDiff(delta, "step");
+      return;
+    }
+
+    review.moveLineCursor(delta);
+  };
+
   const maxCodeHorizontalOffset = useMemo(() => {
     // Wrapped rows never consume the horizontal offset. Avoid scanning every code line—especially
     // long Unicode lines—until nowrap mode actually needs a global horizontal extent.
@@ -940,6 +956,11 @@ export function App({
     },
     [maxCodeHorizontalOffset, wrapLines],
   );
+
+  /** Choose how the review stream marks the line the reviewer is on. */
+  const selectCursorLine = useCallback((style: CursorLine) => {
+    setCursorLine(style);
+  }, []);
 
   /** Preserve the current review position before changing the active diff layout. */
   const selectLayoutMode = useCallback((mode: LayoutMode) => {
@@ -1411,18 +1432,23 @@ export function App({
   /** Start a user-authored inline note and move keyboard focus into it. */
   const startUserNote = useCallback(
     (fileId?: string, hunkIndex?: number, target?: UserNoteLineTarget) => {
+      // A live hover is the more recent intent, so it outranks the resting current line.
+      const restingTarget = cursorLine === "off" ? null : review.lineCursor;
       const hoverTarget = fileId === undefined ? activeAddNoteTarget : null;
+      const keyboardTarget = fileId === undefined ? (hoverTarget ?? restingTarget) : null;
       const draft = review.startUserNote(
-        fileId ?? hoverTarget?.fileId,
-        hunkIndex ?? hoverTarget?.hunkIndex,
-        target ?? hoverTarget?.target,
+        fileId ?? keyboardTarget?.fileId,
+        hunkIndex ?? keyboardTarget?.hunkIndex,
+        target ?? keyboardTarget?.target,
+        // A pointer-placed note is already on screen; one placed from the current line may not be.
+        { preserveViewport: fileId !== undefined || hoverTarget !== null },
       );
       if (draft) {
         setActiveAddNoteTarget(null);
         setFocusArea("note");
       }
     },
-    [activeAddNoteTarget, review.startUserNote],
+    [activeAddNoteTarget, cursorLine, review.lineCursor, review.startUserNote],
   );
 
   /** Mark the inline draft note textarea as the active keyboard input. */
@@ -1513,6 +1539,8 @@ export function App({
       resolvedKeys: resolvedCommandKeys,
       scrollCodeHorizontally,
       scrollDiff,
+      stepDiffLine,
+      selectCursorLine,
       selectLayoutMode,
       startUserNote: () => startUserNote(),
       toggleAgentNotes,
@@ -1538,6 +1566,7 @@ export function App({
   // hints and the checkbox state have to stay live.
   const menus = buildAppMenus({
     commands: appCommands,
+    cursorLine,
     extensionCommands: extensionAppCommands.commands,
     fileViewEntries: selectedFileViewEntries,
     fileViewApplyAllLabel: selectedFileViewBulkTarget
@@ -1819,6 +1848,9 @@ export function App({
           layoutToggleRequestId={layoutToggleRequestId}
           selectedFileTopAlignRequestId={review.selectedFileTopAlignRequestId}
           selectedHunkRevealRequestId={review.selectedHunkRevealRequestId}
+          cursorLine={cursorLine}
+          lineCursor={review.lineCursor}
+          lineCursorRevealRequestId={review.lineCursorRevealRequestId}
           theme={activeTheme}
           width={diffPaneWidth}
           onActiveAddNoteAffordanceChange={setActiveAddNoteTarget}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -71,6 +71,7 @@ import {
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
 import { createGuardedReviewNavigation } from "./lib/extensionNavigation";
+import type { LineCursor } from "./lib/lineCursors";
 import { buildExtensionReviewSelection } from "./lib/extensionSelection";
 import { useFilePresentationController } from "./fileViews/useFilePresentationController";
 import { useFilePresentationRendering } from "./fileViews/useFilePresentationRendering";
@@ -101,6 +102,7 @@ type ThemeSelectorState = {
 };
 
 const FAST_CODE_HORIZONTAL_SCROLL_COLUMNS = 8;
+const EMPTY_LINE_CURSORS: LineCursor[] = [];
 
 /**
  * Trailing debounce before one `selection_changed` event is emitted.
@@ -327,11 +329,11 @@ export function App({
   // App computes layout geometry below this hook call, so the controller reads
   // the current values through a ref instead of a render-time parameter.
   const noteGeometryRef = useRef<AgentNoteGeometrySnapshot | null>(null);
-  const responsiveLayout = resolveResponsiveLayout(layoutMode, terminal.width);
-  const resolvedLayout = responsiveLayout.layout;
+  // The diff pane measures the review stream, so it is the one that can enumerate navigable lines.
+  const [lineCursors, setLineCursors] = useState<LineCursor[]>(EMPTY_LINE_CURSORS);
   const review = useReviewController({
     files: reviewFiles,
-    layout: resolvedLayout,
+    lineCursors,
     noteGeometry: noteGeometryRef,
     stmlEnabled,
   });
@@ -766,9 +768,11 @@ export function App({
 
   const bodyPadding = pagerMode ? 0 : BODY_PADDING;
   const bodyWidth = Math.max(0, terminal.width - bodyPadding);
+  const responsiveLayout = resolveResponsiveLayout(layoutMode, terminal.width);
   const canForceShowSidebar = bodyWidth >= SIDEBAR_MIN_WIDTH + DIVIDER_WIDTH + DIFF_MIN_WIDTH;
   const sidebarAreaVisible =
     sidebarVisible && (responsiveLayout.showSidebar || (forceSidebarOpen && canForceShowSidebar));
+  const resolvedLayout = responsiveLayout.layout;
   const reportedLayoutRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const signature = `${layoutMode}:${resolvedLayout}`;
@@ -1871,6 +1875,7 @@ export function App({
           onViewportCenteredHunkChange={(fileId, hunkIndex) =>
             review.selectHunk(fileId, hunkIndex, { preserveViewport: true })
           }
+          onLineCursorsChange={setLineCursors}
         />
 
         {sidebarLayout.right.map((pane, index) => {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1876,6 +1876,7 @@ export function App({
             review.selectHunk(fileId, hunkIndex, { preserveViewport: true })
           }
           onLineCursorsChange={setLineCursors}
+          onViewportLineCursorChange={review.anchorLineCursor}
         />
 
         {sidebarLayout.right.map((pane, index) => {

--- a/src/ui/AppHost.cursor-line.test.tsx
+++ b/src/ui/AppHost.cursor-line.test.tsx
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
+import type { CursorLine } from "../core/types";
+import { createTestVcsAppBootstrap } from "../../test/helpers/app-bootstrap";
+import { createTestDiffFile, lines } from "../../test/helpers/diff-helpers";
+import { AppHost } from "./AppHost";
+
+const BEFORE = lines(
+  "const alpha = 1;",
+  "const beta = 2;",
+  "const gamma = 3;",
+  "const delta = 4;",
+  "const epsilon = 5;",
+);
+const AFTER = lines(
+  "const alpha = 1;",
+  "const beta = 22222;",
+  "const gamma = 3;",
+  "const delta = 4;",
+  "const epsilon = 5;",
+);
+
+async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
+  await act(async () => {
+    await setup.renderOnce();
+    await Bun.sleep(0);
+    await setup.renderOnce();
+  });
+}
+
+function createCursorLineBootstrap(
+  cursorLine: CursorLine,
+  initialMode: "split" | "stack" = "stack",
+) {
+  return {
+    ...createTestVcsAppBootstrap({
+      files: [
+        createTestDiffFile({
+          id: "s",
+          path: "sample.ts",
+          before: BEFORE,
+          after: AFTER,
+          context: 3,
+        }),
+      ],
+      initialMode,
+    }),
+    initialCursorLine: cursorLine,
+  };
+}
+
+/** Read the background the review stream painted across one rendered code row. */
+function rowBackground(setup: Awaited<ReturnType<typeof testRender>>, needle: string) {
+  const frame = setup.captureSpans();
+  for (const line of frame.lines) {
+    const text = line.spans.map((span) => span.text).join("");
+    if (!text.includes(needle)) {
+      continue;
+    }
+
+    // The widest painted run is the code content, not the rail or the line-number gutter.
+    const widest = line.spans
+      .filter((span) => span.text.trim().length > 0)
+      .sort((left, right) => right.text.length - left.text.length)[0];
+    if (widest) {
+      return { r: widest.bg.r, g: widest.bg.g, b: widest.bg.b };
+    }
+  }
+
+  throw new Error(`No rendered row contained ${JSON.stringify(needle)}.`);
+}
+
+/** Read the background painted behind one rendered row's line-number gutter. */
+function gutterBackground(setup: Awaited<ReturnType<typeof testRender>>, needle: string) {
+  const frame = setup.captureSpans();
+  for (const line of frame.lines) {
+    const text = line.spans.map((span) => span.text).join("");
+    if (!text.includes(needle)) {
+      continue;
+    }
+
+    const gutter = line.spans.find((span) => /\d/.test(span.text));
+    if (gutter) {
+      return { r: gutter.bg.r, g: gutter.bg.g, b: gutter.bg.b };
+    }
+  }
+
+  throw new Error(`No rendered gutter for ${JSON.stringify(needle)}.`);
+}
+
+async function renderCursorLineApp(
+  cursorLine: CursorLine,
+  initialMode: "split" | "stack" = "stack",
+) {
+  const setup = await testRender(
+    <AppHost bootstrap={createCursorLineBootstrap(cursorLine, initialMode) as never} />,
+    { width: 200, height: 16 },
+  );
+  await flush(setup);
+  await act(async () => {
+    await Bun.sleep(60);
+    await setup.renderOnce();
+  });
+  return setup;
+}
+
+describe("current line highlight", () => {
+  test("marks the current row apart from the rows around it", async () => {
+    const setup = await renderCursorLineApp("row");
+
+    try {
+      // The cursor seeds on the hunk's first line, so only that context row is marked.
+      expect(rowBackground(setup, "alpha = 1")).not.toEqual(rowBackground(setup, "gamma = 3"));
+      expect(rowBackground(setup, "gamma = 3")).toEqual(rowBackground(setup, "delta = 4"));
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("keeps added and removed lines telling themselves apart under the highlight", async () => {
+    const setup = await renderCursorLineApp("row");
+
+    try {
+      await act(async () => {
+        await setup.mockInput.typeText("j");
+      });
+      await flush(setup);
+      const removed = rowBackground(setup, "beta = 2;");
+      expect(removed.r).toBeGreaterThan(removed.g);
+
+      await act(async () => {
+        await setup.mockInput.typeText("j");
+      });
+      await flush(setup);
+      const added = rowBackground(setup, "beta = 22222");
+      expect(added.g).toBeGreaterThan(added.r);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("lifts added and removed rows as far as it lifts context rows", async () => {
+    const marked = await renderCursorLineApp("row");
+    const plain = await renderCursorLineApp("off");
+
+    /** Compare one row's marked and unmarked paint the way a reader perceives it. */
+    const lift = (needle: string) => {
+      const a = rowBackground(marked, needle);
+      const b = rowBackground(plain, needle);
+      return Math.abs(a.r + a.g + a.b - (b.r + b.g + b.b));
+    };
+
+    try {
+      for (let step = 0; step < 2; step += 1) {
+        await act(async () => {
+          await marked.mockInput.typeText("j");
+        });
+        await flush(marked);
+      }
+
+      // Blending toward one fixed highlight color left added rows barely moving, because the
+      // highlight and the added background already shared a hue. Every row must lift alike.
+      const addedLift = lift("beta = 22222");
+      const contextLift = lift("alpha = 1");
+      expect(addedLift).toBeGreaterThan(0.1);
+      expect(addedLift).toBeGreaterThan(contextLift * 0.5);
+    } finally {
+      await act(async () => {
+        marked.renderer.destroy();
+        plain.renderer.destroy();
+      });
+    }
+  });
+
+  test("number style marks the gutter without repainting the code", async () => {
+    const setup = await renderCursorLineApp("number");
+    const plain = await renderCursorLineApp("off");
+
+    try {
+      expect(rowBackground(setup, "alpha = 1")).toEqual(rowBackground(plain, "alpha = 1"));
+      expect(gutterBackground(setup, "alpha = 1")).not.toEqual(
+        gutterBackground(plain, "alpha = 1"),
+      );
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+        plain.renderer.destroy();
+      });
+    }
+  });
+
+  test("marks both halves of a split context row", async () => {
+    const setup = await renderCursorLineApp("row", "split");
+
+    try {
+      // Both halves show the same source line, so marking one would read as half a row.
+      expect(rowBackground(setup, "alpha = 1")).not.toEqual(rowBackground(setup, "gamma = 3"));
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("off style leaves every row painted the same", async () => {
+    const setup = await renderCursorLineApp("off");
+
+    try {
+      expect(rowBackground(setup, "alpha = 1")).toEqual(rowBackground(setup, "gamma = 3"));
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+});

--- a/src/ui/AppHost.cursor-line.test.tsx
+++ b/src/ui/AppHost.cursor-line.test.tsx
@@ -110,7 +110,6 @@ describe("current line highlight", () => {
     const setup = await renderCursorLineApp("row");
 
     try {
-      // The cursor seeds on the hunk's first line, so only that context row is marked.
       expect(rowBackground(setup, "alpha = 1")).not.toEqual(rowBackground(setup, "gamma = 3"));
       expect(rowBackground(setup, "gamma = 3")).toEqual(rowBackground(setup, "delta = 4"));
     } finally {
@@ -163,8 +162,6 @@ describe("current line highlight", () => {
         await flush(marked);
       }
 
-      // Blending toward one fixed highlight color left added rows barely moving, because the
-      // highlight and the added background already shared a hue. Every row must lift alike.
       const addedLift = lift("beta = 22222");
       const contextLift = lift("alpha = 1");
       expect(addedLift).toBeGreaterThan(0.1);
@@ -198,7 +195,6 @@ describe("current line highlight", () => {
     const setup = await renderCursorLineApp("row", "split");
 
     try {
-      // Both halves show the same source line, so marking one would read as half a row.
       expect(rowBackground(setup, "alpha = 1")).not.toEqual(rowBackground(setup, "gamma = 3"));
     } finally {
       await act(async () => {

--- a/src/ui/AppHost.file-views.test.tsx
+++ b/src/ui/AppHost.file-views.test.tsx
@@ -361,8 +361,6 @@ describe("AppHost file views", () => {
       let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("▶ Hunk 1"));
       expect(frame).not.toContain("▶ Hunk 2");
 
-      // Presentation rows bound to a source line are stops of their own, so the default step key
-      // walks them instead of an invisible raw-diff cursor.
       await act(async () => {
         await setup.mockInput.typeText("j");
       });

--- a/src/ui/AppHost.file-views.test.tsx
+++ b/src/ui/AppHost.file-views.test.tsx
@@ -328,4 +328,50 @@ describe("AppHost file views", () => {
       });
     }
   });
+
+  test("steps the current line through the rows an alternate presentation renders", async () => {
+    const { extension, root } = copyJsxFileViewExtension();
+    const extensions = await loadStartupExtensions({
+      cliExtensionPaths: [extension],
+      cwd: root,
+      env: { XDG_CONFIG_HOME: root } as NodeJS.ProcessEnv,
+      extensions: { enabled: true, extensionConfigs: {}, paths: [], repoPaths: [] },
+    });
+    expect(extensions.issues).toEqual([]);
+
+    const bootstrap = createTestVcsAppBootstrap({
+      changesetId: "changeset:jsx-runtime-proof",
+      files: [createTwoHunkFile()],
+      initialMode: "stack",
+      inputMode: "stack",
+      vcsOptions: { extensionPaths: [extension] },
+    });
+    bootstrap.extensions = extensions;
+
+    const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={() => {}} />, {
+      width: 120,
+      height: 24,
+    });
+
+    try {
+      await waitForFrame(setup, (frame) => frame.includes("runtime-proof.ts"));
+      await act(async () => {
+        await setup.mockInput.pressKey("F8");
+      });
+      let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("▶ Hunk 1"));
+      expect(frame).not.toContain("▶ Hunk 2");
+
+      // Presentation rows bound to a source line are stops of their own, so the default step key
+      // walks them instead of an invisible raw-diff cursor.
+      await act(async () => {
+        await setup.mockInput.typeText("j");
+      });
+      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("▶ Hunk 2"));
+      expect(frame).not.toContain("▶ Hunk 1");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
 });

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1902,7 +1902,7 @@ describe("App interactions", () => {
       expect(initialFrame).not.toContain("line08");
 
       let frame = initialFrame;
-      for (let index = 0; index < 24; index += 1) {
+      for (let index = 0; index < 48; index += 1) {
         await act(async () => {
           await setup.mockInput.pressArrow("down");
         });
@@ -1916,7 +1916,7 @@ describe("App interactions", () => {
       expect(frame).toContain("line08");
       expect(frame).not.toContain("line01");
 
-      for (let index = 0; index < 12; index += 1) {
+      for (let index = 0; index < 32; index += 1) {
         await act(async () => {
           await setup.mockInput.pressArrow("up");
         });
@@ -1936,10 +1936,13 @@ describe("App interactions", () => {
   });
 
   test("the first down-arrow step still advances content under the always-pinned file header above a collapsed gap", async () => {
-    const setup = await testRender(<AppHost bootstrap={createCollapsedTopBootstrap()} />, {
-      width: 220,
-      height: 10,
-    });
+    const setup = await testRender(
+      <AppHost bootstrap={{ ...createCollapsedTopBootstrap(), initialCursorLine: "off" }} />,
+      {
+        width: 220,
+        height: 10,
+      },
+    );
 
     try {
       await flush(setup);
@@ -2041,7 +2044,7 @@ describe("App interactions", () => {
       expect(initialFrame).not.toContain("line08");
 
       let frame = initialFrame;
-      for (let index = 0; index < 12; index += 1) {
+      for (let index = 0; index < 32; index += 1) {
         await act(async () => {
           await setup.mockInput.pressArrow("down");
         });
@@ -2055,7 +2058,7 @@ describe("App interactions", () => {
       expect(frame).toContain("line08");
       expect(frame).not.toContain("line01");
 
-      for (let index = 0; index < 12; index += 1) {
+      for (let index = 0; index < 32; index += 1) {
         await act(async () => {
           await setup.mockInput.pressArrow("up");
         });

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -1446,7 +1446,7 @@ describe("App interactions", () => {
       expect(frame).toContain("Why prefs.ts changed");
       expect(frame).not.toContain("@@ -1,1 +1,2 @@");
       expect(frame).not.toContain("1 - export const message");
-      expect(frame.indexOf("Agent note - prefs.ts R2")).toBeLessThan(
+      expect(frame.indexOf("Agent note - prefs.ts R2")).toBeGreaterThan(
         frame.indexOf("export const added = true;"),
       );
     } finally {

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -829,20 +829,25 @@ export function DiffPane({
     () => buildLineCursors(files, sectionGeometry),
     [files, sectionGeometry],
   );
-  const lineCursorBoundsOf = useCallback<LineCursorBoundsLookup>(
-    (cursor) => {
-      const sectionIndex = fileSectionIndexById.get(cursor.fileId);
+  /** Locate one measured row in whole-stream rows, addressed by its file and plan anchor. */
+  const rowBoundsInStream = useCallback(
+    (fileId: string, stableKey: string) => {
+      const sectionIndex = fileSectionIndexById.get(fileId);
       if (sectionIndex === undefined) {
         return undefined;
       }
 
       const section = fileSectionLayouts[sectionIndex];
-      const bounds = sectionGeometry[sectionIndex]?.rowBoundsByStableKey.get(cursor.stableKey);
+      const bounds = sectionGeometry[sectionIndex]?.rowBoundsByStableKey.get(stableKey);
       return section && bounds
         ? { top: section.bodyTop + bounds.top, height: bounds.height }
         : undefined;
     },
     [fileSectionIndexById, fileSectionLayouts, sectionGeometry],
+  );
+  const lineCursorBoundsOf = useCallback<LineCursorBoundsLookup>(
+    (cursor) => rowBoundsInStream(cursor.fileId, cursor.stableKey),
+    [rowBoundsInStream],
   );
 
   useEffect(() => {
@@ -1498,12 +1503,15 @@ export function DiffPane({
     const sectionRelativeHunkTop =
       selectedEstimatedHunkBounds.top - selectedEstimatedHunkBounds.sectionTop;
     const sectionRelativeHunkBottom = sectionRelativeHunkTop + selectedEstimatedHunkBounds.height;
-    const noteRow = geometry.rowBounds.find(
-      (row) =>
-        row.key.startsWith("inline-note:") &&
-        row.top >= sectionRelativeHunkTop &&
-        row.top < sectionRelativeHunkBottom,
-    );
+    // An open draft is the note the reviewer is waiting on, even when earlier notes share its hunk.
+    const noteRow =
+      (draftNote ? geometry.rowBoundsByStableKey.get(`inline-note:${draftNote.id}`) : undefined) ??
+      geometry.rowBounds.find(
+        (row) =>
+          row.key.startsWith("inline-note:") &&
+          row.top >= sectionRelativeHunkTop &&
+          row.top < sectionRelativeHunkBottom,
+      );
 
     if (!noteRow) {
       return null;
@@ -1513,7 +1521,7 @@ export function DiffPane({
       top: selectedEstimatedHunkBounds.sectionTop + noteRow.top,
       height: noteRow.height,
     };
-  }, [scrollToNote, sectionGeometry, selectedEstimatedHunkBounds, selectedFileIndex]);
+  }, [draftNote, scrollToNote, sectionGeometry, selectedEstimatedHunkBounds, selectedFileIndex]);
   const selectedEstimatedHunkTop = selectedEstimatedHunkBounds?.top ?? null;
   const selectedEstimatedHunkHeight = selectedEstimatedHunkBounds?.height ?? null;
   const selectedEstimatedHunkStartRowId = selectedEstimatedHunkBounds?.startRowId ?? null;
@@ -1608,12 +1616,25 @@ export function DiffPane({
           buildInStreamFileHeaderHeights(previousFiles),
         );
       if (anchor) {
-        const nextTop = resolveViewportRowAnchorTop(
+        const anchorTop = resolveViewportRowAnchorTop(
           files,
           sectionGeometry,
           anchor,
           sectionHeaderHeights,
         );
+        // Holding the anchor row still keeps the code from jumping, but the card opens below it and
+        // can hang off the bottom, so give up the minimum height needed to show all of it.
+        const draftBounds = draftNote
+          ? rowBoundsInStream(draftNote.fileId, `inline-note:${draftNote.id}`)
+          : undefined;
+        const nextTop = draftBounds
+          ? computeLineRevealScrollTop({
+              lineTop: draftBounds.top,
+              lineHeight: draftBounds.height,
+              scrollTop: anchorTop,
+              viewportHeight: scrollRef.current?.viewport.height || scrollViewport.height,
+            })
+          : anchorTop;
         const restoreViewportAnchor = () => {
           scrollRef.current?.scrollTo(nextTop);
         };
@@ -1693,12 +1714,14 @@ export function DiffPane({
     previousSectionGeometryRef.current = sectionGeometry;
     previousFilesRef.current = files;
   }, [
-    draftNote?.id,
+    draftNote,
     files,
     layout,
     layoutToggleRequestId,
     layoutToggleScrollTop,
+    rowBoundsInStream,
     scrollRef,
+    scrollViewport.height,
     scrollViewport.top,
     sectionGeometry,
     sectionHeaderHeights,

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -36,9 +36,11 @@ import {
   RAPID_SCROLL_OVERSCAN_IDLE_MS,
 } from "../../lib/adaptiveScrollOverscan";
 import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "../../lib/hunkScroll";
+import { inlineNoteStableKey } from "../../diff/reviewRenderPlan";
 import {
   buildLineCursors,
   clampLineCursorToViewport,
+  EMPTY_LINE_CURSORS,
   type LineCursorBoundsLookup,
 } from "../../lib/lineCursors";
 import {
@@ -188,7 +190,6 @@ const EMPTY_EXPANDED_GAP_KEYS: ReadonlySet<string> = new Set();
 const EMPTY_EXPANDED_GAPS_BY_FILE_ID: Record<string, ReadonlySet<string>> = {};
 const EMPTY_FILE_VIEWS: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
 const EMPTY_SOURCE_STATUS_BY_FILE_ID: Record<string, FileSourceStatus> = {};
-const EMPTY_LINE_CURSORS: LineCursor[] = [];
 const NOOP_TOGGLE_GAP = () => {};
 
 /** Render the main multi-file review stream. */
@@ -554,7 +555,9 @@ export function DiffPane({
   const previousFilesRef = useRef<DiffFile[]>(files);
   const previousLayoutRef = useRef(layout);
   const previousWrapLinesRef = useRef(wrapLines);
-  const previousDraftNoteIdRef = useRef(draftNote?.id ?? null);
+  const draftNoteId = draftNote?.id ?? null;
+  const draftNoteFileId = draftNote?.fileId ?? null;
+  const previousDraftNoteIdRef = useRef(draftNoteId);
   const previousSelectedFileTopAlignRequestIdRef = useRef(selectedFileTopAlignRequestId);
   const previousLayoutToggleRequestIdRef = useRef(layoutToggleRequestId);
   const previousSelectedHunkRevealRequestIdRef = useRef(selectedHunkRevealRequestId);
@@ -825,7 +828,6 @@ export function DiffPane({
     [fileSectionLayouts],
   );
 
-  // The measured stream is what the reviewer actually sees, so it is also what `j` and `k` walk.
   const lineCursors = useMemo(
     // Nothing reads the stops while the marker is off, and enumerating them costs one object per
     // rendered row of the whole changeset every time geometry is remeasured.
@@ -1248,9 +1250,7 @@ export function DiffPane({
       return;
     }
 
-    // One review position per settled scroll: the current line owns it whenever there is one, so
-    // the marker and the selection cannot drift apart on the same wheel tick.
-    if (cursorLine !== "off" && lineCursors.length > 0) {
+    if (lineCursors.length > 0) {
       const clampedCursor = clampLineCursorToViewport({
         boundsOf: lineCursorBoundsOf,
         current: lineCursor,
@@ -1284,7 +1284,6 @@ export function DiffPane({
 
     onViewportCenteredHunkChange?.(centeredTarget.fileId, centeredTarget.hunkIndex);
   }, [
-    cursorLine,
     fileSectionLayouts,
     files,
     lineCursor,
@@ -1506,9 +1505,10 @@ export function DiffPane({
     const sectionRelativeHunkTop =
       selectedEstimatedHunkBounds.top - selectedEstimatedHunkBounds.sectionTop;
     const sectionRelativeHunkBottom = sectionRelativeHunkTop + selectedEstimatedHunkBounds.height;
-    // An open draft is the note the reviewer is waiting on, even when earlier notes share its hunk.
     const noteRow =
-      (draftNote ? geometry.rowBoundsByStableKey.get(`inline-note:${draftNote.id}`) : undefined) ??
+      (draftNoteId
+        ? geometry.rowBoundsByStableKey.get(inlineNoteStableKey(draftNoteId))
+        : undefined) ??
       geometry.rowBounds.find(
         (row) =>
           row.key.startsWith("inline-note:") &&
@@ -1524,7 +1524,7 @@ export function DiffPane({
       top: selectedEstimatedHunkBounds.sectionTop + noteRow.top,
       height: noteRow.height,
     };
-  }, [draftNote, scrollToNote, sectionGeometry, selectedEstimatedHunkBounds, selectedFileIndex]);
+  }, [draftNoteId, scrollToNote, sectionGeometry, selectedEstimatedHunkBounds, selectedFileIndex]);
   const selectedEstimatedHunkTop = selectedEstimatedHunkBounds?.top ?? null;
   const selectedEstimatedHunkHeight = selectedEstimatedHunkBounds?.height ?? null;
   const selectedEstimatedHunkStartRowId = selectedEstimatedHunkBounds?.startRowId ?? null;
@@ -1605,7 +1605,7 @@ export function DiffPane({
     const wrapChanged = previousWrapLinesRef.current !== wrapLines;
     const previousSectionMetrics = previousSectionGeometryRef.current;
     const previousFiles = previousFilesRef.current;
-    const currentDraftNoteId = draftNote?.id ?? null;
+    const currentDraftNoteId = draftNoteId;
     const draftChanged = previousDraftNoteIdRef.current !== currentDraftNoteId;
 
     if (draftChanged && previousSectionMetrics && previousFiles.length > 0) {
@@ -1625,11 +1625,10 @@ export function DiffPane({
           anchor,
           sectionHeaderHeights,
         );
-        // Holding the anchor row still keeps the code from jumping, but the card opens below it and
-        // can hang off the bottom, so give up the minimum height needed to show all of it.
-        const draftBounds = draftNote
-          ? rowBoundsInStream(draftNote.fileId, `inline-note:${draftNote.id}`)
-          : undefined;
+        const draftBounds =
+          draftNoteId && draftNoteFileId
+            ? rowBoundsInStream(draftNoteFileId, inlineNoteStableKey(draftNoteId))
+            : undefined;
         const nextTop = draftBounds
           ? computeLineRevealScrollTop({
               lineTop: draftBounds.top,
@@ -1717,7 +1716,8 @@ export function DiffPane({
     previousSectionGeometryRef.current = sectionGeometry;
     previousFilesRef.current = files;
   }, [
-    draftNote,
+    draftNoteFileId,
+    draftNoteId,
     files,
     layout,
     layoutToggleRequestId,
@@ -1968,7 +1968,6 @@ export function DiffPane({
 
   const previousLineCursorRevealRequestIdRef = useRef(lineCursorRevealRequestId);
 
-  // Measured bounds rather than a row count, so wrapped rows taller than one row still fit.
   useLayoutEffect(() => {
     if (previousLineCursorRevealRequestIdRef.current === lineCursorRevealRequestId) {
       return;

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -24,6 +24,7 @@ import type {
 import type { LineCursor } from "../../lib/lineCursors";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
+import type { CursorHighlight } from "../../diff/renderRows";
 import type { DraftReviewNote } from "../../hooks/useReviewController";
 import {
   alwaysShowReviewNote,
@@ -35,7 +36,7 @@ import {
   RAPID_SCROLL_OVERSCAN_IDLE_MS,
 } from "../../lib/adaptiveScrollOverscan";
 import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "../../lib/hunkScroll";
-import { lineStableKey } from "../../diff/reviewRenderPlan";
+import { buildLineCursors, type LineCursorBoundsLookup } from "../../lib/lineCursors";
 import {
   measureDiffSectionGeometry,
   type DiffSectionGeometry,
@@ -238,6 +239,7 @@ export function DiffPane({
   onScrollCodeHorizontally = () => {},
   onSelectFile,
   onToggleGap = NOOP_TOGGLE_GAP,
+  onLineCursorsChange,
   onViewportCenteredHunkChange,
 }: {
   codeHorizontalOffset?: number;
@@ -294,6 +296,7 @@ export function DiffPane({
   onScrollCodeHorizontally?: (delta: number) => void;
   onSelectFile: (fileId: string) => void;
   onToggleGap?: (fileId: string, gapKey: string) => void;
+  onLineCursorsChange?: (cursors: LineCursor[]) => void;
   onViewportCenteredHunkChange?: (fileId: string, hunkIndex: number) => void;
 }) {
   const renderTopChrome = showTopChrome ?? !pagerMode;
@@ -810,6 +813,35 @@ export function DiffPane({
     [estimatedBodyHeights, files, sectionHeaderHeights],
   );
   const totalContentHeight = fileSectionLayouts[fileSectionLayouts.length - 1]?.sectionBottom ?? 0;
+  const fileSectionIndexById = useMemo(
+    () => buildFileSectionIndexById(fileSectionLayouts),
+    [fileSectionLayouts],
+  );
+
+  // The measured stream is what the reviewer actually sees, so it is also what `j` and `k` walk.
+  const lineCursors = useMemo(
+    () => buildLineCursors(files, sectionGeometry),
+    [files, sectionGeometry],
+  );
+  const lineCursorBoundsOf = useCallback<LineCursorBoundsLookup>(
+    (cursor) => {
+      const sectionIndex = fileSectionIndexById.get(cursor.fileId);
+      if (sectionIndex === undefined) {
+        return undefined;
+      }
+
+      const section = fileSectionLayouts[sectionIndex];
+      const bounds = sectionGeometry[sectionIndex]?.rowBoundsByStableKey.get(cursor.stableKey);
+      return section && bounds
+        ? { top: section.bodyTop + bounds.top, height: bounds.height }
+        : undefined;
+    },
+    [fileSectionIndexById, fileSectionLayouts, sectionGeometry],
+  );
+
+  useEffect(() => {
+    onLineCursorsChange?.(lineCursors);
+  }, [lineCursors, onLineCursorsChange]);
 
   // Read the live scroll box position during render so pinned-header ownership flips
   // immediately after imperative scrolls instead of waiting for the polled viewport snapshot.
@@ -877,9 +909,16 @@ export function DiffPane({
 
   // One object per cursor move, so the section and row memos below only see a new reference when
   // the current line actually moves.
-  const cursorLineTarget = useMemo(
-    () => (lineCursor ? { hunkIndex: lineCursor.hunkIndex, ...lineCursor.target } : undefined),
-    [lineCursor],
+  const cursorHighlight = useMemo(
+    () =>
+      cursorLine === "off" || !lineCursor
+        ? undefined
+        : ({
+            stableKey: lineCursor.stableKey,
+            style: cursorLine,
+            side: lineCursor.target.side,
+          } satisfies CursorHighlight),
+    [cursorLine, lineCursor],
   );
 
   const copySelectedRowKeysByFile = useMemo(
@@ -1234,10 +1273,6 @@ export function DiffPane({
     (): FileRenderWindowItem[] =>
       files.map((file, sectionIndex) => ({ kind: "file", fileId: file.id, sectionIndex })),
     [files],
-  );
-  const fileSectionIndexById = useMemo(
-    () => buildFileSectionIndexById(fileSectionLayouts),
-    [fileSectionLayouts],
   );
   const fileRenderWindow = useMemo(
     () =>
@@ -1889,22 +1924,18 @@ export function DiffPane({
     previousLineCursorRevealRequestIdRef.current = lineCursorRevealRequestId;
 
     const scrollBox = scrollRef.current;
-    if (!scrollBox || !lineCursor || !cursorLineTarget) {
+    if (!scrollBox || !lineCursor) {
       return;
     }
 
-    const sectionIndex = files.findIndex((file) => file.id === lineCursor.fileId);
-    const section = fileSectionLayouts[sectionIndex];
-    const bounds = sectionGeometry[sectionIndex]?.rowBoundsByStableKey.get(
-      lineStableKey(cursorLineTarget.hunkIndex, cursorLineTarget.side, cursorLineTarget.line),
-    );
-    if (!section || !bounds) {
+    const bounds = lineCursorBoundsOf(lineCursor);
+    if (!bounds) {
       return;
     }
 
     const viewportHeight = scrollBox.viewport.height || scrollViewport.height;
     const revealScrollTop = computeLineRevealScrollTop({
-      lineTop: section.bodyTop + bounds.top,
+      lineTop: bounds.top,
       lineHeight: bounds.height,
       scrollTop: scrollBox.scrollTop,
       viewportHeight,
@@ -1917,14 +1948,11 @@ export function DiffPane({
     scrollBox.scrollTo(clampReviewScrollTop(revealScrollTop, viewportHeight));
   }, [
     clampReviewScrollTop,
-    cursorLineTarget,
-    fileSectionLayouts,
-    files,
     lineCursor,
+    lineCursorBoundsOf,
     lineCursorRevealRequestId,
     scrollRef,
     scrollViewport.height,
-    sectionGeometry,
     suppressViewportSelectionSync,
   ]);
 
@@ -2028,10 +2056,7 @@ export function DiffPane({
                       selectedHunkIndex={file.id === selectedFileId ? selectedHunkIndex : -1}
                       copySelectedRowRanges={copySelectedRowKeysByFile.get(file.id)}
                       copySelectedSide={copySelectionSide}
-                      cursorLine={cursorLine}
-                      cursorLineTarget={
-                        file.id === lineCursor?.fileId ? cursorLineTarget : undefined
-                      }
+                      cursorHighlight={file.id === lineCursor?.fileId ? cursorHighlight : undefined}
                       shouldLoadHighlight={
                         (!wrapLines || initialWrappedRenderWindowWarmed) &&
                         highlightPrefetchFileIds.has(file.id)

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -188,6 +188,7 @@ const EMPTY_EXPANDED_GAP_KEYS: ReadonlySet<string> = new Set();
 const EMPTY_EXPANDED_GAPS_BY_FILE_ID: Record<string, ReadonlySet<string>> = {};
 const EMPTY_FILE_VIEWS: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
 const EMPTY_SOURCE_STATUS_BY_FILE_ID: Record<string, FileSourceStatus> = {};
+const EMPTY_LINE_CURSORS: LineCursor[] = [];
 const NOOP_TOGGLE_GAP = () => {};
 
 /** Render the main multi-file review stream. */
@@ -826,8 +827,10 @@ export function DiffPane({
 
   // The measured stream is what the reviewer actually sees, so it is also what `j` and `k` walk.
   const lineCursors = useMemo(
-    () => buildLineCursors(files, sectionGeometry),
-    [files, sectionGeometry],
+    // Nothing reads the stops while the marker is off, and enumerating them costs one object per
+    // rendered row of the whole changeset every time geometry is remeasured.
+    () => (cursorLine === "off" ? EMPTY_LINE_CURSORS : buildLineCursors(files, sectionGeometry)),
+    [cursorLine, files, sectionGeometry],
   );
   /** Locate one measured row in whole-stream rows, addressed by its file and plan anchor. */
   const rowBoundsInStream = useCallback(

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -16,10 +16,12 @@ import {
 import { DEFAULT_TAB_WIDTH } from "../../../core/tabWidth";
 import type {
   AgentAnnotation,
+  CursorLine,
   DiffFile,
   LayoutMode,
   UserNoteLineTarget,
 } from "../../../core/types";
+import type { LineCursor } from "../../lib/lineCursors";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
 import type { DraftReviewNote } from "../../hooks/useReviewController";
@@ -32,7 +34,8 @@ import {
   computeRapidScrollOverscanRows,
   RAPID_SCROLL_OVERSCAN_IDLE_MS,
 } from "../../lib/adaptiveScrollOverscan";
-import { computeHunkRevealScrollTop } from "../../lib/hunkScroll";
+import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "../../lib/hunkScroll";
+import { lineStableKey } from "../../diff/reviewRenderPlan";
 import {
   measureDiffSectionGeometry,
   type DiffSectionGeometry,
@@ -195,6 +198,9 @@ export function DiffPane({
   scrollRef,
   selectedFileId,
   selectedHunkIndex,
+  cursorLine = "off",
+  lineCursor = null,
+  lineCursorRevealRequestId = 0,
   scrollToNote = false,
   draftNote = null,
   draftNoteFocused = false,
@@ -246,6 +252,9 @@ export function DiffPane({
   scrollRef: RefObject<ScrollBoxRenderable | null>;
   selectedFileId?: string;
   selectedHunkIndex: number;
+  cursorLine?: CursorLine;
+  lineCursor?: LineCursor | null;
+  lineCursorRevealRequestId?: number;
   scrollToNote?: boolean;
   draftNote?: DraftReviewNote | null;
   draftNoteFocused?: boolean;
@@ -865,6 +874,13 @@ export function DiffPane({
     }
     return resolveCopySelectionSide(copySelectionDrag.anchor.column, layout, diffContentWidth);
   }, [copySelectionDrag, diffContentWidth, layout]);
+
+  // One object per cursor move, so the section and row memos below only see a new reference when
+  // the current line actually moves.
+  const cursorLineTarget = useMemo(
+    () => (lineCursor ? { hunkIndex: lineCursor.hunkIndex, ...lineCursor.target } : undefined),
+    [lineCursor],
+  );
 
   const copySelectedRowKeysByFile = useMemo(
     () =>
@@ -1863,6 +1879,55 @@ export function DiffPane({
     suppressViewportSelectionSync,
   ]);
 
+  const previousLineCursorRevealRequestIdRef = useRef(lineCursorRevealRequestId);
+
+  // Measured bounds rather than a row count, so wrapped rows taller than one row still fit.
+  useLayoutEffect(() => {
+    if (previousLineCursorRevealRequestIdRef.current === lineCursorRevealRequestId) {
+      return;
+    }
+    previousLineCursorRevealRequestIdRef.current = lineCursorRevealRequestId;
+
+    const scrollBox = scrollRef.current;
+    if (!scrollBox || !lineCursor || !cursorLineTarget) {
+      return;
+    }
+
+    const sectionIndex = files.findIndex((file) => file.id === lineCursor.fileId);
+    const section = fileSectionLayouts[sectionIndex];
+    const bounds = sectionGeometry[sectionIndex]?.rowBoundsByStableKey.get(
+      lineStableKey(cursorLineTarget.hunkIndex, cursorLineTarget.side, cursorLineTarget.line),
+    );
+    if (!section || !bounds) {
+      return;
+    }
+
+    const viewportHeight = scrollBox.viewport.height || scrollViewport.height;
+    const revealScrollTop = computeLineRevealScrollTop({
+      lineTop: section.bodyTop + bounds.top,
+      lineHeight: bounds.height,
+      scrollTop: scrollBox.scrollTop,
+      viewportHeight,
+    });
+    if (revealScrollTop === scrollBox.scrollTop) {
+      return;
+    }
+
+    suppressViewportSelectionSync();
+    scrollBox.scrollTo(clampReviewScrollTop(revealScrollTop, viewportHeight));
+  }, [
+    clampReviewScrollTop,
+    cursorLineTarget,
+    fileSectionLayouts,
+    files,
+    lineCursor,
+    lineCursorRevealRequestId,
+    scrollRef,
+    scrollViewport.height,
+    sectionGeometry,
+    suppressViewportSelectionSync,
+  ]);
+
   // Keep keyboard step scrolling at exactly one row while wheel scrolling uses its own multiplier.
   useEffect(() => {
     const scrollBox = scrollRef.current;
@@ -1963,6 +2028,10 @@ export function DiffPane({
                       selectedHunkIndex={file.id === selectedFileId ? selectedHunkIndex : -1}
                       copySelectedRowRanges={copySelectedRowKeysByFile.get(file.id)}
                       copySelectedSide={copySelectionSide}
+                      cursorLine={cursorLine}
+                      cursorLineTarget={
+                        file.id === lineCursor?.fileId ? cursorLineTarget : undefined
+                      }
                       shouldLoadHighlight={
                         (!wrapLines || initialWrappedRenderWindowWarmed) &&
                         highlightPrefetchFileIds.has(file.id)

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -36,7 +36,11 @@ import {
   RAPID_SCROLL_OVERSCAN_IDLE_MS,
 } from "../../lib/adaptiveScrollOverscan";
 import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "../../lib/hunkScroll";
-import { buildLineCursors, type LineCursorBoundsLookup } from "../../lib/lineCursors";
+import {
+  buildLineCursors,
+  clampLineCursorToViewport,
+  type LineCursorBoundsLookup,
+} from "../../lib/lineCursors";
 import {
   measureDiffSectionGeometry,
   type DiffSectionGeometry,
@@ -241,6 +245,7 @@ export function DiffPane({
   onToggleGap = NOOP_TOGGLE_GAP,
   onLineCursorsChange,
   onViewportCenteredHunkChange,
+  onViewportLineCursorChange,
 }: {
   codeHorizontalOffset?: number;
   diffContentWidth: number;
@@ -298,6 +303,7 @@ export function DiffPane({
   onToggleGap?: (fileId: string, gapKey: string) => void;
   onLineCursorsChange?: (cursors: LineCursor[]) => void;
   onViewportCenteredHunkChange?: (fileId: string, hunkIndex: number) => void;
+  onViewportLineCursorChange?: (cursor: LineCursor) => void;
 }) {
   const renderTopChrome = showTopChrome ?? !pagerMode;
   const renderer = useRenderer();
@@ -1222,7 +1228,6 @@ export function DiffPane({
     if (
       previousViewportTop === null ||
       previousViewportTop === scrollViewport.top ||
-      !onViewportCenteredHunkChange ||
       suppressViewportSelectionSyncRef.current ||
       // A requested file-top align is still settling, so this viewport move is our own scroll
       // rather than the user's. The timed suppression above can expire before the align lands on
@@ -1232,6 +1237,22 @@ export function DiffPane({
       files.length === 0 ||
       scrollViewport.height <= 0
     ) {
+      return;
+    }
+
+    // One review position per settled scroll: the current line owns it whenever there is one, so
+    // the marker and the selection cannot drift apart on the same wheel tick.
+    if (cursorLine !== "off" && lineCursors.length > 0) {
+      const clampedCursor = clampLineCursorToViewport({
+        boundsOf: lineCursorBoundsOf,
+        current: lineCursor,
+        cursors: lineCursors,
+        scrollTop: scrollViewport.top,
+        viewportHeight: scrollViewport.height,
+      });
+      if (clampedCursor && clampedCursor !== lineCursor) {
+        onViewportLineCursorChange?.(clampedCursor);
+      }
       return;
     }
 
@@ -1253,11 +1274,16 @@ export function DiffPane({
       return;
     }
 
-    onViewportCenteredHunkChange(centeredTarget.fileId, centeredTarget.hunkIndex);
+    onViewportCenteredHunkChange?.(centeredTarget.fileId, centeredTarget.hunkIndex);
   }, [
+    cursorLine,
     fileSectionLayouts,
     files,
+    lineCursor,
+    lineCursorBoundsOf,
+    lineCursors,
     onViewportCenteredHunkChange,
+    onViewportLineCursorChange,
     scrollViewport.height,
     scrollViewport.top,
     sectionGeometry,

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -1,7 +1,8 @@
 import { memo } from "react";
-import type { CursorLine, DiffFile, LayoutMode, UserNoteLineTarget } from "../../../core/types";
+import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../../core/types";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import { PierreDiffView, type ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
+import type { CursorHighlight } from "../../diff/renderRows";
 import type { VisibleBodyBounds } from "../../diff/rowWindowing";
 import type { DiffSectionGeometry } from "../../diff/diffSectionGeometry";
 import type { VisibleAgentNote } from "../../lib/agentAnnotations";
@@ -25,8 +26,7 @@ interface DiffSectionProps {
   selectedHunkIndex: number;
   copySelectedRowRanges?: Map<string, CopySelectedRowRange>;
   copySelectedSide?: "left" | "right";
-  cursorLine?: CursorLine;
-  cursorLineTarget?: UserNoteLineTarget & { hunkIndex: number };
+  cursorHighlight?: CursorHighlight;
   shouldLoadHighlight: boolean;
   sectionGeometry?: DiffSectionGeometry;
   separatorWidth: number;
@@ -64,8 +64,7 @@ function DiffSectionComponent({
   selectedHunkIndex,
   copySelectedRowRanges,
   copySelectedSide,
-  cursorLine,
-  cursorLineTarget,
+  cursorHighlight,
   shouldLoadHighlight,
   sectionGeometry,
   separatorWidth,
@@ -161,8 +160,7 @@ function DiffSectionComponent({
           codeHorizontalOffset={codeHorizontalOffset}
           copySelectedRowRanges={copySelectedRowRanges}
           copySelectedSide={copySelectedSide}
-          cursorLine={cursorLine}
-          cursorLineTarget={cursorLineTarget}
+          cursorHighlight={cursorHighlight}
           theme={theme}
           width={viewWidth}
           visibleAgentNotes={visibleAgentNotes}
@@ -200,8 +198,7 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
     previous.selectedHunkIndex === next.selectedHunkIndex &&
     previous.copySelectedRowRanges === next.copySelectedRowRanges &&
     previous.copySelectedSide === next.copySelectedSide &&
-    previous.cursorLine === next.cursorLine &&
-    previous.cursorLineTarget === next.cursorLineTarget &&
+    previous.cursorHighlight === next.cursorHighlight &&
     previous.shouldLoadHighlight === next.shouldLoadHighlight &&
     previous.sectionGeometry === next.sectionGeometry &&
     previous.separatorWidth === next.separatorWidth &&

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../../core/types";
+import type { CursorLine, DiffFile, LayoutMode, UserNoteLineTarget } from "../../../core/types";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import { PierreDiffView, type ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
 import type { VisibleBodyBounds } from "../../diff/rowWindowing";
@@ -25,6 +25,8 @@ interface DiffSectionProps {
   selectedHunkIndex: number;
   copySelectedRowRanges?: Map<string, CopySelectedRowRange>;
   copySelectedSide?: "left" | "right";
+  cursorLine?: CursorLine;
+  cursorLineTarget?: UserNoteLineTarget & { hunkIndex: number };
   shouldLoadHighlight: boolean;
   sectionGeometry?: DiffSectionGeometry;
   separatorWidth: number;
@@ -62,6 +64,8 @@ function DiffSectionComponent({
   selectedHunkIndex,
   copySelectedRowRanges,
   copySelectedSide,
+  cursorLine,
+  cursorLineTarget,
   shouldLoadHighlight,
   sectionGeometry,
   separatorWidth,
@@ -157,6 +161,8 @@ function DiffSectionComponent({
           codeHorizontalOffset={codeHorizontalOffset}
           copySelectedRowRanges={copySelectedRowRanges}
           copySelectedSide={copySelectedSide}
+          cursorLine={cursorLine}
+          cursorLineTarget={cursorLineTarget}
           theme={theme}
           width={viewWidth}
           visibleAgentNotes={visibleAgentNotes}
@@ -194,6 +200,8 @@ export const DiffSection = memo(DiffSectionComponent, (previous, next) => {
     previous.selectedHunkIndex === next.selectedHunkIndex &&
     previous.copySelectedRowRanges === next.copySelectedRowRanges &&
     previous.copySelectedSide === next.copySelectedSide &&
+    previous.cursorLine === next.cursorLine &&
+    previous.cursorLineTarget === next.cursorLineTarget &&
     previous.shouldLoadHighlight === next.shouldLoadHighlight &&
     previous.sectionGeometry === next.sectionGeometry &&
     previous.separatorWidth === next.separatorWidth &&

--- a/src/ui/components/panes/DiffSection.tsx
+++ b/src/ui/components/panes/DiffSection.tsx
@@ -141,6 +141,7 @@ function DiffSectionComponent({
               rowBoundsByStableKey: new Map(),
             }
           }
+          cursorHighlight={cursorHighlight}
           selectedHunkIndex={selectedHunkIndex}
           theme={theme}
           visibleBodyBounds={visibleBodyBounds}

--- a/src/ui/components/panes/FileView.test.tsx
+++ b/src/ui/components/panes/FileView.test.tsx
@@ -97,7 +97,7 @@ describe("FileView custom rows", () => {
     }
   });
 
-  test("renders a host-owned note immediately before its bound alternate row", async () => {
+  test("renders a host-owned note immediately after its bound alternate row", async () => {
     const file = createTestDiffFile({ id: "noted", path: "noted.ts" });
     const fileView = resolveTestLayout(
       {
@@ -140,7 +140,7 @@ describe("FileView custom rows", () => {
       const frame = setup.captureCharFrame();
       expect(frame).toContain("Review bound output");
       expect(frame).toContain("BOUND PRESENTATION");
-      expect(frame.indexOf("Review bound output")).toBeLessThan(
+      expect(frame.indexOf("Review bound output")).toBeGreaterThan(
         frame.indexOf("BOUND PRESENTATION"),
       );
       expect(

--- a/src/ui/components/panes/FileView.tsx
+++ b/src/ui/components/panes/FileView.tsx
@@ -9,7 +9,7 @@ import type {
 } from "../../../extension-api/types";
 import type { AppTheme } from "../../themes";
 import type { DiffSectionGeometry } from "../../diff/diffSectionGeometry";
-import type { CursorHighlight } from "../../diff/renderRows";
+import { plannedRowMatchesCursor, type CursorHighlight } from "../../diff/renderRows";
 import { cursorLineHighlightBg } from "../../diff/rowStyle";
 import { resolveVisibleRowIndexWindow, type VisibleBodyBounds } from "../../diff/rowWindowing";
 import { reviewRowId } from "../../lib/ids";
@@ -185,9 +185,7 @@ function FileViewComponent({
         const row = plannedRow.row;
         const index = plannedRow.rowIndex;
         const selected = isFileViewRowSelected(layout, index, selectedHunkIndex);
-        const onCursorRow =
-          cursorHighlight !== undefined &&
-          plannedRow.stableAliasKeys?.includes(cursorHighlight.stableKey) === true;
+        const onCursorRow = plannedRowMatchesCursor(plannedRow, cursorHighlight);
         const rowBackground = selected ? theme.selectedHunk : theme.panel;
         const fixedHeight = row.component?.height;
         const View = row.component?.render as

--- a/src/ui/components/panes/FileView.tsx
+++ b/src/ui/components/panes/FileView.tsx
@@ -9,9 +9,12 @@ import type {
 } from "../../../extension-api/types";
 import type { AppTheme } from "../../themes";
 import type { DiffSectionGeometry } from "../../diff/diffSectionGeometry";
+import type { CursorHighlight } from "../../diff/renderRows";
+import { cursorLineHighlightBg } from "../../diff/rowStyle";
 import { resolveVisibleRowIndexWindow, type VisibleBodyBounds } from "../../diff/rowWindowing";
 import { reviewRowId } from "../../lib/ids";
 import { toExtensionPaintTheme } from "../../lib/extensionPaintTheme";
+import type { PlannedFileViewRow } from "../../fileViews/renderPlan";
 import type { FileViewRowFailure } from "../../fileViews/types";
 import type { ResolvedFileViewLayout } from "../../fileViews/useFileViews";
 import { AgentInlineNote } from "./AgentInlineNote";
@@ -104,6 +107,7 @@ function FileViewComponent({
   file,
   fileView,
   geometry,
+  cursorHighlight,
   selectedHunkIndex,
   theme,
   visibleBodyBounds,
@@ -113,6 +117,8 @@ function FileViewComponent({
   file: DiffFile;
   fileView: ResolvedFileViewLayout;
   geometry: DiffSectionGeometry;
+  /** The current line within this file, when the review-stream cursor rests in it. */
+  cursorHighlight?: CursorHighlight;
   selectedHunkIndex: number;
   theme: AppTheme;
   visibleBodyBounds?: VisibleBodyBounds;
@@ -121,7 +127,7 @@ function FileViewComponent({
 }) {
   const { layout } = fileView;
   const publicTheme = useMemo(() => toExtensionPaintTheme(theme), [theme]);
-  const plannedRows =
+  const plannedRows: readonly PlannedFileViewRow[] =
     geometry.fileViewRows ??
     layout.rows.map((row, rowIndex) => ({
       kind: "file-view-row" as const,
@@ -179,6 +185,10 @@ function FileViewComponent({
         const row = plannedRow.row;
         const index = plannedRow.rowIndex;
         const selected = isFileViewRowSelected(layout, index, selectedHunkIndex);
+        const onCursorRow =
+          cursorHighlight !== undefined &&
+          plannedRow.stableAliasKeys?.includes(cursorHighlight.stableKey) === true;
+        const rowBackground = selected ? theme.selectedHunk : theme.panel;
         const fixedHeight = row.component?.height;
         const View = row.component?.render as
           | ((props: ExtensionFileViewRowComponentProps) => ReactNode)
@@ -203,7 +213,10 @@ function FileViewComponent({
                     overflow: "hidden" as const,
                   }),
               flexDirection: "row",
-              backgroundColor: selected ? theme.selectedHunk : theme.panel,
+              // Presentation rows carry no line-number column, so both marker styles paint a band.
+              backgroundColor: onCursorRow
+                ? cursorLineHighlightBg(rowBackground, theme)
+                : rowBackground,
             }}
           >
             {View && fixedHeight !== undefined ? (

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2413,7 +2413,7 @@ describe("UI components", () => {
     expect(frame).toContain("Agent note - alpha.ts R2");
     expect(frame).toContain("Annotation for alpha.ts");
     expect(frame).toContain("Why alpha.ts changed");
-    expect(frame.indexOf("Agent note - alpha.ts R2")).toBeLessThan(
+    expect(frame.indexOf("Agent note - alpha.ts R2")).toBeGreaterThan(
       frame.indexOf("2 + export const add = true;"),
     );
     expect(frame).toContain("Agent note - beta.ts R1");
@@ -2424,7 +2424,7 @@ describe("UI components", () => {
     expect(frame).not.toContain("confidence");
   });
 
-  test("DiffPane split inline notes hand off directly to the anchored row without shifting it", async () => {
+  test("DiffPane split inline notes hand off directly from the anchored row without shifting it", async () => {
     const bootstrap = createBootstrap();
     const theme = resolveTheme("github-dark-default", null);
     const frame = await captureFrame(
@@ -2452,10 +2452,10 @@ describe("UI components", () => {
     );
 
     const lines = frame.split("\n");
-    const noteBottomIndex = lines.findIndex((line) => line.includes("╰") && line.includes("╯"));
-    expect(noteBottomIndex).toBeGreaterThanOrEqual(0);
-    expect(lines[noteBottomIndex + 1]).toContain("export const add = true;");
-    expect(lines[noteBottomIndex + 1]?.trim()).not.toBe("│");
+    const noteTopIndex = lines.findIndex((line) => line.includes("╭") && line.includes("╮"));
+    expect(noteTopIndex).toBeGreaterThan(0);
+    expect(lines[noteTopIndex - 1]).toContain("export const add = true;");
+    expect(lines[noteTopIndex - 1]?.trim()).not.toBe("│");
 
     const changedLine = lines.find((line) => line.includes("export const alpha = 2;"));
     const annotatedLine = lines.find((line) => line.includes("export const add = true;"));
@@ -3020,7 +3020,7 @@ describe("UI components", () => {
     expect(frame).toContain("Ungrounded note");
     expect(frame).toContain("Falls back to the first visible");
     expect(frame).toContain("row.");
-    expect(frame.indexOf("Agent note - note-fallback.ts hunk")).toBeLessThan(
+    expect(frame.indexOf("Agent note - note-fallback.ts hunk")).toBeGreaterThan(
       frame.indexOf("1 - export const value = 1;"),
     );
   });

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,7 +1,7 @@
 import { useRenderer } from "@opentui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DEFAULT_TAB_WIDTH } from "../../core/tabWidth";
-import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
+import type { CursorLine, DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
 import { AgentInlineNote } from "../components/panes/AgentInlineNote";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
@@ -13,7 +13,8 @@ import { spansForHighlightedSourceLine, type DiffRow } from "./pierre";
 import { plannedReviewRowVisible } from "./plannedReviewRows";
 import { buildDiffSectionRowPlan } from "./diffSectionRowPlan";
 import { resolveVisiblePlannedRowWindow, type VisibleBodyBounds } from "./rowWindowing";
-import { diffMessage, DiffRowView, fitText } from "./renderRows";
+import { diffMessage, DiffRowView, fitText, type CursorHighlight } from "./renderRows";
+import { lineStableKey } from "./reviewRenderPlan";
 import { useHighlightedDiff } from "./useHighlightedDiff";
 import { useHighlightedSource } from "./useHighlightedSource";
 
@@ -63,6 +64,8 @@ export function PierreDiffView({
   codeHorizontalOffset = 0,
   copySelectedRowRanges,
   copySelectedSide,
+  cursorLine = "off",
+  cursorLineTarget,
   expandedGapKeys = EMPTY_EXPANDED_GAP_KEYS,
   file,
   layout,
@@ -89,6 +92,9 @@ export function PierreDiffView({
   codeHorizontalOffset?: number;
   copySelectedRowRanges?: Map<string, CopySelectedRowRange>;
   copySelectedSide?: "left" | "right";
+  cursorLine?: CursorLine;
+  /** The current line within this file, when the review-stream cursor sits in it. */
+  cursorLineTarget?: UserNoteLineTarget & { hunkIndex: number };
   expandedGapKeys?: ReadonlySet<string>;
   file: DiffFile | undefined;
   layout: Exclude<LayoutMode, "auto">;
@@ -261,6 +267,23 @@ export function PierreDiffView({
     return next;
   }, [plannedRows]);
 
+  // Matching on the render plan's own line anchor lets split and stack share one lookup. One
+  // object per cursor position keeps DiffRowView's memo effective for every other row.
+  const cursor = useMemo(
+    () =>
+      cursorLine === "off" || !cursorLineTarget
+        ? null
+        : {
+            stableKey: lineStableKey(
+              cursorLineTarget.hunkIndex,
+              cursorLineTarget.side,
+              cursorLineTarget.line,
+            ),
+            highlight: { style: cursorLine, side: cursorLineTarget.side } satisfies CursorHighlight,
+          },
+    [cursorLine, cursorLineTarget],
+  );
+
   /** One shared hover handler for every diff row; DiffRowView passes the hovered row's key. */
   const handleHoverRow = useCallback(
     (rowKey: string) => {
@@ -371,6 +394,11 @@ export function PierreDiffView({
           );
         }
 
+        const isCursorRow =
+          cursor !== null &&
+          (plannedRow.stableKey === cursor.stableKey ||
+            plannedRow.stableAliasKeys?.includes(cursor.stableKey) === true);
+
         return (
           <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
             <DiffRowView
@@ -385,6 +413,7 @@ export function PierreDiffView({
               selected={plannedRow.row.hunkIndex === selectedHunkIndex}
               copySelectedRowRange={copySelectedRowRanges?.get(plannedRow.key)}
               copySelectedSide={copySelectedSide}
+              cursorHighlight={isCursorRow ? cursor.highlight : undefined}
               anchorId={plannedRow.anchorId}
               noteGuideSide={plannedRow.noteGuideSide}
               showAddNoteBadge={

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -13,7 +13,13 @@ import { spansForHighlightedSourceLine, type DiffRow } from "./pierre";
 import { plannedReviewRowVisible } from "./plannedReviewRows";
 import { buildDiffSectionRowPlan } from "./diffSectionRowPlan";
 import { resolveVisiblePlannedRowWindow, type VisibleBodyBounds } from "./rowWindowing";
-import { diffMessage, DiffRowView, fitText, type CursorHighlight } from "./renderRows";
+import {
+  diffMessage,
+  DiffRowView,
+  fitText,
+  plannedRowMatchesCursor,
+  type CursorHighlight,
+} from "./renderRows";
 import { useHighlightedDiff } from "./useHighlightedDiff";
 import { useHighlightedSource } from "./useHighlightedSource";
 
@@ -374,11 +380,7 @@ export function PierreDiffView({
           );
         }
 
-        // Matching on the render plan's own anchor lets split and stack share one lookup.
-        const isCursorRow =
-          cursorHighlight !== undefined &&
-          (plannedRow.stableKey === cursorHighlight.stableKey ||
-            plannedRow.stableAliasKeys?.includes(cursorHighlight.stableKey) === true);
+        const isCursorRow = plannedRowMatchesCursor(plannedRow, cursorHighlight);
 
         return (
           <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>

--- a/src/ui/diff/PierreDiffView.tsx
+++ b/src/ui/diff/PierreDiffView.tsx
@@ -1,7 +1,7 @@
 import { useRenderer } from "@opentui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DEFAULT_TAB_WIDTH } from "../../core/tabWidth";
-import type { CursorLine, DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
+import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
 import { AgentInlineNote } from "../components/panes/AgentInlineNote";
 import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
@@ -14,7 +14,6 @@ import { plannedReviewRowVisible } from "./plannedReviewRows";
 import { buildDiffSectionRowPlan } from "./diffSectionRowPlan";
 import { resolveVisiblePlannedRowWindow, type VisibleBodyBounds } from "./rowWindowing";
 import { diffMessage, DiffRowView, fitText, type CursorHighlight } from "./renderRows";
-import { lineStableKey } from "./reviewRenderPlan";
 import { useHighlightedDiff } from "./useHighlightedDiff";
 import { useHighlightedSource } from "./useHighlightedSource";
 
@@ -64,8 +63,7 @@ export function PierreDiffView({
   codeHorizontalOffset = 0,
   copySelectedRowRanges,
   copySelectedSide,
-  cursorLine = "off",
-  cursorLineTarget,
+  cursorHighlight,
   expandedGapKeys = EMPTY_EXPANDED_GAP_KEYS,
   file,
   layout,
@@ -92,9 +90,8 @@ export function PierreDiffView({
   codeHorizontalOffset?: number;
   copySelectedRowRanges?: Map<string, CopySelectedRowRange>;
   copySelectedSide?: "left" | "right";
-  cursorLine?: CursorLine;
-  /** The current line within this file, when the review-stream cursor sits in it. */
-  cursorLineTarget?: UserNoteLineTarget & { hunkIndex: number };
+  /** The current line within this file, when the review-stream cursor rests in it. */
+  cursorHighlight?: CursorHighlight;
   expandedGapKeys?: ReadonlySet<string>;
   file: DiffFile | undefined;
   layout: Exclude<LayoutMode, "auto">;
@@ -267,23 +264,6 @@ export function PierreDiffView({
     return next;
   }, [plannedRows]);
 
-  // Matching on the render plan's own line anchor lets split and stack share one lookup. One
-  // object per cursor position keeps DiffRowView's memo effective for every other row.
-  const cursor = useMemo(
-    () =>
-      cursorLine === "off" || !cursorLineTarget
-        ? null
-        : {
-            stableKey: lineStableKey(
-              cursorLineTarget.hunkIndex,
-              cursorLineTarget.side,
-              cursorLineTarget.line,
-            ),
-            highlight: { style: cursorLine, side: cursorLineTarget.side } satisfies CursorHighlight,
-          },
-    [cursorLine, cursorLineTarget],
-  );
-
   /** One shared hover handler for every diff row; DiffRowView passes the hovered row's key. */
   const handleHoverRow = useCallback(
     (rowKey: string) => {
@@ -394,10 +374,11 @@ export function PierreDiffView({
           );
         }
 
+        // Matching on the render plan's own anchor lets split and stack share one lookup.
         const isCursorRow =
-          cursor !== null &&
-          (plannedRow.stableKey === cursor.stableKey ||
-            plannedRow.stableAliasKeys?.includes(cursor.stableKey) === true);
+          cursorHighlight !== undefined &&
+          (plannedRow.stableKey === cursorHighlight.stableKey ||
+            plannedRow.stableAliasKeys?.includes(cursorHighlight.stableKey) === true);
 
         return (
           <box key={plannedRow.key} id={rowId} style={{ width: "100%", flexDirection: "column" }}>
@@ -413,7 +394,7 @@ export function PierreDiffView({
               selected={plannedRow.row.hunkIndex === selectedHunkIndex}
               copySelectedRowRange={copySelectedRowRanges?.get(plannedRow.key)}
               copySelectedSide={copySelectedSide}
-              cursorHighlight={isCursorRow ? cursor.highlight : undefined}
+              cursorHighlight={isCursorRow ? cursorHighlight : undefined}
               anchorId={plannedRow.anchorId}
               noteGuideSide={plannedRow.noteGuideSide}
               showAddNoteBadge={

--- a/src/ui/diff/diffSectionGeometry.ts
+++ b/src/ui/diff/diffSectionGeometry.ts
@@ -23,6 +23,8 @@ export interface DiffSectionRowBounds extends VerticalBounds {
   key: string;
   stableKey: string;
   stableKeys: string[];
+  /** Exact collapsed gap that produced this synthesized source row. */
+  expandedGapKey?: string;
 }
 
 /**
@@ -348,6 +350,11 @@ export function measureDiffSectionGeometry(
       key: row.key,
       stableKey: row.stableKey,
       stableKeys,
+      ...(row.kind === "diff-row" &&
+      (row.row.type === "split-line" || row.row.type === "stack-line") &&
+      row.row.expandedGapKey
+        ? { expandedGapKey: row.row.expandedGapKey }
+        : {}),
       // Record both the starting top and the measured height so callers can translate between
       // scroll positions and stable review-row identities across wrap/layout changes.
       top: bodyHeight,

--- a/src/ui/diff/expandCollapsedRows.test.ts
+++ b/src/ui/diff/expandCollapsedRows.test.ts
@@ -158,6 +158,7 @@ describe("expandCollapsedRows", () => {
     expect(first.right.lineNumber).toBe(1);
     expect(first.left.spans[0]?.text).toBe("alpha");
     expect(first.right.spans[0]?.text).toBe("alpha");
+    expect(first.expandedGapKey).toBe(gapKey("before", 0));
 
     const third = inserted[2];
     if (!third || third.type !== "split-line") {
@@ -188,6 +189,7 @@ describe("expandCollapsedRows", () => {
     expect(first.cell.oldLineNumber).toBe(2);
     expect(first.cell.newLineNumber).toBe(2);
     expect(first.cell.spans[0]?.text).toBe("beta");
+    expect(first.expandedGapKey).toBe(gapKey("before", 0));
   });
 
   test("changes the collapsed-row label to indicate expansion", () => {

--- a/src/ui/diff/expandCollapsedRows.ts
+++ b/src/ui/diff/expandCollapsedRows.ts
@@ -115,6 +115,7 @@ function buildSplitContextRow(
     left: cell(oldLineNumber),
     right: cell(newLineNumber),
     isExpansionRow: true,
+    expandedGapKey: gapKey(position, hunkIndex),
   };
 }
 
@@ -142,6 +143,7 @@ function buildStackContextRow(
     hunkIndex,
     cell,
     isExpansionRow: true,
+    expandedGapKey: gapKey(position, hunkIndex),
   };
 }
 

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -129,6 +129,8 @@ export type DiffRow =
       // Expanded rows carry the neighbor hunk's index for ordering but must not
       // count toward that hunk's bounds or anchor position.
       isExpansionRow?: true;
+      /** Exact collapsed gap this synthesized row reveals. */
+      expandedGapKey?: string;
     }
   | {
       type: "stack-line";
@@ -137,6 +139,8 @@ export type DiffRow =
       hunkIndex: number;
       cell: StackLineCell;
       isExpansionRow?: true;
+      /** Exact collapsed gap this synthesized row reveals. */
+      expandedGapKey?: string;
     };
 
 /** Expand source tabs before terminal rendering so downstream geometry stays predictable. */

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -42,6 +42,8 @@ import type { CopySelectedRowRange } from "../components/panes/copySelection";
 import type { CursorLine } from "../../core/types";
 
 export interface CursorHighlight {
+  /** The render plan anchor of the row the cursor rests on, shared with reveal lookups. */
+  stableKey: string;
   style: Exclude<CursorLine, "off">;
   /** Which half of a split row the cursor sits on, and where a note would anchor. */
   side: "old" | "new";

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -13,6 +13,7 @@ import {
   diffRailMarker,
   dimRailColor,
   neutralRailColor,
+  cursorLineHighlightBg,
   selectionHighlightBg,
   splitCellPalette,
   splitGutterText,
@@ -38,6 +39,22 @@ import {
   wrapSanitizedTextByWidth,
 } from "../lib/text";
 import type { CopySelectedRowRange } from "../components/panes/copySelection";
+import type { CursorLine } from "../../core/types";
+
+export interface CursorHighlight {
+  style: Exclude<CursorLine, "off">;
+  /** Which half of a split row the cursor sits on, and where a note would anchor. */
+  side: "old" | "new";
+}
+
+interface RowHighlight {
+  bg: (baseBg: string) => string;
+  /** Global columns to blend; absent blends the gutter alone. */
+  colRange?: CopySelectedRowRange;
+}
+
+/** Column span covering a row's whole content column, in the global columns selection uses. */
+const FULL_ROW_COL_RANGE: CopySelectedRowRange = { startCol: 0, endCol: Number.MAX_SAFE_INTEGER };
 
 /** Clamp a label to one terminal row with an ellipsis. */
 export function fitText(text: string, width: number) {
@@ -327,7 +344,7 @@ function renderInlineSpans(
   fallbackBg: string,
   keyPrefix: string,
   horizontalOffset = 0,
-  selectionTheme?: AppTheme,
+  highlightBg?: (baseBg: string) => string,
   selectionColRange?: { start: number; end: number },
   spansAreSanitized = false,
 ) {
@@ -336,7 +353,7 @@ function renderInlineSpans(
     horizontalOffset,
     width,
   );
-  const needsBlending = selectionTheme && selectionColRange;
+  const needsBlending = highlightBg && selectionColRange;
   const paddingAmount = Math.max(0, width - usedWidth);
   let paddingMerged = false;
   const lastSpan = trimmed.at(-1);
@@ -430,7 +447,7 @@ function renderInlineSpans(
         <span
           key={`${keyPrefix}:${elementIndex++}`}
           fg={span.fg ?? fallbackColor}
-          bg={selectionHighlightBg(span.bg ?? fallbackBg, selectionTheme)}
+          bg={highlightBg(span.bg ?? fallbackBg)}
         >
           {selected}
         </span>,
@@ -473,11 +490,7 @@ function renderInlineSpans(
         }
         if (inSel > 0) {
           elements.push(
-            <span
-              key={`${keyPrefix}:pad-sel`}
-              fg={fallbackColor}
-              bg={selectionHighlightBg(fallbackBg, selectionTheme)}
-            >
+            <span key={`${keyPrefix}:pad-sel`} fg={fallbackColor} bg={highlightBg(fallbackBg)}>
               {" ".repeat(inSel)}
             </span>,
           );
@@ -1126,27 +1139,30 @@ function resolvePlainContentWidth(totalWidth: number, prefixWidth: number, gutte
 }
 
 /**
- * Apply the selection-highlight blend to a cell palette's gutter bg only.
+ * Apply a highlight blend to a cell palette's gutter bg only.
  *
  * The content bg is intentionally left untouched here so renderInlineSpans can apply the same
  * blend uniformly across every rendered span (including syntax-emphasis spans that supply their
  * own bg). Pre-blending contentBg would cause the fallback path to double-blend.
  */
-function applySelectionPalette<P extends { gutterBg: string; contentBg: string }>(
+function applyHighlightPalette<P extends { gutterBg: string; contentBg: string }>(
   palette: P,
-  theme: AppTheme,
+  highlightBg: (baseBg: string) => string,
 ): P {
   return {
     ...palette,
-    gutterBg: selectionHighlightBg(palette.gutterBg, theme),
+    gutterBg: highlightBg(palette.gutterBg),
   };
 }
 
-/** Apply the selection-highlight blend to a prefix descriptor. */
-function applySelectionPrefix<P extends { bg: string }>(prefix: P, theme: AppTheme): P {
+/** Apply a highlight blend to a prefix descriptor. */
+function applyHighlightPrefix<P extends { bg: string }>(
+  prefix: P,
+  highlightBg: (baseBg: string) => string,
+): P {
   return {
     ...prefix,
-    bg: selectionHighlightBg(prefix.bg, theme),
+    bg: highlightBg(prefix.bg),
   };
 }
 
@@ -1164,13 +1180,12 @@ function renderSplitCell(
     fg: string;
     bg: string;
   },
-  selected = false,
-  selectionColRange?: CopySelectedRowRange,
+  highlight?: RowHighlight,
   paneOffset = 0,
 ) {
   const basePalette = splitCellPalette(cell.kind, theme, cell.moveKind);
-  const palette = selected ? applySelectionPalette(basePalette, theme) : basePalette;
-  const resolvedPrefix = selected && prefix ? applySelectionPrefix(prefix, theme) : prefix;
+  const palette = highlight ? applyHighlightPalette(basePalette, highlight.bg) : basePalette;
+  const resolvedPrefix = highlight && prefix ? applyHighlightPrefix(prefix, highlight.bg) : prefix;
   const prefixWidth = resolvedPrefix?.text.length ?? 0;
   const { gutterWidth, contentWidth } = resolveSplitCellGeometry(
     width,
@@ -1182,14 +1197,12 @@ function renderSplitCell(
 
   // Convert global selection column range to content-local range.
   const globalContentStart = paneOffset + prefixWidth + gutterWidth;
+  const colRange = highlight?.colRange;
   const localColRange =
-    selectionColRange && globalContentStart < selectionColRange.endCol
+    colRange && globalContentStart < colRange.endCol
       ? {
-          start: Math.max(0, selectionColRange.startCol - globalContentStart),
-          end: Math.min(
-            contentWidth,
-            Math.max(0, selectionColRange.endCol - globalContentStart + 1),
-          ),
+          start: Math.max(0, colRange.startCol - globalContentStart),
+          end: Math.min(contentWidth, Math.max(0, colRange.endCol - globalContentStart + 1)),
         }
       : undefined;
 
@@ -1210,7 +1223,7 @@ function renderSplitCell(
         palette.contentBg,
         `${keyPrefix}:content`,
         contentOffset,
-        selected ? theme : undefined,
+        highlight?.bg,
         localColRange,
       )}
     </>
@@ -1231,12 +1244,11 @@ function renderStackCell(
     fg: string;
     bg: string;
   },
-  selected = false,
-  selectionColRange?: CopySelectedRowRange,
+  highlight?: RowHighlight,
 ) {
   const basePalette = stackCellPalette(cell.kind, theme, cell.moveKind);
-  const palette = selected ? applySelectionPalette(basePalette, theme) : basePalette;
-  const resolvedPrefix = selected && prefix ? applySelectionPrefix(prefix, theme) : prefix;
+  const palette = highlight ? applyHighlightPalette(basePalette, highlight.bg) : basePalette;
+  const resolvedPrefix = highlight && prefix ? applyHighlightPrefix(prefix, highlight.bg) : prefix;
   const prefixWidth = resolvedPrefix?.text.length ?? 0;
   const { gutterWidth, contentWidth } = resolveStackCellGeometry(
     width,
@@ -1247,14 +1259,12 @@ function renderStackCell(
 
   // Convert global selection column range to content-local range.
   const globalContentStart = prefixWidth + gutterWidth;
+  const colRange = highlight?.colRange;
   const localColRange =
-    selectionColRange && globalContentStart < selectionColRange.endCol
+    colRange && globalContentStart < colRange.endCol
       ? {
-          start: Math.max(0, selectionColRange.startCol - globalContentStart),
-          end: Math.min(
-            contentWidth,
-            Math.max(0, selectionColRange.endCol - globalContentStart + 1),
-          ),
+          start: Math.max(0, colRange.startCol - globalContentStart),
+          end: Math.min(contentWidth, Math.max(0, colRange.endCol - globalContentStart + 1)),
         }
       : undefined;
 
@@ -1275,7 +1285,7 @@ function renderStackCell(
         palette.contentBg,
         `${keyPrefix}:content`,
         contentOffset,
-        selected ? theme : undefined,
+        highlight?.bg,
         localColRange,
       )}
     </>
@@ -1294,24 +1304,21 @@ function renderWrappedSplitCellLine(
     fg: string;
     bg: string;
   },
-  selected = false,
-  selectionColRange?: CopySelectedRowRange,
+  highlight?: RowHighlight,
   paneOffset = 0,
 ) {
-  const resolvedPalette = selected ? applySelectionPalette(palette, theme) : palette;
-  const resolvedPrefix = selected ? applySelectionPrefix(prefix, theme) : prefix;
+  const resolvedPalette = highlight ? applyHighlightPalette(palette, highlight.bg) : palette;
+  const resolvedPrefix = highlight ? applyHighlightPrefix(prefix, highlight.bg) : prefix;
 
   const prefixWidth = prefix.text.length;
   const gutterWidth = line.gutterText.length;
   const globalContentStart = paneOffset + prefixWidth + gutterWidth;
+  const colRange = highlight?.colRange;
   const localColRange =
-    selectionColRange && globalContentStart < selectionColRange.endCol
+    colRange && globalContentStart < colRange.endCol
       ? {
-          start: Math.max(0, selectionColRange.startCol - globalContentStart),
-          end: Math.min(
-            contentWidth,
-            Math.max(0, selectionColRange.endCol - globalContentStart + 1),
-          ),
+          start: Math.max(0, colRange.startCol - globalContentStart),
+          end: Math.min(contentWidth, Math.max(0, colRange.endCol - globalContentStart + 1)),
         }
       : undefined;
 
@@ -1334,7 +1341,7 @@ function renderWrappedSplitCellLine(
         resolvedPalette.contentBg,
         `${keyPrefix}:content`,
         0,
-        selected ? theme : undefined,
+        highlight?.bg,
         localColRange,
         true,
       )}
@@ -1354,23 +1361,20 @@ function renderWrappedStackCellLine(
     fg: string;
     bg: string;
   },
-  selected = false,
-  selectionColRange?: CopySelectedRowRange,
+  highlight?: RowHighlight,
 ) {
-  const resolvedPalette = selected ? applySelectionPalette(palette, theme) : palette;
-  const resolvedPrefix = selected ? applySelectionPrefix(prefix, theme) : prefix;
+  const resolvedPalette = highlight ? applyHighlightPalette(palette, highlight.bg) : palette;
+  const resolvedPrefix = highlight ? applyHighlightPrefix(prefix, highlight.bg) : prefix;
 
   const prefixWidth = prefix.text.length;
   const gutterWidth = line.gutterText.length;
   const globalContentStart = prefixWidth + gutterWidth;
+  const colRange = highlight?.colRange;
   const localColRange =
-    selectionColRange && globalContentStart < selectionColRange.endCol
+    colRange && globalContentStart < colRange.endCol
       ? {
-          start: Math.max(0, selectionColRange.startCol - globalContentStart),
-          end: Math.min(
-            contentWidth,
-            Math.max(0, selectionColRange.endCol - globalContentStart + 1),
-          ),
+          start: Math.max(0, colRange.startCol - globalContentStart),
+          end: Math.min(contentWidth, Math.max(0, colRange.endCol - globalContentStart + 1)),
         }
       : undefined;
 
@@ -1393,7 +1397,7 @@ function renderWrappedStackCellLine(
         resolvedPalette.contentBg,
         `${keyPrefix}:content`,
         0,
-        selected ? theme : undefined,
+        highlight?.bg,
         localColRange,
         true,
       )}
@@ -1667,6 +1671,7 @@ function renderRow(
   selected: boolean,
   copySelectedRowRange: CopySelectedRowRange | undefined,
   copySelectedSide: "left" | "right" | undefined,
+  cursorHighlight: CursorHighlight | undefined,
   anchorId?: string,
   noteGuideSide?: "old" | "new",
   showAddNoteBadge = false,
@@ -1682,6 +1687,41 @@ function renderRow(
   // selection represents.
   const hasLeftSelection = hasCopySelection && copySelectedSide !== "right";
   const hasRightSelection = hasCopySelection && copySelectedSide !== "left";
+
+  // An active drag outranks the resting cursor, so copy selection keeps its exact extent. On a
+  // split change row the two sides are different note targets, so each resolves separately.
+  const resolveHighlight = (hasSelection: boolean, onCursor: boolean): RowHighlight | undefined => {
+    if (hasSelection) {
+      return {
+        bg: (baseBg) => selectionHighlightBg(baseBg, theme),
+        colRange: copySelectedRowRange,
+      };
+    }
+
+    if (!onCursor) {
+      return undefined;
+    }
+
+    return {
+      bg: (baseBg) => cursorLineHighlightBg(baseBg, theme),
+      colRange: cursorHighlight?.style === "row" ? FULL_ROW_COL_RANGE : undefined,
+    };
+  };
+
+  // A split context row shows the same source line on both halves, so marking one of them would
+  // read as half a row. Change rows keep the split, since the halves are different note targets.
+  const splitContextRow =
+    row.type === "split-line" && row.left.kind === "context" && row.right.kind === "context";
+  const onCursorRow = cursorHighlight !== undefined;
+  const leftHighlight = resolveHighlight(
+    hasLeftSelection,
+    onCursorRow && (splitContextRow || cursorHighlight.side === "old"),
+  );
+  const rightHighlight = resolveHighlight(
+    hasRightSelection,
+    onCursorRow && (splitContextRow || cursorHighlight.side === "new"),
+  );
+  const cellHighlight = resolveHighlight(hasCopySelection, cursorHighlight !== undefined);
   let baseRow: ReactNode;
 
   if (row.type === "collapsed") {
@@ -1760,8 +1800,7 @@ function renderRow(
                 `${row.key}:left`,
                 codeHorizontalOffset,
                 leftPrefix,
-                hasLeftSelection,
-                hasLeftSelection ? copySelectedRowRange : undefined,
+                leftHighlight,
                 0,
               )}
               {renderSplitCell(
@@ -1773,8 +1812,7 @@ function renderRow(
                 `${row.key}:right`,
                 codeHorizontalOffset,
                 rightPrefix,
-                hasRightSelection,
-                hasRightSelection ? copySelectedRowRange : undefined,
+                rightHighlight,
                 leftWidth,
               )}
               {guideOnNewSide ? (
@@ -1836,7 +1874,7 @@ function renderRow(
 
             const showBadgeOnLine = showAddNoteBadge && index === 0;
             let styledRow: StyledText;
-            if (hasCopySelection) {
+            if (leftHighlight || rightHighlight) {
               styledRow = styledTextFromSpanNodes([
                 renderWrappedSplitCellLine(
                   leftLine,
@@ -1845,8 +1883,7 @@ function renderRow(
                   theme,
                   `${row.key}:left:${index}`,
                   leftPrefix,
-                  hasLeftSelection,
-                  copySelectedRowRange,
+                  leftHighlight,
                   0,
                 ),
                 renderWrappedSplitCellLine(
@@ -1856,8 +1893,7 @@ function renderRow(
                   theme,
                   `${row.key}:right:${index}`,
                   rightPrefix,
-                  hasRightSelection,
-                  copySelectedRowRange,
+                  rightHighlight,
                   leftWidth,
                 ),
                 guideOnNewSide ? (
@@ -1975,8 +2011,7 @@ function renderRow(
                 `${row.key}:stack`,
                 codeHorizontalOffset,
                 prefix,
-                hasCopySelection,
-                hasCopySelection ? copySelectedRowRange : undefined,
+                cellHighlight,
               )}
               {guideOnNewSide ? (
                 <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
@@ -2022,8 +2057,7 @@ function renderRow(
                 theme,
                 `${row.key}:stack:${index}`,
                 prefix,
-                hasCopySelection,
-                hasCopySelection ? copySelectedRowRange : undefined,
+                cellHighlight,
               ),
               guideOnNewSide ? (
                 <span key={`${row.key}:note-guide:${index}`} fg={theme.noteBorder}>
@@ -2088,6 +2122,7 @@ interface DiffRowViewProps {
   selected: boolean;
   copySelectedRowRange?: CopySelectedRowRange;
   copySelectedSide?: "left" | "right";
+  cursorHighlight?: CursorHighlight;
   anchorId?: string;
   noteGuideSide?: "old" | "new";
   showAddNoteBadge?: boolean;
@@ -2116,6 +2151,7 @@ export const DiffRowView = memo(
     selected,
     copySelectedRowRange,
     copySelectedSide,
+    cursorHighlight,
     anchorId,
     noteGuideSide,
     showAddNoteBadge,
@@ -2135,6 +2171,7 @@ export const DiffRowView = memo(
       selected,
       copySelectedRowRange,
       copySelectedSide,
+      cursorHighlight,
       anchorId,
       noteGuideSide,
       showAddNoteBadge,
@@ -2156,6 +2193,7 @@ export const DiffRowView = memo(
       previous.selected === next.selected &&
       previous.copySelectedRowRange === next.copySelectedRowRange &&
       previous.copySelectedSide === next.copySelectedSide &&
+      previous.cursorHighlight === next.cursorHighlight &&
       previous.anchorId === next.anchorId &&
       previous.noteGuideSide === next.noteGuideSide &&
       previous.showAddNoteBadge === next.showAddNoteBadge &&

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -49,6 +49,17 @@ export interface CursorHighlight {
   side: "old" | "new";
 }
 
+/** Report whether one planned row carries the anchor the cursor rests on. */
+export function plannedRowMatchesCursor(
+  row: { stableKey: string; stableAliasKeys?: readonly string[] },
+  cursor: CursorHighlight | undefined,
+) {
+  return (
+    cursor !== undefined &&
+    (row.stableKey === cursor.stableKey || row.stableAliasKeys?.includes(cursor.stableKey) === true)
+  );
+}
+
 interface RowHighlight {
   bg: (baseBg: string) => string;
   /** Global columns to blend; absent blends the gutter alone. */
@@ -1157,6 +1168,23 @@ function applyHighlightPalette<P extends { gutterBg: string; contentBg: string }
   };
 }
 
+/**
+ * Choose which highlight paints one half of a row.
+ *
+ * An active drag outranks the resting cursor, so copy selection keeps its exact extent.
+ */
+function pickRowHighlight(
+  selection: RowHighlight,
+  cursor: RowHighlight | undefined,
+  hasSelection: boolean,
+  onCursor: boolean,
+) {
+  if (hasSelection) {
+    return selection;
+  }
+  return onCursor ? cursor : undefined;
+}
+
 /** Apply a highlight blend to a prefix descriptor. */
 function applyHighlightPrefix<P extends { bg: string }>(
   prefix: P,
@@ -1690,40 +1718,39 @@ function renderRow(
   const hasLeftSelection = hasCopySelection && copySelectedSide !== "right";
   const hasRightSelection = hasCopySelection && copySelectedSide !== "left";
 
-  // An active drag outranks the resting cursor, so copy selection keeps its exact extent. On a
-  // split change row the two sides are different note targets, so each resolves separately.
-  const resolveHighlight = (hasSelection: boolean, onCursor: boolean): RowHighlight | undefined => {
-    if (hasSelection) {
-      return {
-        bg: (baseBg) => selectionHighlightBg(baseBg, theme),
-        colRange: copySelectedRowRange,
-      };
-    }
-
-    if (!onCursor) {
-      return undefined;
-    }
-
-    return {
-      bg: (baseBg) => cursorLineHighlightBg(baseBg, theme),
-      colRange: cursorHighlight?.style === "row" ? FULL_ROW_COL_RANGE : undefined,
-    };
-  };
-
   // A split context row shows the same source line on both halves, so marking one of them would
   // read as half a row. Change rows keep the split, since the halves are different note targets.
   const splitContextRow =
     row.type === "split-line" && row.left.kind === "context" && row.right.kind === "context";
   const onCursorRow = cursorHighlight !== undefined;
-  const leftHighlight = resolveHighlight(
+  const selectionHighlight: RowHighlight = {
+    bg: (baseBg) => selectionHighlightBg(baseBg, theme),
+    colRange: copySelectedRowRange,
+  };
+  const cursorRowHighlight: RowHighlight | undefined = onCursorRow
+    ? {
+        bg: (baseBg) => cursorLineHighlightBg(baseBg, theme),
+        colRange: cursorHighlight.style === "row" ? FULL_ROW_COL_RANGE : undefined,
+      }
+    : undefined;
+  const leftHighlight = pickRowHighlight(
+    selectionHighlight,
+    cursorRowHighlight,
     hasLeftSelection,
     onCursorRow && (splitContextRow || cursorHighlight.side === "old"),
   );
-  const rightHighlight = resolveHighlight(
+  const rightHighlight = pickRowHighlight(
+    selectionHighlight,
+    cursorRowHighlight,
     hasRightSelection,
     onCursorRow && (splitContextRow || cursorHighlight.side === "new"),
   );
-  const cellHighlight = resolveHighlight(hasCopySelection, cursorHighlight !== undefined);
+  const cellHighlight = pickRowHighlight(
+    selectionHighlight,
+    cursorRowHighlight,
+    hasCopySelection,
+    onCursorRow,
+  );
   let baseRow: ReactNode;
 
   if (row.type === "collapsed") {

--- a/src/ui/diff/reviewRenderPlan.test.ts
+++ b/src/ui/diff/reviewRenderPlan.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { parseDiffFromFile } from "@pierre/diffs";
 import type { DiffFile } from "../../core/types";
-import type { PlannedReviewRow } from "./reviewRenderPlan";
+import {
+  contextLineStableKeyTarget,
+  lineStableKey,
+  lineStableKeyTarget,
+  type PlannedReviewRow,
+} from "./reviewRenderPlan";
 import { resolveTheme } from "../themes";
 
 const { buildSplitRows, buildStackRows } = await import("./pierre");
@@ -364,5 +369,40 @@ describe("review render plan", () => {
       "annotation:counted:0:0",
     ]);
     expect(inlineNotes.every((row) => row.noteIndex === 0 && row.noteCount === 1)).toBe(true);
+  });
+});
+
+describe("line stable key targets", () => {
+  test("reads a single-sided anchor back into a note target", () => {
+    expect(lineStableKeyTarget(lineStableKey(2, "old", 41))).toEqual({
+      hunkIndex: 2,
+      side: "old",
+      line: 41,
+    });
+    expect(lineStableKeyTarget(lineStableKey(0, "new", 7))).toEqual({
+      hunkIndex: 0,
+      side: "new",
+      line: 7,
+    });
+  });
+
+  test("reads a shared context anchor as its new-side line", () => {
+    expect(contextLineStableKeyTarget("line:3:context:12:14")).toEqual({
+      hunkIndex: 3,
+      side: "new",
+      line: 14,
+    });
+  });
+
+  test("keeps the two anchor shapes apart", () => {
+    expect(lineStableKeyTarget("line:3:context:12:14")).toBeNull();
+    expect(contextLineStableKeyTarget(lineStableKey(3, "new", 14))).toBeNull();
+  });
+
+  test("ignores anchors that do not name a source line", () => {
+    for (const stableKey of ["meta:hunk-header:1", "meta:collapsed:before:0", "inline-note:x"]) {
+      expect(lineStableKeyTarget(stableKey)).toBeNull();
+      expect(contextLineStableKeyTarget(stableKey)).toBeNull();
+    }
   });
 });

--- a/src/ui/diff/reviewRenderPlan.test.ts
+++ b/src/ui/diff/reviewRenderPlan.test.ts
@@ -60,7 +60,7 @@ function firstInlineNote(plannedRows: PlannedReviewRow[]) {
 
 function inlineNoteAnchorRow(plannedRows: PlannedReviewRow[]) {
   const noteIndex = plannedRows.findIndex((row) => row.kind === "inline-note");
-  return noteIndex >= 0 ? plannedRows[noteIndex + 1] : undefined;
+  return noteIndex > 0 ? plannedRows[noteIndex - 1] : undefined;
 }
 
 function guidedSplitLineNumbers(plannedRows: PlannedReviewRow[], side: "old" | "new") {
@@ -74,7 +74,7 @@ function guidedSplitLineNumbers(plannedRows: PlannedReviewRow[], side: "old" | "
 }
 
 describe("review render plan", () => {
-  test("inserts an inline note before the anchor row and starts the guide after the anchor", () => {
+  test("inserts an inline note after the anchor row and starts the guide below the note", () => {
     const theme = resolveTheme("github-dark-default", null);
     const file = createDiffFile(
       "alpha",
@@ -120,7 +120,7 @@ describe("review render plan", () => {
     expect(guidedSplitLineNumbers(plannedRows, "new")).toEqual([3]);
   });
 
-  test("anchors deletion-only notes to old-side rows without a dangling guide below the note", () => {
+  test("anchors deletion-only notes to old-side rows without a dangling guide above the note", () => {
     const theme = resolveTheme("github-dark-default", null);
     const file = createDiffFile(
       "deleted",

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -67,14 +67,19 @@ function uniqueStableKeys(keys: Array<string | undefined>) {
   return next;
 }
 
+/** Build the file-scoped stable anchor for one source line on either diff side. */
+export function lineStableKey(hunkIndex: number, side: "old" | "new", lineNumber: number) {
+  return `line:${hunkIndex}:${side}:${lineNumber}`;
+}
+
 /** Build the file-scoped stable anchor for one old-side source line. */
 function oldLineStableKey(hunkIndex: number, lineNumber?: number) {
-  return lineNumber === undefined ? undefined : `line:${hunkIndex}:old:${lineNumber}`;
+  return lineNumber === undefined ? undefined : lineStableKey(hunkIndex, "old", lineNumber);
 }
 
 /** Build the file-scoped stable anchor for one new-side source line. */
 function newLineStableKey(hunkIndex: number, lineNumber?: number) {
-  return lineNumber === undefined ? undefined : `line:${hunkIndex}:new:${lineNumber}`;
+  return lineNumber === undefined ? undefined : lineStableKey(hunkIndex, "new", lineNumber);
 }
 
 /** Build the file-scoped stable anchor for one context row shared by both sides. */

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -225,9 +225,9 @@ function rowOverlapsAnnotation(row: DiffLineRow, annotation: AgentAnnotation) {
 }
 
 /**
- * Resolve the rendered diff row before which the inline note should appear.
+ * Resolve the rendered diff row after which the inline note should appear.
  * Range-less notes intentionally anchor beside the first code row in the file,
- * not above hunk header metadata.
+ * not against hunk header metadata.
  */
 function findInlineNoteAnchorRow(rows: DiffRow[], annotation: AgentAnnotation) {
   const fileLineRows = lineRows(rows);
@@ -250,8 +250,8 @@ function buildInlineVisibleNotePlacements(rows: DiffRow[], visibleAgentNotes: Vi
 
     const anchorSide = annotationAnchor(note.annotation)?.side;
     const coveredRows = fileLineRows.filter((row) => rowOverlapsAnnotation(row, note.annotation));
-    // The inline card already sits directly above its anchor; start any range guide after that row
-    // so the first code line below the note does not show a dangling right-gutter connector.
+    // The card sits directly below its anchor, so guiding that row too would draw a connector
+    // above the note with nothing above it to connect to.
     const guideRows = coveredRows.filter((row) => row.key !== anchorRow.key);
     const anchorPlacements = placementsByAnchor.get(anchorRow.key) ?? [];
 
@@ -348,6 +348,18 @@ export function buildReviewRenderPlan({
       anchoredHunks.add(row.hunkIndex);
     }
 
+    plannedRows.push({
+      kind: "diff-row",
+      key: `diff-row:${row.key}`,
+      stableKey: diffStableKey,
+      stableAliasKeys: diffStableAliasKeys,
+      fileId: row.fileId,
+      hunkIndex: row.hunkIndex,
+      row,
+      anchorId,
+      noteGuideSide: noteGuideSideByRowKey.get(row.key),
+    });
+
     const anchoredNotes = placementsByAnchor.get(row.key) ?? [];
     anchoredNotes.forEach((placement) => {
       plannedRows.push({
@@ -363,18 +375,6 @@ export function buildReviewRenderPlan({
         noteCount: placement.noteCount,
         noteIndex: placement.noteIndex,
       });
-    });
-
-    plannedRows.push({
-      kind: "diff-row",
-      key: `diff-row:${row.key}`,
-      stableKey: diffStableKey,
-      stableAliasKeys: diffStableAliasKeys,
-      fileId: row.fileId,
-      hunkIndex: row.hunkIndex,
-      row,
-      anchorId,
-      noteGuideSide: noteGuideSideByRowKey.get(row.key),
     });
   }
 

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -1,4 +1,4 @@
-import type { AgentAnnotation } from "../../core/types";
+import type { AgentAnnotation, UserNoteLineTarget } from "../../core/types";
 import { annotationAnchor, type VisibleAgentNote } from "../lib/agentAnnotations";
 import { diffHunkId } from "../lib/ids";
 import type { DiffRow } from "./pierre";
@@ -87,6 +87,42 @@ function contextLineStableKey(hunkIndex: number, oldLineNumber?: number, newLine
   return oldLineNumber === undefined || newLineNumber === undefined
     ? undefined
     : `line:${hunkIndex}:context:${oldLineNumber}:${newLineNumber}`;
+}
+
+const SIDED_LINE_STABLE_KEY = /^line:(\d+):(old|new):(\d+)$/;
+const CONTEXT_LINE_STABLE_KEY = /^line:(\d+):context:\d+:(\d+)$/;
+
+/**
+ * Recover the source line one single-sided stable anchor names.
+ *
+ * Line navigation walks measured rows, so it has to read targets back out of the same anchors the
+ * plan writes rather than re-deriving them from the parsed diff.
+ */
+export function lineStableKeyTarget(
+  stableKey: string,
+): (UserNoteLineTarget & { hunkIndex: number }) | null {
+  const match = SIDED_LINE_STABLE_KEY.exec(stableKey);
+  if (!match) {
+    return null;
+  }
+
+  return { hunkIndex: Number(match[1]), side: match[2] as "old" | "new", line: Number(match[3]) };
+}
+
+/**
+ * Recover the source line one shared context anchor names.
+ *
+ * Resolves to the new side, which is what the add-note affordance already anchors to.
+ */
+export function contextLineStableKeyTarget(
+  stableKey: string,
+): (UserNoteLineTarget & { hunkIndex: number }) | null {
+  const match = CONTEXT_LINE_STABLE_KEY.exec(stableKey);
+  if (!match) {
+    return null;
+  }
+
+  return { hunkIndex: Number(match[1]), side: "new", line: Number(match[2]) };
 }
 
 /** Resolve the stable anchor keys for one rendered diff row across split and stack layouts. */

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -72,6 +72,11 @@ export function lineStableKey(hunkIndex: number, side: "old" | "new", lineNumber
   return `line:${hunkIndex}:${side}:${lineNumber}`;
 }
 
+/** Build the stable anchor for one inline note card. */
+export function inlineNoteStableKey(noteId: string) {
+  return `inline-note:${noteId}`;
+}
+
 /** Build the file-scoped stable anchor for one old-side source line. */
 function oldLineStableKey(hunkIndex: number, lineNumber?: number) {
   return lineNumber === undefined ? undefined : lineStableKey(hunkIndex, "old", lineNumber);
@@ -92,12 +97,7 @@ function contextLineStableKey(hunkIndex: number, oldLineNumber?: number, newLine
 const SIDED_LINE_STABLE_KEY = /^line:(\d+):(old|new):(\d+)$/;
 const CONTEXT_LINE_STABLE_KEY = /^line:(\d+):context:\d+:(\d+)$/;
 
-/**
- * Recover the source line one single-sided stable anchor names.
- *
- * Line navigation walks measured rows, so it has to read targets back out of the same anchors the
- * plan writes rather than re-deriving them from the parsed diff.
- */
+/** Recover the source line one single-sided stable anchor names. */
 export function lineStableKeyTarget(
   stableKey: string,
 ): (UserNoteLineTarget & { hunkIndex: number }) | null {
@@ -250,8 +250,6 @@ function buildInlineVisibleNotePlacements(rows: DiffRow[], visibleAgentNotes: Vi
 
     const anchorSide = annotationAnchor(note.annotation)?.side;
     const coveredRows = fileLineRows.filter((row) => rowOverlapsAnnotation(row, note.annotation));
-    // The card sits directly below its anchor, so guiding that row too would draw a connector
-    // above the note with nothing above it to connect to.
     const guideRows = coveredRows.filter((row) => row.key !== anchorRow.key);
     const anchorPlacements = placementsByAnchor.get(anchorRow.key) ?? [];
 
@@ -365,7 +363,7 @@ export function buildReviewRenderPlan({
       plannedRows.push({
         kind: "inline-note",
         key: `inline-note:${placement.note.id}:${row.key}:${placement.noteIndex}`,
-        stableKey: `inline-note:${placement.note.id}`,
+        stableKey: inlineNoteStableKey(placement.note.id),
         fileId,
         hunkIndex: placement.hunkIndex,
         annotationId: placement.note.id,

--- a/src/ui/diff/rowStyle.test.ts
+++ b/src/ui/diff/rowStyle.test.ts
@@ -32,8 +32,6 @@ describe("cursorLineHighlightBg", () => {
     const context = stackCellPalette("context", DARK).contentBg;
     const added = stackCellPalette("addition", DARK).contentBg;
 
-    // Blending toward one fixed highlight color barely moved a background already sharing its
-    // hue, which left the marker invisible on added rows.
     const shift = (from: string) => {
       const to = cursorLineHighlightBg(from, DARK);
       return contrastRatio(to, from);

--- a/src/ui/diff/rowStyle.test.ts
+++ b/src/ui/diff/rowStyle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { contrastRatio } from "../lib/color";
+import { THEMES, TRANSPARENT_BACKGROUND, withTransparentSurfaces } from "../themes";
+import { cursorLineHighlightBg, stackCellPalette } from "./rowStyle";
+
+const DARK = THEMES.find((theme) => theme.id === "github-dark-dimmed")!;
+const LIGHT = THEMES.find((theme) => theme.id === "github-light-default")!;
+
+describe("cursorLineHighlightBg", () => {
+  test("marks context rows on transparent surfaces", () => {
+    for (const base of [DARK, LIGHT]) {
+      const theme = withTransparentSurfaces(base);
+      const context = stackCellPalette("context", theme);
+
+      expect(context.contentBg).toBe(TRANSPARENT_BACKGROUND);
+      expect(cursorLineHighlightBg(context.contentBg, theme)).not.toBe(TRANSPARENT_BACKGROUND);
+    }
+  });
+
+  test("keeps the marked row readable on every built-in theme", () => {
+    for (const base of THEMES) {
+      for (const theme of [base, withTransparentSurfaces(base)]) {
+        for (const kind of ["context", "addition", "deletion"] as const) {
+          const marked = cursorLineHighlightBg(stackCellPalette(kind, theme).contentBg, theme);
+          expect(contrastRatio(theme.text, marked)).toBeGreaterThan(3);
+        }
+      }
+    }
+  });
+
+  test("moves added and removed rows as far as it moves context rows", () => {
+    const context = stackCellPalette("context", DARK).contentBg;
+    const added = stackCellPalette("addition", DARK).contentBg;
+
+    // Blending toward one fixed highlight color barely moved a background already sharing its
+    // hue, which left the marker invisible on added rows.
+    const shift = (from: string) => {
+      const to = cursorLineHighlightBg(from, DARK);
+      return contrastRatio(to, from);
+    };
+
+    expect(shift(added)).toBeGreaterThan(1.2);
+    expect(shift(context)).toBeGreaterThan(1.2);
+  });
+});

--- a/src/ui/diff/rowStyle.ts
+++ b/src/ui/diff/rowStyle.ts
@@ -1,10 +1,12 @@
-import type { AppTheme } from "../themes";
+import { TRANSPARENT_BACKGROUND, type AppTheme } from "../themes";
 import { blendHex } from "../lib/color";
 import type { SplitLineCell, StackLineCell } from "./pierre";
 
 const INACTIVE_RAIL_BLEND = 0.35;
 const SELECTION_BG_BLEND = 0.75;
+const CURSOR_LINE_BG_BLEND = 0.2;
 const selectionBackgroundCache = new WeakMap<AppTheme, Map<string, string>>();
+const cursorLineBackgroundCache = new WeakMap<AppTheme, Map<string, string>>();
 
 /** The diff rail marker is always visible in Hunk stack and split rows. */
 export function diffRailMarker() {
@@ -27,6 +29,35 @@ export function selectionHighlightBg(baseBg: string, theme: AppTheme) {
   let background = backgrounds.get(baseBg);
   if (!background) {
     background = blendHex(theme.selectedHunk, baseBg, SELECTION_BG_BLEND);
+    backgrounds.set(baseBg, background);
+  }
+  return background;
+}
+
+/**
+ * Lift a cell background toward the theme text color to mark the current line.
+ *
+ * Shifts luminance rather than hue: blending toward one fixed color barely moves a background
+ * already sharing that hue, which left the marker invisible on added rows.
+ */
+export function cursorLineHighlightBg(baseBg: string, theme: AppTheme) {
+  // Marking a row means painting it, so a transparent surface still gets a band. Blend from the
+  // appearance's own extreme, since reading the sentinel as a color yields black on light themes.
+  const source =
+    baseBg === TRANSPARENT_BACKGROUND
+      ? theme.appearance === "dark"
+        ? "#000000"
+        : "#ffffff"
+      : baseBg;
+
+  let backgrounds = cursorLineBackgroundCache.get(theme);
+  if (!backgrounds) {
+    backgrounds = new Map();
+    cursorLineBackgroundCache.set(theme, backgrounds);
+  }
+  let background = backgrounds.get(baseBg);
+  if (!background) {
+    background = blendHex(theme.text, source, CURSOR_LINE_BG_BLEND);
     backgrounds.set(baseBg, background);
   }
   return background;

--- a/src/ui/diff/rowStyle.ts
+++ b/src/ui/diff/rowStyle.ts
@@ -8,6 +8,26 @@ const CURSOR_LINE_BG_BLEND = 0.2;
 const selectionBackgroundCache = new WeakMap<AppTheme, Map<string, string>>();
 const cursorLineBackgroundCache = new WeakMap<AppTheme, Map<string, string>>();
 
+/** Memoize one derived row background per theme and base color. */
+function cachedRowBackground(
+  cache: WeakMap<AppTheme, Map<string, string>>,
+  theme: AppTheme,
+  baseBg: string,
+  blend: () => string,
+) {
+  let backgrounds = cache.get(theme);
+  if (!backgrounds) {
+    backgrounds = new Map();
+    cache.set(theme, backgrounds);
+  }
+  let background = backgrounds.get(baseBg);
+  if (background === undefined) {
+    background = blend();
+    backgrounds.set(baseBg, background);
+  }
+  return background;
+}
+
 /** The diff rail marker is always visible in Hunk stack and split rows. */
 export function diffRailMarker() {
   return "▌";
@@ -21,17 +41,9 @@ export function diffRailMarker() {
  * harder toward the visible highlight color.
  */
 export function selectionHighlightBg(baseBg: string, theme: AppTheme) {
-  let backgrounds = selectionBackgroundCache.get(theme);
-  if (!backgrounds) {
-    backgrounds = new Map();
-    selectionBackgroundCache.set(theme, backgrounds);
-  }
-  let background = backgrounds.get(baseBg);
-  if (!background) {
-    background = blendHex(theme.selectedHunk, baseBg, SELECTION_BG_BLEND);
-    backgrounds.set(baseBg, background);
-  }
-  return background;
+  return cachedRowBackground(selectionBackgroundCache, theme, baseBg, () =>
+    blendHex(theme.selectedHunk, baseBg, SELECTION_BG_BLEND),
+  );
 }
 
 /**
@@ -41,26 +53,17 @@ export function selectionHighlightBg(baseBg: string, theme: AppTheme) {
  * already sharing that hue, which left the marker invisible on added rows.
  */
 export function cursorLineHighlightBg(baseBg: string, theme: AppTheme) {
-  // Marking a row means painting it, so a transparent surface still gets a band. Blend from the
-  // appearance's own extreme, since reading the sentinel as a color yields black on light themes.
-  const source =
-    baseBg === TRANSPARENT_BACKGROUND
-      ? theme.appearance === "dark"
-        ? "#000000"
-        : "#ffffff"
-      : baseBg;
-
-  let backgrounds = cursorLineBackgroundCache.get(theme);
-  if (!backgrounds) {
-    backgrounds = new Map();
-    cursorLineBackgroundCache.set(theme, backgrounds);
-  }
-  let background = backgrounds.get(baseBg);
-  if (!background) {
-    background = blendHex(theme.text, source, CURSOR_LINE_BG_BLEND);
-    backgrounds.set(baseBg, background);
-  }
-  return background;
+  return cachedRowBackground(cursorLineBackgroundCache, theme, baseBg, () => {
+    // Reading the sentinel as a color yields black, so a transparent surface blends from the
+    // appearance's own extreme instead.
+    const source =
+      baseBg === TRANSPARENT_BACKGROUND
+        ? theme.appearance === "dark"
+          ? "#000000"
+          : "#ffffff"
+        : baseBg;
+    return blendHex(theme.text, source, CURSOR_LINE_BG_BLEND);
+  });
 }
 
 /** Return the neutral active-hunk rail color for the current theme. */

--- a/src/ui/fileViews/geometry.test.ts
+++ b/src/ui/fileViews/geometry.test.ts
@@ -126,4 +126,34 @@ describe("file-view geometry", () => {
     expect(geometry.hunkAnchorRows.get(0)).toBe(noteHeight);
     expect(geometry.hunkBounds.get(0)).toMatchObject({ top: 0, height: noteHeight + 2 });
   });
+
+  test("indexes every navigable row under the source line the review stream reveals it by", () => {
+    const checked = validateFileViewLayout(
+      {
+        rows: [
+          {
+            id: "summary",
+            spans: [{ text: "hunk 1" }],
+            sourceRanges: [{ side: "new", range: [1, 1] }],
+          },
+          { id: "detail", spans: [{ text: "detail" }] },
+        ],
+        hunkRows: [{ startRow: 0, endRow: 1 }],
+      },
+      1,
+      80,
+    );
+    if (!checked.valid) throw new Error(checked.issue);
+
+    const plan = buildFileViewRenderPlan(checked.value.layout, []);
+    const geometry = measureFileViewGeometry({
+      resolved: checked.value,
+      plannedRows: plan.rows,
+      width: 80,
+    });
+
+    // The reveal effect resolves a cursor through this map, so an unindexed anchor scrolls nowhere.
+    expect(geometry.rowBoundsByStableKey.get("line:0:new:1")).toMatchObject({ top: 0 });
+    expect(geometry.rowBoundsByStableKey.get("file-view:summary")).toMatchObject({ top: 0 });
+  });
 });

--- a/src/ui/fileViews/geometry.test.ts
+++ b/src/ui/fileViews/geometry.test.ts
@@ -121,9 +121,9 @@ describe("file-view geometry", () => {
     });
 
     expect(geometry.fileViewRows).toBe(plan.rows);
-    expect(geometry.rowBounds.map((row) => row.height)).toEqual([noteHeight, 2]);
+    expect(geometry.rowBounds.map((row) => row.height)).toEqual([2, noteHeight]);
     expect(geometry.bodyHeight).toBe(noteHeight + 2);
-    expect(geometry.hunkAnchorRows.get(0)).toBe(noteHeight);
+    expect(geometry.hunkAnchorRows.get(0)).toBe(0);
     expect(geometry.hunkBounds.get(0)).toMatchObject({ top: 0, height: noteHeight + 2 });
   });
 

--- a/src/ui/fileViews/geometry.test.ts
+++ b/src/ui/fileViews/geometry.test.ts
@@ -152,7 +152,6 @@ describe("file-view geometry", () => {
       width: 80,
     });
 
-    // The reveal effect resolves a cursor through this map, so an unindexed anchor scrolls nowhere.
     expect(geometry.rowBoundsByStableKey.get("line:0:new:1")).toMatchObject({ top: 0 });
     expect(geometry.rowBoundsByStableKey.get("file-view:summary")).toMatchObject({ top: 0 });
   });

--- a/src/ui/fileViews/geometry.ts
+++ b/src/ui/fileViews/geometry.ts
@@ -49,14 +49,19 @@ export function measureFileViewGeometry({
     const entry: DiffSectionRowBounds = {
       key: row.key,
       stableKey: row.stableKey,
-      stableKeys: [row.stableKey],
+      stableKeys:
+        row.kind === "file-view-row" && row.stableAliasKeys
+          ? [row.stableKey, ...row.stableAliasKeys]
+          : [row.stableKey],
       top: bodyHeight,
       height: plannedFileViewRowHeight(row, resolved, width),
     };
     rowBounds.push(entry);
     rowBoundsByKey.set(entry.key, entry);
-    if (!rowBoundsByStableKey.has(entry.stableKey)) {
-      rowBoundsByStableKey.set(entry.stableKey, entry);
+    for (const stableKey of entry.stableKeys) {
+      if (!rowBoundsByStableKey.has(stableKey)) {
+        rowBoundsByStableKey.set(stableKey, entry);
+      }
     }
     bodyHeight += entry.height;
   }

--- a/src/ui/fileViews/renderPlan.test.ts
+++ b/src/ui/fileViews/renderPlan.test.ts
@@ -31,7 +31,7 @@ function note(
 }
 
 describe("file-view render plan", () => {
-  test("inserts notes before the uniquely bound preferred-side row", () => {
+  test("inserts notes after the uniquely bound preferred-side row", () => {
     const plan = buildFileViewRenderPlan(layout, [
       note("both", { oldRange: [3, 3], newRange: [6, 7] }),
     ]);
@@ -39,10 +39,10 @@ describe("file-view render plan", () => {
     expect(plan.unresolvedNoteIds).toEqual([]);
     expect(plan.rows.map((row) => `${row.kind}:${row.key}`)).toEqual([
       "file-view-row:file-view:old-summary",
-      "inline-note:inline-note:both:file-view:new-summary:0",
       "file-view-row:file-view:new-summary",
+      "inline-note:inline-note:both:file-view:new-summary:0",
     ]);
-    expect(plan.rows[1]).toMatchObject({
+    expect(plan.rows[2]).toMatchObject({
       kind: "inline-note",
       anchorRowIndex: 1,
       anchorSide: "new",

--- a/src/ui/fileViews/renderPlan.test.ts
+++ b/src/ui/fileViews/renderPlan.test.ts
@@ -50,6 +50,44 @@ describe("file-view render plan", () => {
     });
   });
 
+  test("anchors each row on the source line the raw diff addresses", () => {
+    const plan = buildFileViewRenderPlan(layout, []);
+
+    expect(
+      plan.rows.map((row) => (row.kind === "file-view-row" ? row.stableAliasKeys : [])),
+    ).toEqual([["line:0:old:2"], ["line:0:new:5"]]);
+  });
+
+  test("gives one source line to the first row that presents it", () => {
+    const repeated: ExtensionFileViewLayout = {
+      rows: [
+        { id: "first", spans: [{ text: "a" }], sourceRanges: [{ side: "new", range: [5, 5] }] },
+        { id: "second", spans: [{ text: "b" }], sourceRanges: [{ side: "new", range: [5, 5] }] },
+      ],
+      hunkRows: [{ startRow: 0, endRow: 1 }],
+    };
+    const plan = buildFileViewRenderPlan(repeated, []);
+
+    expect(
+      plan.rows.map((row) => (row.kind === "file-view-row" ? row.stableAliasKeys : [])),
+    ).toEqual([["line:0:new:5"], undefined]);
+  });
+
+  test("leaves rows outside one hunk unaddressable by line navigation", () => {
+    const spanningHunks: ExtensionFileViewLayout = {
+      ...layout,
+      hunkRows: [
+        { startRow: 0, endRow: 1 },
+        { startRow: 0, endRow: 1 },
+      ],
+    };
+    const plan = buildFileViewRenderPlan(spanningHunks, []);
+
+    expect(plan.rows.every((row) => row.kind !== "file-view-row" || !row.stableAliasKeys)).toBe(
+      true,
+    );
+  });
+
   test("groups notes at one anchor in stable input order", () => {
     const plan = buildFileViewRenderPlan(layout, [
       note("first", { newRange: [5, 5] }),

--- a/src/ui/fileViews/renderPlan.ts
+++ b/src/ui/fileViews/renderPlan.ts
@@ -1,6 +1,6 @@
 import type { AgentAnnotation } from "../../core/types";
 import type { ExtensionFileViewLayout, ExtensionFileViewRow } from "../../extension-api/types";
-import { lineStableKey } from "../diff/reviewRenderPlan";
+import { inlineNoteStableKey, lineStableKey } from "../diff/reviewRenderPlan";
 import { annotationAnchor, type VisibleAgentNote } from "../lib/agentAnnotations";
 
 /** One validated extension row or host-owned inline note in an alternate file presentation. */
@@ -50,12 +50,7 @@ function hunkOwnersByRow(layout: ExtensionFileViewLayout) {
   });
 }
 
-/**
- * Build the line anchor one presentation row shares with the raw diff, if it has exactly one hunk.
- *
- * Reusing the raw diff's anchor is what lets the current line walk, highlight, and reveal inside an
- * alternate view, and what keeps it in place when a draft note forces the file back to raw diff.
- */
+/** Build the line anchor one presentation row shares with the raw diff, if it owns exactly one hunk. */
 function rowLineStableKey(row: ExtensionFileViewRow, hunkIndex: number) {
   const sourceRange = row.sourceRanges?.[0];
   return hunkIndex < 0 || !sourceRange
@@ -133,7 +128,7 @@ export function buildFileViewRenderPlan(
       rows.push({
         kind: "inline-note",
         key: `inline-note:${placement.note.id}:file-view:${row.id}:${noteIndex}`,
-        stableKey: `inline-note:${placement.note.id}`,
+        stableKey: inlineNoteStableKey(placement.note.id),
         annotation: placement.note.annotation,
         anchorRowIndex: rowIndex,
         anchorSide: placement.anchorSide,

--- a/src/ui/fileViews/renderPlan.ts
+++ b/src/ui/fileViews/renderPlan.ts
@@ -1,5 +1,6 @@
 import type { AgentAnnotation } from "../../core/types";
 import type { ExtensionFileViewLayout, ExtensionFileViewRow } from "../../extension-api/types";
+import { lineStableKey } from "../diff/reviewRenderPlan";
 import { annotationAnchor, type VisibleAgentNote } from "../lib/agentAnnotations";
 
 /** One validated extension row or host-owned inline note in an alternate file presentation. */
@@ -8,6 +9,8 @@ export type PlannedFileViewRow =
       readonly kind: "file-view-row";
       readonly key: string;
       readonly stableKey: string;
+      /** The source line this row presents, so review-stream navigation can address it. */
+      readonly stableAliasKeys?: readonly string[];
       readonly row: ExtensionFileViewRow;
       readonly rowIndex: number;
     }
@@ -45,6 +48,19 @@ function hunkOwnersByRow(layout: ExtensionFileViewLayout) {
     for (const hunkIndex of starts[rowIndex]!) active.add(hunkIndex);
     return active.size === 1 ? active.values().next().value! : -1;
   });
+}
+
+/**
+ * Build the line anchor one presentation row shares with the raw diff, if it has exactly one hunk.
+ *
+ * Reusing the raw diff's anchor is what lets the current line walk, highlight, and reveal inside an
+ * alternate view, and what keeps it in place when a draft note forces the file back to raw diff.
+ */
+function rowLineStableKey(row: ExtensionFileViewRow, hunkIndex: number) {
+  const sourceRange = row.sourceRanges?.[0];
+  return hunkIndex < 0 || !sourceRange
+    ? undefined
+    : lineStableKey(hunkIndex, sourceRange.side, sourceRange.range[0]);
 }
 
 /** Find the unique validated presentation row containing one note's preferred source anchor. */
@@ -93,6 +109,7 @@ export function buildFileViewRenderPlan(
   }
 
   const rows: PlannedFileViewRow[] = [];
+  const claimedLineKeys = new Set<string>();
   for (const [rowIndex, row] of layout.rows.entries()) {
     const anchoredNotes = notesByRow.get(rowIndex) ?? [];
     for (const [noteIndex, placement] of anchoredNotes.entries()) {
@@ -110,7 +127,21 @@ export function buildFileViewRenderPlan(
       });
     }
     const key = `file-view:${row.id}`;
-    rows.push({ kind: "file-view-row", key, stableKey: key, row, rowIndex });
+    const lineKey = rowLineStableKey(row, hunkOwnerByRow[rowIndex]!);
+    // Only the first row on a line claims it, matching how measured bounds resolve duplicates.
+    const claimsLine = lineKey !== undefined && !claimedLineKeys.has(lineKey);
+    if (claimsLine) {
+      claimedLineKeys.add(lineKey);
+    }
+
+    rows.push({
+      kind: "file-view-row",
+      key,
+      stableKey: key,
+      ...(claimsLine ? { stableAliasKeys: [lineKey] } : {}),
+      row,
+      rowIndex,
+    });
   }
 
   return {

--- a/src/ui/fileViews/renderPlan.ts
+++ b/src/ui/fileViews/renderPlan.ts
@@ -111,21 +111,6 @@ export function buildFileViewRenderPlan(
   const rows: PlannedFileViewRow[] = [];
   const claimedLineKeys = new Set<string>();
   for (const [rowIndex, row] of layout.rows.entries()) {
-    const anchoredNotes = notesByRow.get(rowIndex) ?? [];
-    for (const [noteIndex, placement] of anchoredNotes.entries()) {
-      rows.push({
-        kind: "inline-note",
-        key: `inline-note:${placement.note.id}:file-view:${row.id}:${noteIndex}`,
-        stableKey: `inline-note:${placement.note.id}`,
-        annotation: placement.note.annotation,
-        anchorRowIndex: rowIndex,
-        anchorSide: placement.anchorSide,
-        hunkIndex: placement.hunkIndex,
-        note: placement.note,
-        noteCount: anchoredNotes.length,
-        noteIndex,
-      });
-    }
     const key = `file-view:${row.id}`;
     const lineKey = rowLineStableKey(row, hunkOwnerByRow[rowIndex]!);
     // Only the first row on a line claims it, matching how measured bounds resolve duplicates.
@@ -142,6 +127,22 @@ export function buildFileViewRenderPlan(
       row,
       rowIndex,
     });
+
+    const anchoredNotes = notesByRow.get(rowIndex) ?? [];
+    for (const [noteIndex, placement] of anchoredNotes.entries()) {
+      rows.push({
+        kind: "inline-note",
+        key: `inline-note:${placement.note.id}:file-view:${row.id}:${noteIndex}`,
+        stableKey: `inline-note:${placement.note.id}`,
+        annotation: placement.note.annotation,
+        anchorRowIndex: rowIndex,
+        anchorSide: placement.anchorSide,
+        hunkIndex: placement.hunkIndex,
+        note: placement.note,
+        noteCount: anchoredNotes.length,
+        noteIndex,
+      });
+    }
   }
 
   return {

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -72,6 +72,22 @@ function createAlphaFile(sourceFetcher?: DiffFile["sourceFetcher"]) {
   );
 }
 
+/** Build one file with two independently expandable gaps. */
+function createTwoGapFile(sourceFetcher: DiffFile["sourceFetcher"]) {
+  const beforeLines = Array.from({ length: 50 }, (_, index) => `line ${index + 1}`);
+  const afterLines = [...beforeLines];
+  afterLines[9] = "line 10 changed";
+  afterLines[39] = "line 40 changed";
+  return createDiffFile(
+    "alpha",
+    "alpha.ts",
+    lines(...beforeLines),
+    lines(...afterLines),
+    null,
+    sourceFetcher,
+  );
+}
+
 /** Let deferred filters and follow-up effects settle before reading controller state. */
 async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
   await act(async () => {
@@ -104,6 +120,7 @@ function ReviewControllerHarness({
   const [lineCursors, setLineCursors] = useState<LineCursor[]>([]);
   const controller = useReviewController({ files, lineCursors, noteGeometry, stmlEnabled });
   const visibleFiles = controller.visibleFiles;
+  const { expandedGapsByFileId, sourceStatusByFileId } = controller;
 
   useEffect(() => {
     setLineCursors(
@@ -115,11 +132,17 @@ function ReviewControllerHarness({
             "stack",
             true,
             resolveTheme("github-dark-default", null),
+            [],
+            0,
+            true,
+            false,
+            expandedGapsByFileId[file.id],
+            sourceStatusByFileId[file.id],
           ),
         ),
       ),
     );
-  }, [visibleFiles]);
+  }, [expandedGapsByFileId, sourceStatusByFileId, visibleFiles]);
 
   useEffect(() => {
     onController(controller);
@@ -911,6 +934,43 @@ describe("useReviewController", () => {
 
       const reCollapsed = expectValue(controllerRef.current).expandedGapsByFileId["alpha"];
       expect(reCollapsed?.has("before:0")).toBe(false);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("the latest gap expansion receives the current line when one source load reveals two gaps", async () => {
+    const deferred = createTestDeferred<string | null>();
+    const sourceFetcher = createTestSourceFetcher(() => deferred.promise);
+    const sourceLines = Array.from({ length: 50 }, (_, index) => `line ${index + 1}`);
+    sourceLines[9] = "line 10 changed";
+    sourceLines[39] = "line 40 changed";
+    const { controllerRef, setup } = await renderReviewController([
+      createTwoGapFile(sourceFetcher),
+    ]);
+
+    try {
+      await flush(setup);
+      expect(expectValue(controllerRef.current).selectedFile?.metadata.hunks).toHaveLength(2);
+
+      await act(async () => {
+        expectValue(controllerRef.current).toggleGap("alpha", "before:0");
+        expectValue(controllerRef.current).toggleGap("alpha", "before:1");
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).sourceStatusByFileId.alpha?.kind).toBe("loading");
+      expect(sourceFetcher.calls).toEqual(["new"]);
+
+      deferred.resolve(lines(...sourceLines));
+      await flush(setup);
+
+      const controller = expectValue(controllerRef.current);
+      expect(controller.expandedGapsByFileId.alpha?.has("before:0")).toBe(true);
+      expect(controller.expandedGapsByFileId.alpha?.has("before:1")).toBe(true);
+      expect(expectValue(controller.lineCursor).expandedGapKey).toBe("before:1");
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -101,7 +101,6 @@ function ReviewControllerHarness({
   onSetFiles?: (setFiles: (nextFiles: DiffFile[]) => void) => void;
 }) {
   const [files, setFiles] = useState(initialFiles);
-  // Mirror the diff pane: navigable lines are published from the measured review stream.
   const [lineCursors, setLineCursors] = useState<LineCursor[]>([]);
   const controller = useReviewController({ files, lineCursors, noteGeometry, stmlEnabled });
   const visibleFiles = controller.visibleFiles;
@@ -1404,7 +1403,6 @@ describe("useReviewController", () => {
       await flush(setup);
       expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(0);
 
-      // Walk far enough that the stream has to roll into the file's second hunk.
       for (let step = 0; step < 40; step += 1) {
         await act(async () => {
           expectValue(controllerRef.current).moveLineCursor(1);

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -98,7 +98,7 @@ function ReviewControllerHarness({
   onSetFiles?: (setFiles: (nextFiles: DiffFile[]) => void) => void;
 }) {
   const [files, setFiles] = useState(initialFiles);
-  const controller = useReviewController({ files, noteGeometry, stmlEnabled });
+  const controller = useReviewController({ files, layout: "stack", noteGeometry, stmlEnabled });
 
   useEffect(() => {
     onController(controller);
@@ -1299,6 +1299,203 @@ describe("useReviewController", () => {
       expect(String(loggedErrors[0]?.[0])).toContain("alpha");
     } finally {
       console.error = originalConsoleError;
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("seeds the current line at the selected hunk so the indicator is visible on launch", async () => {
+    const { controllerRef, setup } = await renderReviewController([createAlphaFile()]);
+
+    try {
+      await flush(setup);
+
+      const cursor = expectValue(expectValue(controllerRef.current).lineCursor);
+      expect(cursor.fileId).toBe("alpha");
+      expect(cursor.hunkIndex).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("moves the current line one row at a time and clamps at the top of the stream", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const first = expectValue(expectValue(controllerRef.current).lineCursor);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveLineCursor(1);
+      });
+      await flush(setup);
+      const second = expectValue(expectValue(controllerRef.current).lineCursor);
+      expect(second).not.toEqual(first);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveLineCursor(-1);
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toEqual(first);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveLineCursor(-1);
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toEqual(first);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("requests a reveal every time the current line moves", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const initialRequestId = expectValue(controllerRef.current).lineCursorRevealRequestId;
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveLineCursor(1);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).lineCursorRevealRequestId).toBe(
+        initialRequestId + 1,
+      );
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("carries hunk selection along as the current line crosses a hunk boundary", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(0);
+
+      // Walk far enough that the stream has to roll into the file's second hunk.
+      for (let step = 0; step < 40; step += 1) {
+        await act(async () => {
+          expectValue(controllerRef.current).moveLineCursor(1);
+        });
+      }
+      await flush(setup);
+
+      const cursor = expectValue(expectValue(controllerRef.current).lineCursor);
+      expect(cursor.hunkIndex).toBe(1);
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("moves the current line to the row a note is started on", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        expectValue(controllerRef.current).startUserNote("alpha", 1, { side: "new", line: 12 });
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).lineCursor).toEqual({
+        fileId: "alpha",
+        hunkIndex: 1,
+        target: { side: "new", line: 12 },
+      });
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("carries the current line along when hunk navigation moves the selection", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      expect(expectValue(expectValue(controllerRef.current).lineCursor).hunkIndex).toBe(0);
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToHunk(1);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+      expect(expectValue(expectValue(controllerRef.current).lineCursor).hunkIndex).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("recovers the current line when a reload retires the hunk it was on", async () => {
+    const { controllerRef, setFilesRef, setup } = await renderReviewController([
+      createTwoHunkFile(),
+    ]);
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        expectValue(controllerRef.current).selectHunk("alpha", 1);
+      });
+      await flush(setup);
+      expect(expectValue(expectValue(controllerRef.current).lineCursor).hunkIndex).toBe(1);
+
+      await act(async () => {
+        expectValue(setFilesRef.current)([createSingleHunkFile()]);
+      });
+      await flush(setup);
+
+      const cursor = expectValue(expectValue(controllerRef.current).lineCursor);
+      expect(cursor.fileId).toBe("alpha");
+      expect(cursor.hunkIndex).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("re-seeds the current line into the file a filter leaves visible", async () => {
+    const { controllerRef, setup } = await renderReviewController([
+      createDiffFile("alpha", "alpha.ts", "export const alpha = 1;\n", "export const alpha = 2;\n"),
+      createDiffFile(
+        "beta",
+        "beta.ts",
+        "export const beta = 1;\n",
+        "export const betaValue = 2;\n",
+      ),
+    ]);
+
+    try {
+      await flush(setup);
+      expect(expectValue(expectValue(controllerRef.current).lineCursor).fileId).toBe("alpha");
+
+      await act(async () => {
+        expectValue(controllerRef.current).setFilter("beta");
+      });
+      await flush(setup);
+
+      expect(expectValue(expectValue(controllerRef.current).lineCursor).fileId).toBe("beta");
+    } finally {
       await act(async () => {
         setup.renderer.destroy();
       });

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -9,6 +9,9 @@ import {
   createTestSourceFetcher,
   lines,
 } from "../../../test/helpers/diff-helpers";
+import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
+import { buildLineCursors, type LineCursor } from "../lib/lineCursors";
+import { resolveTheme } from "../themes";
 import { useReviewController, type ReviewController } from "./useReviewController";
 
 /** Build a DiffFile with real parsed hunks using the controller's preferred defaults. */
@@ -98,7 +101,26 @@ function ReviewControllerHarness({
   onSetFiles?: (setFiles: (nextFiles: DiffFile[]) => void) => void;
 }) {
   const [files, setFiles] = useState(initialFiles);
-  const controller = useReviewController({ files, layout: "stack", noteGeometry, stmlEnabled });
+  // Mirror the diff pane: navigable lines are published from the measured review stream.
+  const [lineCursors, setLineCursors] = useState<LineCursor[]>([]);
+  const controller = useReviewController({ files, lineCursors, noteGeometry, stmlEnabled });
+  const visibleFiles = controller.visibleFiles;
+
+  useEffect(() => {
+    setLineCursors(
+      buildLineCursors(
+        visibleFiles,
+        visibleFiles.map((file) =>
+          measureDiffSectionGeometry(
+            file,
+            "stack",
+            true,
+            resolveTheme("github-dark-default", null),
+          ),
+        ),
+      ),
+    );
+  }, [visibleFiles]);
 
   useEffect(() => {
     onController(controller);
@@ -1414,6 +1436,7 @@ describe("useReviewController", () => {
       expect(expectValue(controllerRef.current).lineCursor).toEqual({
         fileId: "alpha",
         hunkIndex: 1,
+        stableKey: "line:1:new:12",
         target: { side: "new", line: 12 },
       });
       expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -178,6 +178,7 @@ export interface ReviewController {
   userNotesByFileId: Record<string, UserReviewNote[]>;
   lineCursor: LineCursor | null;
   lineCursorRevealRequestId: number;
+  anchorLineCursor: (cursor: LineCursor) => void;
   moveLineCursor: (delta: number) => void;
   moveToAnnotatedFile: (delta: number) => void;
   moveToAnnotatedHunk: (delta: number) => void;
@@ -436,6 +437,15 @@ export function useReviewController({
   useEffect(() => {
     reconcileLineCursor();
   }, [reconcileLineCursor]);
+
+  /** Adopt a current line the viewport already settled on, without scrolling back to it. */
+  const anchorLineCursor = useCallback(
+    (cursor: LineCursor) => {
+      applyLineCursor(cursor);
+      selectHunk(cursor.fileId, cursor.hunkIndex, { preserveViewport: true });
+    },
+    [applyLineCursor, selectHunk],
+  );
 
   /** Move the current line one row through the visible review stream. */
   const moveLineCursor = useCallback(
@@ -1173,6 +1183,7 @@ export function useReviewController({
     visibleFiles,
     addLiveComment,
     addLiveCommentBatch,
+    anchorLineCursor,
     clearFilter,
     cancelDraftNote,
     clearLiveComments,

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -250,7 +250,9 @@ export function useReviewController({
   const [lineCursorRevealRequestId, setLineCursorRevealRequestId] = useState(0);
   const previousLineCursorsRef = useRef(lineCursors);
   const pendingLineCursorRef = useRef<
-    { kind: "reveal"; fileId: string } | { kind: "restore"; cursor: LineCursor } | null
+    | { kind: "reveal"; fileId: string; gapKey: string }
+    | { kind: "restore"; cursor: LineCursor }
+    | null
   >(null);
   const lineCursorBeforeExpandRef = useRef(new Map<string, LineCursor>());
   const [scrollToNote, setScrollToNote] = useState(false);
@@ -443,7 +445,10 @@ export function useReviewController({
           .map((cursor) => cursor.stableKey),
       );
       const firstRevealed = lineCursors.find(
-        (cursor) => cursor.fileId === pending.fileId && !alreadyStopped.has(cursor.stableKey),
+        (cursor) =>
+          cursor.fileId === pending.fileId &&
+          cursor.expandedGapKey === pending.gapKey &&
+          !alreadyStopped.has(cursor.stableKey),
       );
       if (firstRevealed) {
         pendingLineCursorRef.current = null;
@@ -598,7 +603,7 @@ export function useReviewController({
         if (lineCursorRef.current) {
           lineCursorBeforeExpandRef.current.set(restorePointKey, lineCursorRef.current);
         }
-        pendingLineCursorRef.current = { kind: "reveal", fileId };
+        pendingLineCursorRef.current = { kind: "reveal", fileId, gapKey };
       } else {
         lineCursorBeforeExpandRef.current.delete(restorePointKey);
         pendingLineCursorRef.current = restorePoint

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -40,9 +40,9 @@ import type {
 import type { FileSourceStatus } from "../diff/expandCollapsedRows";
 import { selectGapForKeyboardToggle } from "../diff/expandCollapsedRows";
 import { trailingCollapsedLines } from "../diff/pierre";
+import { lineStableKey } from "../diff/reviewRenderPlan";
 import { findNextHunkCursor } from "../lib/hunks";
 import {
-  buildLineCursors,
   findNextLineCursor,
   firstLineCursorInHunk,
   resolveLineCursor,
@@ -57,6 +57,37 @@ import {
   findNextAnnotatedFile,
   resolveReviewNavigationTarget,
 } from "../lib/reviewState";
+
+const EMPTY_LINE_CURSORS: LineCursor[] = [];
+
+/**
+ * Resolve the navigable line one note target sits on.
+ *
+ * Notes can address a side the stream does not stop on — the old half of a context row, say — so
+ * fall back to that line's own anchor, which reveal and rendering still resolve through aliases.
+ */
+function lineCursorAt(
+  cursors: LineCursor[],
+  fileId: string,
+  hunkIndex: number,
+  target: UserNoteLineTarget,
+): LineCursor {
+  const stop = cursors.find(
+    (cursor) =>
+      cursor.fileId === fileId &&
+      cursor.hunkIndex === hunkIndex &&
+      cursor.target.side === target.side &&
+      cursor.target.line === target.line,
+  );
+  return (
+    stop ?? {
+      fileId,
+      hunkIndex,
+      stableKey: lineStableKey(hunkIndex, target.side, target.line),
+      target,
+    }
+  );
+}
 
 /** Clamp one numeric index into an inclusive range. */
 function clamp(value: number, min: number, max: number) {
@@ -205,13 +236,16 @@ export interface AgentNoteGeometrySnapshot {
 
 export function useReviewController({
   files,
-  layout,
+  lineCursors = EMPTY_LINE_CURSORS,
   noteGeometry,
   stmlEnabled = false,
 }: {
   files: DiffFile[];
-  /** Resolved layout, so line navigation follows the order rows are actually rendered in. */
-  layout: Exclude<LayoutMode, "auto">;
+  /**
+   * Navigable lines in rendered order, published by the pane that measures the review stream.
+   * Headless callers get none, which leaves `j` and `k` scrolling the viewport.
+   */
+  lineCursors?: LineCursor[];
   /** Allow STML bodies for live comments in this explicitly opted-in session. */
   stmlEnabled?: boolean;
   /**
@@ -375,8 +409,6 @@ export function useReviewController({
   useEffect(() => {
     reconcileSelectedHunkIndex();
   }, [reconcileSelectedHunkIndex]);
-
-  const lineCursors = useMemo(() => buildLineCursors(visibleFiles, layout), [layout, visibleFiles]);
 
   /**
    * Keep the current line on a row the review stream still renders.
@@ -935,7 +967,7 @@ export function useReviewController({
       }
 
       const target = requestedTarget ?? firstCommentTargetForHunk(hunk);
-      applyLineCursor({ fileId: file.id, hunkIndex, target });
+      applyLineCursor(lineCursorAt(lineCursors, file.id, hunkIndex, target));
       const draft: DraftReviewNote = {
         id: `draft:${file.id}:${hunkIndex}:${Date.now()}`,
         fileId: file.id,
@@ -956,7 +988,7 @@ export function useReviewController({
       );
       return draft;
     },
-    [allFiles, applyLineCursor, selectHunk, selectedFile?.id, selectedHunkIndex],
+    [allFiles, applyLineCursor, lineCursors, selectHunk, selectedFile?.id, selectedHunkIndex],
   );
 
   /** Update the body of the active draft note. */

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -41,6 +41,13 @@ import type { FileSourceStatus } from "../diff/expandCollapsedRows";
 import { selectGapForKeyboardToggle } from "../diff/expandCollapsedRows";
 import { trailingCollapsedLines } from "../diff/pierre";
 import { findNextHunkCursor } from "../lib/hunks";
+import {
+  buildLineCursors,
+  findNextLineCursor,
+  firstLineCursorInHunk,
+  resolveLineCursor,
+  type LineCursor,
+} from "../lib/lineCursors";
 import { agentNoteMarkupWidth } from "../lib/agentNoteGeometry";
 import { reviewNoteSource } from "../lib/agentAnnotations";
 import { STML_REFERENCE_WIDTH, validateStmlMarkup } from "../lib/stml/layout";
@@ -138,6 +145,9 @@ export interface ReviewController {
   reviewNoteCount: number;
   reviewNoteSummaries: SessionReviewNoteSummary[];
   userNotesByFileId: Record<string, UserReviewNote[]>;
+  lineCursor: LineCursor | null;
+  lineCursorRevealRequestId: number;
+  moveLineCursor: (delta: number) => void;
   moveToAnnotatedFile: (delta: number) => void;
   moveToAnnotatedHunk: (delta: number) => void;
   moveToFile: (delta: number) => void;
@@ -179,6 +189,7 @@ export interface ReviewController {
     fileId?: string,
     hunkIndex?: number,
     target?: UserNoteLineTarget,
+    options?: { preserveViewport?: boolean },
   ) => DraftReviewNote | null;
   setFilter: (value: string) => void;
   updateDraftNote: (body: string) => void;
@@ -194,10 +205,13 @@ export interface AgentNoteGeometrySnapshot {
 
 export function useReviewController({
   files,
+  layout,
   noteGeometry,
   stmlEnabled = false,
 }: {
   files: DiffFile[];
+  /** Resolved layout, so line navigation follows the order rows are actually rendered in. */
+  layout: Exclude<LayoutMode, "auto">;
   /** Allow STML bodies for live comments in this explicitly opted-in session. */
   stmlEnabled?: boolean;
   /**
@@ -212,6 +226,11 @@ export function useReviewController({
   const [selectedHunkIndex, setSelectedHunkIndex] = useState(0);
   const [selectedFileTopAlignRequestId, setSelectedFileTopAlignRequestId] = useState(0);
   const [selectedHunkRevealRequestId, setSelectedHunkRevealRequestId] = useState(0);
+  const [lineCursor, setLineCursor] = useState<LineCursor | null>(null);
+  // A held key drains as one stdin chunk, so every press in the burst would otherwise read the
+  // same pre-batch state and the cursor would advance a single row.
+  const lineCursorRef = useRef<LineCursor | null>(null);
+  const [lineCursorRevealRequestId, setLineCursorRevealRequestId] = useState(0);
   const [scrollToNote, setScrollToNote] = useState(false);
   const [liveCommentsByFileId, setLiveCommentsByFileId] = useState<Record<string, LiveComment[]>>(
     {},
@@ -356,6 +375,52 @@ export function useReviewController({
   useEffect(() => {
     reconcileSelectedHunkIndex();
   }, [reconcileSelectedHunkIndex]);
+
+  const lineCursors = useMemo(() => buildLineCursors(visibleFiles, layout), [layout, visibleFiles]);
+
+  /**
+   * Keep the current line on a row the review stream still renders.
+   *
+   * Seeding from the selected hunk makes the marker visible from launch, not just after the
+   * first keypress.
+   */
+  const applyLineCursor = useCallback((next: LineCursor | null) => {
+    lineCursorRef.current = next;
+    setLineCursor(next);
+  }, []);
+
+  const reconcileLineCursor = useCallback(() => {
+    const resolved = resolveLineCursor(lineCursors, lineCursorRef.current);
+    if (resolved?.fileId === selectedFileId && resolved?.hunkIndex === selectedHunkIndex) {
+      applyLineCursor(resolved);
+      return;
+    }
+
+    // Selection moved without the cursor, so `]` and the sidebar leave one review position
+    // rather than stranding the marker in the hunk the reviewer just left.
+    applyLineCursor(firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex));
+  }, [applyLineCursor, lineCursors, selectedFileId, selectedHunkIndex]);
+
+  useEffect(() => {
+    reconcileLineCursor();
+  }, [reconcileLineCursor]);
+
+  /** Move the current line one row through the visible review stream. */
+  const moveLineCursor = useCallback(
+    (delta: number) => {
+      const nextCursor = findNextLineCursor(lineCursors, lineCursorRef.current, delta);
+      if (!nextCursor) {
+        return;
+      }
+
+      applyLineCursor(nextCursor);
+      setLineCursorRevealRequestId((current) => current + 1);
+      // Selection follows the line so notes and `[`/`]` agree on where the reviewer is; the
+      // reveal above already owns scrolling, so this must not scroll too.
+      selectHunk(nextCursor.fileId, nextCursor.hunkIndex, { preserveViewport: true });
+    },
+    [applyLineCursor, lineCursors, selectHunk],
+  );
 
   /** Move through the full visible review stream one hunk at a time. */
   const moveToHunk = useCallback(
@@ -861,6 +926,7 @@ export function useReviewController({
       fileId = selectedFile?.id,
       hunkIndex = selectedHunkIndex,
       requestedTarget?: UserNoteLineTarget,
+      options?: { preserveViewport?: boolean },
     ): DraftReviewNote | null => {
       const file = allFiles.find((candidate) => candidate.id === fileId);
       const hunk = file?.metadata.hunks[hunkIndex];
@@ -869,6 +935,7 @@ export function useReviewController({
       }
 
       const target = requestedTarget ?? firstCommentTargetForHunk(hunk);
+      applyLineCursor({ fileId: file.id, hunkIndex, target });
       const draft: DraftReviewNote = {
         id: `draft:${file.id}:${hunkIndex}:${Date.now()}`,
         fileId: file.id,
@@ -885,11 +952,11 @@ export function useReviewController({
       selectHunk(
         file.id,
         hunkIndex,
-        requestedTarget ? { preserveViewport: true } : { scrollToNote: true },
+        options?.preserveViewport ? { preserveViewport: true } : { scrollToNote: true },
       );
       return draft;
     },
-    [allFiles, selectHunk, selectedFile?.id, selectedHunkIndex],
+    [allFiles, applyLineCursor, selectHunk, selectedFile?.id, selectedHunkIndex],
   );
 
   /** Update the body of the active draft note. */
@@ -1056,6 +1123,8 @@ export function useReviewController({
     liveCommentCount,
     liveCommentSummaries,
     liveCommentsByFileId,
+    lineCursor,
+    lineCursorRevealRequestId,
     reviewNoteCount,
     reviewNoteSummaries,
     userNotesByFileId,
@@ -1075,6 +1144,7 @@ export function useReviewController({
     clearFilter,
     cancelDraftNote,
     clearLiveComments,
+    moveLineCursor,
     moveToAnnotatedFile,
     moveToAnnotatedHunk,
     moveToFile,

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -40,11 +40,13 @@ import type {
 import type { FileSourceStatus } from "../diff/expandCollapsedRows";
 import { selectGapForKeyboardToggle } from "../diff/expandCollapsedRows";
 import { trailingCollapsedLines } from "../diff/pierre";
-import { lineStableKey } from "../diff/reviewRenderPlan";
 import { findNextHunkCursor } from "../lib/hunks";
 import {
+  EMPTY_LINE_CURSORS,
   findNextLineCursor,
   firstLineCursorInHunk,
+  hasLineCursor,
+  lineCursorAt,
   resolveLineCursor,
   type LineCursor,
 } from "../lib/lineCursors";
@@ -58,35 +60,15 @@ import {
   resolveReviewNavigationTarget,
 } from "../lib/reviewState";
 
-const EMPTY_LINE_CURSORS: LineCursor[] = [];
-
-/**
- * Resolve the navigable line one note target sits on.
- *
- * Notes can address a side the stream does not stop on — the old half of a context row, say — so
- * fall back to that line's own anchor, which reveal and rendering still resolve through aliases.
- */
-function lineCursorAt(
-  cursors: LineCursor[],
-  fileId: string,
-  hunkIndex: number,
-  target: UserNoteLineTarget,
-): LineCursor {
-  const stop = cursors.find(
-    (cursor) =>
-      cursor.fileId === fileId &&
-      cursor.hunkIndex === hunkIndex &&
-      cursor.target.side === target.side &&
-      cursor.target.line === target.line,
-  );
-  return (
-    stop ?? {
-      fileId,
-      hunkIndex,
-      stableKey: lineStableKey(hunkIndex, target.side, target.line),
-      target,
-    }
-  );
+/** Add or remove one gap key from a file's expansion set. */
+function toggledGaps(current: ReadonlySet<string> | undefined, gapKey: string, expanding: boolean) {
+  const next = new Set(current ?? []);
+  if (expanding) {
+    next.add(gapKey);
+  } else {
+    next.delete(gapKey);
+  }
+  return next;
 }
 
 /** Clamp one numeric index into an inclusive range. */
@@ -266,11 +248,10 @@ export function useReviewController({
   // same pre-batch state and the cursor would advance a single row.
   const lineCursorRef = useRef<LineCursor | null>(null);
   const [lineCursorRevealRequestId, setLineCursorRevealRequestId] = useState(0);
-  // Expanding a gap is a request to read what it hid, so the marker moves to the first revealed
-  // line; collapsing puts it back where it was, but only if the collapse retired the row it is on.
   const previousLineCursorsRef = useRef(lineCursors);
-  const revealExpandedFileIdRef = useRef<string | null>(null);
-  const restoreLineCursorRef = useRef<LineCursor | null>(null);
+  const pendingLineCursorRef = useRef<
+    { kind: "reveal"; fileId: string } | { kind: "restore"; cursor: LineCursor } | null
+  >(null);
   const lineCursorBeforeExpandRef = useRef(new Map<string, LineCursor>());
   const [scrollToNote, setScrollToNote] = useState(false);
   const [liveCommentsByFileId, setLiveCommentsByFileId] = useState<Record<string, LiveComment[]>>(
@@ -324,6 +305,11 @@ export function useReviewController({
     if (staleFileIds.size > 0) {
       for (const fileId of staleFileIds) {
         sourceLoadRequestsRef.current.delete(fileId);
+        for (const restorePointKey of lineCursorBeforeExpandRef.current.keys()) {
+          if (restorePointKey.startsWith(`${fileId}:`)) {
+            lineCursorBeforeExpandRef.current.delete(restorePointKey);
+          }
+        }
       }
       setSourceStatusByFileId((prev) => removeKeys(prev, staleFileIds));
       setExpandedGapsByFileId((prev) => removeKeys(prev, staleFileIds));
@@ -449,18 +435,18 @@ export function useReviewController({
     const previousCursors = previousLineCursorsRef.current;
     previousLineCursorsRef.current = lineCursors;
 
-    const revealFileId = revealExpandedFileIdRef.current;
-    if (revealFileId !== null) {
+    const pending = pendingLineCursorRef.current;
+    if (pending?.kind === "reveal") {
       const alreadyStopped = new Set(
         previousCursors
-          .filter((cursor) => cursor.fileId === revealFileId)
+          .filter((cursor) => cursor.fileId === pending.fileId)
           .map((cursor) => cursor.stableKey),
       );
       const firstRevealed = lineCursors.find(
-        (cursor) => cursor.fileId === revealFileId && !alreadyStopped.has(cursor.stableKey),
+        (cursor) => cursor.fileId === pending.fileId && !alreadyStopped.has(cursor.stableKey),
       );
       if (firstRevealed) {
-        revealExpandedFileIdRef.current = null;
+        pendingLineCursorRef.current = null;
         revealLineCursor(firstRevealed);
         return;
       }
@@ -468,20 +454,10 @@ export function useReviewController({
 
     // Only take the restore point when the collapse actually retired the row the marker was on;
     // the reviewer may have stepped well clear of the gap since expanding it.
-    const restorePoint = restoreLineCursorRef.current;
-    const current = lineCursorRef.current;
-    if (
-      restorePoint &&
-      !(
-        current &&
-        lineCursors.some(
-          (cursor) => cursor.fileId === current.fileId && cursor.stableKey === current.stableKey,
-        )
-      )
-    ) {
-      const restored = resolveLineCursor(lineCursors, restorePoint);
+    if (pending?.kind === "restore" && !hasLineCursor(lineCursors, lineCursorRef.current)) {
+      const restored = resolveLineCursor(lineCursors, pending.cursor);
       if (restored) {
-        restoreLineCursorRef.current = null;
+        pendingLineCursorRef.current = null;
         revealLineCursor(restored);
         return;
       }
@@ -493,8 +469,6 @@ export function useReviewController({
       return;
     }
 
-    // Selection moved without the cursor, so `]` and the sidebar leave one review position
-    // rather than stranding the marker in the hunk the reviewer just left.
     applyLineCursor(firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex));
   }, [applyLineCursor, lineCursors, revealLineCursor, selectedFileId, selectedHunkIndex]);
 
@@ -519,13 +493,9 @@ export function useReviewController({
         return;
       }
 
-      applyLineCursor(nextCursor);
-      setLineCursorRevealRequestId((current) => current + 1);
-      // Selection follows the line so notes and `[`/`]` agree on where the reviewer is; the
-      // reveal above already owns scrolling, so this must not scroll too.
-      selectHunk(nextCursor.fileId, nextCursor.hunkIndex, { preserveViewport: true });
+      revealLineCursor(nextCursor);
     },
-    [applyLineCursor, lineCursors, selectHunk],
+    [lineCursors, revealLineCursor],
   );
 
   /** Move through the full visible review stream one hunk at a time. */
@@ -621,31 +591,29 @@ export function useReviewController({
         return;
       }
 
-      // Decide against the mirror, not the state: a held `z` drains as one chunk and every toggle
-      // in the burst would otherwise read the same pre-batch expansion set.
       const restorePointKey = `${fileId}:${gapKey}`;
+      const restorePoint = lineCursorBeforeExpandRef.current.get(restorePointKey) ?? null;
       const expanding = !expandedGapsRef.current[fileId]?.has(gapKey);
       if (expanding) {
         if (lineCursorRef.current) {
           lineCursorBeforeExpandRef.current.set(restorePointKey, lineCursorRef.current);
         }
-        revealExpandedFileIdRef.current = fileId;
-        restoreLineCursorRef.current = null;
+        pendingLineCursorRef.current = { kind: "reveal", fileId };
       } else {
-        revealExpandedFileIdRef.current = null;
-        restoreLineCursorRef.current =
-          lineCursorBeforeExpandRef.current.get(restorePointKey) ?? null;
         lineCursorBeforeExpandRef.current.delete(restorePointKey);
+        pendingLineCursorRef.current = restorePoint
+          ? { kind: "restore", cursor: restorePoint }
+          : null;
       }
 
-      const nextGaps = new Set(expandedGapsRef.current[fileId] ?? []);
-      if (expanding) {
-        nextGaps.add(gapKey);
-      } else {
-        nextGaps.delete(gapKey);
-      }
-      expandedGapsRef.current = { ...expandedGapsRef.current, [fileId]: nextGaps };
-      setExpandedGapsByFileId((prev) => ({ ...prev, [fileId]: nextGaps }));
+      expandedGapsRef.current = {
+        ...expandedGapsRef.current,
+        [fileId]: toggledGaps(expandedGapsRef.current[fileId], gapKey, expanding),
+      };
+      setExpandedGapsByFileId((prev) => ({
+        ...prev,
+        [fileId]: toggledGaps(prev[fileId], gapKey, expanding),
+      }));
 
       // The fetcher caches its own resolved text; we mirror it into React state
       // as a tagged status so the UI can distinguish loading, loaded, and error

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -266,6 +266,12 @@ export function useReviewController({
   // same pre-batch state and the cursor would advance a single row.
   const lineCursorRef = useRef<LineCursor | null>(null);
   const [lineCursorRevealRequestId, setLineCursorRevealRequestId] = useState(0);
+  // Expanding a gap is a request to read what it hid, so the marker moves to the first revealed
+  // line; collapsing puts it back where it was, but only if the collapse retired the row it is on.
+  const previousLineCursorsRef = useRef(lineCursors);
+  const revealExpandedFileIdRef = useRef<string | null>(null);
+  const restoreLineCursorRef = useRef<LineCursor | null>(null);
+  const lineCursorBeforeExpandRef = useRef(new Map<string, LineCursor>());
   const [scrollToNote, setScrollToNote] = useState(false);
   const [liveCommentsByFileId, setLiveCommentsByFileId] = useState<Record<string, LiveComment[]>>(
     {},
@@ -287,6 +293,10 @@ export function useReviewController({
   // waiting for React's state updater to commit.
   const sourceStatusRef = useRef(sourceStatusByFileId);
   sourceStatusRef.current = sourceStatusByFileId;
+  // Mirror the expansion set for the same reason: toggleGap has to know which way it is toggling
+  // before its own updater commits.
+  const expandedGapsRef = useRef(expandedGapsByFileId);
+  expandedGapsRef.current = expandedGapsByFileId;
   const sourceLoadRequestsRef = useRef(new Map<string, SourceLoadRequest>());
   const nextSourceLoadRequestIdRef = useRef(1);
 
@@ -422,7 +432,61 @@ export function useReviewController({
     setLineCursor(next);
   }, []);
 
+  /** Move the current line to a row the reviewer just asked to see, and scroll to it. */
+  const revealLineCursor = useCallback(
+    (cursor: LineCursor) => {
+      applyLineCursor(cursor);
+      setLineCursorRevealRequestId((current) => current + 1);
+      selectHunk(cursor.fileId, cursor.hunkIndex, { preserveViewport: true });
+    },
+    [applyLineCursor, selectHunk],
+  );
+
   const reconcileLineCursor = useCallback(() => {
+    // Expansion remeasures before its source text loads, so a toggle records what it wants and
+    // this waits for the list that actually carries the revealed rows. Each request survives until
+    // it resolves or the next toggle replaces it.
+    const previousCursors = previousLineCursorsRef.current;
+    previousLineCursorsRef.current = lineCursors;
+
+    const revealFileId = revealExpandedFileIdRef.current;
+    if (revealFileId !== null) {
+      const alreadyStopped = new Set(
+        previousCursors
+          .filter((cursor) => cursor.fileId === revealFileId)
+          .map((cursor) => cursor.stableKey),
+      );
+      const firstRevealed = lineCursors.find(
+        (cursor) => cursor.fileId === revealFileId && !alreadyStopped.has(cursor.stableKey),
+      );
+      if (firstRevealed) {
+        revealExpandedFileIdRef.current = null;
+        revealLineCursor(firstRevealed);
+        return;
+      }
+    }
+
+    // Only take the restore point when the collapse actually retired the row the marker was on;
+    // the reviewer may have stepped well clear of the gap since expanding it.
+    const restorePoint = restoreLineCursorRef.current;
+    const current = lineCursorRef.current;
+    if (
+      restorePoint &&
+      !(
+        current &&
+        lineCursors.some(
+          (cursor) => cursor.fileId === current.fileId && cursor.stableKey === current.stableKey,
+        )
+      )
+    ) {
+      const restored = resolveLineCursor(lineCursors, restorePoint);
+      if (restored) {
+        restoreLineCursorRef.current = null;
+        revealLineCursor(restored);
+        return;
+      }
+    }
+
     const resolved = resolveLineCursor(lineCursors, lineCursorRef.current);
     if (resolved?.fileId === selectedFileId && resolved?.hunkIndex === selectedHunkIndex) {
       applyLineCursor(resolved);
@@ -432,7 +496,7 @@ export function useReviewController({
     // Selection moved without the cursor, so `]` and the sidebar leave one review position
     // rather than stranding the marker in the hunk the reviewer just left.
     applyLineCursor(firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex));
-  }, [applyLineCursor, lineCursors, selectedFileId, selectedHunkIndex]);
+  }, [applyLineCursor, lineCursors, revealLineCursor, selectedFileId, selectedHunkIndex]);
 
   useEffect(() => {
     reconcileLineCursor();
@@ -557,16 +621,31 @@ export function useReviewController({
         return;
       }
 
-      setExpandedGapsByFileId((prev) => {
-        const current = prev[fileId];
-        const next = new Set(current ?? []);
-        if (next.has(gapKey)) {
-          next.delete(gapKey);
-        } else {
-          next.add(gapKey);
+      // Decide against the mirror, not the state: a held `z` drains as one chunk and every toggle
+      // in the burst would otherwise read the same pre-batch expansion set.
+      const restorePointKey = `${fileId}:${gapKey}`;
+      const expanding = !expandedGapsRef.current[fileId]?.has(gapKey);
+      if (expanding) {
+        if (lineCursorRef.current) {
+          lineCursorBeforeExpandRef.current.set(restorePointKey, lineCursorRef.current);
         }
-        return { ...prev, [fileId]: next };
-      });
+        revealExpandedFileIdRef.current = fileId;
+        restoreLineCursorRef.current = null;
+      } else {
+        revealExpandedFileIdRef.current = null;
+        restoreLineCursorRef.current =
+          lineCursorBeforeExpandRef.current.get(restorePointKey) ?? null;
+        lineCursorBeforeExpandRef.current.delete(restorePointKey);
+      }
+
+      const nextGaps = new Set(expandedGapsRef.current[fileId] ?? []);
+      if (expanding) {
+        nextGaps.add(gapKey);
+      } else {
+        nextGaps.delete(gapKey);
+      }
+      expandedGapsRef.current = { ...expandedGapsRef.current, [fileId]: nextGaps };
+      setExpandedGapsByFileId((prev) => ({ ...prev, [fileId]: nextGaps }));
 
       // The fetcher caches its own resolved text; we mirror it into React state
       // as a tagged status so the UI can distinguish loading, loaded, and error

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -50,6 +50,8 @@ function createTestCommands(resolvedKeys?: ResolvedCommandKeys) {
     resolvedKeys,
     scrollCodeHorizontally: record("scrollCodeHorizontally"),
     scrollDiff: record("scrollDiff"),
+    selectCursorLine: record("selectCursorLine"),
+    stepDiffLine: record("stepDiffLine"),
     selectLayoutMode: record("selectLayoutMode"),
     startUserNote: record("startUserNote"),
     toggleAgentNotes: record("toggleAgentNotes"),
@@ -95,10 +97,10 @@ describe("built-in command chords", () => {
       "scrollDiff:-1,viewport",
       "scrollDiff:-1,viewport",
       "scrollDiff:-1,viewport",
-      "scrollDiff:1,step",
-      "scrollDiff:1,step",
-      "scrollDiff:-1,step",
-      "scrollDiff:-1,step",
+      "stepDiffLine:1",
+      "stepDiffLine:1",
+      "stepDiffLine:-1",
+      "stepDiffLine:-1",
       "scrollDiff:1,half",
       "scrollDiff:-1,half",
     ]);
@@ -219,6 +221,9 @@ describe("builtinCommandKeyDefaults", () => {
       "hunk.review.nextAnnotatedFile",
       "hunk.review.previousAnnotatedFile",
       "hunk.view.applyFilePresentationToAllMatching",
+      "hunk.view.cursorLineNumber",
+      "hunk.view.cursorLineOff",
+      "hunk.view.cursorLineRow",
       "hunk.view.toggleCopyDecorations",
     ]);
   });

--- a/src/ui/lib/appCommands.ts
+++ b/src/ui/lib/appCommands.ts
@@ -1,5 +1,5 @@
 import type { KeyEvent } from "@opentui/core";
-import type { LayoutMode } from "../../core/types";
+import type { CursorLine, LayoutMode } from "../../core/types";
 import {
   matchesAnyKeyChord,
   parseKeyChordOrUndefined,
@@ -91,6 +91,8 @@ export interface BuildAppCommandsOptions {
   resolvedKeys?: ResolvedCommandKeys;
   scrollCodeHorizontally: (delta: number) => void;
   scrollDiff: (delta: number, unit: ScrollUnit) => void;
+  stepDiffLine: (delta: number) => void;
+  selectCursorLine: (style: CursorLine) => void;
   selectLayoutMode: (mode: LayoutMode) => void;
   startUserNote: () => void;
   toggleAgentNotes: () => void;
@@ -203,13 +205,13 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       id: "hunk.review.stepDown",
       title: "Scroll down one row",
       defaultKeys: ["down", "j"],
-      run: () => options.scrollDiff(1, "step"),
+      run: () => options.stepDiffLine(1),
     },
     {
       id: "hunk.review.stepUp",
       title: "Scroll up one row",
       defaultKeys: ["up", "k"],
-      run: () => options.scrollDiff(-1, "step"),
+      run: () => options.stepDiffLine(-1),
     },
     {
       id: "hunk.review.scrollCodeLeft",
@@ -226,6 +228,27 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       defaultKeys: ["right", "shift+right"],
       run: (key) =>
         options.scrollCodeHorizontally(key.shift ? FAST_CODE_HORIZONTAL_SCROLL_COLUMNS : 1),
+    },
+    {
+      id: "hunk.view.cursorLineRow",
+      title: "Highlight the current row",
+      defaultKeys: [],
+      run: () => options.selectCursorLine("row"),
+      closesMenu: true,
+    },
+    {
+      id: "hunk.view.cursorLineNumber",
+      title: "Mark the current line number",
+      defaultKeys: [],
+      run: () => options.selectCursorLine("number"),
+      closesMenu: true,
+    },
+    {
+      id: "hunk.view.cursorLineOff",
+      title: "Hide the current-line marker",
+      defaultKeys: [],
+      run: () => options.selectCursorLine("off"),
+      closesMenu: true,
     },
     {
       id: "hunk.view.layoutSplit",
@@ -437,6 +460,8 @@ const NOOP_COMMAND_OPTIONS: BuildAppCommandsOptions = (() => {
     requestQuit: noop,
     scrollCodeHorizontally: noop,
     scrollDiff: noop,
+    stepDiffLine: noop,
+    selectCursorLine: noop,
     selectLayoutMode: noop,
     startUserNote: noop,
     toggleAgentNotes: noop,

--- a/src/ui/lib/appMenus.test.ts
+++ b/src/ui/lib/appMenus.test.ts
@@ -16,6 +16,7 @@ import { resolveCommandKeys } from "./keymap";
 /** The app-state half of the menu options, so tests only state what they exercise. */
 const MENU_STATE: Omit<BuildAppMenusOptions, "commands" | "extensionCommands"> = {
   copyDecorations: true,
+  cursorLine: "row" as const,
   layoutMode: "stack",
   renderSidebar: false,
   showAgentNotes: true,
@@ -49,6 +50,8 @@ function createTestCommands(overrides: Partial<BuildAppCommandsOptions> = {}) {
     requestQuit: record("requestQuit"),
     scrollCodeHorizontally: noop,
     scrollDiff: noop,
+    selectCursorLine: noop,
+    stepDiffLine: noop,
     selectLayoutMode: noop,
     startUserNote: noop,
     toggleAgentNotes: noop,
@@ -96,6 +99,19 @@ function registeredCommand(
 }
 
 describe("buildAppMenus", () => {
+  test("the current-line entries check the active style", () => {
+    const { commands } = createTestCommands();
+
+    const checkedFor = (cursorLine: BuildAppMenusOptions["cursorLine"]) =>
+      items(buildAppMenus({ commands, ...MENU_STATE, cursorLine }).view)
+        .filter((item) => item.checked && item.label.startsWith("Current line:"))
+        .map((item) => item.label);
+
+    expect(checkedFor("row")).toEqual(["Current line: full row"]);
+    expect(checkedFor("number")).toEqual(["Current line: line number"]);
+    expect(checkedFor("off")).toEqual(["Current line: off"]);
+  });
+
   test("labels, hints, and checked state come from the commands and app state", () => {
     const { commands } = createTestCommands();
     const menus = buildAppMenus({ commands, ...MENU_STATE });
@@ -123,6 +139,7 @@ describe("buildAppMenus", () => {
       "Line numbers",
       "Line wrapping",
       "Copy decorations",
+      "Current line: full row",
     ]);
     expect(items(menus.view).map((item) => item.label)).toContain("Themes…");
     expect(items(menus.agent).map((item) => item.label)).toEqual([

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -1,4 +1,4 @@
-import type { LayoutMode } from "../../core/types";
+import type { CursorLine, LayoutMode } from "../../core/types";
 import type { AppMenus, MenuEntry, MenuId } from "../components/chrome/menu";
 import { executeAppCommand, isCommandEnabled, type AppCommand } from "./appCommands";
 
@@ -37,6 +37,7 @@ export interface BuildAppMenusOptions {
   /** Live label for the stable host command that applies the selected presentation changeset-wide. */
   fileViewApplyAllLabel?: string;
   copyDecorations: boolean;
+  cursorLine: CursorLine;
   layoutMode: LayoutMode;
   renderSidebar: boolean;
   showAgentNotes: boolean;
@@ -125,6 +126,7 @@ export function buildAppMenus({
   fileViewEntries = [],
   fileViewApplyAllLabel,
   copyDecorations,
+  cursorLine,
   layoutMode,
   renderSidebar,
   showAgentNotes,
@@ -169,6 +171,21 @@ export function buildAppMenus({
         commandId: "hunk.view.toggleCopyDecorations",
         label: "Copy decorations",
         checked: copyDecorations,
+      },
+      {
+        commandId: "hunk.view.cursorLineRow",
+        label: "Current line: full row",
+        checked: cursorLine === "row",
+      },
+      {
+        commandId: "hunk.view.cursorLineNumber",
+        label: "Current line: line number",
+        checked: cursorLine === "number",
+      },
+      {
+        commandId: "hunk.view.cursorLineOff",
+        label: "Current line: off",
+        checked: cursorLine === "off",
       },
     ],
     navigate: [

--- a/src/ui/lib/hunkScroll.test.ts
+++ b/src/ui/lib/hunkScroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { computeHunkRevealScrollTop } from "./hunkScroll";
+import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "./hunkScroll";
 
 describe("computeHunkRevealScrollTop", () => {
   test("keeps a fitting hunk fully visible when the preferred padding would clip the end", () => {
@@ -55,5 +55,37 @@ describe("computeHunkRevealScrollTop", () => {
         viewportHeight: 0,
       }),
     ).toBe(19);
+  });
+});
+
+describe("computeLineRevealScrollTop", () => {
+  test("leaves the viewport alone when the line is already visible", () => {
+    expect(
+      computeLineRevealScrollTop({ lineTop: 12, lineHeight: 1, scrollTop: 10, viewportHeight: 20 }),
+    ).toBe(10);
+  });
+
+  test("scrolls up just far enough to reach a line above the viewport", () => {
+    expect(
+      computeLineRevealScrollTop({ lineTop: 4, lineHeight: 1, scrollTop: 10, viewportHeight: 20 }),
+    ).toBe(4);
+  });
+
+  test("scrolls down just far enough to reach a line below the viewport", () => {
+    expect(
+      computeLineRevealScrollTop({ lineTop: 40, lineHeight: 1, scrollTop: 10, viewportHeight: 20 }),
+    ).toBe(21);
+  });
+
+  test("keeps a tall wrapped line's end on screen", () => {
+    expect(
+      computeLineRevealScrollTop({ lineTop: 28, lineHeight: 3, scrollTop: 10, viewportHeight: 20 }),
+    ).toBe(11);
+  });
+
+  test("never scrolls above the top of the stream", () => {
+    expect(
+      computeLineRevealScrollTop({ lineTop: 0, lineHeight: 40, scrollTop: 5, viewportHeight: 20 }),
+    ).toBe(0);
   });
 });

--- a/src/ui/lib/hunkScroll.ts
+++ b/src/ui/lib/hunkScroll.ts
@@ -33,3 +33,37 @@ export function computeHunkRevealScrollTop({
 
   return desiredTop;
 }
+
+/**
+ * Pick a scroll target that brings the current line just into view.
+ *
+ * This runs on every step key, so it moves the minimum distance and stays put while the line is
+ * already on screen; hunk reveal's top bias would yank the viewport on each keystroke.
+ */
+export function computeLineRevealScrollTop({
+  lineTop,
+  lineHeight,
+  scrollTop,
+  viewportHeight,
+}: {
+  lineTop: number;
+  lineHeight: number;
+  scrollTop: number;
+  viewportHeight: number;
+}) {
+  const clampedTop = Math.max(0, lineTop);
+  const clampedHeight = Math.max(1, lineHeight);
+  const clampedViewportHeight = Math.max(0, viewportHeight);
+
+  if (clampedTop < scrollTop) {
+    return clampedTop;
+  }
+
+  const lineBottom = clampedTop + clampedHeight;
+  const viewportBottom = scrollTop + clampedViewportHeight;
+  if (lineBottom > viewportBottom) {
+    return Math.max(0, lineBottom - clampedViewportHeight);
+  }
+
+  return scrollTop;
+}

--- a/src/ui/lib/lineCursors.test.ts
+++ b/src/ui/lib/lineCursors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import type { DiffFile, LayoutMode } from "../../core/types";
+import { gapKey } from "../diff/expandCollapsedRows";
+import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
+import { resolveTheme } from "../themes";
 import {
   buildLineCursors,
   findNextLineCursor,
@@ -7,6 +11,16 @@ import {
   resolveLineCursor,
   type LineCursor,
 } from "./lineCursors";
+
+const theme = resolveTheme("github-dark-default", null);
+
+/** Enumerate the stops the review stream renders for these files in one layout. */
+function cursorsFor(files: DiffFile[], layout: Exclude<LayoutMode, "auto">) {
+  return buildLineCursors(
+    files,
+    files.map((file) => measureDiffSectionGeometry(file, layout, true, theme)),
+  );
+}
 
 /** Build a file whose single hunk wraps one changed line in context. */
 function createContextWrappedFile(id: string, path: string) {
@@ -30,26 +44,58 @@ function createTwoHunkFile(id: string, path: string) {
   });
 }
 
+/** Build a file whose only change sits below a collapsible gap. */
+function createCollapsedGapFile() {
+  const before = lines("one", "two", "three", "four", "five", "six");
+  return createTestDiffFile({
+    id: "alpha",
+    path: "alpha.ts",
+    before,
+    after: lines("one", "two", "three", "four", "five", "SIX"),
+    context: 1,
+  });
+}
+
 describe("buildLineCursors", () => {
   test("walks context and changed lines in rendered order", () => {
-    const cursors = buildLineCursors([createContextWrappedFile("alpha", "alpha.ts")], "stack");
+    const cursors = cursorsFor([createContextWrappedFile("alpha", "alpha.ts")], "stack");
 
     expect(cursors).toEqual([
-      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 1 } },
-      { fileId: "alpha", hunkIndex: 0, target: { side: "old", line: 2 } },
-      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 2 } },
-      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 3 } },
+      {
+        fileId: "alpha",
+        hunkIndex: 0,
+        stableKey: "line:0:context:1:1",
+        target: { side: "new", line: 1 },
+      },
+      {
+        fileId: "alpha",
+        hunkIndex: 0,
+        stableKey: "line:0:old:2",
+        target: { side: "old", line: 2 },
+      },
+      {
+        fileId: "alpha",
+        hunkIndex: 0,
+        stableKey: "line:0:new:2",
+        target: { side: "new", line: 2 },
+      },
+      {
+        fileId: "alpha",
+        hunkIndex: 0,
+        stableKey: "line:0:context:3:3",
+        target: { side: "new", line: 3 },
+      },
     ]);
   });
 
   test("keeps old and new line numbering independent across hunks", () => {
-    const cursors = buildLineCursors([createTwoHunkFile("alpha", "alpha.ts")], "stack");
+    const cursors = cursorsFor([createTwoHunkFile("alpha", "alpha.ts")], "stack");
 
-    expect(cursors).toEqual([
-      { fileId: "alpha", hunkIndex: 0, target: { side: "old", line: 1 } },
-      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 1 } },
-      { fileId: "alpha", hunkIndex: 1, target: { side: "old", line: 10 } },
-      { fileId: "alpha", hunkIndex: 1, target: { side: "new", line: 10 } },
+    expect(cursors.map((cursor) => ({ hunkIndex: cursor.hunkIndex, ...cursor.target }))).toEqual([
+      { hunkIndex: 0, side: "old", line: 1 },
+      { hunkIndex: 0, side: "new", line: 1 },
+      { hunkIndex: 1, side: "old", line: 10 },
+      { hunkIndex: 1, side: "new", line: 10 },
     ]);
   });
 
@@ -62,7 +108,7 @@ describe("buildLineCursors", () => {
       context: 0,
     });
 
-    expect(buildLineCursors([file], "split").map((cursor) => cursor.target)).toEqual([
+    expect(cursorsFor([file], "split").map((cursor) => cursor.target)).toEqual([
       { side: "old", line: 1 },
       { side: "new", line: 1 },
       { side: "old", line: 2 },
@@ -81,7 +127,7 @@ describe("buildLineCursors", () => {
       context: 0,
     });
 
-    expect(buildLineCursors([file], "stack").map((cursor) => cursor.target)).toEqual([
+    expect(cursorsFor([file], "stack").map((cursor) => cursor.target)).toEqual([
       { side: "old", line: 1 },
       { side: "old", line: 2 },
       { side: "old", line: 3 },
@@ -91,8 +137,35 @@ describe("buildLineCursors", () => {
     ]);
   });
 
+  test("stops on the lines an expanded gap reveals", () => {
+    const file = createCollapsedGapFile();
+    const source = lines("one", "two", "three", "four", "five", "SIX");
+    const collapsed = measureDiffSectionGeometry(file, "stack", true, theme);
+    const expanded = measureDiffSectionGeometry(
+      file,
+      "stack",
+      true,
+      theme,
+      [],
+      120,
+      true,
+      false,
+      new Set([gapKey("before", 0)]),
+      { kind: "loaded", text: source },
+    );
+
+    const collapsedLines = buildLineCursors([file], [collapsed]).map(
+      (cursor) => cursor.target.line,
+    );
+    const expandedLines = buildLineCursors([file], [expanded]).map((cursor) => cursor.target.line);
+
+    expect(collapsedLines).not.toContain(1);
+    expect(expandedLines).toContain(1);
+    expect(expandedLines.length).toBeGreaterThan(collapsedLines.length);
+  });
+
   test("flattens every visible file into one review stream", () => {
-    const cursors = buildLineCursors(
+    const cursors = cursorsFor(
       [createTwoHunkFile("alpha", "alpha.ts"), createTwoHunkFile("beta", "beta.ts")],
       "stack",
     );
@@ -103,12 +176,12 @@ describe("buildLineCursors", () => {
   });
 
   test("returns nothing when no files are visible", () => {
-    expect(buildLineCursors([], "stack")).toEqual([]);
+    expect(buildLineCursors([], [])).toEqual([]);
   });
 });
 
 describe("findNextLineCursor", () => {
-  const cursors = buildLineCursors(
+  const cursors = cursorsFor(
     [createTwoHunkFile("alpha", "alpha.ts"), createTwoHunkFile("beta", "beta.ts")],
     "stack",
   );
@@ -140,6 +213,7 @@ describe("findNextLineCursor", () => {
     const retired: LineCursor = {
       fileId: "gamma",
       hunkIndex: 4,
+      stableKey: "line:4:new:99",
       target: { side: "new", line: 99 },
     };
 
@@ -152,7 +226,7 @@ describe("findNextLineCursor", () => {
 });
 
 describe("firstLineCursorInHunk", () => {
-  const cursors = buildLineCursors(
+  const cursors = cursorsFor(
     [createTwoHunkFile("alpha", "alpha.ts"), createTwoHunkFile("beta", "beta.ts")],
     "stack",
   );
@@ -161,6 +235,7 @@ describe("firstLineCursorInHunk", () => {
     expect(firstLineCursorInHunk(cursors, "beta", 1)).toEqual({
       fileId: "beta",
       hunkIndex: 1,
+      stableKey: "line:1:old:10",
       target: { side: "old", line: 10 },
     });
   });
@@ -173,13 +248,17 @@ describe("firstLineCursorInHunk", () => {
     expect(firstLineCursorInHunk(cursors, undefined, 0)).toEqual(cursors[0]!);
   });
 
+  test("returns nothing when the selected file has no navigable lines", () => {
+    expect(firstLineCursorInHunk(cursors, "gamma", 0)).toBeNull();
+  });
+
   test("returns nothing when the stream is empty", () => {
     expect(firstLineCursorInHunk([], "alpha", 0)).toBeNull();
   });
 });
 
 describe("resolveLineCursor", () => {
-  const cursors = buildLineCursors([createTwoHunkFile("alpha", "alpha.ts")], "stack");
+  const cursors = cursorsFor([createTwoHunkFile("alpha", "alpha.ts")], "stack");
 
   test("keeps a cursor that still points at a real line", () => {
     expect(resolveLineCursor(cursors, cursors[2]!)).toEqual(cursors[2]!);
@@ -189,12 +268,14 @@ describe("resolveLineCursor", () => {
     const movedLine: LineCursor = {
       fileId: "alpha",
       hunkIndex: 1,
+      stableKey: "line:1:new:42",
       target: { side: "new", line: 42 },
     };
 
     expect(resolveLineCursor(cursors, movedLine)).toEqual({
       fileId: "alpha",
       hunkIndex: 1,
+      stableKey: "line:1:old:10",
       target: { side: "old", line: 10 },
     });
   });
@@ -203,6 +284,7 @@ describe("resolveLineCursor", () => {
     const retiredHunk: LineCursor = {
       fileId: "alpha",
       hunkIndex: 9,
+      stableKey: "line:9:new:1",
       target: { side: "new", line: 1 },
     };
 
@@ -213,6 +295,7 @@ describe("resolveLineCursor", () => {
     const filteredOut: LineCursor = {
       fileId: "gamma",
       hunkIndex: 0,
+      stableKey: "line:0:new:1",
       target: { side: "new", line: 1 },
     };
 

--- a/src/ui/lib/lineCursors.test.ts
+++ b/src/ui/lib/lineCursors.test.ts
@@ -6,6 +6,7 @@ import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { resolveTheme } from "../themes";
 import {
   buildLineCursors,
+  clampLineCursorToViewport,
   findNextLineCursor,
   firstLineCursorInHunk,
   resolveLineCursor,
@@ -304,5 +305,81 @@ describe("resolveLineCursor", () => {
 
   test("gives up when there is no cursor to resolve", () => {
     expect(resolveLineCursor(cursors, null)).toBeNull();
+  });
+});
+
+describe("clampLineCursorToViewport", () => {
+  const cursors = cursorsFor([createTwoHunkFile("alpha", "alpha.ts")], "stack");
+  // One row per stop, stacked from the top of the stream.
+  const boundsOf = (cursor: LineCursor) => {
+    const index = cursors.findIndex((candidate) => candidate.stableKey === cursor.stableKey);
+    return index < 0 ? undefined : { top: index, height: 1 };
+  };
+
+  test("leaves a visible current line where it is", () => {
+    expect(
+      clampLineCursorToViewport({
+        boundsOf,
+        current: cursors[1]!,
+        cursors,
+        scrollTop: 0,
+        viewportHeight: 3,
+      }),
+    ).toEqual(cursors[1]!);
+  });
+
+  test("snaps down to the first visible line after scrolling past it", () => {
+    expect(
+      clampLineCursorToViewport({
+        boundsOf,
+        current: cursors[0]!,
+        cursors,
+        scrollTop: 2,
+        viewportHeight: 2,
+      }),
+    ).toEqual(cursors[2]!);
+  });
+
+  test("snaps up to the last visible line after scrolling back above it", () => {
+    expect(
+      clampLineCursorToViewport({
+        boundsOf,
+        current: cursors[3]!,
+        cursors,
+        scrollTop: 0,
+        viewportHeight: 2,
+      }),
+    ).toEqual(cursors[1]!);
+  });
+
+  test("adopts the first visible line when the current one left the stream", () => {
+    const retired: LineCursor = {
+      fileId: "alpha",
+      hunkIndex: 9,
+      stableKey: "line:9:new:1",
+      target: { side: "new", line: 1 },
+    };
+
+    expect(
+      clampLineCursorToViewport({
+        boundsOf,
+        current: retired,
+        cursors,
+        scrollTop: 1,
+        viewportHeight: 2,
+      }),
+    ).toEqual(cursors[1]!);
+  });
+
+  test("keeps the current line when there is nothing to clamp to", () => {
+    expect(
+      clampLineCursorToViewport({
+        boundsOf,
+        current: cursors[0]!,
+        cursors: [],
+        scrollTop: 40,
+        viewportHeight: 4,
+      }),
+    ).toEqual(cursors[0]!);
   });
 });

--- a/src/ui/lib/lineCursors.test.ts
+++ b/src/ui/lib/lineCursors.test.ts
@@ -323,7 +323,6 @@ describe("resolveLineCursor", () => {
 
 describe("clampLineCursorToViewport", () => {
   const cursors = cursorsFor([createTwoHunkFile("alpha", "alpha.ts")], "stack");
-  // One row per stop, stacked from the top of the stream.
   const boundsOf = (cursor: LineCursor) => {
     const index = cursors.findIndex((candidate) => candidate.stableKey === cursor.stableKey);
     return index < 0 ? undefined : { top: index, height: 1 };

--- a/src/ui/lib/lineCursors.test.ts
+++ b/src/ui/lib/lineCursors.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import {
+  buildLineCursors,
+  findNextLineCursor,
+  firstLineCursorInHunk,
+  resolveLineCursor,
+  type LineCursor,
+} from "./lineCursors";
+
+/** Build a file whose single hunk wraps one changed line in context. */
+function createContextWrappedFile(id: string, path: string) {
+  return createTestDiffFile({
+    id,
+    path,
+    before: lines("one", "two", "three", "four"),
+    after: lines("one", "TWO", "three", "four"),
+    context: 1,
+  });
+}
+
+/** Build a file with two separated single-line changes and no context. */
+function createTwoHunkFile(id: string, path: string) {
+  return createTestDiffFile({
+    id,
+    path,
+    before: lines("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
+    after: lines("A", "b", "c", "d", "e", "f", "g", "h", "i", "J"),
+    context: 0,
+  });
+}
+
+describe("buildLineCursors", () => {
+  test("walks context and changed lines in rendered order", () => {
+    const cursors = buildLineCursors([createContextWrappedFile("alpha", "alpha.ts")], "stack");
+
+    expect(cursors).toEqual([
+      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 1 } },
+      { fileId: "alpha", hunkIndex: 0, target: { side: "old", line: 2 } },
+      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 2 } },
+      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 3 } },
+    ]);
+  });
+
+  test("keeps old and new line numbering independent across hunks", () => {
+    const cursors = buildLineCursors([createTwoHunkFile("alpha", "alpha.ts")], "stack");
+
+    expect(cursors).toEqual([
+      { fileId: "alpha", hunkIndex: 0, target: { side: "old", line: 1 } },
+      { fileId: "alpha", hunkIndex: 0, target: { side: "new", line: 1 } },
+      { fileId: "alpha", hunkIndex: 1, target: { side: "old", line: 10 } },
+      { fileId: "alpha", hunkIndex: 1, target: { side: "new", line: 10 } },
+    ]);
+  });
+
+  test("pairs a change block's two sides per row in split layout", () => {
+    const file = createTestDiffFile({
+      id: "alpha",
+      path: "alpha.ts",
+      before: lines("a", "b", "c"),
+      after: lines("A", "B", "C"),
+      context: 0,
+    });
+
+    expect(buildLineCursors([file], "split").map((cursor) => cursor.target)).toEqual([
+      { side: "old", line: 1 },
+      { side: "new", line: 1 },
+      { side: "old", line: 2 },
+      { side: "new", line: 2 },
+      { side: "old", line: 3 },
+      { side: "new", line: 3 },
+    ]);
+  });
+
+  test("walks a change block one column at a time in stack layout", () => {
+    const file = createTestDiffFile({
+      id: "alpha",
+      path: "alpha.ts",
+      before: lines("a", "b", "c"),
+      after: lines("A", "B", "C"),
+      context: 0,
+    });
+
+    expect(buildLineCursors([file], "stack").map((cursor) => cursor.target)).toEqual([
+      { side: "old", line: 1 },
+      { side: "old", line: 2 },
+      { side: "old", line: 3 },
+      { side: "new", line: 1 },
+      { side: "new", line: 2 },
+      { side: "new", line: 3 },
+    ]);
+  });
+
+  test("flattens every visible file into one review stream", () => {
+    const cursors = buildLineCursors(
+      [createTwoHunkFile("alpha", "alpha.ts"), createTwoHunkFile("beta", "beta.ts")],
+      "stack",
+    );
+
+    expect(cursors).toHaveLength(8);
+    expect(cursors.slice(0, 4).every((cursor) => cursor.fileId === "alpha")).toBe(true);
+    expect(cursors.slice(4).every((cursor) => cursor.fileId === "beta")).toBe(true);
+  });
+
+  test("returns nothing when no files are visible", () => {
+    expect(buildLineCursors([], "stack")).toEqual([]);
+  });
+});
+
+describe("findNextLineCursor", () => {
+  const cursors = buildLineCursors(
+    [createTwoHunkFile("alpha", "alpha.ts"), createTwoHunkFile("beta", "beta.ts")],
+    "stack",
+  );
+
+  test("steps forward and backward one line at a time", () => {
+    expect(findNextLineCursor(cursors, cursors[0]!, 1)).toEqual(cursors[1]!);
+    expect(findNextLineCursor(cursors, cursors[1]!, -1)).toEqual(cursors[0]!);
+  });
+
+  test("rolls across hunk and file boundaries", () => {
+    expect(findNextLineCursor(cursors, cursors[1]!, 1)).toEqual(cursors[2]!);
+    expect(findNextLineCursor(cursors, cursors[3]!, 1)).toEqual(cursors[4]!);
+    expect(findNextLineCursor(cursors, cursors[4]!, -1)).toEqual(cursors[3]!);
+  });
+
+  test("clamps at both ends instead of wrapping", () => {
+    expect(findNextLineCursor(cursors, cursors[0]!, -1)).toEqual(cursors[0]!);
+    expect(findNextLineCursor(cursors, cursors[cursors.length - 1]!, 1)).toEqual(
+      cursors[cursors.length - 1]!,
+    );
+  });
+
+  test("starts at the top of the stream when no cursor is set", () => {
+    expect(findNextLineCursor(cursors, null, 1)).toEqual(cursors[0]!);
+    expect(findNextLineCursor(cursors, null, -1)).toEqual(cursors[0]!);
+  });
+
+  test("recovers to the top when the current line left the stream", () => {
+    const retired: LineCursor = {
+      fileId: "gamma",
+      hunkIndex: 4,
+      target: { side: "new", line: 99 },
+    };
+
+    expect(findNextLineCursor(cursors, retired, 1)).toEqual(cursors[0]!);
+  });
+
+  test("returns nothing when the stream is empty", () => {
+    expect(findNextLineCursor([], null, 1)).toBeNull();
+  });
+});
+
+describe("firstLineCursorInHunk", () => {
+  const cursors = buildLineCursors(
+    [createTwoHunkFile("alpha", "alpha.ts"), createTwoHunkFile("beta", "beta.ts")],
+    "stack",
+  );
+
+  test("seeds at the first line of the requested hunk", () => {
+    expect(firstLineCursorInHunk(cursors, "beta", 1)).toEqual({
+      fileId: "beta",
+      hunkIndex: 1,
+      target: { side: "old", line: 10 },
+    });
+  });
+
+  test("falls back within the file when the hunk is gone", () => {
+    expect(firstLineCursorInHunk(cursors, "beta", 7)?.fileId).toBe("beta");
+  });
+
+  test("falls back to the top of the stream without a selected file", () => {
+    expect(firstLineCursorInHunk(cursors, undefined, 0)).toEqual(cursors[0]!);
+  });
+
+  test("returns nothing when the stream is empty", () => {
+    expect(firstLineCursorInHunk([], "alpha", 0)).toBeNull();
+  });
+});
+
+describe("resolveLineCursor", () => {
+  const cursors = buildLineCursors([createTwoHunkFile("alpha", "alpha.ts")], "stack");
+
+  test("keeps a cursor that still points at a real line", () => {
+    expect(resolveLineCursor(cursors, cursors[2]!)).toEqual(cursors[2]!);
+  });
+
+  test("falls back to the same hunk when the line is gone", () => {
+    const movedLine: LineCursor = {
+      fileId: "alpha",
+      hunkIndex: 1,
+      target: { side: "new", line: 42 },
+    };
+
+    expect(resolveLineCursor(cursors, movedLine)).toEqual({
+      fileId: "alpha",
+      hunkIndex: 1,
+      target: { side: "old", line: 10 },
+    });
+  });
+
+  test("falls back to the same file when the hunk is gone", () => {
+    const retiredHunk: LineCursor = {
+      fileId: "alpha",
+      hunkIndex: 9,
+      target: { side: "new", line: 1 },
+    };
+
+    expect(resolveLineCursor(cursors, retiredHunk)?.fileId).toBe("alpha");
+  });
+
+  test("gives up when the file left the review stream", () => {
+    const filteredOut: LineCursor = {
+      fileId: "gamma",
+      hunkIndex: 0,
+      target: { side: "new", line: 1 },
+    };
+
+    expect(resolveLineCursor(cursors, filteredOut)).toBeNull();
+  });
+
+  test("gives up when there is no cursor to resolve", () => {
+    expect(resolveLineCursor(cursors, null)).toBeNull();
+  });
+});

--- a/src/ui/lib/lineCursors.test.ts
+++ b/src/ui/lib/lineCursors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
+import {
+  createTestDiffFile,
+  createTestHeaderOnlyDiffFile,
+  lines,
+} from "../../../test/helpers/diff-helpers";
 import type { DiffFile, LayoutMode } from "../../core/types";
 import { gapKey } from "../diff/expandCollapsedRows";
 import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
@@ -174,6 +178,15 @@ describe("buildLineCursors", () => {
     expect(cursors).toHaveLength(8);
     expect(cursors.slice(0, 4).every((cursor) => cursor.fileId === "alpha")).toBe(true);
     expect(cursors.slice(4).every((cursor) => cursor.fileId === "beta")).toBe(true);
+  });
+
+  test("gives no stops to a file the stream renders no source lines for", () => {
+    const empty = createTestHeaderOnlyDiffFile();
+    const cursors = cursorsFor([createTwoHunkFile("alpha", "alpha.ts"), empty], "stack");
+
+    expect(cursors.some((cursor) => cursor.fileId === "alpha")).toBe(true);
+    expect(cursors.some((cursor) => cursor.fileId === empty.id)).toBe(false);
+    expect(firstLineCursorInHunk(cursors, empty.id, 0)).toBeNull();
   });
 
   test("returns nothing when no files are visible", () => {

--- a/src/ui/lib/lineCursors.ts
+++ b/src/ui/lib/lineCursors.ts
@@ -2,113 +2,80 @@
  * Line-granular navigation targets for the review stream.
  *
  * `hunks.ts` flattens the stream into hunks for `[` and `]`; this does the same one level down.
- * Targets come from `hunkContent` rather than the render plan, so they stay cheap to hold, but
- * they are ordered to match the rows the active layout actually draws. Lines revealed by
- * expanding a collapsed gap are still out of reach.
+ * Stops come from the measured render plan rather than the parsed diff, so the marker visits exactly
+ * the rows the active layout draws — expanded gaps and alternate file presentations included — and
+ * every stop carries the plan anchor that rendering, reveal, and note placement already key on.
  */
 
-import type { Hunk } from "@pierre/diffs";
-import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
-
-type ResolvedLayout = Exclude<LayoutMode, "auto">;
+import type { DiffFile, UserNoteLineTarget } from "../../core/types";
+import type { DiffSectionGeometry, DiffSectionRowBounds } from "../diff/diffSectionGeometry";
+import { contextLineStableKeyTarget, lineStableKeyTarget } from "../diff/reviewRenderPlan";
+import type { VerticalBounds } from "./diffSpatial";
 
 export interface LineCursor {
   fileId: string;
   hunkIndex: number;
+  /** The render plan's anchor for this row, shared with reveal and highlight lookups. */
+  stableKey: string;
   target: UserNoteLineTarget;
 }
 
-const cursorsByFileMetadata = new WeakMap<
-  DiffFile["metadata"],
-  Map<ResolvedLayout, LineCursor[]>
->();
+const cursorsBySectionGeometry = new WeakMap<DiffSectionGeometry, LineCursor[]>();
 
-/** Enumerate the source lines one hunk renders, top to bottom. */
-function hunkLineTargets(hunk: Hunk, layout: ResolvedLayout): UserNoteLineTarget[] {
-  const targets: UserNoteLineTarget[] = [];
-  let deletionLineNumber = hunk.deletionStart;
-  let additionLineNumber = hunk.additionStart;
+/** Enumerate the navigable stops one measured row renders, left to right. */
+function rowLineCursors(fileId: string, bounds: DiffSectionRowBounds): LineCursor[] {
+  // A context row shows one source line on both sides, so its sided anchors name the same position.
+  const context = contextLineStableKeyTarget(bounds.stableKey);
+  if (context) {
+    const { hunkIndex, ...target } = context;
+    return [{ fileId, hunkIndex, stableKey: bounds.stableKey, target }];
+  }
 
-  for (const content of hunk.hunkContent) {
-    if (content.type === "context") {
-      for (let offset = 0; offset < content.lines; offset += 1) {
-        // Both sides exist here; the new side is what the mouse affordance already anchors to.
-        targets.push({ side: "new", line: additionLineNumber + offset });
-      }
-
-      deletionLineNumber += content.lines;
-      additionLineNumber += content.lines;
+  const cursors: LineCursor[] = [];
+  for (const stableKey of bounds.stableKeys) {
+    const anchor = lineStableKeyTarget(stableKey);
+    if (!anchor) {
       continue;
     }
 
-    if (layout === "split") {
-      // Split draws one row per pair, padding the shorter side, so the marker has to cross each
-      // row before moving down instead of walking the whole old column first.
-      const pairedLines = Math.max(content.deletions, content.additions);
-      for (let offset = 0; offset < pairedLines; offset += 1) {
-        if (offset < content.deletions) {
-          targets.push({ side: "old", line: deletionLineNumber + offset });
-        }
-
-        if (offset < content.additions) {
-          targets.push({ side: "new", line: additionLineNumber + offset });
-        }
-      }
-    } else {
-      for (let offset = 0; offset < content.deletions; offset += 1) {
-        targets.push({ side: "old", line: deletionLineNumber + offset });
-      }
-
-      for (let offset = 0; offset < content.additions; offset += 1) {
-        targets.push({ side: "new", line: additionLineNumber + offset });
-      }
-    }
-
-    deletionLineNumber += content.deletions;
-    additionLineNumber += content.additions;
+    const { hunkIndex, ...target } = anchor;
+    cursors.push({ fileId, hunkIndex, stableKey, target });
   }
 
-  return targets;
+  return cursors;
 }
 
 /**
- * List one file's cursors, reusing the last result while its parsed diff is unchanged.
+ * List one file's cursors, reusing the last result while its measured rows are unchanged.
  *
- * Selection changes rebuild the visible file array without reparsing, so this keeps a keypress
- * from reallocating one object per source line across the whole changeset.
+ * Geometry is already cached per file, so this keeps a keypress from reallocating one object per
+ * rendered row across the whole changeset.
  */
-function fileLineCursors(file: DiffFile, layout: ResolvedLayout): LineCursor[] {
-  let byLayout = cursorsByFileMetadata.get(file.metadata);
-  if (!byLayout) {
-    byLayout = new Map();
-    cursorsByFileMetadata.set(file.metadata, byLayout);
-  }
-
-  const cached = byLayout.get(layout);
+function fileLineCursors(file: DiffFile, geometry: DiffSectionGeometry): LineCursor[] {
+  const cached = cursorsBySectionGeometry.get(geometry);
   if (cached) {
     return cached;
   }
 
-  const cursors = file.metadata.hunks.flatMap((hunk, hunkIndex) =>
-    hunkLineTargets(hunk, layout).map((target) => ({ fileId: file.id, hunkIndex, target })),
-  );
-  byLayout.set(layout, cursors);
+  const cursors = geometry.rowBounds.flatMap((bounds) => rowLineCursors(file.id, bounds));
+  cursorsBySectionGeometry.set(geometry, cursors);
   return cursors;
 }
 
-/** Flatten the visible files into one review-stream line cursor list. */
-export function buildLineCursors(files: DiffFile[], layout: ResolvedLayout): LineCursor[] {
-  return files.flatMap((file) => fileLineCursors(file, layout));
+/** Flatten the measured review stream into one ordered line cursor list. */
+export function buildLineCursors(
+  files: DiffFile[],
+  sectionGeometry: DiffSectionGeometry[],
+): LineCursor[] {
+  return files.flatMap((file, index) => {
+    const geometry = sectionGeometry[index];
+    return geometry ? fileLineCursors(file, geometry) : [];
+  });
 }
 
-/** Check whether two cursors name the same review-stream line. */
+/** Check whether two cursors name the same review-stream row. */
 function sameLineCursor(left: LineCursor, right: LineCursor) {
-  return (
-    left.fileId === right.fileId &&
-    left.hunkIndex === right.hunkIndex &&
-    left.target.side === right.target.side &&
-    left.target.line === right.target.line
-  );
+  return left.fileId === right.fileId && left.stableKey === right.stableKey;
 }
 
 /** Find the first cursor in one hunk, then anywhere in its file. */
@@ -174,3 +141,6 @@ export function resolveLineCursor(
 
   return nearestCursorInFile(cursors, current.fileId, current.hunkIndex) ?? null;
 }
+
+/** Read one cursor's measured extent in whole-stream rows. */
+export type LineCursorBoundsLookup = (cursor: LineCursor) => VerticalBounds | undefined;

--- a/src/ui/lib/lineCursors.ts
+++ b/src/ui/lib/lineCursors.ts
@@ -1,15 +1,17 @@
 /**
  * Line-granular navigation targets for the review stream.
  *
- * `hunks.ts` flattens the stream into hunks for `[` and `]`; this does the same one level down.
- * Stops come from the measured render plan rather than the parsed diff, so the marker visits exactly
- * the rows the active layout draws — expanded gaps and alternate file presentations included — and
- * every stop carries the plan anchor that rendering, reveal, and note placement already key on.
+ * Stops come from the measured render plan rather than the parsed diff, so they match the rows the
+ * active layout draws and carry the plan anchor rendering, reveal, and note placement already use.
  */
 
 import type { DiffFile, UserNoteLineTarget } from "../../core/types";
 import type { DiffSectionGeometry, DiffSectionRowBounds } from "../diff/diffSectionGeometry";
-import { contextLineStableKeyTarget, lineStableKeyTarget } from "../diff/reviewRenderPlan";
+import {
+  contextLineStableKeyTarget,
+  lineStableKey,
+  lineStableKeyTarget,
+} from "../diff/reviewRenderPlan";
 import type { VerticalBounds } from "./diffSpatial";
 
 export interface LineCursor {
@@ -20,7 +22,25 @@ export interface LineCursor {
   target: UserNoteLineTarget;
 }
 
+export const EMPTY_LINE_CURSORS: LineCursor[] = [];
+
 const cursorsBySectionGeometry = new WeakMap<DiffSectionGeometry, LineCursor[]>();
+const indexesByCursorList = new WeakMap<LineCursor[], Map<string, number>>();
+
+/** Index one cursor list by position, so stepping does not rescan the changeset per keypress. */
+function cursorIndexes(cursors: LineCursor[]) {
+  let indexes = indexesByCursorList.get(cursors);
+  if (!indexes) {
+    indexes = new Map(cursors.map((cursor, index) => [cursorId(cursor), index]));
+    indexesByCursorList.set(cursors, indexes);
+  }
+  return indexes;
+}
+
+/** Identify one navigable line across the whole review stream. */
+function cursorId(cursor: LineCursor) {
+  return `${cursor.fileId}\u0000${cursor.stableKey}`;
+}
 
 /** Enumerate the navigable stops one measured row renders, left to right. */
 function rowLineCursors(fileId: string, bounds: DiffSectionRowBounds): LineCursor[] {
@@ -45,12 +65,7 @@ function rowLineCursors(fileId: string, bounds: DiffSectionRowBounds): LineCurso
   return cursors;
 }
 
-/**
- * List one file's cursors, reusing the last result while its measured rows are unchanged.
- *
- * Geometry is already cached per file, so this keeps a keypress from reallocating one object per
- * rendered row across the whole changeset.
- */
+/** List one file's cursors, reusing the last result while its measured rows are unchanged. */
 function fileLineCursors(file: DiffFile, geometry: DiffSectionGeometry): LineCursor[] {
   const cached = cursorsBySectionGeometry.get(geometry);
   if (cached) {
@@ -71,11 +86,6 @@ export function buildLineCursors(
     const geometry = sectionGeometry[index];
     return geometry ? fileLineCursors(file, geometry) : [];
   });
-}
-
-/** Check whether two cursors name the same review-stream row. */
-function sameLineCursor(left: LineCursor, right: LineCursor) {
-  return left.fileId === right.fileId && left.stableKey === right.stableKey;
 }
 
 /** Find the first cursor in one hunk, then anywhere in its file. */
@@ -110,23 +120,21 @@ export function findNextLineCursor(
   current: LineCursor | null,
   delta: number,
 ): LineCursor | null {
-  const currentIndex = current
-    ? cursors.findIndex((cursor) => sameLineCursor(cursor, current))
-    : -1;
+  const currentIndex = current ? (cursorIndexes(cursors).get(cursorId(current)) ?? -1) : -1;
   if (currentIndex < 0) {
     return cursors[0] ?? null;
   }
 
-  // Line navigation is non-cyclic like hunk navigation, so both ends of the stream clamp.
   const nextIndex = Math.min(Math.max(currentIndex + delta, 0), cursors.length - 1);
   return cursors[nextIndex] ?? null;
 }
 
-/**
- * Keep a cursor pointing at a real line after filtering or a reload retires the one it was on.
- *
- * Falls back toward the same hunk and then the same file, mirroring how file selection recovers.
- */
+/** Check whether one cursor still names a row the review stream renders. */
+export function hasLineCursor(cursors: LineCursor[], cursor: LineCursor | null) {
+  return cursor !== null && cursorIndexes(cursors).has(cursorId(cursor));
+}
+
+/** Keep a cursor pointing at a real line after filtering or a reload retires the one it was on. */
 export function resolveLineCursor(
   cursors: LineCursor[],
   current: LineCursor | null,
@@ -135,26 +143,55 @@ export function resolveLineCursor(
     return null;
   }
 
-  if (cursors.some((cursor) => sameLineCursor(cursor, current))) {
+  if (hasLineCursor(cursors, current)) {
     return current;
   }
 
   return nearestCursorInFile(cursors, current.fileId, current.hunkIndex) ?? null;
 }
 
+/**
+ * Resolve the navigable line one note target sits on.
+ *
+ * Notes can address a side the stream does not stop on, so fall back to that line's own anchor,
+ * which reveal and rendering still resolve through aliases.
+ */
+export function lineCursorAt(
+  cursors: LineCursor[],
+  fileId: string,
+  hunkIndex: number,
+  target: UserNoteLineTarget,
+): LineCursor {
+  const stop = cursors.find(
+    (cursor) =>
+      cursor.fileId === fileId &&
+      cursor.hunkIndex === hunkIndex &&
+      cursor.target.side === target.side &&
+      cursor.target.line === target.line,
+  );
+  return (
+    stop ?? {
+      fileId,
+      hunkIndex,
+      stableKey: lineStableKey(hunkIndex, target.side, target.line),
+      target,
+    }
+  );
+}
+
 /** Read one cursor's measured extent in whole-stream rows. */
 export type LineCursorBoundsLookup = (cursor: LineCursor) => VerticalBounds | undefined;
 
 /**
- * Find the first cursor whose row starts at or after one stream offset.
+ * Find the first cursor whose row satisfies a monotonic viewport test.
  *
  * Cursor tops are non-decreasing, so both edges of the viewport resolve by binary search instead of
  * a walk over every row in the changeset.
  */
-function firstCursorIndexFrom(
+function firstCursorIndexWhere(
   cursors: LineCursor[],
   boundsOf: LineCursorBoundsLookup,
-  offset: number,
+  reached: (bounds: VerticalBounds) => boolean,
 ) {
   let low = 0;
   let high = cursors.length;
@@ -162,7 +199,7 @@ function firstCursorIndexFrom(
   while (low < high) {
     const middle = (low + high) >>> 1;
     const bounds = boundsOf(cursors[middle]!);
-    if (bounds && bounds.top >= offset) {
+    if (bounds && reached(bounds)) {
       high = middle;
     } else {
       low = middle + 1;
@@ -172,34 +209,7 @@ function firstCursorIndexFrom(
   return low;
 }
 
-/** Find the last cursor whose row ends at or before one stream offset. */
-function lastCursorIndexBefore(
-  cursors: LineCursor[],
-  boundsOf: LineCursorBoundsLookup,
-  offset: number,
-) {
-  let low = 0;
-  let high = cursors.length;
-
-  while (low < high) {
-    const middle = (low + high) >>> 1;
-    const bounds = boundsOf(cursors[middle]!);
-    if (bounds && bounds.top + bounds.height > offset) {
-      high = middle;
-    } else {
-      low = middle + 1;
-    }
-  }
-
-  return low - 1;
-}
-
-/**
- * Keep the current line inside the viewport after the reviewer scrolls past it.
- *
- * Paging and wheel scrolling move the viewport without the marker, so the marker follows only once
- * it would otherwise be off screen, landing on the nearest row it left through.
- */
+/** Keep the current line inside the viewport after the reviewer scrolls past it. */
 export function clampLineCursorToViewport({
   boundsOf,
   current,
@@ -229,7 +239,11 @@ export function clampLineCursorToViewport({
 
   const scrolledPastAbove = !currentBounds || currentBounds.top < scrollTop;
   const index = scrolledPastAbove
-    ? firstCursorIndexFrom(cursors, boundsOf, scrollTop)
-    : lastCursorIndexBefore(cursors, boundsOf, viewportBottom);
+    ? firstCursorIndexWhere(cursors, boundsOf, (bounds) => bounds.top >= scrollTop)
+    : firstCursorIndexWhere(
+        cursors,
+        boundsOf,
+        (bounds) => bounds.top + bounds.height > viewportBottom,
+      ) - 1;
   return cursors[Math.min(Math.max(index, 0), cursors.length - 1)] ?? null;
 }

--- a/src/ui/lib/lineCursors.ts
+++ b/src/ui/lib/lineCursors.ts
@@ -1,0 +1,176 @@
+/**
+ * Line-granular navigation targets for the review stream.
+ *
+ * `hunks.ts` flattens the stream into hunks for `[` and `]`; this does the same one level down.
+ * Targets come from `hunkContent` rather than the render plan, so they stay cheap to hold, but
+ * they are ordered to match the rows the active layout actually draws. Lines revealed by
+ * expanding a collapsed gap are still out of reach.
+ */
+
+import type { Hunk } from "@pierre/diffs";
+import type { DiffFile, LayoutMode, UserNoteLineTarget } from "../../core/types";
+
+type ResolvedLayout = Exclude<LayoutMode, "auto">;
+
+export interface LineCursor {
+  fileId: string;
+  hunkIndex: number;
+  target: UserNoteLineTarget;
+}
+
+const cursorsByFileMetadata = new WeakMap<
+  DiffFile["metadata"],
+  Map<ResolvedLayout, LineCursor[]>
+>();
+
+/** Enumerate the source lines one hunk renders, top to bottom. */
+function hunkLineTargets(hunk: Hunk, layout: ResolvedLayout): UserNoteLineTarget[] {
+  const targets: UserNoteLineTarget[] = [];
+  let deletionLineNumber = hunk.deletionStart;
+  let additionLineNumber = hunk.additionStart;
+
+  for (const content of hunk.hunkContent) {
+    if (content.type === "context") {
+      for (let offset = 0; offset < content.lines; offset += 1) {
+        // Both sides exist here; the new side is what the mouse affordance already anchors to.
+        targets.push({ side: "new", line: additionLineNumber + offset });
+      }
+
+      deletionLineNumber += content.lines;
+      additionLineNumber += content.lines;
+      continue;
+    }
+
+    if (layout === "split") {
+      // Split draws one row per pair, padding the shorter side, so the marker has to cross each
+      // row before moving down instead of walking the whole old column first.
+      const pairedLines = Math.max(content.deletions, content.additions);
+      for (let offset = 0; offset < pairedLines; offset += 1) {
+        if (offset < content.deletions) {
+          targets.push({ side: "old", line: deletionLineNumber + offset });
+        }
+
+        if (offset < content.additions) {
+          targets.push({ side: "new", line: additionLineNumber + offset });
+        }
+      }
+    } else {
+      for (let offset = 0; offset < content.deletions; offset += 1) {
+        targets.push({ side: "old", line: deletionLineNumber + offset });
+      }
+
+      for (let offset = 0; offset < content.additions; offset += 1) {
+        targets.push({ side: "new", line: additionLineNumber + offset });
+      }
+    }
+
+    deletionLineNumber += content.deletions;
+    additionLineNumber += content.additions;
+  }
+
+  return targets;
+}
+
+/**
+ * List one file's cursors, reusing the last result while its parsed diff is unchanged.
+ *
+ * Selection changes rebuild the visible file array without reparsing, so this keeps a keypress
+ * from reallocating one object per source line across the whole changeset.
+ */
+function fileLineCursors(file: DiffFile, layout: ResolvedLayout): LineCursor[] {
+  let byLayout = cursorsByFileMetadata.get(file.metadata);
+  if (!byLayout) {
+    byLayout = new Map();
+    cursorsByFileMetadata.set(file.metadata, byLayout);
+  }
+
+  const cached = byLayout.get(layout);
+  if (cached) {
+    return cached;
+  }
+
+  const cursors = file.metadata.hunks.flatMap((hunk, hunkIndex) =>
+    hunkLineTargets(hunk, layout).map((target) => ({ fileId: file.id, hunkIndex, target })),
+  );
+  byLayout.set(layout, cursors);
+  return cursors;
+}
+
+/** Flatten the visible files into one review-stream line cursor list. */
+export function buildLineCursors(files: DiffFile[], layout: ResolvedLayout): LineCursor[] {
+  return files.flatMap((file) => fileLineCursors(file, layout));
+}
+
+/** Check whether two cursors name the same review-stream line. */
+function sameLineCursor(left: LineCursor, right: LineCursor) {
+  return (
+    left.fileId === right.fileId &&
+    left.hunkIndex === right.hunkIndex &&
+    left.target.side === right.target.side &&
+    left.target.line === right.target.line
+  );
+}
+
+/** Find the first cursor in one hunk, then anywhere in its file. */
+function nearestCursorInFile(cursors: LineCursor[], fileId: string, hunkIndex: number) {
+  return (
+    cursors.find((cursor) => cursor.fileId === fileId && cursor.hunkIndex === hunkIndex) ??
+    cursors.find((cursor) => cursor.fileId === fileId)
+  );
+}
+
+/**
+ * Find the first navigable line inside one hunk.
+ *
+ * Stays inside the requested file: falling back to the top of the stream would move the marker,
+ * and with it the selection, off the file the reviewer just picked.
+ */
+export function firstLineCursorInHunk(
+  cursors: LineCursor[],
+  fileId: string | undefined,
+  hunkIndex: number,
+): LineCursor | null {
+  if (!fileId) {
+    return cursors[0] ?? null;
+  }
+
+  return nearestCursorInFile(cursors, fileId, hunkIndex) ?? null;
+}
+
+/** Move forward or backward through the review-stream line cursor list. */
+export function findNextLineCursor(
+  cursors: LineCursor[],
+  current: LineCursor | null,
+  delta: number,
+): LineCursor | null {
+  const currentIndex = current
+    ? cursors.findIndex((cursor) => sameLineCursor(cursor, current))
+    : -1;
+  if (currentIndex < 0) {
+    return cursors[0] ?? null;
+  }
+
+  // Line navigation is non-cyclic like hunk navigation, so both ends of the stream clamp.
+  const nextIndex = Math.min(Math.max(currentIndex + delta, 0), cursors.length - 1);
+  return cursors[nextIndex] ?? null;
+}
+
+/**
+ * Keep a cursor pointing at a real line after filtering or a reload retires the one it was on.
+ *
+ * Falls back toward the same hunk and then the same file, mirroring how file selection recovers.
+ */
+export function resolveLineCursor(
+  cursors: LineCursor[],
+  current: LineCursor | null,
+): LineCursor | null {
+  if (!current) {
+    return null;
+  }
+
+  if (cursors.some((cursor) => sameLineCursor(cursor, current))) {
+    return current;
+  }
+
+  return nearestCursorInFile(cursors, current.fileId, current.hunkIndex) ?? null;
+}

--- a/src/ui/lib/lineCursors.ts
+++ b/src/ui/lib/lineCursors.ts
@@ -144,3 +144,92 @@ export function resolveLineCursor(
 
 /** Read one cursor's measured extent in whole-stream rows. */
 export type LineCursorBoundsLookup = (cursor: LineCursor) => VerticalBounds | undefined;
+
+/**
+ * Find the first cursor whose row starts at or after one stream offset.
+ *
+ * Cursor tops are non-decreasing, so both edges of the viewport resolve by binary search instead of
+ * a walk over every row in the changeset.
+ */
+function firstCursorIndexFrom(
+  cursors: LineCursor[],
+  boundsOf: LineCursorBoundsLookup,
+  offset: number,
+) {
+  let low = 0;
+  let high = cursors.length;
+
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    const bounds = boundsOf(cursors[middle]!);
+    if (bounds && bounds.top >= offset) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+
+  return low;
+}
+
+/** Find the last cursor whose row ends at or before one stream offset. */
+function lastCursorIndexBefore(
+  cursors: LineCursor[],
+  boundsOf: LineCursorBoundsLookup,
+  offset: number,
+) {
+  let low = 0;
+  let high = cursors.length;
+
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    const bounds = boundsOf(cursors[middle]!);
+    if (bounds && bounds.top + bounds.height > offset) {
+      high = middle;
+    } else {
+      low = middle + 1;
+    }
+  }
+
+  return low - 1;
+}
+
+/**
+ * Keep the current line inside the viewport after the reviewer scrolls past it.
+ *
+ * Paging and wheel scrolling move the viewport without the marker, so the marker follows only once
+ * it would otherwise be off screen, landing on the nearest row it left through.
+ */
+export function clampLineCursorToViewport({
+  boundsOf,
+  current,
+  cursors,
+  scrollTop,
+  viewportHeight,
+}: {
+  boundsOf: LineCursorBoundsLookup;
+  current: LineCursor | null;
+  cursors: LineCursor[];
+  scrollTop: number;
+  viewportHeight: number;
+}): LineCursor | null {
+  if (cursors.length === 0 || viewportHeight <= 0) {
+    return current;
+  }
+
+  const viewportBottom = scrollTop + viewportHeight;
+  const currentBounds = current ? boundsOf(current) : undefined;
+  if (
+    currentBounds &&
+    currentBounds.top >= scrollTop &&
+    currentBounds.top + currentBounds.height <= viewportBottom
+  ) {
+    return current;
+  }
+
+  const scrolledPastAbove = !currentBounds || currentBounds.top < scrollTop;
+  const index = scrolledPastAbove
+    ? firstCursorIndexFrom(cursors, boundsOf, scrollTop)
+    : lastCursorIndexBefore(cursors, boundsOf, viewportBottom);
+  return cursors[Math.min(Math.max(index, 0), cursors.length - 1)] ?? null;
+}

--- a/src/ui/lib/lineCursors.ts
+++ b/src/ui/lib/lineCursors.ts
@@ -20,6 +20,8 @@ export interface LineCursor {
   /** The render plan's anchor for this row, shared with reveal and highlight lookups. */
   stableKey: string;
   target: UserNoteLineTarget;
+  /** Exact collapsed gap that produced this cursor, when it is a revealed source line. */
+  expandedGapKey?: string;
 }
 
 export const EMPTY_LINE_CURSORS: LineCursor[] = [];
@@ -48,7 +50,15 @@ function rowLineCursors(fileId: string, bounds: DiffSectionRowBounds): LineCurso
   const context = contextLineStableKeyTarget(bounds.stableKey);
   if (context) {
     const { hunkIndex, ...target } = context;
-    return [{ fileId, hunkIndex, stableKey: bounds.stableKey, target }];
+    return [
+      {
+        fileId,
+        hunkIndex,
+        stableKey: bounds.stableKey,
+        target,
+        ...(bounds.expandedGapKey ? { expandedGapKey: bounds.expandedGapKey } : {}),
+      },
+    ];
   }
 
   const cursors: LineCursor[] = [];
@@ -59,7 +69,13 @@ function rowLineCursors(fileId: string, bounds: DiffSectionRowBounds): LineCurso
     }
 
     const { hunkIndex, ...target } = anchor;
-    cursors.push({ fileId, hunkIndex, stableKey, target });
+    cursors.push({
+      fileId,
+      hunkIndex,
+      stableKey,
+      target,
+      ...(bounds.expandedGapKey ? { expandedGapKey: bounds.expandedGapKey } : {}),
+    });
   }
 
   return cursors;

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -24,8 +24,6 @@ describe("PTY current line", () => {
       await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
       await session.waitIdle({ timeout: 300 });
 
-      // The cursor starts inside the first hunk, well above the fold, so the first step only
-      // moves the highlight. This is the behavior `cursor_line = "off"` trades away.
       expect(await measureKeyScroll(session, "j", 12)).toBe(0);
 
       let stepsBeforeScrolling = 1;
@@ -35,12 +33,9 @@ describe("PTY current line", () => {
         stepsBeforeScrolling += 1;
       }
 
-      // The highlight has to reach the bottom edge before the viewport moves at all.
       expect(stepsBeforeScrolling).toBeGreaterThan(5);
       expect(firstScroll).toBeGreaterThan(0);
 
-      // From there the viewport follows the current line by exactly one row per step, rather
-      // than jumping a quarter screen the way hunk reveal does.
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "k", 12)).toBe(0);
@@ -104,8 +99,6 @@ describe("PTY current line", () => {
       await session.press("c");
       const draft = await session.waitForText(/Draft note/, { timeout: 5_000 });
 
-      // The revealed line is a stop of its own, so the card lands under it rather than under the
-      // first line the parsed hunk knows about.
       expect(lineIndexOf(draft, "Draft note")).toBe(lineIndexOf(draft, "hiddenLine01") + 1);
     } finally {
       session.close();
@@ -136,7 +129,6 @@ describe("PTY current line", () => {
       await session.press("c");
       const expanded = await session.waitForText(/Draft note/, { timeout: 5_000 });
 
-      // Expanding is a request to read what the gap hid, so the marker lands on its first line.
       expect(expanded).toContain("R1 ");
       expect(lineIndexOf(expanded, "Draft note")).toBe(lineIndexOf(expanded, "hiddenLine01") + 1);
       await session.press("escape");
@@ -170,8 +162,6 @@ describe("PTY current line", () => {
       await session.press("space");
       await session.waitIdle({ timeout: 400 });
 
-      // The page left the marker behind, so it re-anchors into the new viewport instead of
-      // dragging the whole page back the moment the reviewer steps again.
       expect(await measureKeyScroll(session, "j", 12)).toBeLessThanOrEqual(1);
     } finally {
       session.close();
@@ -235,7 +225,6 @@ describe("PTY current line", () => {
       await session.press("c");
       const draftAtCursor = await session.waitForText(/Draft note/, { timeout: 5_000 });
 
-      // Without a keyboard line target `c` would open the same card in the same place every time.
       expect(lineIndexOf(draftAtCursor, "Draft note")).toBeGreaterThan(draftRowAtTop);
     } finally {
       session.close();

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -112,6 +112,58 @@ describe("PTY current line", () => {
     }
   });
 
+  test("paging leaves the current line on screen", async () => {
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      await session.press("space");
+      await session.waitIdle({ timeout: 400 });
+
+      // The page left the marker behind, so it re-anchors into the new viewport instead of
+      // dragging the whole page back the moment the reviewer steps again.
+      expect(await measureKeyScroll(session, "j", 12)).toBeLessThanOrEqual(1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a note after paging opens where the reviewer is looking", async () => {
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      await session.press("space");
+      await session.waitIdle({ timeout: 400 });
+      const paged = (await session.text({ immediate: true })).split("\n");
+      const anchor = paged[12]?.trim() ?? "";
+      expect(anchor.length).toBeGreaterThan(0);
+
+      await session.press("c");
+      const draft = await session.waitForText(/Draft note/, { timeout: 5_000 });
+
+      expect(draft).toContain(anchor);
+    } finally {
+      session.close();
+    }
+  });
+
   test("a note anchors at the current line instead of the top of the hunk", async () => {
     const fixture = harness.createPinnedHeaderRepoFixture();
     const session = await harness.launchHunk({

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -104,9 +104,9 @@ describe("PTY current line", () => {
       await session.press("c");
       const draft = await session.waitForText(/Draft note/, { timeout: 5_000 });
 
-      // The revealed line is a stop of its own, so the card lands above it rather than above the
+      // The revealed line is a stop of its own, so the card lands under it rather than under the
       // first line the parsed hunk knows about.
-      expect(lineIndexOf(draft, "Draft note")).toBeLessThan(lineIndexOf(draft, "hiddenLine01"));
+      expect(lineIndexOf(draft, "Draft note")).toBe(lineIndexOf(draft, "hiddenLine01") + 1);
     } finally {
       session.close();
     }

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness, lineIndexOf, measureKeyScroll } from "./harness";
+
+const harness = createPtyHarness();
+
+/** Give PTY-backed startup and redraws enough headroom for slower CI machines. */
+setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("PTY current line", () => {
+  test("stepping moves the current line before it moves the viewport", async () => {
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      // The cursor starts inside the first hunk, well above the fold, so the first step only
+      // moves the highlight. This is the behavior `cursor_line = "off"` trades away.
+      expect(await measureKeyScroll(session, "j", 12)).toBe(0);
+
+      let stepsBeforeScrolling = 1;
+      let firstScroll = 0;
+      for (let step = 0; step < 40 && firstScroll === 0; step += 1) {
+        firstScroll = await measureKeyScroll(session, "j", 12);
+        stepsBeforeScrolling += 1;
+      }
+
+      // The highlight has to reach the bottom edge before the viewport moves at all.
+      expect(stepsBeforeScrolling).toBeGreaterThan(5);
+      expect(firstScroll).toBeGreaterThan(0);
+
+      // From there the viewport follows the current line by exactly one row per step, rather
+      // than jumping a quarter screen the way hunk reveal does.
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      expect(await measureKeyScroll(session, "k", 12)).toBe(0);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a held step key advances one line per press", async () => {
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      let scrolled = 0;
+      for (let step = 0; step < 40 && scrolled === 0; step += 1) {
+        scrolled = await measureKeyScroll(session, "j", 12);
+      }
+      expect(scrolled).toBeGreaterThan(0);
+
+      const before = (await session.text({ immediate: true })).split("\n");
+      const anchor = before[12]?.trim() ?? "";
+      expect(anchor.length).toBeGreaterThan(0);
+
+      // A held key arrives as one chunk and drains synchronously, so every press in the burst
+      // has to see the move the press before it made.
+      await session.writeRaw("jjjjj");
+      await session.waitIdle({ timeout: 800 });
+
+      const after = (await session.text({ immediate: true })).split("\n");
+      expect(12 - after.findIndex((line) => line.trim() === anchor)).toBe(5);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a note anchors at the current line instead of the top of the hunk", async () => {
+    const fixture = harness.createPinnedHeaderRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      await session.press("c");
+      const draftAtTop = await session.waitForText(/Draft note/, { timeout: 5_000 });
+      const draftRowAtTop = lineIndexOf(draftAtTop, "Draft note");
+      expect(draftRowAtTop).toBeGreaterThan(0);
+
+      await session.press("escape");
+      await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
+
+      for (let step = 0; step < 4; step += 1) {
+        await session.press("j");
+        await session.waitIdle({ timeout: 200 });
+      }
+
+      await session.press("c");
+      const draftAtCursor = await session.waitForText(/Draft note/, { timeout: 5_000 });
+
+      // Without a keyboard line target `c` would open the same card in the same place every time.
+      expect(lineIndexOf(draftAtCursor, "Draft note")).toBeGreaterThan(draftRowAtTop);
+    } finally {
+      session.close();
+    }
+  });
+});

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -112,6 +112,48 @@ describe("PTY current line", () => {
     }
   });
 
+  test("expanding a gap moves the current line into it and collapsing puts it back", async () => {
+    const fixture = harness.createExpandableContextFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      cols: 140,
+      rows: 16,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+      await session.press("c");
+      const beforeExpand = await session.waitForText(/Draft note/, { timeout: 5_000 });
+      const startRow = /Draft note[^R]*R(\d+)/.exec(beforeExpand)?.[1];
+      expect(startRow).toBeDefined();
+      await session.press("escape");
+      await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
+
+      await session.press("z");
+      await harness.waitForSnapshot(session, (text) => text.includes("hiddenLine01"), 5_000);
+      await session.waitIdle({ timeout: 500 });
+      await session.press("c");
+      const expanded = await session.waitForText(/Draft note/, { timeout: 5_000 });
+
+      // Expanding is a request to read what the gap hid, so the marker lands on its first line.
+      expect(expanded).toContain("R1 ");
+      expect(lineIndexOf(expanded, "Draft note")).toBe(lineIndexOf(expanded, "hiddenLine01") + 1);
+      await session.press("escape");
+      await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
+
+      await session.press("z");
+      await harness.waitForSnapshot(session, (text) => !text.includes("hiddenLine01"), 5_000);
+      await session.waitIdle({ timeout: 500 });
+      await session.press("c");
+      const collapsed = await session.waitForText(/Draft note/, { timeout: 5_000 });
+
+      expect(collapsed).toContain(`R${startRow} `);
+    } finally {
+      session.close();
+    }
+  });
+
   test("paging leaves the current line on screen", async () => {
     const fixture = harness.createPinnedHeaderRepoFixture();
     const session = await harness.launchHunk({

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -84,6 +84,34 @@ describe("PTY current line", () => {
     }
   });
 
+  test("stepping reaches the lines an expanded gap reveals", async () => {
+    const fixture = harness.createExpandableContextFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      cols: 140,
+      rows: 16,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.press("z");
+      await harness.waitForSnapshot(session, (text) => text.includes("hiddenLine01"), 5_000);
+      // The revealed rows reach navigation one commit after they reach the screen.
+      await session.waitIdle({ timeout: 500 });
+
+      await session.press("k");
+      await session.waitIdle({ timeout: 200 });
+      await session.press("c");
+      const draft = await session.waitForText(/Draft note/, { timeout: 5_000 });
+
+      // The revealed line is a stop of its own, so the card lands above it rather than above the
+      // first line the parsed hunk knows about.
+      expect(lineIndexOf(draft, "Draft note")).toBeLessThan(lineIndexOf(draft, "hiddenLine01"));
+    } finally {
+      session.close();
+    }
+  });
+
   test("a note anchors at the current line instead of the top of the hunk", async () => {
     const fixture = harness.createPinnedHeaderRepoFixture();
     const session = await harness.launchHunk({

--- a/test/pty/key-routing.test.ts
+++ b/test/pty/key-routing.test.ts
@@ -264,7 +264,7 @@ describe("PTY key routing", () => {
   test("step keys still scroll exactly one row while a menu is open", async () => {
     const fixture = harness.createPinnedHeaderRepoFixture();
     const session = await harness.launchHunk({
-      args: ["show", "HEAD"],
+      args: ["show", "HEAD", "--cursor-line", "off"],
       cwd: fixture.dir,
       cols: 120,
       rows: 24,

--- a/test/pty/nav.test.ts
+++ b/test/pty/nav.test.ts
@@ -222,7 +222,8 @@ describe("PTY navigation", () => {
       expect(initial).toContain("first.ts");
       expect(initial).toContain("second.ts");
 
-      for (let index = 0; index < 8; index += 1) {
+      // Split pairs both sides of a change row, so a row costs two presses.
+      for (let index = 0; index < 16; index += 1) {
         await session.press("down");
       }
 

--- a/test/pty/nav.test.ts
+++ b/test/pty/nav.test.ts
@@ -222,7 +222,6 @@ describe("PTY navigation", () => {
       expect(initial).toContain("first.ts");
       expect(initial).toContain("second.ts");
 
-      // Split pairs both sides of a change row, so a row costs two presses.
       for (let index = 0; index < 16; index += 1) {
         await session.press("down");
       }

--- a/test/pty/scroll.test.ts
+++ b/test/pty/scroll.test.ts
@@ -14,7 +14,7 @@ describe("PTY scrolling", () => {
   test("a short last file does not trap upward scrolling at the bottom edge", async () => {
     const fixture = harness.createBottomClampedRepoFixture();
     const session = await harness.launchHunk({
-      args: ["diff", "--mode", "split"],
+      args: ["diff", "--mode", "split", "--cursor-line", "off"],
       cwd: fixture.dir,
       cols: 220,
       rows: 10,
@@ -55,7 +55,7 @@ describe("PTY scrolling", () => {
     const fixture = harness.createPagerPatchFixture(60);
     const session = await harness.launchHunkWithFileBackedStdin({
       stdinFile: fixture.patchFile,
-      args: ["pager"],
+      args: ["pager", "--cursor-line", "off"],
       cols: 140,
       rows: 24,
     });
@@ -75,7 +75,7 @@ describe("PTY scrolling", () => {
   test("step keys still move one row after a click in the review stream", async () => {
     const fixture = harness.createPinnedHeaderRepoFixture();
     const session = await harness.launchHunk({
-      args: ["show", "HEAD"],
+      args: ["show", "HEAD", "--cursor-line", "off"],
       cwd: fixture.dir,
       cols: 120,
       rows: 24,

--- a/website/src/content/docs/docs/agents/comments-and-annotations.md
+++ b/website/src/content/docs/docs/agents/comments-and-annotations.md
@@ -39,4 +39,4 @@ Use `--all --yes` to clear both live agent comments and human notes. Destructive
 
 ## Add a human note
 
-In the TUI, move to the line you mean with `k` / `j` and press `c`, or click an add-note affordance. Human and agent notes are labeled by source. Use `{` and `}` to move through annotated hunks across the review stream.
+In the TUI, select a hunk and press `c` or click an add-note affordance. Human and agent notes are labeled by source. Use `{` and `}` to move through annotated hunks across the review stream.

--- a/website/src/content/docs/docs/agents/comments-and-annotations.md
+++ b/website/src/content/docs/docs/agents/comments-and-annotations.md
@@ -39,4 +39,4 @@ Use `--all --yes` to clear both live agent comments and human notes. Destructive
 
 ## Add a human note
 
-In the TUI, select a hunk and press `c` or click an add-note affordance. Human and agent notes are labeled by source. Use `{` and `}` to move through annotated hunks across the review stream.
+In the TUI, move to the line you mean with `k` / `j` and press `c`, or click an add-note affordance. Human and agent notes are labeled by source. Use `{` and `}` to move through annotated hunks across the review stream.

--- a/website/src/content/docs/docs/configure/layout-and-display.md
+++ b/website/src/content/docs/docs/configure/layout-and-display.md
@@ -40,6 +40,9 @@ menu_bar = true
 agent_notes = false
 copy_decorations = false
 transparent_background = false
+cursor_line = "row"
 ```
 
 `transparent_background` lets the terminal paint Hunk surfaces; turn it off when exact theme surfaces matter more than matching terminal transparency.
+
+`cursor_line` chooses how the line you are on is marked: `row` highlights the whole row, `number` marks only its line number, and `off` removes the marker and returns `k` / `j` to scrolling the view one row at a time. Switch it mid-review from the View menu, or set `--cursor-line <style>` for a single run.

--- a/website/src/content/docs/docs/reference/cli.md
+++ b/website/src/content/docs/docs/reference/cli.md
@@ -19,6 +19,7 @@ This reference is generated from the command metadata used by Hunk itself. Run `
 | Option                      | Description                                                     |
 | --------------------------- | --------------------------------------------------------------- |
 | `--mode <mode>`             | layout mode: auto, split, stack                                 |
+| `--cursor-line <style>`     | current-line marker: row, number, off                           |
 | `--theme <theme>`           | named theme override                                            |
 | `--agent-context <path>`    | JSON sidecar with agent rationale                               |
 | `--pager`                   | use pager-style chrome                                          |

--- a/website/src/content/docs/docs/reference/config.md
+++ b/website/src/content/docs/docs/reference/config.md
@@ -30,6 +30,16 @@ Choose responsive, side-by-side, or stacked diff layout.
 
 ---
 
+**`cursor_line`**
+
+Mark the current line as a full-row highlight or on its line number. `off` restores plain `j`/`k` scrolling.
+
+- **Type:** string
+- **Accepted:** `row`, `number`, or `off`
+- **Built-in default:** `row`
+
+---
+
 **`vcs`**
 
 Select the version-control adapter explicitly. An explicit id outranks detection; an id no loaded backend owns falls back to detection with a startup notice.

--- a/website/src/content/docs/docs/start/keyboard-and-mouse.md
+++ b/website/src/content/docs/docs/start/keyboard-and-mouse.md
@@ -9,7 +9,7 @@ Press `?` at any time for Hunk's in-app shortcut reference. Menus and primary re
 
 | Keys                      | Action                                                |
 | ------------------------- | ----------------------------------------------------- |
-| `↑` / `↓`, `k` / `j`      | Scroll one row                                        |
+| `↑` / `↓`, `k` / `j`      | Move the current line up / down                       |
 | `Space` / `f`, `b`        | Page down / up                                        |
 | `Shift+Space`             | Page up                                               |
 | `d` / `u`                 | Half page down / up                                   |
@@ -20,6 +20,8 @@ Press `?` at any time for Hunk's in-app shortcut reference. Menus and primary re
 | `←` / `→`                 | Scroll unwrapped code; hold Shift for faster movement |
 
 Hunk navigation stays review-wide: hunk and file shortcuts move through the same multi-file stream shown in the main pane.
+
+The current line is highlighted as you move it, and the view scrolls only far enough to keep it visible. Pick the marker from the View menu, or set [`cursor_line`](/docs/configure/layout-and-display/): `number` marks only the line number, and `off` turns the marker off and lets `↑` / `↓` and `k` / `j` scroll the view one row at a time instead.
 
 ## Change the view
 
@@ -45,7 +47,7 @@ Hunk may offer to save view changes on quit. Saving writes personal preferences 
 
 ## Add a human note
 
-Press `c` on the selected hunk or use a visible add-note affordance with the mouse. While editing, app shortcuts are suspended so normal text entry works. Save with the note editor's displayed action or cancel with Escape.
+Press `c` to add a note on the current line, or use a visible add-note affordance with the mouse. With `cursor_line = "off"` the note anchors at the top of the selected hunk instead. While editing, app shortcuts are suspended so normal text entry works. Save with the note editor's displayed action or cancel with Escape.
 
 ## Mouse behavior
 

--- a/website/src/content/docs/docs/start/keyboard-and-mouse.md
+++ b/website/src/content/docs/docs/start/keyboard-and-mouse.md
@@ -21,7 +21,7 @@ Press `?` at any time for Hunk's in-app shortcut reference. Menus and primary re
 
 Hunk navigation stays review-wide: hunk and file shortcuts move through the same multi-file stream shown in the main pane.
 
-The current line is highlighted as you move it, and the view scrolls only far enough to keep it visible. Pick the marker from the View menu, or set [`cursor_line`](/docs/configure/layout-and-display/): `number` marks only the line number, and `off` turns the marker off and lets `↑` / `↓` and `k` / `j` scroll the view one row at a time instead.
+The current line is highlighted as you move it, and the view scrolls only far enough to keep it visible. Paging or scrolling past it moves it to the nearest line still on screen. Pick the marker from the View menu, or set [`cursor_line`](/docs/configure/layout-and-display/): `number` marks only the line number, and `off` turns the marker off and lets `↑` / `↓` and `k` / `j` scroll the view one row at a time instead.
 
 ## Change the view
 

--- a/website/src/content/docs/docs/start/keyboard-and-mouse.md
+++ b/website/src/content/docs/docs/start/keyboard-and-mouse.md
@@ -9,7 +9,7 @@ Press `?` at any time for Hunk's in-app shortcut reference. Menus and primary re
 
 | Keys                      | Action                                                |
 | ------------------------- | ----------------------------------------------------- |
-| `↑` / `↓`, `k` / `j`      | Move the current line up / down                       |
+| `↑` / `↓`, `k` / `j`      | Scroll one row                                        |
 | `Space` / `f`, `b`        | Page down / up                                        |
 | `Shift+Space`             | Page up                                               |
 | `d` / `u`                 | Half page down / up                                   |
@@ -21,7 +21,7 @@ Press `?` at any time for Hunk's in-app shortcut reference. Menus and primary re
 
 Hunk navigation stays review-wide: hunk and file shortcuts move through the same multi-file stream shown in the main pane.
 
-The current line is highlighted as you move it, and the view scrolls only far enough to keep it visible. Paging or scrolling past it moves it to the nearest line still on screen. Pick the marker from the View menu, or set [`cursor_line`](/docs/configure/layout-and-display/): `number` marks only the line number, and `off` turns the marker off and lets `↑` / `↓` and `k` / `j` scroll the view one row at a time instead.
+`↑` / `↓` and `k` / `j` move a highlighted current line, and the view scrolls only far enough to keep it visible. Paging or scrolling past it moves it to the nearest line still on screen, and `c` anchors a note on it. Pick the marker from the View menu, or set [`cursor_line`](/docs/configure/layout-and-display/): `number` marks only the line number, and `off` turns the marker off and lets `↑` / `↓` and `k` / `j` scroll the view one row at a time instead.
 
 ## Change the view
 
@@ -47,7 +47,7 @@ Hunk may offer to save view changes on quit. Saving writes personal preferences 
 
 ## Add a human note
 
-Press `c` to add a note on the current line, or use a visible add-note affordance with the mouse. With `cursor_line = "off"` the note anchors at the top of the selected hunk instead. While editing, app shortcuts are suspended so normal text entry works. Save with the note editor's displayed action or cancel with Escape.
+Press `c` on the selected hunk or use a visible add-note affordance with the mouse. While editing, app shortcuts are suspended so normal text entry works. Save with the note editor's displayed action or cancel with Escape.
 
 ## Mouse behavior
 


### PR DESCRIPTION
Closes #553. Closes #436.

## Behavior

- The line you are on is highlighted, and `j`/`k` (and `↑`/`↓`) move it. The view scrolls only far enough to keep it visible.
- `c` anchors a note at that line instead of the top of the hunk. A live mouse hover still wins, so the pointer flow is unchanged.
- The cursor rolls across hunk and file boundaries, clamps at both ends, and stays in step with `[`/`]` and sidebar selection in both directions.
- `cursor_line` = `row` (default, whole row) | `number` (line-number gutter only) | `off`. Settable in config, with `--cursor-line <style>`, or from the View menu.
- **`off` restores today's `j`/`k` scrolling exactly.**

## On `j`/`k`

`AGENTS.md` says not to reintroduce `j`/`k` *hunk* navigation. This is line navigation, which is what #436 asks for; one commenter there cannot use a mouse. `off` opts out, and the PTY guards that asserted one-row step scrolling now run in that mode, keeping their original coverage.

Say the word and I'll flip the default to `off`.

## Implementation

Hunk already resolves a line-precise note target; it just expires ~2s after the pointer moves. This makes it persistent and keyboard-driven.

- `src/ui/lib/lineCursors.ts` mirrors `hunks.ts` one level down, memoized per parsed file so a keypress does not reallocate the list.
- `useReviewController` owns the cursor beside the existing selection, minting a reveal id like `selectHunk` does.
- Rendering resolves one `RowHighlight` per cell (blend plus optional column span) and hands it to the existing cell renderers, replacing the old `selected` + `selectionColRange` pair. No new theme tokens. The cursor row is found by the render plan's own `line:<hunk>:<side>:<n>` key, so windowing needs no special case.
- On split rows only the cursor's side is highlighted, since the two halves are different note targets.

The marker shifts **luminance**, not hue: blending toward one fixed highlight color barely moves a background that already shares its hue, which left it invisible on added rows. `AppHost.cursor-line.test.tsx` asserts the painted backgrounds, including that added stays green and removed stays red under the marker.

## Known gaps

Targets come from `hunkContent` rather than the render plan, so lines revealed by expanding a collapsed gap are not reachable by `j`/`k`. `z` still expands the gap at the cursor's hunk. Same for files shown through an extension file presentation, which have no `line:` anchors. Both are called out in the module docstring; happy to follow up with a plan-derived target list if you'd prefer that before merge.

## Verification

`format:check`, `lint`, `typecheck`, `check:docs`, `test`, `test:integration`, `test:tty-smoke`, `build:npm`, `check:pack`. Docs updated: keybindings table, keyboard reference, notes guide, display config, plus regenerated CLI/config reference.

Pre-existing failures on `main` at `e0d1757`, unchanged by this PR (verified by stashing it): `AppHost.watch.test.tsx` theme resolution, and 5 PTY extension/file-view tests.

No true interactive TTY run: no controlling terminal here. Instead the real painted spans are asserted via `captureSpans()` across `row`/`number`/`off`, split and stack, light and dark.
