### PR TITLE
fix(ui): preserve syntax state across folded hunks

### DIFF
--- a/.changeset/cool-papayas-itch.md
+++ b/.changeset/cool-papayas-itch.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Preserve syntax highlighting state in source-backed reviews when visible hunks begin inside folded multiline constructs.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -260,11 +260,12 @@ instead of a crash.
 A `load` result is patch text plus how to label it. Everything else on it is
 optional, and each optional field buys one thing:
 
-| Field            | What it adds                                                      |
-| ---------------- | ----------------------------------------------------------------- |
-| `untrackedPaths` | files your VCS calls unknown, synthesized into added-file diffs   |
-| `readFileSource` | exact whole-file contents, for context expansion and highlighting |
-| `extraFiles`     | files reviewed outside the patch, including skipped placeholders  |
+| Field            | What it adds                                                       |
+| ---------------- | ------------------------------------------------------------------ |
+| `untrackedPaths` | files your VCS calls unknown, synthesized into added-file diffs    |
+| `readFileSource` | exact whole-file contents, for context expansion and highlighting  |
+| `sourceCacheKey` | stable source-snapshot identity for highlight reuse across reloads |
+| `extraFiles`     | files reviewed outside the patch, including skipped placeholders   |
 
 `untrackedPaths` is the shorthand: list the repo-root-relative paths your VCS
 reports as unknown and Hunk synthesizes the added-file diffs for you, skipping
