### PR TITLE
fix(git): display quoted Unicode paths

### DIFF
--- a/.changeset/plenty-suns-mate.md
+++ b/.changeset/plenty-suns-mate.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Display tracked CJK and emoji filenames as readable Unicode across review UI, source loading, patch input, and session APIs.

--- a/src/core/diffFile.ts
+++ b/src/core/diffFile.ts
@@ -40,6 +40,7 @@ export interface BuildDiffFileOptions {
   stats?: DiffFile["stats"];
   statsTruncated?: boolean;
   lineMoveKinds?: DiffLineMoveKinds;
+  pathsAreExact?: boolean;
 }
 
 /** Build the normalized per-file model used by the UI regardless of input mode. */
@@ -58,11 +59,14 @@ export function buildDiffFile(
     stats,
     statsTruncated,
     lineMoveKinds,
+    pathsAreExact,
   }: BuildDiffFileOptions = {},
 ): DiffFile {
-  const normalizedMetadata = normalizeDiffMetadataPaths(metadata);
+  const normalizedMetadata = pathsAreExact ? metadata : normalizeDiffMetadataPaths(metadata);
   const path = normalizedMetadata.name;
-  const resolvedPreviousPath = normalizeDiffPath(previousPath) ?? normalizedMetadata.prevName;
+  const resolvedPreviousPath = pathsAreExact
+    ? (previousPath ?? normalizedMetadata.prevName)
+    : (normalizeDiffPath(previousPath) ?? normalizedMetadata.prevName);
   const resolvedIsBinary = isBinary ?? patchLooksBinary(patch);
   const sourceFetcher = sourceFetcherBuilder?.({
     path,

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -690,6 +690,37 @@ describe("loadAppBootstrap", () => {
     expect(paths).toHaveLength(fixtureFiles.length);
   });
 
+  test("loads exact tracked Unicode paths regardless of Git quoting", async () => {
+    const dir = createTempRepo("hunk-git-unicode-tracked-");
+    const relativePaths = [
+      "国際化/日本語-변경-🧪.txt",
+      ...(platform() === "win32" ? [] : ['国際化/tab\tquote"back\\🧪.txt']),
+    ];
+    mkdirSync(join(dir, "国際化"), { recursive: true });
+    for (const relativePath of relativePaths) {
+      writeFileSync(join(dir, ...relativePath.split("/")), "before\n");
+    }
+    git(dir, "add", ".");
+    git(dir, "commit", "-m", "initial");
+    git(dir, "config", "core.quotePath", "false");
+    for (const relativePath of relativePaths) {
+      writeFileSync(join(dir, ...relativePath.split("/")), "after\n");
+    }
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    for (const relativePath of relativePaths) {
+      const file = bootstrap.changeset.files.find((candidate) => candidate.path === relativePath);
+      expect(file?.metadata.name).toBe(relativePath);
+      expect(await file?.sourceFetcher?.getFullText("old")).toBe("before\n");
+      expect(await file?.sourceFetcher?.getFullText("new")).toBe("after\n");
+    }
+  });
+
   test("loads untracked files even when diff.external is configured in the repo", async () => {
     // Regression: a user-configured `diff.external` (e.g. difftastic) silently replaces
     // git's unified-diff output, which left the untracked-file synthesizer with patch
@@ -955,11 +986,12 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["alpha.ts"]);
   });
 
-  test("loads staged new files before the first commit", async () => {
+  test("loads staged new Unicode files before the first commit", async () => {
     const dir = createTempRepo("hunk-git-staged-unborn-");
+    const path = "追加-🧪.ts";
 
-    writeFileSync(join(dir, "alpha.ts"), "export const alpha = 1;\n");
-    git(dir, "add", "alpha.ts");
+    writeFileSync(join(dir, path), "export const alpha = 1;\n");
+    git(dir, "add", path);
 
     const bootstrap = await loadFromRepo(dir, {
       kind: "vcs",
@@ -968,7 +1000,7 @@ describe("loadAppBootstrap", () => {
     });
 
     const file = bootstrap.changeset.files[0];
-    expect(bootstrap.changeset.files.map((entry) => entry.path)).toEqual(["alpha.ts"]);
+    expect(bootstrap.changeset.files.map((entry) => entry.path)).toEqual([path]);
     expect(file?.metadata.type).toBe("new");
     expect(file?.sourceFetcher).toBeDefined();
     expect(await file?.sourceFetcher?.getFullText("old")).toBeNull();
@@ -1565,12 +1597,79 @@ describe("loadAppBootstrap", () => {
 
     expect(bootstrap.changeset.files).toHaveLength(1);
     expect(bootstrap.changeset.files[0]).toMatchObject({
-      path: "src\\tfile.txt",
-      metadata: { name: "src\\tfile.txt", type: "change" },
+      path: "src\tfile.txt",
+      metadata: { name: "src\tfile.txt", type: "change" },
     });
     expect(bootstrap.changeset.files[0]?.stats).toEqual({
       additions: 1,
       deletions: 1,
+    });
+  });
+
+  test("preserves trailing control characters in exact Git-quoted paths", async () => {
+    const escapedPath = String.raw`line\n`;
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: [
+        `diff --git "a/${escapedPath}" "b/${escapedPath}"`,
+        `--- "a/${escapedPath}"`,
+        `+++ "b/${escapedPath}"`,
+        "@@ -1 +1 @@",
+        "-one",
+        "+two",
+      ].join("\n"),
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files[0]?.path).toBe("line\n");
+    expect(bootstrap.changeset.files[0]?.metadata.name).toBe("line\n");
+  });
+
+  test("decodes Git-quoted UTF-8 paths from external patch input", async () => {
+    const escapedPath = String.raw`\345\233\275\351\232\233\345\214\226/\346\227\245\346\234\254\350\252\236-\353\263\200\352\262\275-\360\237\247\252.txt`;
+    const path = "国際化/日本語-변경-🧪.txt";
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: [
+        `diff --git "a/${escapedPath}" "b/${escapedPath}"`,
+        "index 5626abf..f719efd 100644",
+        `--- "a/${escapedPath}"`,
+        `+++ "b/${escapedPath}"`,
+        "@@ -1 +1 @@",
+        "-one",
+        "+two",
+        "",
+      ].join("\n"),
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]).toMatchObject({
+      path,
+      metadata: { name: path, type: "change" },
+    });
+    expect(bootstrap.changeset.files[0]?.patch).toContain(`diff --git a/${path} b/${path}`);
+  });
+
+  test("decodes both sides of Git-quoted UTF-8 rename metadata", async () => {
+    const escapedOldPath = String.raw`\346\227\245\346\234\254\350\252\236.txt`;
+    const escapedNewPath = String.raw`\355\225\234\352\265\255\354\226\264\360\237\247\252.txt`;
+    const bootstrap = await loadAppBootstrap({
+      kind: "patch",
+      text: [
+        `diff --git "a/${escapedOldPath}" "b/${escapedNewPath}"`,
+        "similarity index 100%",
+        `rename from "${escapedOldPath}"`,
+        `rename to "${escapedNewPath}"`,
+      ].join("\n"),
+      options: { mode: "auto" },
+    });
+
+    expect(bootstrap.changeset.files).toHaveLength(1);
+    expect(bootstrap.changeset.files[0]).toMatchObject({
+      path: "한국어🧪.txt",
+      previousPath: "日本語.txt",
+      metadata: { name: "한국어🧪.txt", prevName: "日本語.txt", type: "rename-pure" },
     });
   });
 
@@ -1862,12 +1961,13 @@ describe("loadAppBootstrap source fetcher attachment", () => {
     expect(await untracked?.sourceFetcher?.getFullText("old")).toBeNull();
   });
 
-  test("deleted files attach a fetcher with new=null and old reading the prior contents", async () => {
+  test("deleted Unicode files attach a fetcher with new=null and old source", async () => {
     const dir = createTempRepo("hunk-source-deleted-");
-    writeFileSync(join(dir, "victim.txt"), "going away\n");
-    git(dir, "add", "victim.txt");
+    const path = "削除-🧪.txt";
+    writeFileSync(join(dir, path), "going away\n");
+    git(dir, "add", path);
     git(dir, "commit", "-m", "add victim");
-    git(dir, "rm", "victim.txt");
+    git(dir, "rm", path);
     git(dir, "commit", "-m", "remove victim");
 
     const bootstrap = await loadFromRepo(dir, {
@@ -1877,20 +1977,21 @@ describe("loadAppBootstrap source fetcher attachment", () => {
     });
 
     const file = bootstrap.changeset.files[0];
+    expect(file?.path).toBe(path);
     expect(file?.metadata.type).toBe("deleted");
     expect(file?.sourceFetcher).toBeDefined();
     expect(await file?.sourceFetcher?.getFullText("new")).toBeNull();
     expect(await file?.sourceFetcher?.getFullText("old")).toBe("going away\n");
   });
 
-  test("renamed files read the old side from previousPath blob", async () => {
+  test("renamed Unicode files read the old side from previousPath blob", async () => {
     const dir = createTempRepo("hunk-source-renamed-");
-    writeFileSync(join(dir, "before.txt"), "shared\nold-only\nshared\n");
-    git(dir, "add", "before.txt");
+    writeFileSync(join(dir, "日本語.txt"), "shared\nold-only\nshared\n");
+    git(dir, "add", "日本語.txt");
     git(dir, "commit", "-m", "add before");
-    git(dir, "mv", "before.txt", "after.txt");
-    writeFileSync(join(dir, "after.txt"), "shared\nnew-only\nshared\n");
-    git(dir, "add", "after.txt");
+    git(dir, "mv", "日本語.txt", "한국어🧪.txt");
+    writeFileSync(join(dir, "한국어🧪.txt"), "shared\nnew-only\nshared\n");
+    git(dir, "add", "한국어🧪.txt");
     git(dir, "commit", "-m", "rename and modify");
 
     const bootstrap = await loadFromRepo(dir, {
@@ -1900,8 +2001,8 @@ describe("loadAppBootstrap source fetcher attachment", () => {
     });
 
     const file = bootstrap.changeset.files[0];
-    expect(file?.path).toBe("after.txt");
-    expect(file?.previousPath).toBe("before.txt");
+    expect(file?.path).toBe("한국어🧪.txt");
+    expect(file?.previousPath).toBe("日本語.txt");
     expect(file?.sourceFetcher).toBeDefined();
     expect(await file?.sourceFetcher?.getFullText("old")).toBe("shared\nold-only\nshared\n");
     expect(await file?.sourceFetcher?.getFullText("new")).toBe("shared\nnew-only\nshared\n");

--- a/src/core/loaders.ts
+++ b/src/core/loaders.ts
@@ -11,7 +11,7 @@ import { createSkippedBinaryMetadata, isProbablyBinaryFile } from "./binary";
 import { buildDiffFile, type BuildDiffFileOptions, type DiffFileSourceContext } from "./diffFile";
 import { createFileSourceFetcher, type FileSourceSpec } from "./fileSource";
 import { splitPatchIntoFileChunks, findPatchChunk } from "./patch/chunks";
-import { normalizePatchText, stripTerminalControl } from "./patch/normalize";
+import { normalizePatch, stripTerminalControl } from "./patch/normalize";
 import { DEFAULT_TAB_WIDTH } from "./tabWidth";
 import { getConfiguredVcsAdapter, loadVcsReview, operationFromInput } from "./vcs";
 import type { VcsAdapter } from "./vcs/types";
@@ -220,7 +220,8 @@ function normalizePatchChangeset(
   perFileOptions?: Pick<BuildDiffFileOptions, "sourceFetcherBuilder">,
 ): Changeset {
   const lineMoveKinds = collectLineMoveKinds(patchText);
-  const normalizedPatchText = normalizePatchText(patchText);
+  const normalizedPatch = normalizePatch(patchText);
+  const normalizedPatchText = normalizedPatch.text;
 
   let parsedPatches: ReturnType<typeof parsePatchFiles>;
   try {
@@ -249,19 +250,25 @@ function normalizePatchChangeset(
         .filter(Boolean)
         .join("\n\n") || undefined,
     agentSummary: agentContext?.summary,
-    files: metadataFiles.map((metadata, index) =>
-      buildDiffFile(
-        metadata,
+    files: metadataFiles.map((metadata, index) => {
+      const decodedPaths = normalizedPatch.filePaths[index];
+      const normalizedMetadata = decodedPaths
+        ? { ...metadata, name: decodedPaths.path, prevName: decodedPaths.previousPath }
+        : metadata;
+
+      return buildDiffFile(
+        normalizedMetadata,
         findPatchChunk(metadata, chunks, index),
         index,
         sourceLabel,
         agentContext,
         {
           ...perFileOptions,
+          pathsAreExact: Boolean(decodedPaths),
           lineMoveKinds: hasLineMoveKinds(lineMoveKinds[index]) ? lineMoveKinds[index] : undefined,
         },
-      ),
-    ),
+      );
+    }),
   };
 }
 

--- a/src/core/patch/gitFormat.test.ts
+++ b/src/core/patch/gitFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeGitPatchPrefixes } from "./gitFormat";
+import { normalizeGitPatch, normalizeGitPatchPrefixes } from "./gitFormat";
 
 /** Build a one-file `diff --git` block with the given header and body lines. */
 function patch(...lines: string[]) {
@@ -100,6 +100,136 @@ describe("normalizeGitPatchPrefixes", () => {
     const input = patch('diff --git "foo bar.ts" "foo bar.ts"', "--- foo bar.ts", "+++ foo bar.ts");
     expect(normalizeGitPatchPrefixes(input)).toBe(
       patch("diff --git a/foo bar.ts b/foo bar.ts", "--- a/foo bar.ts", "+++ b/foo bar.ts"),
+    );
+  });
+
+  test("decodes Git-quoted UTF-8 octets in diff and unified headers", () => {
+    const escapedPath = String.raw`\345\233\275\351\232\233\345\214\226/\346\227\245\346\234\254\350\252\236-\353\263\200\352\262\275-\360\237\247\252.txt`;
+    const input = patch(
+      `diff --git "a/${escapedPath}" "b/${escapedPath}"`,
+      `--- "a/${escapedPath}"`,
+      `+++ "b/${escapedPath}"`,
+    );
+
+    expect(normalizeGitPatchPrefixes(input)).toBe(
+      patch(
+        "diff --git a/国際化/日本語-변경-🧪.txt b/国際化/日本語-변경-🧪.txt",
+        "--- a/国際化/日本語-변경-🧪.txt",
+        "+++ b/国際化/日本語-변경-🧪.txt",
+      ),
+    );
+  });
+
+  test("decodes Git-quoted UTF-8 octets in rename metadata", () => {
+    const escapedOldPath = String.raw`\346\227\245\346\234\254\350\252\236.txt`;
+    const escapedNewPath = String.raw`\355\225\234\352\265\255\354\226\264\360\237\247\252.txt`;
+    const input = patch(
+      `diff --git "a/${escapedOldPath}" "b/${escapedNewPath}"`,
+      "similarity index 100%",
+      `rename from "${escapedOldPath}"`,
+      `rename to "${escapedNewPath}"`,
+    );
+
+    expect(normalizeGitPatchPrefixes(input)).toBe(
+      patch(
+        "diff --git a/日本語.txt b/한국어🧪.txt",
+        "similarity index 100%",
+        "rename from 日本語.txt",
+        "rename to 한국어🧪.txt",
+      ),
+    );
+  });
+
+  test("preserves a real top-level a directory in quoted noprefix paths", () => {
+    const path = String.raw`a/tab\t.txt`;
+    const normalized = normalizeGitPatch(
+      patch(`diff --git "${path}" "${path}"`, `--- "${path}"`, `+++ "${path}"`),
+    );
+
+    expect(normalized.text).toBe(
+      patch(
+        String.raw`diff --git a/a/tab\t.txt b/a/tab\t.txt`,
+        String.raw`--- a/a/tab\t.txt`,
+        String.raw`+++ b/a/tab\t.txt`,
+      ),
+    );
+    expect(normalized.filePaths).toEqual([{ path: "a/tab\t.txt" }]);
+  });
+
+  test("uses copy metadata to preserve real mnemonic-looking directories", () => {
+    const escapedOldPath = String.raw`i/\346\227\245\346\234\254\350\252\236.txt`;
+    const escapedNewPath = String.raw`w/\355\225\234\352\265\255\354\226\264.txt`;
+    const normalized = normalizeGitPatch(
+      patch(
+        `diff --git "${escapedOldPath}" "${escapedNewPath}"`,
+        "similarity index 100%",
+        `copy from "${escapedOldPath}"`,
+        `copy to "${escapedNewPath}"`,
+      ),
+    );
+
+    expect(normalized.text).toBe(
+      patch(
+        "diff --git a/i/日本語.txt b/w/한국어.txt",
+        "similarity index 100%",
+        "copy from i/日本語.txt",
+        "copy to w/한국어.txt",
+      ),
+    );
+    expect(normalized.filePaths).toEqual([{ path: "w/한국어.txt", previousPath: "i/日本語.txt" }]);
+  });
+
+  test("retains exact C-style decoded paths beside parser-safe patch text", () => {
+    const escapedPath = String.raw`a/\345\233\275\351\232\233\345\214\226/tab\tquote\"back\\\360\237\247\252.txt`;
+    const normalized = normalizeGitPatch(
+      patch(
+        `diff --git "${escapedPath}" "${escapedPath.replace("a/", "b/")}"`,
+        `--- "${escapedPath}"`,
+        `+++ "${escapedPath.replace("a/", "b/")}"`,
+      ),
+    );
+
+    expect(normalized.text).toContain(`${String.raw`tab\tquote\"back\\`}🧪.txt`);
+    expect(normalized.filePaths).toEqual([{ path: '国際化/tab\tquote"back\\🧪.txt' }]);
+  });
+
+  test("keeps decoded path metadata aligned across multiple file blocks", () => {
+    const firstPath = String.raw`\346\227\245\346\234\254\350\252\236.txt`;
+    const secondPath = String.raw`\355\225\234\352\265\255\354\226\264.txt`;
+    const normalized = normalizeGitPatch(
+      patch(
+        `diff --git "a/${firstPath}" "b/${firstPath}"`,
+        `--- "a/${firstPath}"`,
+        `+++ "b/${firstPath}"`,
+        "@@ -1 +1 @@",
+        "-one",
+        "+two",
+        `diff --git "a/${secondPath}" "b/${secondPath}"`,
+        `--- "a/${secondPath}"`,
+        `+++ "b/${secondPath}"`,
+        "@@ -1 +1 @@",
+        "-three",
+        "+four",
+      ),
+    );
+
+    expect(normalized.filePaths).toEqual([{ path: "日本語.txt" }, { path: "한국어.txt" }]);
+  });
+
+  test("preserves non-UTF-8 octets and protected literal backslashes", () => {
+    const invalidPath = String.raw`a/bad\377-overflow\433-csi\302\233-name\\345.txt`;
+    const input = patch(
+      `diff --git "${invalidPath}" "${invalidPath.replace("a/", "b/")}"`,
+      `--- "${invalidPath}"`,
+      `+++ "${invalidPath.replace("a/", "b/")}"`,
+    );
+
+    expect(normalizeGitPatchPrefixes(input)).toBe(
+      patch(
+        String.raw`diff --git a/bad\377-overflow\433-csi\302\233-name\\345.txt b/bad\377-overflow\433-csi\302\233-name\\345.txt`,
+        String.raw`--- a/bad\377-overflow\433-csi\302\233-name\\345.txt`,
+        String.raw`+++ b/bad\377-overflow\433-csi\302\233-name\\345.txt`,
+      ),
     );
   });
 

--- a/src/core/patch/gitFormat.ts
+++ b/src/core/patch/gitFormat.ts
@@ -13,15 +13,139 @@
  * intentionally limited to each file header block and stop after the `+++ ` file header so hunk
  * body lines that merely look like file headers are preserved verbatim.
  */
-type GitHeaderRewriteMode = "add" | "strip";
+type GitHeaderRewriteMode = "add" | "force-add" | "strip";
 
-export function normalizeGitPatchPrefixes(patchText: string) {
+export interface NormalizedGitPatchFilePaths {
+  path: string;
+  previousPath?: string;
+}
+
+export interface NormalizedGitPatch {
+  text: string;
+  filePaths: Array<NormalizedGitPatchFilePaths | undefined>;
+}
+
+const gitQuotedUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const gitQuotedUtf8Encoder = new TextEncoder();
+const gitUnsafeDecodedHeaderCharacter = /[\x00-\x1f\x7f-\x9f]/;
+const gitSimpleEscapeBytes: Readonly<Record<string, number>> = {
+  a: 0x07,
+  b: 0x08,
+  t: 0x09,
+  n: 0x0a,
+  v: 0x0b,
+  f: 0x0c,
+  r: 0x0d,
+  "\\": 0x5c,
+  '"': 0x22,
+};
+
+/** Decode Git's octal-escaped UTF-8 pathname bytes without exposing escaped controls to parsing. */
+function decodeGitQuotedUtf8Path(path: string) {
+  let decodedPath = "";
+  let index = 0;
+
+  while (index < path.length) {
+    const escape = path.slice(index).match(/^\\([0-7]{3})/);
+    if (!escape) {
+      // Advance over a complete non-octal escape so a protected literal backslash cannot make the
+      // following digits look like an octal byte escape on the next iteration.
+      if (path[index] === "\\" && index + 1 < path.length) {
+        decodedPath += path.slice(index, index + 2);
+        index += 2;
+      } else {
+        decodedPath += path[index];
+        index += 1;
+      }
+      continue;
+    }
+
+    const escapedBytes: number[] = [];
+    const escapedText: string[] = [];
+    while (index < path.length) {
+      const byteEscape = path.slice(index).match(/^\\([0-7]{3})/);
+      if (!byteEscape) {
+        break;
+      }
+      escapedText.push(byteEscape[0]);
+      escapedBytes.push(Number.parseInt(byteEscape[1]!, 8));
+      index += byteEscape[0].length;
+    }
+
+    // Git uses these runs for UTF-8 bytes when core.quotePath is enabled. Leave ASCII control
+    // escapes and invalid byte sequences untouched so normalizing a patch can never add physical
+    // tabs/newlines or replacement characters to a pathname header.
+    if (escapedBytes.every((byte) => byte >= 0x80 && byte <= 0xff)) {
+      try {
+        const decodedBytes = gitQuotedUtf8Decoder.decode(Uint8Array.from(escapedBytes));
+        if (!gitUnsafeDecodedHeaderCharacter.test(decodedBytes)) {
+          decodedPath += decodedBytes;
+          continue;
+        }
+      } catch {
+        // Preserve the original spelling when a repository path is not valid UTF-8.
+      }
+    }
+
+    decodedPath += escapedText.join("");
+  }
+
+  return decodedPath;
+}
+
+/** Decode one syntactically quoted Git pathname, returning null for malformed or invalid UTF-8. */
+function decodeGitQuotedPath(path: string) {
+  const bytes: number[] = [];
+  let index = 0;
+
+  while (index < path.length) {
+    if (path[index] !== "\\") {
+      const codePoint = path.codePointAt(index);
+      if (codePoint === undefined) {
+        break;
+      }
+      const scalar = String.fromCodePoint(codePoint);
+      bytes.push(...gitQuotedUtf8Encoder.encode(scalar));
+      index += scalar.length;
+      continue;
+    }
+
+    const octalEscape = path.slice(index).match(/^\\([0-7]{1,3})/);
+    if (octalEscape) {
+      const byte = Number.parseInt(octalEscape[1]!, 8);
+      if (byte > 0xff) {
+        return null;
+      }
+      bytes.push(byte);
+      index += octalEscape[0].length;
+      continue;
+    }
+
+    const escaped = path[index + 1];
+    const byte = escaped ? gitSimpleEscapeBytes[escaped] : undefined;
+    if (byte === undefined) {
+      return null;
+    }
+    bytes.push(byte);
+    index += 2;
+  }
+
+  try {
+    return gitQuotedUtf8Decoder.decode(Uint8Array.from(bytes));
+  } catch {
+    return null;
+  }
+}
+
+/** Normalize Git patch syntax and retain exact decoded paths separately from parser-safe text. */
+export function normalizeGitPatch(patchText: string): NormalizedGitPatch {
   if (!patchText.includes("diff --git ")) {
-    return patchText;
+    return { text: patchText, filePaths: [] };
   }
 
   const lines = patchText.split("\n");
   const normalizedLines: string[] = [];
+  const filePaths: Array<NormalizedGitPatchFilePaths | undefined> = [];
   let blockLines: string[] = [];
 
   const flushBlock = () => {
@@ -29,9 +153,9 @@ export function normalizeGitPatchPrefixes(patchText: string) {
       return;
     }
 
-    for (const line of rewriteGitPatchBlock(blockLines)) {
-      normalizedLines.push(line);
-    }
+    const rewritten = rewriteGitPatchBlock(blockLines);
+    normalizedLines.push(...rewritten.lines);
+    filePaths.push(rewritten.filePaths);
     blockLines = [];
   };
 
@@ -50,14 +174,19 @@ export function normalizeGitPatchPrefixes(patchText: string) {
   }
 
   flushBlock();
-  return normalizedLines.join("\n");
+  return { text: normalizedLines.join("\n"), filePaths };
+}
+
+/** Preserve the existing text-only normalizer for callers that do not parse file metadata. */
+export function normalizeGitPatchPrefixes(patchText: string) {
+  return normalizeGitPatch(patchText).text;
 }
 
 /** Rewrite one `diff --git` block, keeping file-header rewrites out of hunk bodies. */
 function rewriteGitPatchBlock(blockLines: string[]) {
   const firstLine = blockLines[0];
   if (!firstLine?.startsWith("diff --git ")) {
-    return blockLines;
+    return { lines: blockLines, filePaths: undefined };
   }
 
   const result = rewriteGitDiffHeader(firstLine, blockLines);
@@ -78,10 +207,13 @@ function rewriteGitPatchBlock(blockLines: string[]) {
       continue;
     }
 
-    rewrittenLines.push(line);
+    rewrittenLines.push(rewriteGitMetadataPathLine(line));
   }
 
-  return rewrittenLines;
+  return {
+    lines: rewrittenLines,
+    filePaths: resolveDecodedGitFilePaths(result.decodedPair, blockLines),
+  };
 }
 
 /** Detect prefixed/noprefix `diff --git` lines and rewrite them into Pierre's `a/X b/Y` form. */
@@ -91,16 +223,30 @@ function rewriteGitDiffHeader(
 ): {
   line: string;
   rewriteMode: GitHeaderRewriteMode | null;
+  decodedPair?: { oldPath: string; newPath: string };
 } {
   const rest = line.slice("diff --git ".length).trimEnd();
 
   const quotedMatch = rest.match(/^"((?:\\.|[^"\\])*)" "((?:\\.|[^"\\])*)"$/);
   if (quotedMatch) {
-    const [, oldPath = "", newPath = ""] = quotedMatch;
+    const quotedOldPath = quotedMatch[1] ?? "";
+    const quotedNewPath = quotedMatch[2] ?? "";
+    const oldPath = decodeGitQuotedUtf8Path(quotedOldPath);
+    const newPath = decodeGitQuotedUtf8Path(quotedNewPath);
     const pair = canonicalizeGitPathPair(oldPath, newPath, blockLines);
+    const decodedOldPath = decodeGitQuotedPath(quotedOldPath);
+    const decodedNewPath = decodeGitQuotedPath(quotedNewPath);
+    const decodedPair =
+      decodedOldPath !== null && decodedNewPath !== null
+        ? canonicalizeGitPathPair(decodedOldPath, decodedNewPath, blockLines)
+        : undefined;
     // Pierre's git header parser does not currently handle the quoted `"a/..." "b/..."`
-    // form, so canonicalize quoted paths to the unquoted form even when prefixes exist.
-    return { line: `diff --git ${pair.oldPath} ${pair.newPath}`, rewriteMode: pair.rewriteMode };
+    // form, so decode quoted UTF-8 paths and canonicalize them even when prefixes exist.
+    return {
+      line: `diff --git ${pair.oldPath} ${pair.newPath}`,
+      rewriteMode: pair.rewriteMode,
+      decodedPair,
+    };
   }
 
   const tokens = rest.split(" ");
@@ -125,13 +271,13 @@ function rewriteGitDiffHeader(
 
     // Non-rename noprefix: identical halves regardless of whether the path contains spaces.
     if (firstHalf === secondHalf && firstHalf.length > 0) {
-      return { line: `diff --git a/${firstHalf} b/${secondHalf}`, rewriteMode: "add" };
+      return { line: `diff --git a/${firstHalf} b/${secondHalf}`, rewriteMode: "force-add" };
     }
   }
 
   // Two-token rename without prefix and without spaces in either path.
   if (tokens.length === 2 && tokens[0] && tokens[1]) {
-    return { line: `diff --git a/${tokens[0]} b/${tokens[1]}`, rewriteMode: "add" };
+    return { line: `diff --git a/${tokens[0]} b/${tokens[1]}`, rewriteMode: "force-add" };
   }
 
   // Genuinely ambiguous (rename with spaces and no quoting). Leave untouched and let the
@@ -151,24 +297,66 @@ function splitGitMnemonicPrefix(path: string) {
   return { prefix, path: rest.join("/") };
 }
 
-/** Remove Git's outer quotes from one path-like metadata value. */
+/** Remove Git's outer quotes and decode valid C-style pathname bytes for comparisons. */
 function stripGitPathQuotes(path: string) {
-  return path.match(/^"((?:\\.|[^"\\])*)"$/)?.[1] ?? path;
+  const quotedPath = path.match(/^"((?:\\.|[^"\\])*)"$/)?.[1];
+  return quotedPath === undefined
+    ? path
+    : (decodeGitQuotedPath(quotedPath) ?? decodeGitQuotedUtf8Path(quotedPath));
 }
 
-/** Return rename metadata, which Git writes without mnemonic side prefixes. */
-function findRenameMetadata(blockLines: string[]) {
-  const oldPath = blockLines.find((line) => line.startsWith("rename from "));
-  const newPath = blockLines.find((line) => line.startsWith("rename to "));
+const gitMetadataPathMarkers = ["rename from ", "rename to ", "copy from ", "copy to "] as const;
 
-  if (!oldPath || !newPath) {
-    return null;
+/** Decode quoted UTF-8 bytes in Git rename/copy metadata while preserving unrelated syntax. */
+function rewriteGitMetadataPathLine(line: string) {
+  const marker = gitMetadataPathMarkers.find((candidate) => line.startsWith(candidate));
+  if (!marker) {
+    return line;
   }
 
-  return {
-    oldPath: stripGitPathQuotes(oldPath.slice("rename from ".length)),
-    newPath: stripGitPathQuotes(newPath.slice("rename to ".length)),
-  };
+  const value = line.slice(marker.length);
+  const quotedPath = value.match(/^"((?:\\.|[^"\\])*)"$/)?.[1];
+  if (quotedPath === undefined) {
+    return line;
+  }
+
+  const decodedPath = decodeGitQuotedUtf8Path(quotedPath);
+  return decodedPath === quotedPath ? line : `${marker}${decodedPath}`;
+}
+
+/** Return rename or copy metadata, which Git writes without mnemonic side prefixes. */
+function findRenameOrCopyMetadata(blockLines: string[]) {
+  for (const kind of ["rename", "copy"] as const) {
+    const oldMarker = `${kind} from `;
+    const newMarker = `${kind} to `;
+    const oldPath = blockLines.find((line) => line.startsWith(oldMarker));
+    const newPath = blockLines.find((line) => line.startsWith(newMarker));
+
+    if (oldPath && newPath) {
+      return {
+        oldPath: stripGitPathQuotes(oldPath.slice(oldMarker.length)),
+        newPath: stripGitPathQuotes(newPath.slice(newMarker.length)),
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Prefer exact rename/copy metadata, then fall back to the canonical decoded header pair. */
+function resolveDecodedGitFilePaths(
+  decodedPair: { oldPath: string; newPath: string } | undefined,
+  blockLines: string[],
+): NormalizedGitPatchFilePaths | undefined {
+  if (!decodedPair) {
+    return undefined;
+  }
+
+  const metadata = findRenameOrCopyMetadata(blockLines);
+  const previousPath = metadata?.oldPath ?? decodedPair.oldPath.replace(/^a\//, "");
+  const path = metadata?.newPath ?? decodedPair.newPath.replace(/^b\//, "");
+
+  return previousPath === path ? { path } : { path, previousPath };
 }
 
 /** Return a path with the expected Git side prefix while avoiding double-prefixing. */
@@ -185,16 +373,16 @@ function shouldStripMnemonicPair(oldPath: string, newPath: string, blockLines: s
     return null;
   }
 
-  const rename = findRenameMetadata(blockLines);
-  if (!rename) {
+  const metadata = findRenameOrCopyMetadata(blockLines);
+  if (!metadata) {
     return true;
   }
 
-  if (rename.oldPath === oldPath && rename.newPath === newPath) {
+  if (metadata.oldPath === oldPath && metadata.newPath === newPath) {
     return false;
   }
 
-  if (rename.oldPath === oldMnemonic.path && rename.newPath === newMnemonic.path) {
+  if (metadata.oldPath === oldMnemonic.path && metadata.newPath === newMnemonic.path) {
     return true;
   }
 
@@ -208,6 +396,12 @@ function canonicalizeKnownGitPathPair(oldPath: string, newPath: string, blockLin
   const isCanonical = oldPath.startsWith("a/") && newPath.startsWith("b/");
 
   if (isCanonical) {
+    const metadata = findRenameOrCopyMetadata(blockLines);
+    // With --no-prefix, real top-level a/ and b/ directories can imitate canonical side prefixes.
+    // Rename/copy metadata names the actual paths and disambiguates that otherwise impossible pair.
+    if (metadata?.oldPath === oldPath && metadata.newPath === newPath) {
+      return null;
+    }
     return { oldPath, newPath, rewriteMode: "add" as const, changed: false, isCanonical: true };
   }
 
@@ -228,9 +422,9 @@ function canonicalizeKnownGitPathPair(oldPath: string, newPath: string, blockLin
 function canonicalizeGitPathPair(oldPath: string, newPath: string, blockLines: string[]) {
   return (
     canonicalizeKnownGitPathPair(oldPath, newPath, blockLines) ?? {
-      oldPath: withGitPrefix(oldPath, "a/"),
-      newPath: withGitPrefix(newPath, "b/"),
-      rewriteMode: "add" as const,
+      oldPath: `a/${oldPath}`,
+      newPath: `b/${newPath}`,
+      rewriteMode: "force-add" as const,
       changed: true,
       isCanonical: false,
     }
@@ -253,8 +447,13 @@ function rewriteUnifiedFileLine(
     return line;
   }
 
+  const decodedPathName = quotedPath ? decodeGitQuotedUtf8Path(pathName) : pathName;
   const normalizedPath =
-    mode === "strip" ? (splitGitMnemonicPrefix(pathName)?.path ?? pathName) : pathName;
+    mode === "strip"
+      ? (splitGitMnemonicPrefix(decodedPathName)?.path ?? decodedPathName)
+      : decodedPathName;
 
-  return `${marker}${withGitPrefix(normalizedPath, prefix)}${suffix}`;
+  const prefixedPath =
+    mode === "force-add" ? `${prefix}${normalizedPath}` : withGitPrefix(normalizedPath, prefix);
+  return `${marker}${prefixedPath}${suffix}`;
 }

--- a/src/core/patch/gitFormat.ts
+++ b/src/core/patch/gitFormat.ts
@@ -13,7 +13,7 @@
  * intentionally limited to each file header block and stop after the `+++ ` file header so hunk
  * body lines that merely look like file headers are preserved verbatim.
  */
-type GitHeaderRewriteMode = "add" | "force-add" | "strip";
+type GitHeaderRewriteMode = "add" | "prepend-prefix" | "strip";
 
 export interface NormalizedGitPatchFilePaths {
   path: string;
@@ -271,13 +271,19 @@ function rewriteGitDiffHeader(
 
     // Non-rename noprefix: identical halves regardless of whether the path contains spaces.
     if (firstHalf === secondHalf && firstHalf.length > 0) {
-      return { line: `diff --git a/${firstHalf} b/${secondHalf}`, rewriteMode: "force-add" };
+      return {
+        line: `diff --git a/${firstHalf} b/${secondHalf}`,
+        rewriteMode: "prepend-prefix",
+      };
     }
   }
 
   // Two-token rename without prefix and without spaces in either path.
   if (tokens.length === 2 && tokens[0] && tokens[1]) {
-    return { line: `diff --git a/${tokens[0]} b/${tokens[1]}`, rewriteMode: "force-add" };
+    return {
+      line: `diff --git a/${tokens[0]} b/${tokens[1]}`,
+      rewriteMode: "prepend-prefix",
+    };
   }
 
   // Genuinely ambiguous (rename with spaces and no quoting). Leave untouched and let the
@@ -424,7 +430,7 @@ function canonicalizeGitPathPair(oldPath: string, newPath: string, blockLines: s
     canonicalizeKnownGitPathPair(oldPath, newPath, blockLines) ?? {
       oldPath: `a/${oldPath}`,
       newPath: `b/${newPath}`,
-      rewriteMode: "force-add" as const,
+      rewriteMode: "prepend-prefix" as const,
       changed: true,
       isCanonical: false,
     }
@@ -454,6 +460,8 @@ function rewriteUnifiedFileLine(
       : decodedPathName;
 
   const prefixedPath =
-    mode === "force-add" ? `${prefix}${normalizedPath}` : withGitPrefix(normalizedPath, prefix);
+    mode === "prepend-prefix"
+      ? `${prefix}${normalizedPath}`
+      : withGitPrefix(normalizedPath, prefix);
   return `${marker}${prefixedPath}${suffix}`;
 }

--- a/src/core/patch/normalize.ts
+++ b/src/core/patch/normalize.ts
@@ -1,4 +1,4 @@
-import { normalizeGitPatchPrefixes } from "./gitFormat";
+import { normalizeGitPatch, type NormalizedGitPatch } from "./gitFormat";
 import { stripGitLogMetadata } from "./gitLog";
 
 /** Escape only path characters that break unified-diff header parsing. */
@@ -19,9 +19,14 @@ export function stripTerminalControl(text: string) {
     .replace(/\x1b[@-_]/g, "");
 }
 
-/** Normalize patch text into the parser-friendly form used throughout Hunk. */
-export function normalizePatchText(patchText: string) {
-  return normalizeGitPatchPrefixes(
+/** Normalize patch text and retain exact decoded Git paths beside parser-safe headers. */
+export function normalizePatch(patchText: string): NormalizedGitPatch {
+  return normalizeGitPatch(
     stripGitLogMetadata(stripTerminalControl(patchText.replaceAll("\r\n", "\n"))),
   );
+}
+
+/** Normalize patch text into the parser-friendly form used by text-only callers. */
+export function normalizePatchText(patchText: string) {
+  return normalizePatch(patchText).text;
 }

--- a/src/core/vcs/git.test.ts
+++ b/src/core/vcs/git.test.ts
@@ -93,6 +93,10 @@ describe("git command helpers", () => {
     expect(args).toContain("color.diff.newMoved=cyan bold");
   });
 
+  test("forces byte-safe Git path quoting before stdout decoding", () => {
+    expect(buildGitDiffArgs(makeGitInput())).toContain("core.quotePath=true");
+  });
+
   test("disables external diff tools for stash patches", () => {
     const args = buildGitStashShowArgs({
       kind: "stash-show",

--- a/src/core/vcs/git.ts
+++ b/src/core/vcs/git.ts
@@ -58,9 +58,11 @@ export function appendGitPathspecs(args: string[], pathspecs?: string[]) {
 }
 
 // @pierre/diffs currently assumes git-style a/ and b/ prefixes when parsing patch headers.
-// Force canonical prefixes for git-backed review commands so user/repo git diff config
-// (noprefix, mnemonicPrefix, custom src/dst prefixes) cannot break parsing.
+// Force byte-safe path quoting and canonical prefixes so user/repo git config cannot replace raw
+// non-UTF-8 bytes during stdout decoding or break the shared parser's expected side prefixes.
 const DIFF_PREFIX_NORMALIZATION_ARGS = [
+  "-c",
+  "core.quotePath=true",
   "-c",
   "diff.noprefix=false",
   "-c",

--- a/src/lib/terminalText.test.ts
+++ b/src/lib/terminalText.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { sanitizeTerminalSpans, sanitizeTerminalText } from "./terminalText";
+import { formatTerminalPath, sanitizeTerminalSpans, sanitizeTerminalText } from "./terminalText";
 
 const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
 const OSC_ST = "\x1b]8;;https://example.test\x1b\\";
@@ -82,6 +82,13 @@ describe("sanitizeTerminalText", () => {
     });
 
     expect(output).toBe("safe0\x1b[31mred\x1b[m");
+  });
+
+  test("renders path controls as visible escapes without confusing literal backslashes", () => {
+    const output = formatTerminalPath("dir/literal\\t-tab\tline\nescape\x1b");
+
+    expect(output).toBe("dir/literal\\\\t-tab\\tline\\nescape\\x1b");
+    expectNoUnsafeTerminalControls(output);
   });
 
   test("returns an already-safe mutable span array unchanged", () => {

--- a/src/lib/terminalText.ts
+++ b/src/lib/terminalText.ts
@@ -69,6 +69,28 @@ export function sanitizeTerminalLine(text: string) {
   return sanitizeTerminalText(text, { preserveNewlines: false, preserveTabs: true });
 }
 
+/** Render an exact filesystem path safely without letting controls alter terminal geometry. */
+export function formatTerminalPath(path: string) {
+  let formatted = "";
+  for (const character of path) {
+    const codePoint = character.codePointAt(0)!;
+    if (character === "\\") {
+      formatted += "\\\\";
+    } else if (character === "\t") {
+      formatted += "\\t";
+    } else if (character === "\n") {
+      formatted += "\\n";
+    } else if (character === "\r") {
+      formatted += "\\r";
+    } else if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+      formatted += `\\x${codePoint.toString(16).padStart(2, "0")}`;
+    } else {
+      formatted += character;
+    }
+  }
+  return formatted;
+}
+
 /** Sanitize render spans while preserving their non-text styling metadata. */
 export function sanitizeTerminalSpans<T extends { text: string }>(spans: T[]): T[] {
   let sanitized: T[] | null = null;

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -171,6 +171,35 @@ describe("OpenTUI public components", () => {
     expect(files[0]?.patch).toContain("diff --git a/example.ts b/example.ts");
   });
 
+  test("decodes Git-quoted Unicode paths for public file models", () => {
+    const escapedPath = String.raw`\345\233\275\351\232\233\345\214\226/\346\227\245\346\234\254\350\252\236-\360\237\247\252.txt`;
+    const files = createHunkDiffFilesFromPatch(`diff --git "a/${escapedPath}" "b/${escapedPath}"
+--- "a/${escapedPath}"
++++ "b/${escapedPath}"
+@@ -1 +1 @@
+-before
++after
+`);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.path).toBe("国際化/日本語-🧪.txt");
+    expect(files[0]?.metadata.name).toBe("国際化/日本語-🧪.txt");
+  });
+
+  test("preserves exact trailing controls from Git-quoted public patch paths", () => {
+    const escapedPath = String.raw`line\n`;
+    const files = createHunkDiffFilesFromPatch(`diff --git "a/${escapedPath}" "b/${escapedPath}"
+--- "a/${escapedPath}"
++++ "b/${escapedPath}"
+@@ -1 +1 @@
+-before
++after
+`);
+
+    expect(files[0]?.path).toBe("line\n");
+    expect(files[0]?.metadata.name).toBe("line\n");
+  });
+
   test("exports the bundled theme names", () => {
     expect(HUNK_DIFF_THEME_NAMES).toContain("github-dark-default");
     expect(HUNK_DIFF_THEME_NAMES).toContain("github-light-default");

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -125,6 +125,32 @@ describe("OpenTUI public components", () => {
     expect(frame).toContain("@@ -1,1 +1,2 @@");
   });
 
+  test("renders filename tabs as fixed-width escapes in headers and navigation", async () => {
+    const example = createExampleDiff();
+    const diff = createHunkDiffFile({
+      ...example,
+      id: "tabbed-path",
+      path: "src/tab\tname.ts",
+    });
+    const frame = await captureFrame(
+      <box style={{ width: "100%", flexDirection: "column" }}>
+        <HunkDiffFileHeader file={diff} width={88} theme="github-dark-default" />
+        <HunkFileNav
+          files={[diff]}
+          selectedFileId="tabbed-path"
+          width={32}
+          theme="github-dark-default"
+        />
+      </box>,
+      92,
+      8,
+    );
+
+    expect(frame).toContain("src/tab\\tname.ts");
+    expect(frame).toContain("tab\\tname.ts");
+    expect(frame).not.toContain("\t");
+  });
+
   test("renders the dedicated file navigation primitive", async () => {
     const frame = await captureFrame(
       <HunkFileNav

--- a/src/opentui/model.ts
+++ b/src/opentui/model.ts
@@ -3,7 +3,7 @@ import { patchLooksBinary } from "../core/binary";
 import { normalizeDiffMetadataPaths, normalizeDiffPath } from "../core/diffPaths";
 import { countDiffStats } from "../core/diffFile";
 import { splitPatchIntoFileChunks, findPatchChunk } from "../core/patch/chunks";
-import { normalizePatchText } from "../core/patch/normalize";
+import { normalizePatch } from "../core/patch/normalize";
 import type { DiffFile } from "../core/types";
 import type { HunkDiffFile, HunkDiffFileInput } from "./types";
 
@@ -12,11 +12,15 @@ const NORMALIZED_HUNK_DIFF_FILES = new WeakSet<HunkDiffFile>();
 /** Count visible additions and deletions from Pierre metadata. */
 export const countHunkDiffStats = countDiffStats;
 
-/** Build Hunk's public OpenTUI file model with normalized paths and default stats. */
-export function createHunkDiffFile(input: HunkDiffFileInput): HunkDiffFile {
-  const metadata = normalizeDiffMetadataPaths(input.metadata);
-  const path = normalizeDiffPath(input.path) ?? metadata.name;
-  const previousPath = normalizeDiffPath(input.previousPath) ?? metadata.prevName;
+/** Build one public file while optionally preserving paths decoded exactly from Git quoting. */
+function buildHunkDiffFile(input: HunkDiffFileInput, pathsAreExact: boolean): HunkDiffFile {
+  const metadata = pathsAreExact ? input.metadata : normalizeDiffMetadataPaths(input.metadata);
+  const path = pathsAreExact
+    ? (input.path ?? metadata.name)
+    : (normalizeDiffPath(input.path) ?? metadata.name);
+  const previousPath = pathsAreExact
+    ? (input.previousPath ?? metadata.prevName)
+    : (normalizeDiffPath(input.previousPath) ?? metadata.prevName);
   const normalized = {
     ...input,
     id: input.id,
@@ -28,6 +32,11 @@ export function createHunkDiffFile(input: HunkDiffFileInput): HunkDiffFile {
 
   NORMALIZED_HUNK_DIFF_FILES.add(normalized);
   return normalized;
+}
+
+/** Build Hunk's public OpenTUI file model with normalized paths and default stats. */
+export function createHunkDiffFile(input: HunkDiffFileInput): HunkDiffFile {
+  return buildHunkDiffFile(input, false);
 }
 
 /** Return an already-normalized public file as-is, or normalize a raw input shape. */
@@ -62,18 +71,26 @@ export function toInternalDiffFile(diff: HunkDiffFileInput): DiffFile {
 
 /** Parse unified diff text into Hunk's public OpenTUI file model. */
 export function createHunkDiffFilesFromPatch(patchText: string, sourceId = "patch") {
-  const normalizedPatchText = normalizePatchText(patchText);
-  const chunks = splitPatchIntoFileChunks(normalizedPatchText);
+  const normalizedPatch = normalizePatch(patchText);
+  const chunks = splitPatchIntoFileChunks(normalizedPatch.text);
 
-  return parsePatchFiles(normalizedPatchText, sourceId, true)
+  return parsePatchFiles(normalizedPatch.text, sourceId, true)
     .flatMap((entry) => entry.files)
-    .map((metadata, index) =>
-      createHunkDiffFile({
-        id: `${sourceId}:${index}:${normalizeDiffPath(metadata.name) ?? metadata.name}`,
-        metadata,
-        patch: findPatchChunk(metadata, chunks, index),
-      }),
-    );
+    .map((metadata, index) => {
+      const decodedPaths = normalizedPatch.filePaths[index];
+      const normalizedMetadata = decodedPaths
+        ? { ...metadata, name: decodedPaths.path, prevName: decodedPaths.previousPath }
+        : metadata;
+
+      return buildHunkDiffFile(
+        {
+          id: `${sourceId}:${index}:${normalizedMetadata.name}`,
+          metadata: normalizedMetadata,
+          patch: findPatchChunk(metadata, chunks, index),
+        },
+        Boolean(decodedPaths),
+      );
+    });
 }
 
 /** Adapt a list of public OpenTUI files into Hunk's internal review file model. */

--- a/src/session/agent/cliClient.test.ts
+++ b/src/session/agent/cliClient.test.ts
@@ -325,6 +325,40 @@ describe("Hunk session CLI formatters", () => {
     expect(formatSessionOutput(session)).toContain("  - src/app.ts (+3 -1, hunks: 1)");
   });
 
+  test("human-readable session paths cannot emit terminal controls", () => {
+    const unsafePath = "src/日本語\x1b[2J\tline\n🧪.ts";
+    const session = createTestListedSession({
+      title: unsafePath,
+      sourceLabel: unsafePath,
+      cwd: unsafePath,
+      repoRoot: unsafePath,
+      files: [createTestSessionFileSummary({ path: unsafePath })],
+      snapshot: createTestSessionSnapshot({ selectedFilePath: unsafePath }),
+    });
+    const output = formatSessionOutput(session);
+
+    expect(output).not.toContain("\x1b");
+    expect(output).not.toContain("\t");
+    expect(output).toContain("src/日本語line🧪.ts");
+
+    const reloadOutput = formatReloadOutput(
+      { sessionPath: unsafePath },
+      {
+        sessionId: "session-1",
+        inputKind: "vcs",
+        title: "repo working tree",
+        sourceLabel: "/repo",
+        fileCount: 1,
+        selectedFilePath: unsafePath,
+        selectedHunkIndex: 0,
+      },
+    );
+    expect(reloadOutput).not.toContain("\x1b");
+    expect(reloadOutput).not.toContain("\t");
+    expect(reloadOutput).toContain("session path src/日本語line🧪.ts");
+    expect(reloadOutput).toContain("Selected: src/日本語line🧪.ts hunk 1");
+  });
+
   test("empty and unselected summaries stay explicit in human-readable output", () => {
     const session = createTestListedSession({
       snapshot: createTestSessionSnapshot({

--- a/src/session/agent/cliClient.ts
+++ b/src/session/agent/cliClient.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalText } from "../../lib/terminalText";
 import { resolveSessionBrokerConfig } from "../broker/brokerConfig";
 import type { SessionTerminalLocation, SessionTerminalMetadata } from "@hunk/session-broker-core";
 import { readHunkSessionDaemonCapabilities } from "../client/capabilities";
@@ -223,7 +224,9 @@ export function stringifyJson(value: unknown) {
 }
 
 function formatSelectedSummary(session: ListedSession) {
-  const filePath = session.snapshot.state.selectedFilePath ?? "(none)";
+  const filePath = session.snapshot.state.selectedFilePath
+    ? formatSessionPath(session.snapshot.state.selectedFilePath)
+    : "(none)";
   const hunkNumber = session.snapshot.state.selectedFilePath
     ? session.snapshot.state.selectedHunkIndex + 1
     : 0;
@@ -291,9 +294,9 @@ export function formatListOutput(sessions: ListedSession[]) {
     .map((session) => {
       const terminal = session.terminal;
       return [
-        `${session.sessionId}  ${session.title}`,
-        `  path: ${session.cwd}`,
-        `  repo: ${session.repoRoot ?? "-"}`,
+        `${session.sessionId}  ${formatSessionPath(session.title)}`,
+        `  path: ${formatSessionPath(session.cwd)}`,
+        `  repo: ${session.repoRoot ? formatSessionPath(session.repoRoot) : "-"}`,
         ...formatTerminalLines(terminal, {
           headerLabel: "  terminal",
           locationLabel: "  location",
@@ -306,15 +309,25 @@ export function formatListOutput(sessions: ListedSession[]) {
     .join("\n\n")}\n`;
 }
 
+/** Keep exact session paths in JSON while neutralizing controls in human-readable output. */
+function formatSessionPath(path: string) {
+  return sanitizeTerminalText(path, { preserveNewlines: false, preserveTabs: false });
+}
+
+/** Sanitize selectors because session-path targets can contain arbitrary filesystem characters. */
+function formatSessionSelector(selector: SessionSelectorInput) {
+  return formatSessionPath(describeSessionSelector(selector));
+}
+
 export function formatSessionOutput(session: ListedSession) {
   const terminal = session.terminal;
 
   return [
     `Session: ${session.sessionId}`,
-    `Title: ${session.title}`,
-    `Source: ${session.sourceLabel}`,
-    `Path: ${session.cwd}`,
-    `Repo: ${session.repoRoot ?? "-"}`,
+    `Title: ${formatSessionPath(session.title)}`,
+    `Source: ${formatSessionPath(session.sourceLabel)}`,
+    `Path: ${formatSessionPath(session.cwd)}`,
+    `Repo: ${session.repoRoot ? formatSessionPath(session.repoRoot) : "-"}`,
     `Input: ${session.inputKind}`,
     ...((session.experimentalFeatures?.length ?? 0) > 0
       ? [`Experimental features: ${session.experimentalFeatures!.join(", ")}`]
@@ -330,14 +343,16 @@ export function formatSessionOutput(session: ListedSession) {
     "Files:",
     ...session.files.map(
       (file) =>
-        `  - ${file.path} (+${file.additions} -${file.deletions}, hunks: ${file.hunkCount})`,
+        `  - ${formatSessionPath(file.path)} (+${file.additions} -${file.deletions}, hunks: ${file.hunkCount})`,
     ),
     "",
   ].join("\n");
 }
 
 export function formatContextOutput(context: SelectedSessionContext) {
-  const selectedFile = context.selectedFile?.path ?? "(none)";
+  const selectedFile = context.selectedFile?.path
+    ? formatSessionPath(context.selectedFile.path)
+    : "(none)";
   const hunkNumber = context.selectedHunk ? context.selectedHunk.index + 1 : 0;
   const oldRange = context.selectedHunk?.oldRange
     ? `${context.selectedHunk.oldRange[0]}..${context.selectedHunk.oldRange[1]}`
@@ -348,9 +363,9 @@ export function formatContextOutput(context: SelectedSessionContext) {
 
   return [
     `Session: ${context.sessionId}`,
-    `Title: ${context.title}`,
-    `Path: ${context.cwd ?? "-"}`,
-    `Repo: ${context.repoRoot ?? "-"}`,
+    `Title: ${formatSessionPath(context.title)}`,
+    `Path: ${context.cwd ? formatSessionPath(context.cwd) : "-"}`,
+    `Repo: ${context.repoRoot ? formatSessionPath(context.repoRoot) : "-"}`,
     `File: ${selectedFile}`,
     `Hunk: ${context.selectedHunk ? hunkNumber : "-"}`,
     `Old range: ${oldRange}`,
@@ -369,15 +384,17 @@ export function formatContextOutput(context: SelectedSessionContext) {
 
 /** Render one human-readable summary of the exported live session review model. */
 export function formatReviewOutput(review: SessionReview) {
-  const selectedFile = review.selectedFile?.path ?? "(none)";
+  const selectedFile = review.selectedFile?.path
+    ? formatSessionPath(review.selectedFile.path)
+    : "(none)";
   const hunkNumber = review.selectedHunk ? review.selectedHunk.index + 1 : "-";
 
   return [
     `Session: ${review.sessionId}`,
-    `Title: ${review.title}`,
-    `Source: ${review.sourceLabel}`,
-    `Path: ${review.cwd ?? "-"}`,
-    `Repo: ${review.repoRoot ?? "-"}`,
+    `Title: ${formatSessionPath(review.title)}`,
+    `Source: ${formatSessionPath(review.sourceLabel)}`,
+    `Path: ${review.cwd ? formatSessionPath(review.cwd) : "-"}`,
+    `Repo: ${review.repoRoot ? formatSessionPath(review.repoRoot) : "-"}`,
     `Input: ${review.inputKind}`,
     ...((review.experimentalFeatures?.length ?? 0) > 0
       ? [`Experimental features: ${review.experimentalFeatures!.join(", ")}`]
@@ -391,13 +408,14 @@ export function formatReviewOutput(review: SessionReview) {
       ? [
           "Notes:",
           ...review.reviewNotes.map(
-            (note) => `  - ${note.noteId} [${note.source}] ${note.filePath}: ${note.body}`,
+            (note) =>
+              `  - ${note.noteId} [${note.source}] ${formatSessionPath(note.filePath)}: ${note.body}`,
           ),
         ]
       : []),
     "Files:",
     ...review.files.flatMap((file) => [
-      `  - ${file.path} (+${file.additions} -${file.deletions}, hunks: ${file.hunkCount})`,
+      `  - ${formatSessionPath(file.path)} (+${file.additions} -${file.deletions}, hunks: ${file.hunkCount})`,
       ...file.hunks.map((hunk) => `      hunk ${hunk.index + 1}: ${hunk.header}`),
     ]),
     "",
@@ -408,14 +426,14 @@ export function formatNavigationOutput(
   selector: SessionSelectorInput,
   result: NavigatedSelectionResult,
 ) {
-  return `Focused ${result.filePath} hunk ${result.hunkIndex + 1} in ${describeSessionSelector(selector)}.\n`;
+  return `Focused ${formatSessionPath(result.filePath)} hunk ${result.hunkIndex + 1} in ${formatSessionSelector(selector)}.\n`;
 }
 
 export function formatReloadOutput(selector: SessionSelectorInput, result: ReloadedSessionResult) {
   const selected = result.selectedFilePath
-    ? `${result.selectedFilePath} hunk ${result.selectedHunkIndex + 1}`
+    ? `${formatSessionPath(result.selectedFilePath)} hunk ${result.selectedHunkIndex + 1}`
     : "(no files)";
-  return `Reloaded ${describeSessionSelector(selector)} with ${result.title} (${result.fileCount} files). Selected: ${selected}.\n`;
+  return `Reloaded ${formatSessionSelector(selector)} with ${formatSessionPath(result.title)} (${result.fileCount} files). Selected: ${selected}.\n`;
 }
 
 /** Format the STML render notes attached to one applied comment, if any. */
@@ -429,7 +447,7 @@ function formatMarkupNotes(result: AppliedCommentResult, indent = "") {
 
 export function formatCommentOutput(selector: SessionSelectorInput, result: AppliedCommentResult) {
   return `${[
-    `Added live comment ${result.commentId} on ${result.filePath}:${result.line} (${result.side}) in hunk ${result.hunkIndex + 1} for ${describeSessionSelector(selector)}.`,
+    `Added live comment ${result.commentId} on ${formatSessionPath(result.filePath)}:${result.line} (${result.side}) in hunk ${result.hunkIndex + 1} for ${formatSessionSelector(selector)}.`,
     ...formatMarkupNotes(result),
   ].join("\n")}\n`;
 }
@@ -439,13 +457,13 @@ export function formatCommentApplyOutput(
   result: AppliedCommentBatchResult,
 ) {
   if (result.applied.length === 0) {
-    return `Applied 0 live comments to ${describeSessionSelector(selector)}.\n`;
+    return `Applied 0 live comments to ${formatSessionSelector(selector)}.\n`;
   }
 
   return `${[
-    `Applied ${result.applied.length} live comments to ${describeSessionSelector(selector)}:`,
+    `Applied ${result.applied.length} live comments to ${formatSessionSelector(selector)}:`,
     ...result.applied.flatMap((comment) => [
-      `  - ${comment.commentId} on ${comment.filePath}:${comment.line} (${comment.side}) hunk ${comment.hunkIndex + 1}`,
+      `  - ${comment.commentId} on ${formatSessionPath(comment.filePath)}:${comment.line} (${comment.side}) hunk ${comment.hunkIndex + 1}`,
       ...formatMarkupNotes(comment, "    "),
     ]),
     "",
@@ -457,13 +475,13 @@ export function formatCommentListOutput(
   comments: SessionLiveCommentSummary[],
 ) {
   if (comments.length === 0) {
-    return `No live comments for ${describeSessionSelector(selector)}.\n`;
+    return `No live comments for ${formatSessionSelector(selector)}.\n`;
   }
 
   return `${comments
     .map((comment) =>
       [
-        `${comment.commentId}  ${comment.filePath}:${comment.line} (${comment.side})`,
+        `${comment.commentId}  ${formatSessionPath(comment.filePath)}:${comment.line} (${comment.side})`,
         `  hunk: ${comment.hunkIndex + 1}`,
         `  summary: ${comment.summary}`,
         ...(comment.author ? [`  author: ${comment.author}`] : []),
@@ -477,7 +495,7 @@ export function formatRemoveCommentOutput(
   result: RemovedCommentResult,
 ) {
   const label = result.source === "user" ? "user note" : "live comment";
-  return `Removed ${label} ${result.commentId} from ${describeSessionSelector(selector)}. Remaining comments: ${result.remainingCommentCount}.\n`;
+  return `Removed ${label} ${result.commentId} from ${formatSessionSelector(selector)}. Remaining comments: ${result.remainingCommentCount}.\n`;
 }
 
 export function formatNoteListOutput(
@@ -485,13 +503,13 @@ export function formatNoteListOutput(
   notes: SessionReviewNoteSummary[],
 ) {
   if (notes.length === 0) {
-    return `No review notes for ${describeSessionSelector(selector)}.\n`;
+    return `No review notes for ${formatSessionSelector(selector)}.\n`;
   }
 
   return `${notes
     .map((note) =>
       [
-        `${note.noteId}  ${note.filePath} [${note.source}]`,
+        `${note.noteId}  ${formatSessionPath(note.filePath)} [${note.source}]`,
         ...(note.hunkIndex !== undefined ? [`  hunk: ${note.hunkIndex + 1}`] : []),
         `  body: ${note.body}`,
         ...(note.author ? [`  author: ${note.author}`] : []),
@@ -505,8 +523,8 @@ export function formatClearCommentsOutput(
   result: ClearedCommentsResult,
 ) {
   const scope = result.filePath
-    ? `${result.filePath} in ${describeSessionSelector(selector)}`
-    : describeSessionSelector(selector);
+    ? `${formatSessionPath(result.filePath)} in ${formatSessionSelector(selector)}`
+    : formatSessionSelector(selector);
   const label = result.includeUser ? "comments" : "live comments";
   return `Cleared ${result.removedCount} ${label} from ${scope}. Remaining comments: ${result.remainingCommentCount}.\n`;
 }

--- a/src/session/app/registration.test.ts
+++ b/src/session/app/registration.test.ts
@@ -74,6 +74,23 @@ describe("session registration", () => {
     });
   });
 
+  test("registration and initial selection preserve exact Unicode rename paths", () => {
+    const bootstrap = createBootstrap();
+    const file = bootstrap.changeset.files[0]!;
+    bootstrap.changeset.files = [
+      { ...file, path: "国際化/한국어-🧪.txt", previousPath: "国際化/日本語.txt" },
+    ];
+
+    const registration = createSessionRegistration(bootstrap);
+    const snapshot = createInitialSessionSnapshot(bootstrap);
+
+    expect(registration.info.files[0]).toMatchObject({
+      path: "国際化/한국어-🧪.txt",
+      previousPath: "国際化/日本語.txt",
+    });
+    expect(snapshot.state.selectedFilePath).toBe("国際化/한국어-🧪.txt");
+  });
+
   // Intent: reloads refresh review metadata without changing the live session identity.
   test("updateSessionRegistration preserves identity while refreshing input metadata", () => {
     const current = createSessionRegistration(createBootstrap());

--- a/src/ui/lib/files.test.ts
+++ b/src/ui/lib/files.test.ts
@@ -143,6 +143,19 @@ describe("files helpers", () => {
     ]);
   });
 
+  test("file labels and sidebar entries render path tabs as fixed-width escapes", () => {
+    const file = createTestDiffFile({ id: "tabbed-path", path: "src/tab\tname.ts" });
+
+    expect(fileLabelParts(file)).toEqual({
+      filename: "src/tab\\tname.ts",
+      stateLabel: null,
+    });
+    expect(buildSidebarEntries([file])).toEqual([
+      { kind: "group", id: "group:src:0", label: "src/" },
+      expect.objectContaining({ kind: "file", name: "tab\\tname.ts" }),
+    ]);
+  });
+
   test("fileLabelParts strips parser-added line endings from rename labels", () => {
     const renamedAcrossDirectories = {
       ...createTestDiffFile({

--- a/src/ui/lib/files.ts
+++ b/src/ui/lib/files.ts
@@ -3,7 +3,7 @@ import type { FileDiffMetadata } from "@pierre/diffs";
 import { normalizeDiffPath } from "../../core/diffPaths";
 import type { AgentAnnotation, DiffFile } from "../../core/types";
 import { readMetadataChangeType } from "../../extensions/events";
-import { sanitizeTerminalLine } from "../../lib/terminalText";
+import { formatTerminalPath } from "../../lib/terminalText";
 
 export interface FileListEntry {
   kind: "file";
@@ -47,9 +47,9 @@ export type SidebarEntry = FileListEntry | FileGroupEntry;
 
 /** Build the filename-first label shown inside one sidebar row. */
 function sidebarFileName(file: SidebarFileSource) {
-  const path = sanitizeTerminalLine(normalizeDiffPath(file.path) ?? file.path);
+  const path = formatTerminalPath(normalizeDiffPath(file.path) ?? file.path);
   const previousPath = file.previousPath
-    ? sanitizeTerminalLine(normalizeDiffPath(file.previousPath) ?? file.previousPath)
+    ? formatTerminalPath(normalizeDiffPath(file.previousPath) ?? file.previousPath)
     : undefined;
 
   if (!previousPath || previousPath === path) {
@@ -147,7 +147,7 @@ export function buildSidebarEntries(files: readonly SidebarFileSource[]): Sideba
   let activeGroup: string | undefined;
 
   files.forEach((file, index) => {
-    const path = sanitizeTerminalLine(normalizeDiffPath(file.path) ?? file.path);
+    const path = formatTerminalPath(normalizeDiffPath(file.path) ?? file.path);
     const group = dirname(path);
 
     if (group !== activeGroup) {
@@ -191,9 +191,9 @@ export function fileLabelParts(file: DiffFile | undefined): {
     return { filename: "No file selected", stateLabel: null };
   }
 
-  const path = sanitizeTerminalLine(normalizeDiffPath(file.path) ?? file.path);
+  const path = formatTerminalPath(normalizeDiffPath(file.path) ?? file.path);
   const previousPath = file.previousPath
-    ? sanitizeTerminalLine(normalizeDiffPath(file.previousPath) ?? file.previousPath)
+    ? formatTerminalPath(normalizeDiffPath(file.previousPath) ?? file.previousPath)
     : undefined;
   const baseLabel = previousPath && previousPath !== path ? `${previousPath} -> ${path}` : path;
 

--- a/src/ui/staticDiffPager.ts
+++ b/src/ui/staticDiffPager.ts
@@ -38,7 +38,11 @@ import {
   stackRailColor,
 } from "./diff/rowStyle";
 import { sliceTextByWidth } from "./lib/text";
-import { sanitizeTerminalLine, sanitizeTerminalText } from "../lib/terminalText";
+import {
+  formatTerminalPath,
+  sanitizeTerminalLine,
+  sanitizeTerminalText,
+} from "../lib/terminalText";
 import { resolveTheme, withTransparentSurfaces, type AppTheme } from "./themes";
 
 const DEFAULT_STATIC_WIDTH = 120;
@@ -286,8 +290,8 @@ function fileStatusLabel(file: DiffFile) {
 function fileDisplayPath(file: DiffFile) {
   const previousPath = file.previousPath ?? file.metadata.prevName;
   return previousPath && previousPath !== file.path
-    ? `${sanitizeTerminalLine(previousPath)} → ${sanitizeTerminalLine(file.path)}`
-    : sanitizeTerminalLine(file.path);
+    ? `${formatTerminalPath(previousPath)} → ${formatTerminalPath(file.path)}`
+    : formatTerminalPath(file.path);
 }
 
 function fileModeText(file: DiffFile) {

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -551,6 +551,26 @@ export function createPtyHarness() {
     ]);
   }
 
+  /** Build a staged Unicode rename for exact Git path rendering coverage. */
+  function createUnicodePathRepoFixture() {
+    const dir = makeTempDir("hunk-tuistory-unicode-path-");
+    const previousPath = "国際化/日本語.txt";
+    const path = "国際化/한국어-🧪.txt";
+
+    runGit(["init"], dir);
+    runGit(["config", "user.name", "Pi"], dir);
+    runGit(["config", "user.email", "pi@example.com"], dir);
+    writeText(join(dir, previousPath), "shared\nold-only\nshared\n");
+    runGit(["add", "."], dir);
+    runGit(["commit", "-m", "initial"], dir);
+    runGit(["config", "core.quotePath", "false"], dir);
+    runGit(["mv", previousPath, path], dir);
+    writeText(join(dir, path), "shared\nnew-only\nshared\n");
+    runGit(["add", "."], dir);
+
+    return { dir, path, previousPath };
+  }
+
   function createTwoFileRepoFixture() {
     return createGitRepoFixture([
       {
@@ -924,6 +944,7 @@ export function createPtyHarness() {
     createSidebarJumpRepoFixture,
     createTabbedFilePair,
     createTwoFileRepoFixture,
+    createUnicodePathRepoFixture,
     createWatchFilePair,
     createWideCharacterFilePair,
     ensureKeyboardIsLive,

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -83,6 +83,29 @@ describe("PTY layout", () => {
     }
   });
 
+  test("renamed CJK and emoji paths render as Unicode in the sidebar and file header", async () => {
+    const fixture = harness.createUnicodePathRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--staged", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 220,
+      rows: 16,
+    });
+
+    try {
+      const snapshot = await session.waitForText(/한국어-🧪\.txt/, {
+        timeout: 15_000,
+      });
+
+      expect(snapshot).toContain("国際化/");
+      expect(snapshot).toContain("日本語.txt");
+      expect(snapshot).toContain("한국어-🧪.txt");
+      expect(snapshot).not.toContain("\\345\\233\\275");
+    } finally {
+      session.close();
+    }
+  });
+
   test("the CLI tab width reaches interactive app rendering", async () => {
     const fixture = harness.createTabbedFilePair();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Summary

- decode Git C-quoted UTF-8 pathname bytes into exact Unicode paths while keeping parser-safe patch headers for Pierre
- preserve canonical paths across source loading, filtering, rename/copy metadata, OpenTUI models, extensions, and session APIs
- force byte-safe Git quoting before JavaScript string decoding and sanitize paths only at human-readable terminal output boundaries
- cover CJK/emoji additions, deletions, renames, copies, no-prefix patches, malformed escapes, source fetching, sessions, and PTY rendering

Closes #667.

## Before

![Before: Git octal escapes shown instead of the Unicode rename path](https://gist.githubusercontent.com/benvinegar/99c97305ed05405d55ca8a35f5f11752/raw/9e6fbc6998adab686112b299e455d60503412f67/hunk-667-before.svg)

## After

![After: the exact CJK and emoji rename path is readable](https://gist.githubusercontent.com/benvinegar/99c97305ed05405d55ca8a35f5f11752/raw/a18956d4f06dc09241182ba94c8a10677f1fb6e1/hunk-667-after.svg)

Both screenshots use the same staged rename with Git's default `core.quotePath=true` behavior.

## Testing

- `bun run typecheck`
- `bun run lint`
- focused core, loader, OpenTUI, session, and registration suites: 162 passed, 1 skipped
- `bun run test:integration`: 87 passed
- `bun run test:tty-smoke`: 9 passed
- Unicode rename PTY regression after the final rebase: passed

The unrestricted `bun test` command still discovers website Playwright specs under Bun and encounters unrelated existing test-runner failures; all affected and integration suites pass.

*This PR description was generated by Pi using OpenAI GPT-5.4*
