### PR TITLE
fix(ui): preserve file headers on narrow terminals

### DIFF
--- a/.changeset/fuzzy-paths-fit.md
+++ b/.changeset/fuzzy-paths-fit.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep file stats visible and use three-dot path truncation on narrow terminals.

--- a/src/opentui/HunkDiffFileHeader.tsx
+++ b/src/opentui/HunkDiffFileHeader.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { DiffFileHeaderRow } from "../ui/components/panes/DiffFileHeaderRow";
+import { maxFileHeaderStatsWidth } from "../ui/lib/fileHeader";
 import { resolveTheme } from "../ui/themes";
 import { toInternalDiffFile } from "./model";
 import type { HunkDiffFileHeaderProps } from "./types";
@@ -13,16 +14,12 @@ export function HunkDiffFileHeader({
 }: HunkDiffFileHeaderProps) {
   const resolvedTheme = resolveTheme(theme, null);
   const internalFile = useMemo(() => toInternalDiffFile(file), [file]);
-  const headerStatsWidth = Math.max(
-    7,
-    `+${internalFile.stats.additions}${internalFile.statsTruncated ? "+" : ""} -${internalFile.stats.deletions}`
-      .length,
-  );
+  const headerStatsWidth = maxFileHeaderStatsWidth([internalFile]);
 
   return (
     <DiffFileHeaderRow
       file={internalFile}
-      headerLabelWidth={Math.max(1, width - headerStatsWidth - 2)}
+      headerLabelWidth={Math.max(0, width - 2 - headerStatsWidth - 1)}
       headerStatsWidth={headerStatsWidth}
       theme={resolvedTheme}
       onSelect={onSelect}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -95,6 +95,7 @@ import {
   type SidebarPlacement,
 } from "./lib/sidebarPanes";
 import { nextExtensionTrustPromptRoot } from "./lib/extensionTrustPrompt";
+import { maxFileHeaderStatsWidth } from "./lib/fileHeader";
 import { openSelectedFileInEditor } from "./lib/openInEditor";
 import { resolveResponsiveLayout } from "./lib/responsive";
 import { resizeSidebarWidth } from "./lib/sidebar";
@@ -902,8 +903,10 @@ export function App({
     ],
   );
   const renderSidebar = sidebarLayout.left.length + sidebarLayout.right.length > 0;
-  const diffPaneWidth = Math.max(DIFF_MIN_WIDTH, bodyWidth - sidebarLayout.totalWidth);
-  const diffContentWidth = Math.max(12, diffPaneWidth - 2);
+  // DIFF_MIN_WIDTH reserves room while planning sidebars; the pane itself must
+  // still fit terminals narrower than that preferred minimum.
+  const diffPaneWidth = Math.max(0, bodyWidth - sidebarLayout.totalWidth);
+  const diffContentWidth = Math.max(0, diffPaneWidth - 2);
   // Mirrors toggleSidebar's reveal half: visible again, forced open when the
   // responsive layout alone would keep it hidden and the terminal has room.
   revealSidebarAreaRef.current = () => {
@@ -1880,9 +1883,9 @@ export function App({
     0,
   );
   const topTitle = `${bootstrap.changeset.title}  +${totalAdditions}  -${totalDeletions}`;
-  const diffHeaderStatsWidth = Math.min(24, Math.max(16, Math.floor(diffContentWidth / 3)));
-  const diffHeaderLabelWidth = Math.max(8, diffContentWidth - diffHeaderStatsWidth - 1);
-  const diffSeparatorWidth = Math.max(4, diffContentWidth - 2);
+  const diffHeaderStatsWidth = maxFileHeaderStatsWidth(filteredFiles);
+  const diffHeaderLabelWidth = Math.max(0, diffContentWidth - diffHeaderStatsWidth - 1);
+  const diffSeparatorWidth = Math.max(0, diffContentWidth - 2);
   // Mirror the App layout: bodyPadding/2 left-padding, then every left pane
   // plus its divider. Keep this in lockstep with the body container's
   // paddingLeft and the sidebar render branch below.

--- a/src/ui/AppHost.responsive.test.tsx
+++ b/src/ui/AppHost.responsive.test.tsx
@@ -108,6 +108,26 @@ describe("responsive app", () => {
     expect(tight).not.toMatch(/▌.*▌/);
   });
 
+  test("narrow viewports keep file stats visible and mark truncated paths with three dots", async () => {
+    const bootstrap = createTestVcsAppBootstrap({
+      changesetId: "changeset:narrow-header",
+      files: [
+        createTestDiffFile({
+          after: "export const value = 2;\n",
+          before: "export const value = 1;\n",
+          id: "narrow-header",
+          path: "packages/visual-studio-code-vscode/extension-postgres.ts",
+        }),
+      ],
+      initialMode: "auto",
+    });
+
+    const frame = await captureFrameForBootstrap(bootstrap, 40, 12);
+
+    expect(frame).toContain("packages/visual-studio-cod... +1 -1");
+    expect(frame).not.toContain("packages/visual-studio-code-.");
+  });
+
   test("View menu sidebar checkmark follows actual medium-viewport visibility", async () => {
     const setup = await testRender(<AppHost bootstrap={createBootstrap("auto")} />, {
       width: 180,

--- a/src/ui/components/panes/DiffFileHeaderRow.tsx
+++ b/src/ui/components/panes/DiffFileHeaderRow.tsx
@@ -1,6 +1,5 @@
 import type { DiffFile } from "../../../core/types";
-import { fileLabelParts } from "../../lib/files";
-import { fitText } from "../../lib/text";
+import { fileHeaderStats, fitFileHeaderLabel } from "../../lib/fileHeader";
 import type { AppTheme } from "../../themes";
 
 interface DiffFileHeaderRowProps {
@@ -19,9 +18,8 @@ export function DiffFileHeaderRow({
   theme,
   onSelect,
 }: DiffFileHeaderRowProps) {
-  const additionsText = `+${file.stats.additions}${file.statsTruncated ? "+" : ""}`;
-  const deletionsText = `-${file.stats.deletions}`;
-  const { filename, stateLabel } = fileLabelParts(file);
+  const { additionsText, deletionsText } = fileHeaderStats(file);
+  const { filename, stateLabel } = fitFileHeaderLabel(file, headerLabelWidth);
 
   return (
     <box
@@ -39,9 +37,7 @@ export function DiffFileHeaderRow({
     >
       {/* Clicking the file header jumps the main stream selection without collapsing to a single-file view. */}
       <box style={{ flexDirection: "row" }}>
-        <text fg={theme.text}>
-          {fitText(filename, Math.max(1, headerLabelWidth - (stateLabel?.length ?? 0)))}
-        </text>
+        <text fg={theme.text}>{filename}</text>
         {stateLabel && <text fg={theme.muted}>{stateLabel}</text>}
       </box>
       <box

--- a/src/ui/components/panes/copySelection.ts
+++ b/src/ui/components/panes/copySelection.ts
@@ -11,8 +11,8 @@ import {
   type DiffSectionRowBounds,
 } from "../../diff/diffSectionGeometry";
 import type { FileSectionLayout } from "../../lib/fileSectionLayout";
-import { fileLabelParts } from "../../lib/files";
-import { cellRangeToCharRange, fitText, measureTextWidth, sliceTextByWidth } from "../../lib/text";
+import { fileHeaderStats, fitFileHeaderLabel } from "../../lib/fileHeader";
+import { cellRangeToCharRange, measureTextWidth, sliceTextByWidth } from "../../lib/text";
 import type { AppTheme } from "../../themes";
 
 export type CopySelectionPoint =
@@ -162,14 +162,9 @@ function renderFileHeaderCopyText({
   headerStatsWidth: number;
   width: number;
 }) {
-  const additionsText = `+${file.stats.additions}${file.statsTruncated ? "+" : ""}`;
-  const deletionsText = `-${file.stats.deletions}`;
-  const statsText = `${additionsText} ${deletionsText} `.padStart(headerStatsWidth);
-  const { filename, stateLabel } = fileLabelParts(file);
-  const label = `${fitText(
-    filename,
-    Math.max(1, headerLabelWidth - (stateLabel?.length ?? 0)),
-  )}${stateLabel ?? ""}`;
+  const statsText = fileHeaderStats(file).text.padStart(headerStatsWidth);
+  const { filename, stateLabel } = fitFileHeaderLabel(file, headerLabelWidth);
+  const label = `${filename}${stateLabel ?? ""}`;
   // The gap and clamp are measured in cells to mirror DiffFileHeaderRow's space-between flex
   // layout, so wide-character filenames keep the stats columns aligned with the screen.
   const availableGap = Math.max(1, width - 2 - measureTextWidth(label) - statsText.length);

--- a/src/ui/lib/fileHeader.test.ts
+++ b/src/ui/lib/fileHeader.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile } from "../../../test/helpers/diff-helpers";
+import {
+  FILE_HEADER_OVERFLOW_MARKER,
+  fileHeaderStats,
+  fitFileHeaderLabel,
+  maxFileHeaderStatsWidth,
+} from "./fileHeader";
+import { measureTextWidth } from "./text";
+
+describe("file header layout", () => {
+  test("reserves only the widest rendered stats text", () => {
+    const small = createTestDiffFile({ id: "small", path: "small.ts" });
+    const large = createTestDiffFile({ id: "large", path: "large.ts" });
+    small.stats = { additions: 1, deletions: 0 };
+    large.stats = { additions: 1234, deletions: 56 };
+    large.statsTruncated = true;
+
+    expect(fileHeaderStats(small)).toMatchObject({ text: "+1 -0 ", width: 6 });
+    expect(fileHeaderStats(large)).toMatchObject({ text: "+1234+ -56 ", width: 11 });
+    expect(maxFileHeaderStatsWidth([small, large])).toBe(11);
+  });
+
+  test("fits long paths with three dots while preserving terminal-cell width", () => {
+    const file = createTestDiffFile({
+      id: "long-path",
+      path: "packages/visual-studio-code-vscode/extension-postgres.ts",
+    });
+
+    const label = fitFileHeaderLabel(file, 29);
+
+    expect(label.filename).toBe(`packages/visual-studio-cod${FILE_HEADER_OVERFLOW_MARKER}`);
+    expect(measureTextWidth(label.filename)).toBe(29);
+  });
+
+  test("keeps state labels outside the path truncation budget", () => {
+    const file = createTestDiffFile({ id: "new-file", path: "longer-filename.ts" });
+    file.metadata.type = "new";
+
+    expect(fitFileHeaderLabel(file, 14)).toEqual({ filename: "longe...", stateLabel: " (new)" });
+  });
+
+  test("drops a state label before it can displace the path or stats", () => {
+    const file = createTestDiffFile({ id: "tiny-new-file", path: "longer-filename.ts" });
+    file.metadata.type = "new";
+
+    expect(fitFileHeaderLabel(file, 5)).toEqual({ filename: "lo...", stateLabel: null });
+    expect(fitFileHeaderLabel(file, 0)).toEqual({ filename: "", stateLabel: null });
+  });
+});

--- a/src/ui/lib/fileHeader.ts
+++ b/src/ui/lib/fileHeader.ts
@@ -1,0 +1,46 @@
+import type { DiffFile } from "../../core/types";
+import { fileLabelParts } from "./files";
+import { fitText, measureTextWidth } from "./text";
+
+/** The explicit overflow marker used for file paths in review headers. */
+export const FILE_HEADER_OVERFLOW_MARKER = "...";
+
+/** Build the styled text fragments and measured width for one file's line counts. */
+export function fileHeaderStats(file: Pick<DiffFile, "stats" | "statsTruncated">) {
+  const additionsText = `+${file.stats.additions}${file.statsTruncated ? "+" : ""}`;
+  const deletionsText = `-${file.stats.deletions}`;
+  const text = `${additionsText} ${deletionsText} `;
+
+  return {
+    additionsText,
+    deletionsText,
+    text,
+    width: measureTextWidth(text),
+  };
+}
+
+/** Reserve only the columns needed by the widest visible file stats. */
+export function maxFileHeaderStatsWidth(
+  files: readonly Pick<DiffFile, "stats" | "statsTruncated">[],
+) {
+  return Math.max(0, ...files.map((file) => fileHeaderStats(file).width));
+}
+
+/** Fit a file label while keeping its state suffix and using an explicit three-dot marker. */
+export function fitFileHeaderLabel(file: DiffFile, width: number) {
+  const { filename, stateLabel } = fileLabelParts(file);
+  const stateWidth = measureTextWidth(stateLabel ?? "");
+  // The path is the primary identity. Drop a state suffix when it would leave
+  // no path cell rather than letting the left column displace the stats.
+  const visibleStateLabel = stateLabel && stateWidth < width ? stateLabel : null;
+  const visibleStateWidth = visibleStateLabel ? stateWidth : 0;
+
+  return {
+    filename: fitText(
+      filename,
+      Math.max(0, width - visibleStateWidth),
+      FILE_HEADER_OVERFLOW_MARKER,
+    ),
+    stateLabel: visibleStateLabel,
+  };
+}

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -459,8 +459,8 @@ export function cellRangeToCharRange(text: string, startCell: number, endCell: n
   return { startIndex, endIndex: Math.max(startIndex, endIndex) };
 }
 
-/** Clamp text to a fixed width using a plain-dot terminal fallback marker. */
-export function fitText(text: string, width: number) {
+/** Clamp text to a fixed width using a cell-aware overflow marker. */
+export function fitText(text: string, width: number, overflowMarker = ".") {
   const safeText = sanitizeTerminalLine(text);
   if (width <= 0) {
     return "";
@@ -470,11 +470,10 @@ export function fitText(text: string, width: number) {
     return safeText;
   }
 
-  if (width === 1) {
-    return ".";
-  }
-
-  return `${sliceTextByWidth(safeText, 0, width - 1).text}.`;
+  const safeMarker = sanitizeTerminalLine(overflowMarker);
+  const marker = sliceTextByWidth(safeMarker, 0, width);
+  const textWidth = Math.max(0, width - marker.width);
+  return `${sliceTextByWidth(safeText, 0, textWidth).text}${marker.text}`;
 }
 
 /** Clamp and then right-pad text to an exact width. */

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -540,6 +540,17 @@ export function createPtyHarness() {
     return { dir };
   }
 
+  /** Build the long-path fixture used to verify narrow file-header layout. */
+  function createNarrowHeaderTestRepoFixture() {
+    return createGitRepoFixture([
+      {
+        path: "packages/visual-studio-code-vscode/extension-postgres.ts",
+        before: "export const value = 1;\n",
+        after: "export const value = 2;\n",
+      },
+    ]);
+  }
+
   function createTwoFileRepoFixture() {
     return createGitRepoFixture([
       {
@@ -906,6 +917,7 @@ export function createPtyHarness() {
     createLongWrapFilePair,
     createMultiFilePagerPatchFixture,
     createMultiHunkFilePair,
+    createNarrowHeaderTestRepoFixture,
     createPagerPatchFixture,
     createPinnedHeaderRepoFixture,
     createScrollableFilePair,

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -186,6 +186,31 @@ describe("PTY layout", () => {
     }
   });
 
+  test("narrow terminals preserve stats and use three dots for truncated file paths", async () => {
+    const fixture = harness.createNarrowHeaderTestRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "auto"],
+      cwd: fixture.dir,
+      cols: 40,
+      rows: 12,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      const snapshot = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("packages/visual-studio-cod... +1 -1"),
+        5_000,
+      );
+
+      expect(snapshot).not.toContain("packages/visual-studio-code-.");
+    } finally {
+      session.close();
+    }
+  });
+
   test("auto layout responds to live terminal resize in a real PTY", async () => {
     const fixture = harness.createTwoFileRepoFixture();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Summary

- keep the review pane within the physical viewport below its preferred minimum width
- reserve only the columns the visible file stats actually need
- truncate file paths with an explicit `...` marker across rendered and copied headers
- add component, helper, and PTY regression coverage for a 40-column terminal

## Before and after

40-column PTY reproduction:

| Before | After |
| --- | --- |
| ![Before: the long file path ends abruptly with a single dot and the stats are clipped](https://gist.githubusercontent.com/benvinegar/345e5d9e3f6065f65306a66acbc088d9/raw/8ba3c6571e2b8133325d1fa6a6c7626cba7f8f2e/hunk-639-before.svg) | ![After: the path uses three-dot truncation and the file stats remain visible](https://gist.githubusercontent.com/benvinegar/345e5d9e3f6065f65306a66acbc088d9/raw/b6b7b77b18b1180145f695239f275b8676afc259/hunk-639-after.svg) |

At 80 columns, the same header shows the complete path:

![Wider viewport: the complete packages/visual-studio-code-vscode/extension-postgres.ts path and stats are visible](https://gist.githubusercontent.com/benvinegar/345e5d9e3f6065f65306a66acbc088d9/raw/f470239ace9ed5476e2cf7b98afbe76aa5cadbbd/hunk-639-wide.svg)

## Testing

- `bun run typecheck`
- `bun run lint`
- targeted unit/component tests for file headers, responsive layout, copy selection, and OpenTUI exports
- `bun run test:integration`
- `bun run test:tty-smoke`

Fixes #639

*This PR description was generated by Pi using GPT-5.3 Codex*