@@ -364,6 +365,7 @@ async load(input, ctx) {
     sourceLabel: ctx.cwd,
     title: "Mercurial working copy",
     patchText: await runHgDiff(ctx.cwd),
+    sourceCacheKey: `${oldRev}:${newRev}`,
     readFileSource: async ({ path, previousPath, changeType, side }) => {
       if (side === "old") {
         return changeType === "new" ? null : hgCat(oldRev, previousPath ?? path);
@@ -378,8 +380,13 @@ Return `null` for a side that has no content — the old side of an added file, 
 path the revision never contained — rather than throwing. Hunk calls the reader
 **at most once per file and side** and caches what it resolves, so you do not
 need your own cache, and it never calls it for a file the diff reports as
-binary. Leaving `readFileSource` off is fine: Hunk falls back to the content the
-patch itself carries, which renders the same diff with less context available.
+binary. When equivalent reloads close over the same source base, return the same
+opaque `sourceCacheKey` so Hunk can reuse its highlighted output. An equal per-file
+patch plus that key must guarantee equal old/new source answers for the file; change
+it when source state outside the patch changes. Omit it when the adapter cannot prove
+stable identity and Hunk will invalidate conservatively. Leaving
+`readFileSource` off is fine: Hunk falls back to the content the patch itself carries,
+which renders the same diff with less context available.
 
 #### Files outside the patch
 

--- a/src/core/fileSource.ts
+++ b/src/core/fileSource.ts
@@ -12,6 +12,8 @@ export type FileSourceSpec = { kind: "none" } | { kind: "fs"; absolutePath: stri
 export type FileSourceSide = "old" | "new";
 
 export interface FileSourceFetcher {
+  /** Stable identity for source state not already represented by the file's patch. */
+  readonly cacheKey?: string;
   /**
    * Returns the file's full source text on the requested side, or `null` when
    * the side is not reachable (deleted side, missing path, provider error).

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -612,6 +612,14 @@ export interface ExtensionVcsPatchResult {
    */
   readFileSource?: ExtensionVcsFileSourceReader;
   /**
+   * Opaque stable identity for source state not already represented by each file's patch.
+   *
+   * Reuse a value across loads only when an equal per-file patch plus this key guarantees
+   * the same old/new source answers for that file. Hunk uses the combination to retain
+   * highlighted output; when omitted, every new reader is treated as a new snapshot.
+   */
+  sourceCacheKey?: string;
+  /**
    * Files to review beside `patchText`, in the order they should appear.
    *
    * Each entry is either its own one-file patch or a skipped placeholder.

--- a/src/extensions/default/vcs/git/index.test.ts
+++ b/src/extensions/default/vcs/git/index.test.ts
@@ -102,12 +102,24 @@ describe("GitVcsAdapter", () => {
     expect(result.patchText).toContain("diff --git a/tracked.txt b/tracked.txt");
     expect(result.patchText).toContain("+new");
     expect(result.extraFiles?.map((file) => file.path)).toContain("untracked.txt");
+    expect(result.sourceCacheKey).toContain("git-source-v1");
+
+    const equivalentResult = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, {
+      cwd: repo,
+    });
+    expect(equivalentResult.sourceCacheKey).toBe(result.sourceCacheKey);
 
     const readSource = result.readFileSource;
     expect(readSource).toBeDefined();
     const trackedFile = { path: "tracked.txt", changeType: "change", isUntracked: false } as const;
     expect(await readSource?.({ ...trackedFile, side: "old" })).toBe("old\n");
     expect(await readSource?.({ ...trackedFile, side: "new" })).toBe("new\n");
+
+    git(repo, "add", "tracked.txt");
+    const changedIndexResult = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, {
+      cwd: repo,
+    });
+    expect(changedIndexResult.sourceCacheKey).not.toBe(result.sourceCacheKey);
 
     // The untracked file is reported as its own one-file patch rather than as a
     // path Hunk reads back, so Git's own binary detection and quoting decide
@@ -137,6 +149,7 @@ describe("GitVcsAdapter", () => {
     expect(showResult.title).toContain("show HEAD");
     expect(showResult.patchText).toContain("diff --git a/file.txt b/file.txt");
     expect(showResult.patchText).toContain("+two");
+    expect(showResult.sourceCacheKey).toContain("git-source-v1");
 
     const showFile = { path: "file.txt", changeType: "change", isUntracked: false } as const;
     expect(await showResult.readFileSource?.({ ...showFile, side: "old" })).toBe("one\n");
@@ -155,6 +168,7 @@ describe("GitVcsAdapter", () => {
 
     expect(stashResult.title).toContain("stash");
     expect(stashResult.patchText).toContain("diff --git a/file.txt b/file.txt");
+    expect(stashResult.sourceCacheKey).toContain("git-source-v1");
     expect(stashResult.patchText).toContain("+three");
   });
 

--- a/src/extensions/default/vcs/git/index.test.ts
+++ b/src/extensions/default/vcs/git/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
@@ -14,6 +14,10 @@ import type {
 // through that contract too — including the capabilities Git is the only
 // bundled backend to use.
 const gitOperations: ExtensionVcsOperations = GitVcsAdapter.operations;
+
+// Hosted Windows runners can spend several seconds starting each real Git process.
+// Keep this integration-like adapter suite bounded without using Bun's five-second default.
+setDefaultTimeout(30_000);
 
 describe("GitVcsAdapter published surface", () => {
   test("implements every review operation the contract defines", () => {

--- a/src/extensions/default/vcs/git/index.ts
+++ b/src/extensions/default/vcs/git/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
@@ -81,50 +82,89 @@ export function statSignature(path: string) {
 /* Exact file sources                                                          */
 /* -------------------------------------------------------------------------- */
 
-/**
- * Build a source reader that answers from exact Git old/new endpoints.
- *
- * The endpoints are resolved once, while the operation loads, and closed over:
- * by the time Hunk asks for a file's text the revisions are already pinned to
- * concrete commits, so expanded context can never be read from a ref that moved
- * mid-review.
- */
-function createGitSourceReader(
-  repoRoot: string,
-  endpoints: GitDiffEndpoints,
-  gitExecutable: string,
-): ExtensionVcsFileSourceReader {
-  return ({ path, previousPath, changeType, side }) => {
-    // An added file has no old side and a deleted one has no new side; asking
-    // Git for either would just be a failed lookup.
-    if (side === "old") {
-      return changeType === "new"
-        ? Promise.resolve(null)
-        : readGitFileSource(gitEndpointSourceSpec(endpoints.old, repoRoot, previousPath ?? path), {
-            gitExecutable,
-          });
-    }
+/** Exact source reader plus a stable identity for its complete old/new snapshot. */
+interface GitSourceCapability {
+  readFileSource: ExtensionVcsFileSourceReader;
+  sourceCacheKey: string;
+}
 
-    return changeType === "deleted"
-      ? Promise.resolve(null)
-      : readGitFileSource(gitEndpointSourceSpec(endpoints.new, repoRoot, path), { gitExecutable });
-  };
+/** Hash semantic index entries so filesystem-stat refreshes do not defeat cache reuse. */
+function gitIndexCacheKey(input: GitBackedInput, repoRoot: string, gitExecutable: string) {
+  const entries = runGitText({
+    input,
+    args: ["ls-files", "--stage", "-z"],
+    cwd: repoRoot,
+    gitExecutable,
+  });
+  return createHash("sha256").update(entries).digest("hex");
+}
+
+/** Describe one resolved endpoint for source-cache reuse across adapter reloads. */
+function gitEndpointCacheKey(endpoint: GitDiffEndpoints["old"], indexCacheKey: string) {
+  if (endpoint.kind === "git-ref") {
+    return `ref:${endpoint.ref}`;
+  }
+  if (endpoint.kind === "index") {
+    return `index:${indexCacheKey}`;
+  }
+  return endpoint.kind;
 }
 
 /**
- * Build a source reader for a single-revision review.
+ * Build a source reader that answers from exact Git old/new endpoints.
  *
- * The ref is pinned to a commit object here so the reader keeps naming the same
- * revision even if the branch or stash it was spelled as moves afterwards.
+ * The endpoint key omits worktree contents because the per-file patch fingerprint
+ * already describes their delta. Immutable refs and the index hash identify the
+ * base, so unchanged files can safely retain highlighting across watch reloads.
  */
-function createGitRevisionSourceReader(
+function createGitSourceCapability(
+  input: GitBackedInput,
+  repoRoot: string,
+  endpoints: GitDiffEndpoints,
+  gitExecutable: string,
+): GitSourceCapability {
+  const needsIndex = endpoints.old.kind === "index" || endpoints.new.kind === "index";
+  const indexCacheKey = needsIndex ? gitIndexCacheKey(input, repoRoot, gitExecutable) : "unused";
+
+  return {
+    sourceCacheKey: [
+      "git-source-v1",
+      gitEndpointCacheKey(endpoints.old, indexCacheKey),
+      gitEndpointCacheKey(endpoints.new, indexCacheKey),
+    ].join(":"),
+    readFileSource: ({ path, previousPath, changeType, side }) => {
+      // An added file has no old side and a deleted one has no new side; asking
+      // Git for either would just be a failed lookup.
+      if (side === "old") {
+        return changeType === "new"
+          ? Promise.resolve(null)
+          : readGitFileSource(
+              gitEndpointSourceSpec(endpoints.old, repoRoot, previousPath ?? path),
+              {
+                gitExecutable,
+              },
+            );
+      }
+
+      return changeType === "deleted"
+        ? Promise.resolve(null)
+        : readGitFileSource(gitEndpointSourceSpec(endpoints.new, repoRoot, path), {
+            gitExecutable,
+          });
+    },
+  };
+}
+
+/** Build a pinned source capability for a single-revision review. */
+function createGitRevisionSourceCapability(
   input: GitBackedInput,
   ref: string,
   repoRoot: string,
   gitExecutable: string,
-): ExtensionVcsFileSourceReader {
+): GitSourceCapability {
   const newRef = resolveGitCommitRef(input, ref, { cwd: repoRoot, gitExecutable });
-  return createGitSourceReader(
+  return createGitSourceCapability(
+    input,
     repoRoot,
     { old: { kind: "git-ref", ref: `${newRef}^` }, new: { kind: "git-ref", ref: newRef } },
     gitExecutable,
@@ -132,20 +172,22 @@ function createGitRevisionSourceReader(
 }
 
 /**
- * Build a source reader for a working-tree review, when both sides are exact.
+ * Build a source capability for a working-tree review, when both sides are exact.
  *
  * Ranges that do not reduce to one old/new pair — octopus merges, multi-positive
  * revision sets — deliberately get no reader at all rather than a guess, so
  * expanded rows are never read from the wrong revision.
  */
-function createGitDiffSourceReader(
+function createGitDiffSourceCapability(
   input: ExtensionVcsDiffInput,
   repoRoot: string,
   cwd: string,
   gitExecutable: string,
-): ExtensionVcsFileSourceReader | undefined {
+): GitSourceCapability | undefined {
   const endpoints = resolveGitDiffEndpoints(input, { cwd, repoRoot, gitExecutable });
-  return endpoints ? createGitSourceReader(repoRoot, endpoints, gitExecutable) : undefined;
+  return endpoints
+    ? createGitSourceCapability(input, repoRoot, endpoints, gitExecutable)
+    : undefined;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -288,6 +330,7 @@ export const GitVcsAdapter = {
           runGitText({ input, args: buildGitDiffNumstatArgs(input), cwd, gitExecutable }),
         ).filter((file) => shouldSkipLargeTrackedDiff(file, repoRoot));
         const colorMoved = resolveGitColorMovedOptions(input, { cwd, gitExecutable });
+        const sourceCapability = createGitDiffSourceCapability(input, repoRoot, cwd, gitExecutable);
 
         return {
           repoRoot,
@@ -303,7 +346,7 @@ export const GitVcsAdapter = {
             cwd,
             gitExecutable,
           }),
-          readFileSource: createGitDiffSourceReader(input, repoRoot, cwd, gitExecutable),
+          ...sourceCapability,
           extraFiles: [
             ...largeTrackedFiles.map(
               (file): ExtensionVcsExtraFile => ({
@@ -349,6 +392,12 @@ export const GitVcsAdapter = {
       async load(input, { cwd, gitExecutable = "git" }) {
         const repoRoot = resolveGitRepoRoot(input, { cwd, gitExecutable });
         const repoName = basename(repoRoot);
+        const sourceCapability = createGitRevisionSourceCapability(
+          input,
+          input.ref ?? "HEAD",
+          repoRoot,
+          gitExecutable,
+        );
 
         return {
           repoRoot,
@@ -363,12 +412,7 @@ export const GitVcsAdapter = {
             cwd,
             gitExecutable,
           }),
-          readFileSource: createGitRevisionSourceReader(
-            input,
-            input.ref ?? "HEAD",
-            repoRoot,
-            gitExecutable,
-          ),
+          ...sourceCapability,
         };
       },
       watchPlan(input, { cwd, gitExecutable = "git" }) {
@@ -388,6 +432,12 @@ export const GitVcsAdapter = {
       async load(input, { cwd, gitExecutable = "git" }) {
         const repoRoot = resolveGitRepoRoot(input, { cwd, gitExecutable });
         const repoName = basename(repoRoot);
+        const sourceCapability = createGitRevisionSourceCapability(
+          input,
+          input.ref ?? "stash@{0}",
+          repoRoot,
+          gitExecutable,
+        );
 
         return {
           repoRoot,
@@ -402,12 +452,7 @@ export const GitVcsAdapter = {
             cwd,
             gitExecutable,
           }),
-          readFileSource: createGitRevisionSourceReader(
-            input,
-            input.ref ?? "stash@{0}",
-            repoRoot,
-            gitExecutable,
-          ),
+          ...sourceCapability,
         };
       },
       watchPlan(input, { cwd, gitExecutable = "git" }) {

--- a/src/extensions/vcsPatchResult.test.ts
+++ b/src/extensions/vcsPatchResult.test.ts
@@ -33,6 +33,7 @@ describe("published source readers", () => {
     const requests: ExtensionVcsFileSourceRequest[] = [];
     const result = toInternalVcsPatchResult(
       baseResult({
+        sourceCacheKey: "snapshot-1",
         readFileSource: async (request) => {
           requests.push(request);
           return `${request.side} text`;
@@ -48,6 +49,7 @@ describe("published source readers", () => {
       isBinary: false,
     });
 
+    expect(fetcher?.cacheKey).toBe("snapshot-1");
     expect(await fetcher?.getFullText("old")).toBe("old text");
     expect(await fetcher?.getFullText("new")).toBe("new text");
     // Asking again is served from the cache the boundary owns, so an adapter

--- a/src/extensions/vcsPatchResult.ts
+++ b/src/extensions/vcsPatchResult.ts
@@ -34,7 +34,10 @@ type SourceFetcherBuilder = NonNullable<BuildDiffFileOptions["sourceFetcherBuild
  * stateless. A rejected read is deliberately left uncached: a source that was
  * too large to expand once should be retried, not remembered as broken.
  */
-function toSourceFetcherBuilder(read: ExtensionVcsFileSourceReader): SourceFetcherBuilder {
+function toSourceFetcherBuilder(
+  read: ExtensionVcsFileSourceReader,
+  sourceCacheKey: string | undefined,
+): SourceFetcherBuilder {
   return (file) => {
     if (file.isBinary) {
       return undefined;
@@ -43,6 +46,7 @@ function toSourceFetcherBuilder(read: ExtensionVcsFileSourceReader): SourceFetch
     const cache = new Map<FileSourceSide, string | null>();
 
     return {
+      cacheKey: sourceCacheKey,
       async getFullText(side) {
         if (cache.has(side)) {
           return cache.get(side) ?? null;
@@ -109,7 +113,7 @@ function toInternalExtraFile(
 /** Convert one published patch result into the internal result loaders consume. */
 export function toInternalVcsPatchResult(result: ExtensionVcsPatchResult): VcsPatchResult {
   const sourceFetcherBuilder = result.readFileSource
-    ? toSourceFetcherBuilder(result.readFileSource)
+    ? toSourceFetcherBuilder(result.readFileSource, result.sourceCacheKey)
     : undefined;
 
   return {

--- a/src/ui/AppHost.extension-dialogs.test.tsx
+++ b/src/ui/AppHost.extension-dialogs.test.tsx
@@ -1,10 +1,11 @@
 import { execSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { removeTestDirectory } from "../../test/helpers/filesystem";
 import { loadAppBootstrap } from "../core/loaders";
 import type { AppBootstrap, CliInput } from "../core/types";
 import type { HunkSessionBrokerClient } from "../session/types";
@@ -21,9 +22,9 @@ import { AppHost } from "./AppHost";
 
 const tempDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
+    await removeTestDirectory(dir);
   }
 });
 

--- a/src/ui/AppHost.extension-navigation.test.tsx
+++ b/src/ui/AppHost.extension-navigation.test.tsx
@@ -1,10 +1,11 @@
 import { execSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { removeTestDirectory } from "../../test/helpers/filesystem";
 import { loadAppBootstrap } from "../core/loaders";
 import type { AppBootstrap } from "../core/types";
 import { loadStartupExtensions } from "../extensions/startup";
@@ -19,9 +20,9 @@ import { AppHost } from "./AppHost";
 
 const tempDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
+    await removeTestDirectory(dir);
   }
 });
 

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -1,10 +1,11 @@
 import { execSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { removeTestDirectory } from "../../test/helpers/filesystem";
 import { loadAppBootstrap } from "../core/loaders";
 import type { AppBootstrap } from "../core/types";
 import { loadStartupExtensions } from "../extensions/startup";
@@ -19,9 +20,9 @@ import { AppHost } from "./AppHost";
 
 const tempDirs: string[] = [];
 
-afterEach(() => {
+afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
+    await removeTestDirectory(dir);
   }
 });
 

--- a/src/ui/AppHost.extensions.test.tsx
+++ b/src/ui/AppHost.extensions.test.tsx
@@ -1,10 +1,11 @@
 import { execSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { removeTestDirectory } from "../../test/helpers/filesystem";
 import { loadAppBootstrap } from "../core/loaders";
 import type { AppBootstrap, CliInput } from "../core/types";
 import type { HunkSessionBrokerClient } from "../session/types";
@@ -34,9 +35,9 @@ import { AppHost } from "./AppHost";
 const tempDirs: string[] = [];
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 
-afterEach(() => {
+afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
+    await removeTestDirectory(dir);
   }
   if (originalXdgConfigHome === undefined) {
     delete process.env.XDG_CONFIG_HOME;

--- a/src/ui/AppHost.keybindings.test.tsx
+++ b/src/ui/AppHost.keybindings.test.tsx
@@ -1,10 +1,11 @@
 import { execSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { removeTestDirectory } from "../../test/helpers/filesystem";
 import { resolveConfiguredCliInput } from "../core/config";
 import { loadAppBootstrap } from "../core/loaders";
 import type { AppBootstrap } from "../core/types";
@@ -22,9 +23,9 @@ import { AppHost } from "./AppHost";
 const tempDirs: string[] = [];
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 
-afterEach(() => {
+afterEach(async () => {
   for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
+    await removeTestDirectory(dir);
   }
   if (originalXdgConfigHome === undefined) {
     delete process.env.XDG_CONFIG_HOME;

--- a/src/ui/AppHost.reload.test.tsx
+++ b/src/ui/AppHost.reload.test.tsx
@@ -1,10 +1,11 @@
 import { execSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { removeTestDirectory } from "../../test/helpers/filesystem";
 
 const { loadAppBootstrap } = await import("../core/loaders");
 const { AppHost } = await import("./AppHost");
@@ -76,7 +77,7 @@ describe("reload stale highlight cache", () => {
       await act(async () => {
         setup.renderer.destroy();
       });
-      rmSync(dir, { force: true, recursive: true });
+      await removeTestDirectory(dir);
     }
   });
 
@@ -131,7 +132,7 @@ describe("reload stale highlight cache", () => {
       await act(async () => {
         setup.renderer.destroy();
       });
-      rmSync(dir, { force: true, recursive: true });
+      await removeTestDirectory(dir);
     }
   });
 });

--- a/src/ui/diff/pierre.test.ts
+++ b/src/ui/diff/pierre.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { parseDiffFromFile } from "@pierre/diffs";
+import { parseDiffFromFile, parsePatchFiles } from "@pierre/diffs";
+import { createTwoFilesPatch } from "diff";
 import type { DiffFile } from "../../core/types";
 import {
   buildSplitRows,
@@ -15,6 +16,7 @@ import { stackCellPalette } from "./rowStyle";
 import { buildReviewRenderPlan } from "./reviewRenderPlan";
 import { measureTextWidth } from "../lib/text";
 import { TRANSPARENT_BACKGROUND, resolveTheme } from "../themes";
+import { createTestSourceFetcher } from "../../../test/helpers/diff-helpers";
 import { createTestCustomThemes } from "../../../test/helpers/theme-helpers";
 
 function createDiffFile(): DiffFile {
@@ -45,6 +47,55 @@ function createDiffFile(): DiffFile {
     },
     metadata,
     agent: null,
+  };
+}
+
+const ELIXIR_HEREDOC_BEFORE = `defmodule Repro do
+  @doc """
+  Line one.
+  Line two.
+  Line three.
+  Line four.
+  Line five.
+  """
+  def hello do
+    :world
+  end
+end
+`;
+const ELIXIR_HEREDOC_AFTER = ELIXIR_HEREDOC_BEFORE.replace("Line five.", "Line five, edited.");
+const ELIXIR_HEREDOC_PATCH = `diff --git a/repro.ex b/repro.ex
+--- a/repro.ex
++++ b/repro.ex
+@@ -4,9 +4,9 @@
+   Line two.
+   Line three.
+   Line four.
+-  Line five.
++  Line five, edited.
+   """
+   def hello do
+     :world
+   end
+ end
+`;
+
+/** Build issue #664's partial Elixir diff with optional authoritative source text. */
+function createElixirHeredocDiffFile(sourceFetcher?: DiffFile["sourceFetcher"]): DiffFile {
+  const metadata = parsePatchFiles(ELIXIR_HEREDOC_PATCH, "issue-664", true)[0]?.files[0];
+  if (!metadata) {
+    throw new Error("Expected issue #664 patch metadata");
+  }
+
+  return {
+    id: "issue-664",
+    path: "repro.ex",
+    patch: ELIXIR_HEREDOC_PATCH,
+    language: "elixir",
+    stats: { additions: 1, deletions: 1 },
+    metadata,
+    agent: null,
+    sourceFetcher,
   };
 }
 
@@ -116,6 +167,107 @@ describe("Pierre diff rows", () => {
         (span) => span.text.includes("export") && typeof span.fg === "string",
       ),
     ).toBe(true);
+  });
+
+  test("uses full source to keep partial Elixir hunks inside the correct heredoc state", async () => {
+    const sourceFetcher = createTestSourceFetcher((side) =>
+      side === "old" ? ELIXIR_HEREDOC_BEFORE : ELIXIR_HEREDOC_AFTER,
+    );
+    const file = createElixirHeredocDiffFile(sourceFetcher);
+    const theme = resolveTheme("github-dark-default", null);
+    const highlighted = await loadHighlightedDiff(file, theme);
+    const rows = buildStackRows(file, highlighted, theme);
+    const rowFor = (text: string) =>
+      rows.find(
+        (row) =>
+          row.type === "stack-line" && row.cell.spans.some((span) => span.text.includes(text)),
+      );
+    const docRow = rowFor("Line two.");
+    const functionRow = rowFor("def");
+    const additionRow = rowFor("edited");
+
+    expect(sourceFetcher.calls).toEqual(["old", "new"]);
+    expect(docRow?.type === "stack-line" ? docRow.cell.spans[0]?.fg : undefined).toBe("#8B949E");
+    expect(
+      functionRow?.type === "stack-line"
+        ? functionRow.cell.spans.find((span) => span.text.includes("def"))?.fg
+        : undefined,
+    ).toBe("#FF7B72");
+    expect(
+      additionRow?.type === "stack-line"
+        ? additionRow.cell.spans.find((span) => span.text.includes("edited"))?.bg
+        : undefined,
+    ).toBeDefined();
+  });
+
+  test("falls back to patch-fragment highlighting when authoritative source cannot load", async () => {
+    const sourceFetcher = createTestSourceFetcher(() => {
+      throw new Error("source unavailable");
+    });
+    const file = createElixirHeredocDiffFile(sourceFetcher);
+    const theme = resolveTheme("github-dark-default", null);
+    const highlighted = await loadHighlightedDiff(file, theme);
+    const rows = buildStackRows(file, highlighted, theme);
+    const functionRow = rows.find(
+      (row) =>
+        row.type === "stack-line" && row.cell.spans.some((span) => span.text.includes("def hello")),
+    );
+
+    expect(sourceFetcher.calls).toEqual(["old", "new"]);
+    expect(functionRow?.type).toBe("stack-line");
+    expect(functionRow?.type === "stack-line" ? functionRow.cell.spans[0]?.fg : undefined).toBe(
+      "#A5D6FF",
+    );
+  });
+
+  test("preserves different old and new grammar states across partial diff hunks", async () => {
+    const oldText = [
+      'const message = "closed";',
+      ...Array.from({ length: 8 }, (_, index) => `const gap${index + 1} = ${index + 1};`),
+      "const target = 1;",
+      "",
+    ].join("\n");
+    const newText = [
+      "const message = `open",
+      ...Array.from({ length: 8 }, (_, index) => `const gap${index + 1} = ${index + 1};`),
+      "const target = 2;`;",
+      "",
+    ].join("\n");
+    const patch = createTwoFilesPatch("state.ts", "state.ts", oldText, newText, "", "", {
+      context: 1,
+    });
+    const metadata = parsePatchFiles(patch, "grammar-state", true)[0]?.files[0];
+    if (!metadata) {
+      throw new Error("Expected partial grammar-state metadata");
+    }
+    const sourceFetcher = createTestSourceFetcher((side) => (side === "old" ? oldText : newText));
+    const file: DiffFile = {
+      id: "grammar-state",
+      path: "state.ts",
+      patch,
+      language: "typescript",
+      stats: { additions: 2, deletions: 2 },
+      metadata,
+      agent: null,
+      sourceFetcher,
+    };
+    const theme = resolveTheme("github-dark-default", null);
+    const highlighted = await loadHighlightedDiff(file, theme);
+    const rows = buildSplitRows(file, highlighted, theme);
+    const contextRow = rows.find(
+      (row) =>
+        row.type === "split-line" &&
+        row.left.spans.some((span) => span.text.includes("gap8")) &&
+        row.right.spans.some((span) => span.text.includes("gap8")),
+    );
+
+    expect(contextRow?.type).toBe("split-line");
+    if (!contextRow || contextRow.type !== "split-line") {
+      throw new Error("Expected second-hunk context row");
+    }
+    expect(contextRow.left.spans.map((span) => span.fg)).not.toEqual(
+      contextRow.right.spans.map((span) => span.fg),
+    );
   });
 
   test("keeps word-diff highlight backgrounds transparent when a theme uses transparent tints", async () => {

--- a/src/ui/diff/pierre.ts
+++ b/src/ui/diff/pierre.ts
@@ -16,6 +16,11 @@ import { sanitizeTerminalLine } from "../../lib/terminalText";
 import { TRANSPARENT_BACKGROUND, type AppTheme } from "../themes";
 import { expandDiffTabs } from "./codeColumns";
 import {
+  createSourceBackedHighlightPlan,
+  remapSourceBackedHighlight,
+  type SourceBackedHighlightPlan,
+} from "./sourceBackedHighlight";
+import {
   ensureSyntaxHighlightThemeRegistered,
   syntaxHighlightThemeName,
 } from "./syntaxHighlightTheme";
@@ -593,38 +598,97 @@ function aliasHighlightedContextLines(file: DiffFile, highlighted: HighlightedDi
   return highlighted;
 }
 
+/** Load and validate authoritative source snapshots for one partial diff when available. */
+async function loadSourceBackedHighlightPlan(file: DiffFile) {
+  if (!file.metadata.isPartial || !file.sourceFetcher || file.metadata.hunks.length === 0) {
+    return null;
+  }
+
+  try {
+    const [oldText, newText] = await Promise.all([
+      file.sourceFetcher.getFullText("old"),
+      file.sourceFetcher.getFullText("new"),
+    ]);
+    return createSourceBackedHighlightPlan(file.metadata, oldText, newText);
+  } catch {
+    // Full-source highlighting is an enhancement over the patch-only path. Source races,
+    // unavailable sides, and size limits must fall back without hiding the visible diff.
+    return null;
+  }
+}
+
+/** Convert Pierre output into partial-diff line indexes without losing side-specific grammar state. */
+function finalizeHighlightedDiff(
+  file: DiffFile,
+  sourcePlan: SourceBackedHighlightPlan | null,
+  highlighted: ReturnType<typeof renderDiffWithHighlighter>,
+): HighlightedDiffCode {
+  const code = {
+    deletionLines: highlighted.code.deletionLines as Array<HastNode | undefined>,
+    additionLines: highlighted.code.additionLines as Array<HastNode | undefined>,
+  };
+
+  // Full old/new sources can put identical context text in different lexical states. Preserve
+  // those authoritative per-side nodes; aliasing remains safe only for patch-fragment highlighting.
+  return sourcePlan
+    ? remapSourceBackedHighlight(sourcePlan, code)
+    : aliasHighlightedContextLines(file, code);
+}
+
+/** Render one metadata snapshot through an already prepared highlighter. */
+function renderHighlightedDiff(
+  file: DiffFile,
+  metadata: FileDiffMetadata,
+  highlighter: Awaited<ReturnType<typeof prepareHighlighter>>,
+  theme: HighlightThemeInput,
+  sourcePlan: SourceBackedHighlightPlan | null,
+) {
+  return queueHighlightedWork(() => {
+    const highlighted = renderDiffWithHighlighter(
+      metadata,
+      highlighter,
+      pierreRenderOptions(theme),
+    );
+    return finalizeHighlightedDiff(file, sourcePlan, highlighted);
+  });
+}
+
 /** Highlight a diff file and return just the rendered line trees the UI needs. */
 export async function loadHighlightedDiff(
   file: DiffFile,
   theme: HighlightThemeInput = "dark",
 ): Promise<HighlightedDiffCode> {
+  const sourcePlan = await loadSourceBackedHighlightPlan(file);
+
   try {
     const highlighter = await prepareHighlighter(file.language, theme);
-    return queueHighlightedWork(() => {
-      const highlighted = renderDiffWithHighlighter(
-        file.metadata,
+    try {
+      return await renderHighlightedDiff(
+        file,
+        sourcePlan?.metadata ?? file.metadata,
         highlighter,
-        pierreRenderOptions(theme),
+        theme,
+        sourcePlan,
       );
-      return aliasHighlightedContextLines(file, {
-        deletionLines: highlighted.code.deletionLines as Array<HastNode | undefined>,
-        additionLines: highlighted.code.additionLines as Array<HastNode | undefined>,
-      });
-    });
+    } catch (error) {
+      if (!sourcePlan) {
+        throw error;
+      }
+
+      // A validated source graft should render like ordinary complete-file metadata. If Pierre
+      // still rejects it, preserve the pre-existing patch-fragment behavior rather than blanking it.
+      return await renderHighlightedDiff(file, file.metadata, highlighter, theme, null);
+    }
   } catch {
     const fallbackTheme = highlightThemeAppearance(theme);
     const highlighter = await prepareHighlighter("text", fallbackTheme);
-    return queueHighlightedWork(() => {
-      const highlighted = renderDiffWithHighlighter(
-        { ...file.metadata, lang: "text" },
-        highlighter,
-        pierreRenderOptions(fallbackTheme),
-      );
-      return aliasHighlightedContextLines(file, {
-        deletionLines: highlighted.code.deletionLines as Array<HastNode | undefined>,
-        additionLines: highlighted.code.additionLines as Array<HastNode | undefined>,
-      });
-    });
+    return await renderHighlightedDiff(
+      file,
+      { ...file.metadata, lang: "text" },
+      highlighter,
+      fallbackTheme,
+      null,
+    );
   }
 }
 

--- a/src/ui/diff/sourceBackedHighlight.test.ts
+++ b/src/ui/diff/sourceBackedHighlight.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { parsePatchFiles } from "@pierre/diffs";
+import {
+  createSourceBackedHighlightPlan,
+  remapSourceBackedHighlight,
+} from "./sourceBackedHighlight";
+
+const PARTIAL_PATCH = `diff --git a/repro.ex b/repro.ex
+--- a/repro.ex
++++ b/repro.ex
+@@ -4,4 +4,4 @@
+   Line two.
+-  Line three.
++  Line three, edited.
+   """
+   def hello do
+`;
+const OLD_SOURCE = `defmodule Repro do
+  @doc """
+  Line one.
+  Line two.
+  Line three.
+  """
+  def hello do
+    :world
+  end
+end
+`;
+const NEW_SOURCE = OLD_SOURCE.replace("Line three.", "Line three, edited.");
+
+/** Parse one test patch into its single partial file metadata object. */
+function parsePartialMetadata(patch = PARTIAL_PATCH) {
+  const metadata = parsePatchFiles(patch, "source-backed-test", true)[0]?.files[0];
+  if (!metadata) {
+    throw new Error("Expected one partial patch file");
+  }
+  return metadata;
+}
+
+describe("source-backed highlight planning", () => {
+  test("grafts validated source prefixes and remaps them to partial line indexes", () => {
+    const metadata = parsePartialMetadata();
+    const plan = createSourceBackedHighlightPlan(
+      metadata,
+      OLD_SOURCE.replaceAll("\n", "\r\n"),
+      NEW_SOURCE,
+    );
+
+    expect(plan).not.toBeNull();
+    if (!plan) {
+      throw new Error("Expected a source-backed highlight plan");
+    }
+
+    expect(plan.metadata.isPartial).toBe(false);
+    expect(plan.metadata.deletionLines[0]).toBe("defmodule Repro do\n");
+    expect(plan.metadata.deletionLines.at(-1)).toBe("  def hello do\n");
+    expect(plan.deletionLineMap).toEqual([3, 4, 5, 6]);
+    expect(plan.additionLineMap).toEqual([3, 4, 5, 6]);
+
+    const remapped = remapSourceBackedHighlight(plan, {
+      deletionLines: plan.metadata.deletionLines.map((_, index) => `old-${index}`),
+      additionLines: plan.metadata.additionLines.map((_, index) => `new-${index}`),
+    });
+    expect(remapped.deletionLines).toEqual(["old-3", "old-4", "old-5", "old-6"]);
+    expect(remapped.additionLines).toEqual(["new-3", "new-4", "new-5", "new-6"]);
+  });
+
+  test("rejects source snapshots that raced or do not match the visible patch", () => {
+    const metadata = parsePartialMetadata();
+
+    expect(
+      createSourceBackedHighlightPlan(
+        metadata,
+        OLD_SOURCE,
+        NEW_SOURCE.replace("Line two.", "A mismatched hidden snapshot."),
+      ),
+    ).toBeNull();
+    expect(createSourceBackedHighlightPlan(metadata, null, NEW_SOURCE)).toBeNull();
+  });
+
+  test("accepts an absent side for added and deleted files", () => {
+    const addedPatch = `diff --git a/added.ex b/added.ex
+new file mode 100644
+--- /dev/null
++++ b/added.ex
+@@ -0,0 +1,2 @@
++@doc """
++body
+\\ No newline at end of file
+`;
+    const deletedPatch = `diff --git a/deleted.ex b/deleted.ex
+deleted file mode 100644
+--- a/deleted.ex
++++ /dev/null
+@@ -1,2 +0,0 @@
+-@doc """
+-body
+\\ No newline at end of file
+`;
+
+    const added = createSourceBackedHighlightPlan(
+      parsePartialMetadata(addedPatch),
+      null,
+      '@doc """\nbody',
+    );
+    const deleted = createSourceBackedHighlightPlan(
+      parsePartialMetadata(deletedPatch),
+      '@doc """\nbody',
+      null,
+    );
+
+    expect(added?.metadata.deletionLines).toEqual([]);
+    expect(added?.metadata.additionLines.at(-1)).toBe("body");
+    expect(deleted?.metadata.additionLines).toEqual([]);
+    expect(deleted?.metadata.deletionLines.at(-1)).toBe("body");
+  });
+});

--- a/src/ui/diff/sourceBackedHighlight.ts
+++ b/src/ui/diff/sourceBackedHighlight.ts
@@ -1,0 +1,231 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+/** Metadata plus index maps for highlighting a partial diff against authoritative source text. */
+export interface SourceBackedHighlightPlan {
+  metadata: FileDiffMetadata;
+  deletionLineMap: number[];
+  additionLineMap: number[];
+}
+
+interface HighlightLineArrays<T> {
+  deletionLines: Array<T | undefined>;
+  additionLines: Array<T | undefined>;
+}
+
+/** Split normalized source into Pierre-compatible lines while retaining final newlines. */
+function splitSourceLines(text: string) {
+  const normalized = text.replaceAll("\r\n", "\n");
+  const lines: string[] = [];
+  let start = 0;
+
+  while (start < normalized.length) {
+    const newline = normalized.indexOf("\n", start);
+    if (newline < 0) {
+      lines.push(normalized.slice(start));
+      break;
+    }
+
+    lines.push(normalized.slice(start, newline + 1));
+    start = newline + 1;
+  }
+
+  return lines;
+}
+
+/** Convert a unified-diff side start into a zero-based source insertion/line index. */
+function sourceStartIndex(start: number, count: number) {
+  return count === 0 ? start : Math.max(start - 1, 0);
+}
+
+/** Assign one validated partial-line index to its corresponding full-source index. */
+function assignSourceLine(
+  map: number[],
+  partialLines: string[],
+  fullLines: string[],
+  partialIndex: number,
+  fullIndex: number,
+) {
+  if (
+    partialIndex < 0 ||
+    partialIndex >= partialLines.length ||
+    fullIndex < 0 ||
+    fullIndex >= fullLines.length ||
+    partialLines[partialIndex] !== fullLines[fullIndex]
+  ) {
+    return false;
+  }
+
+  const existing = map[partialIndex];
+  if (existing !== undefined && existing >= 0 && existing !== fullIndex) {
+    return false;
+  }
+
+  map[partialIndex] = fullIndex;
+  return true;
+}
+
+/** Return whether every partial line received an authoritative source mapping. */
+function mapIsComplete(map: number[]) {
+  for (let index = 0; index < map.length; index += 1) {
+    if (!Number.isInteger(map[index]) || (map[index] ?? -1) < 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Build highlight-only full-source metadata while preserving the original partial diff's hunks.
+ * Returns null when a source snapshot cannot be proven to match every visible patch line.
+ */
+export function createSourceBackedHighlightPlan(
+  metadata: FileDiffMetadata,
+  oldText: string | null,
+  newText: string | null,
+): SourceBackedHighlightPlan | null {
+  if (!metadata.isPartial || metadata.hunks.length === 0) {
+    return null;
+  }
+
+  if (
+    (oldText === null && metadata.type !== "new") ||
+    (newText === null && metadata.type !== "deleted")
+  ) {
+    return null;
+  }
+
+  const fullDeletionLines = splitSourceLines(oldText ?? "");
+  const fullAdditionLines = splitSourceLines(newText ?? "");
+  const deletionLineMap = Array.from({ length: metadata.deletionLines.length }, () => -1);
+  const additionLineMap = Array.from({ length: metadata.additionLines.length }, () => -1);
+  let previousDeletionEnd = 0;
+  let previousAdditionEnd = 0;
+  let finalDeletionEnd = 0;
+  let finalAdditionEnd = 0;
+  let valid = true;
+
+  const hunks = metadata.hunks.map((hunk) => {
+    const deletionStartIndex = sourceStartIndex(hunk.deletionStart, hunk.deletionCount);
+    const additionStartIndex = sourceStartIndex(hunk.additionStart, hunk.additionCount);
+
+    if (
+      (oldText !== null && deletionStartIndex - previousDeletionEnd !== hunk.collapsedBefore) ||
+      (newText !== null && additionStartIndex - previousAdditionEnd !== hunk.collapsedBefore)
+    ) {
+      valid = false;
+    }
+
+    let deletionIndex = deletionStartIndex;
+    let additionIndex = additionStartIndex;
+    const hunkContent = hunk.hunkContent.map((content) => {
+      const adjusted = {
+        ...content,
+        additionLineIndex: additionIndex,
+        deletionLineIndex: deletionIndex,
+      };
+
+      if (content.type === "context") {
+        for (let offset = 0; offset < content.lines; offset += 1) {
+          valid =
+            assignSourceLine(
+              deletionLineMap,
+              metadata.deletionLines,
+              fullDeletionLines,
+              content.deletionLineIndex + offset,
+              deletionIndex + offset,
+            ) && valid;
+          valid =
+            assignSourceLine(
+              additionLineMap,
+              metadata.additionLines,
+              fullAdditionLines,
+              content.additionLineIndex + offset,
+              additionIndex + offset,
+            ) && valid;
+        }
+
+        deletionIndex += content.lines;
+        additionIndex += content.lines;
+      } else {
+        for (let offset = 0; offset < content.deletions; offset += 1) {
+          valid =
+            assignSourceLine(
+              deletionLineMap,
+              metadata.deletionLines,
+              fullDeletionLines,
+              content.deletionLineIndex + offset,
+              deletionIndex + offset,
+            ) && valid;
+        }
+        for (let offset = 0; offset < content.additions; offset += 1) {
+          valid =
+            assignSourceLine(
+              additionLineMap,
+              metadata.additionLines,
+              fullAdditionLines,
+              content.additionLineIndex + offset,
+              additionIndex + offset,
+            ) && valid;
+        }
+
+        deletionIndex += content.deletions;
+        additionIndex += content.additions;
+      }
+
+      return adjusted;
+    });
+
+    if (
+      deletionIndex - deletionStartIndex !== hunk.deletionCount ||
+      additionIndex - additionStartIndex !== hunk.additionCount ||
+      deletionIndex > fullDeletionLines.length ||
+      additionIndex > fullAdditionLines.length
+    ) {
+      valid = false;
+    }
+
+    previousDeletionEnd = deletionIndex;
+    previousAdditionEnd = additionIndex;
+    finalDeletionEnd = deletionIndex;
+    finalAdditionEnd = additionIndex;
+
+    return {
+      ...hunk,
+      additionLineIndex: additionStartIndex,
+      deletionLineIndex: deletionStartIndex,
+      hunkContent,
+    };
+  });
+
+  if (!valid || !mapIsComplete(deletionLineMap) || !mapIsComplete(additionLineMap)) {
+    return null;
+  }
+
+  return {
+    metadata: {
+      ...metadata,
+      isPartial: false,
+      deletionLines: fullDeletionLines.slice(0, finalDeletionEnd),
+      additionLines: fullAdditionLines.slice(0, finalAdditionEnd),
+      hunks,
+    },
+    deletionLineMap,
+    additionLineMap,
+  };
+}
+
+/** Remap full-source highlighted lines onto the original partial metadata indexes. */
+export function remapSourceBackedHighlight<T>(
+  plan: SourceBackedHighlightPlan,
+  highlighted: HighlightLineArrays<T>,
+): HighlightLineArrays<T> {
+  return {
+    deletionLines: plan.deletionLineMap.map(
+      (sourceIndex) => highlighted.deletionLines[sourceIndex],
+    ),
+    additionLines: plan.additionLineMap.map(
+      (sourceIndex) => highlighted.additionLines[sourceIndex],
+    ),
+  };
+}

--- a/src/ui/diff/useHighlightedDiff.test.ts
+++ b/src/ui/diff/useHighlightedDiff.test.ts
@@ -4,7 +4,7 @@ import { resolveTheme } from "../themes";
 import { highlightedDiffCacheKey } from "./useHighlightedDiff";
 
 describe("highlighted diff cache keys", () => {
-  test("invalidates source-backed partial highlights when the source provider changes", () => {
+  test("invalidates source-backed partial highlights when an unversioned provider changes", () => {
     const base = createTestDiffFile({ id: "cache", path: "cache.ts" });
     const firstFetcher = createTestSourceFetcher(() => "first source\n");
     const secondFetcher = createTestSourceFetcher(() => "second source\n");
@@ -28,6 +28,41 @@ describe("highlighted diff cache keys", () => {
         ...second,
         metadata: { ...second.metadata, isPartial: false },
       }),
+    );
+  });
+
+  test("reuses source-backed highlights for equivalent versioned providers", () => {
+    const base = createTestDiffFile({ id: "cache", path: "cache.ts" });
+    const firstFetcher = Object.assign(
+      createTestSourceFetcher(() => "same source\n"),
+      {
+        cacheKey: "snapshot-1",
+      },
+    );
+    const secondFetcher = Object.assign(
+      createTestSourceFetcher(() => "same source\n"),
+      {
+        cacheKey: "snapshot-1",
+      },
+    );
+    const changedFetcher = Object.assign(
+      createTestSourceFetcher(() => "changed source\n"),
+      {
+        cacheKey: "snapshot-2",
+      },
+    );
+    const file = {
+      ...base,
+      metadata: { ...base.metadata, isPartial: true },
+      sourceFetcher: firstFetcher,
+    };
+    const theme = resolveTheme("github-dark-default", null);
+
+    expect(highlightedDiffCacheKey(theme, file)).toBe(
+      highlightedDiffCacheKey(theme, { ...file, sourceFetcher: secondFetcher }),
+    );
+    expect(highlightedDiffCacheKey(theme, file)).not.toBe(
+      highlightedDiffCacheKey(theme, { ...file, sourceFetcher: changedFetcher }),
     );
   });
 });

--- a/src/ui/diff/useHighlightedDiff.test.ts
+++ b/src/ui/diff/useHighlightedDiff.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile, createTestSourceFetcher } from "../../../test/helpers/diff-helpers";
+import { resolveTheme } from "../themes";
+import { highlightedDiffCacheKey } from "./useHighlightedDiff";
+
+describe("highlighted diff cache keys", () => {
+  test("invalidates source-backed partial highlights when the source provider changes", () => {
+    const base = createTestDiffFile({ id: "cache", path: "cache.ts" });
+    const firstFetcher = createTestSourceFetcher(() => "first source\n");
+    const secondFetcher = createTestSourceFetcher(() => "second source\n");
+    const first = {
+      ...base,
+      metadata: { ...base.metadata, isPartial: true },
+      sourceFetcher: firstFetcher,
+    };
+    const second = { ...first, sourceFetcher: secondFetcher };
+    const theme = resolveTheme("github-dark-default", null);
+
+    expect(highlightedDiffCacheKey(theme, first)).toBe(highlightedDiffCacheKey(theme, first));
+    expect(highlightedDiffCacheKey(theme, first)).not.toBe(highlightedDiffCacheKey(theme, second));
+    expect(
+      highlightedDiffCacheKey(theme, {
+        ...first,
+        metadata: { ...first.metadata, isPartial: false },
+      }),
+    ).toBe(
+      highlightedDiffCacheKey(theme, {
+        ...second,
+        metadata: { ...second.metadata, isPartial: false },
+      }),
+    );
+  });
+});

--- a/src/ui/diff/useHighlightedDiff.ts
+++ b/src/ui/diff/useHighlightedDiff.ts
@@ -86,6 +86,10 @@ function sourceFetcherFingerprint(file: DiffFile) {
     return "patch-only";
   }
 
+  if (file.sourceFetcher.cacheKey !== undefined) {
+    return `source-cache:${file.sourceFetcher.cacheKey.length}:${file.sourceFetcher.cacheKey}`;
+  }
+
   let id = sourceFetcherIds.get(file.sourceFetcher);
   if (id === undefined) {
     id = nextSourceFetcherId;

--- a/src/ui/diff/useHighlightedDiff.ts
+++ b/src/ui/diff/useHighlightedDiff.ts
@@ -15,6 +15,8 @@ const MAX_CACHE_ENTRIES = 40;
 
 const SHARED_HIGHLIGHTED_DIFF_CACHE = new Map<string, HighlightedDiffCode>();
 const SHARED_HIGHLIGHT_PROMISES = new Map<string, Promise<HighlightedDiffCode>>();
+const sourceFetcherIds = new WeakMap<NonNullable<DiffFile["sourceFetcher"]>, number>();
+let nextSourceFetcherId = 1;
 
 /** Evict the oldest entries when the cache exceeds MAX_CACHE_ENTRIES.
  *  Map iteration order is insertion order, so the first keys are the oldest. */
@@ -78,10 +80,25 @@ function patchFingerprint(file: DiffFile) {
   return `${patch.length}:${patch.slice(0, 64)}:${patch.slice(mid, mid + 64)}:${patch.slice(-64)}`;
 }
 
-/** Cache key that includes a content fingerprint so stale entries are never served
- *  after reload. Unchanged files keep their cache hit across reloads. */
-function buildCacheKey(theme: AppTheme, file: DiffFile) {
-  return `${theme.id}:${syntaxHighlightThemeName(theme)}:${file.id}:${patchFingerprint(file)}`;
+/** Identify the source snapshot provider used to recover grammar state for a partial diff. */
+function sourceFetcherFingerprint(file: DiffFile) {
+  if (!file.metadata.isPartial || !file.sourceFetcher) {
+    return "patch-only";
+  }
+
+  let id = sourceFetcherIds.get(file.sourceFetcher);
+  if (id === undefined) {
+    id = nextSourceFetcherId;
+    nextSourceFetcherId += 1;
+    sourceFetcherIds.set(file.sourceFetcher, id);
+  }
+
+  return `source:${id}`;
+}
+
+/** Cache key that includes patch and source-provider identity so reloads cannot reuse stale grammar state. */
+export function highlightedDiffCacheKey(theme: AppTheme, file: DiffFile) {
+  return `${theme.id}:${syntaxHighlightThemeName(theme)}:${file.id}:${patchFingerprint(file)}:${sourceFetcherFingerprint(file)}`;
 }
 
 /** Only commit a highlight result if the promise is still the active one for that key.
@@ -105,7 +122,7 @@ function commitHighlightResult(
 function ensureHighlightedDiffLoaded(
   file: DiffFile,
   theme: AppTheme,
-  cacheKey = buildCacheKey(theme, file),
+  cacheKey = highlightedDiffCacheKey(theme, file),
 ) {
   const cached = SHARED_HIGHLIGHTED_DIFF_CACHE.get(cacheKey);
   if (cached) {
@@ -174,7 +191,7 @@ export function useHighlightedDiff({
 }) {
   const [highlighted, setHighlighted] = useState<HighlightedDiffCode | null>(null);
   const [highlightedCacheKey, setHighlightedCacheKey] = useState<string | null>(null);
-  const appearanceCacheKey = file ? buildCacheKey(theme, file) : null;
+  const appearanceCacheKey = file ? highlightedDiffCacheKey(theme, file) : null;
 
   // Use a layout effect so a newly available cached result can replace the plain-text fallback
   // before the next diff paint whenever possible. That reduces flash/stutter as files enter view.

--- a/test/helpers/filesystem.ts
+++ b/test/helpers/filesystem.ts
@@ -1,0 +1,19 @@
+import { rm } from "node:fs/promises";
+
+const WINDOWS_RETRYABLE_REMOVE_ERRORS = new Set(["EBUSY", "ENOTEMPTY", "EPERM"]);
+
+/** Remove a test directory after transient Windows process handles are released. */
+export async function removeTestDirectory(path: string) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await rm(path, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      const code = error instanceof Error && "code" in error ? String(error.code) : undefined;
+      if (!code || !WINDOWS_RETRYABLE_REMOVE_ERRORS.has(code) || attempt >= 20) {
+        throw error;
+      }
+      await Bun.sleep(100);
+    }
+  }
+}

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -571,6 +571,31 @@ export function createPtyHarness() {
     return { dir, path, previousPath };
   }
 
+  /** Build issue #664's Elixir heredoc edit in a real source-backed Git review. */
+  function createElixirHeredocRepoFixture() {
+    const before = `defmodule Repro do
+  @doc """
+  Line one.
+  Line two.
+  Line three.
+  Line four.
+  Line five.
+  """
+  def hello do
+    :world
+  end
+end
+`;
+
+    return createGitRepoFixture([
+      {
+        path: "repro.ex",
+        before,
+        after: before.replace("Line five.", "Line five, edited."),
+      },
+    ]);
+  }
+
   function createTwoFileRepoFixture() {
     return createGitRepoFixture([
       {
@@ -931,6 +956,7 @@ export function createPtyHarness() {
     createExpandableContextFilePair,
     createCrossFileHunkNavigationRepoFixture,
     createDeletionOnlyFilePair,
+    createElixirHeredocRepoFixture,
     createIsolatedConfigHome,
     createRepoExtensionFixture,
     createLinkedWorktreeWatchFixture,

--- a/test/pty/highlighting.test.ts
+++ b/test/pty/highlighting.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+
+/** Give source loading and asynchronous Shiki highlighting enough headroom in CI. */
+setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("PTY syntax highlighting", () => {
+  test("keeps code after a hidden Elixir heredoc opener out of the string token state", async () => {
+    const fixture = harness.createElixirHeredocRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 100,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/Line five, edited/, { timeout: 15_000 });
+
+      let keywords = "";
+      let comments = "";
+      for (let iteration = 0; iteration < 200; iteration += 1) {
+        await session.waitIdle({ timeout: 50 });
+        keywords = await session.text({ immediate: true, only: { foreground: "#ff7b72" } });
+        comments = await session.text({ immediate: true, only: { foreground: "#8b949e" } });
+        if (keywords.includes("def") && comments.includes("Line five, edited.")) {
+          break;
+        }
+      }
+
+      expect(keywords).toContain("def");
+      expect(comments).toContain("Line five, edited.");
+      expect(comments).toContain('"""');
+      expect(
+        await session.text({ immediate: true, only: { foreground: "#a5d6ff" } }),
+      ).not.toContain("def hello");
+    } finally {
+      session.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- highlight partial VCS diffs against validated old/new source prefixes so hidden multiline openers preserve Shiki grammar state
- remap source-backed tokens onto the existing Pierre rows while retaining per-side syntax and word-diff styling
- fall back to patch-fragment highlighting when source is unavailable, stale, or rejected
- invalidate highlight caches when the source provider changes
- add unit and PTY regression coverage for the Elixir heredoc case in #664

## Screenshots

### Before

Patch-only highlighting incorrectly keeps `def hello do` in the hidden heredoc's string state.

![Before: def hello is incorrectly highlighted as a string](https://gist.githubusercontent.com/benvinegar/acda0cb92789d9aa8d80969d8a6d227b/raw/8d0575049b0aa3102eaaa0248f1e0c11217574fc/hunk-664-before.png)

### After

Source-backed highlighting restores `def` to the Elixir keyword state.

![After: def hello is correctly highlighted as Elixir code](https://gist.githubusercontent.com/benvinegar/acda0cb92789d9aa8d80969d8a6d227b/raw/8d0575049b0aa3102eaaa0248f1e0c11217574fc/hunk-664-after.png)

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- focused unit tests: 26 passed
- `bun run test:integration`: 87 passed
- `bun run test:tty-smoke`: 9 passed
- real Git/PTY Elixir reproduction

## Notes

This corrects source-backed reviews such as `diff`, `show`, and `stash show`. Arbitrary source-less `hunk patch` input remains best-effort because omitted lexical context cannot be reconstructed reliably.

`bun run test` has one unrelated existing failure in `src/extensions/hostRuntimeModules.test.ts`, reproduced on untouched `origin/main`.

Addresses #664.

*This PR description was generated by Pi using OpenAI GPT-5.6*

