### PR TITLE
feat(extensions): let file views refresh their prepared layouts

### DIFF
--- a/.changeset/file-view-refresh.md
+++ b/.changeset/file-view-refresh.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Extension file views can now refresh their prepared layouts with `fileViews.refresh`, letting stateful views redraw without a file or width change.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -85,7 +85,14 @@ File-view registrations are selected per file but remain inside the one
 host-owned review stream. `src/ui/fileViews/useFileViews.ts` bounds asynchronous
 extension work and retains only immutable layouts accepted by
 `src/ui/fileViews/layout.ts`; width and registration identity are part of that
-accepted geometry. `src/ui/fileViews/renderPlan.ts` is the shared insertion
+accepted geometry. A stateful view has no such identity to change, so
+`ctx.fileViews.refresh` bumps an invalidation epoch owned by
+`src/ui/fileViews/useFilePresentationController.ts` and modeled in
+`src/ui/fileViews/state.ts`. That epoch participates in the same retention key,
+re-preparing the files presenting that view while their current rows stay
+visible. One map counts both view-wide and per-file invalidation, and
+`fileViewLayoutEpoch` is the single place that composes them into the epoch a
+`(file, view)` preparation is retained under. `src/ui/fileViews/renderPlan.ts` is the shared insertion
 plan for validated extension rows and host-owned inline notes. It resolves only
 unambiguous exact-source bindings and returns an explicit unresolved set, so
 `DiffPane` falls the complete file back to Pierre rather than guessing or

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -836,6 +836,71 @@ changeset that passes that view's `matches` function, including files hidden by
 the current filter. Nonmatches retain their existing choices, and host
 constraints such as an active draft may temporarily keep a selected file raw.
 
+`ctx.fileViews.refresh("view-id")` invalidates that view's prepared layouts.
+Hunk treats `layout` as a pure derivation of `(file, width)` and reuses a
+prepared result until one of those changes, so a view holding its own state — a
+fold, a toggled overlay, a display mode — has nothing to change and would
+otherwise keep painting its first answer. Flip the state, then ask for the
+re-derivation:
+
+```ts
+import type { HunkExtensionAPI } from "hunkdiff/extension";
+
+export default function (hunk: HunkExtensionAPI) {
+  let expanded = false;
+
+  hunk.registerFileView({
+    id: "outline",
+    title: "Outline",
+    matches: (file) => file.path.endsWith(".ts"),
+    layout: ({ file }) => ({
+      rows: (file.hunks ?? []).map((entry) => ({
+        id: `hunk:${entry.index}`,
+        spans: [{ text: expanded ? `Hunk ${entry.index + 1} · ${entry.header}` : entry.header }],
+      })),
+      hunkRows: (file.hunks ?? []).map((entry) => ({ startRow: entry.index, endRow: entry.index })),
+    }),
+  });
+
+  hunk.registerCommand(
+    { id: "toggle-detail", title: "Toggle outline detail", key: "f9" },
+    (ctx) => {
+      expanded = !expanded;
+      ctx.fileViews.refresh("outline");
+    },
+  );
+}
+```
+
+Refresh defaults to view-wide, not current-file: every file presenting the view
+re-runs `matches` and `layout`, while files on raw diff or on another view do no
+work. The rows already on screen stay there until their replacement resolves, so
+a refresh never flashes back to raw diff mid-flight; a re-layout that declines,
+throws, or times out falls back to raw exactly like any other failed layout.
+Unknown ids warn and do nothing, and ids resolve the same way `select` resolves
+them.
+
+When the state that changed belongs to one file rather than the whole view — a
+fold, a per-file edit buffer — scope the invalidation with `{ fileId }` so the
+other files presenting the view keep their prepared rows:
+
+```ts
+const folded = new Map<string, boolean>();
+
+hunk.registerCommand({ id: "fold", title: "Fold this file", key: "f10" }, (ctx) => {
+  const fileId = ctx.selection.file?.id;
+  if (!fileId) return;
+  folded.set(fileId, !folded.get(fileId));
+  ctx.fileViews.refresh("outline", { fileId });
+});
+```
+
+That matters because **View → Apply “…” to all matching files** can leave one
+view presenting every matching file in the changeset, and each of those files
+would otherwise re-run third-party `layout` for a change only one of them made.
+A `fileId` no reviewed file carries invalidates nothing and warns about nothing,
+since ids can race a reload.
+
 ### `hunk.registerCommand(command, handler)`
 
 Register a named command, optionally bound to a key. Commands are not a

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -942,6 +942,33 @@ export interface ExtensionFileViewControls {
   toggle(viewId: string): void;
   /** Report whether this extension's view is active for the current file. */
   isActive(viewId: string): boolean;
+  /**
+   * Mark this view's prepared layouts stale so a stateful view can redraw.
+   *
+   * Hunk treats `layout` as a pure derivation of `(file, width)` and reuses a
+   * prepared result until one of those — or the registration itself — changes.
+   * A view that keeps its own state (a fold, a toggled overlay) has no such
+   * change to announce, so this is how it asks for a re-derivation.
+   *
+   * Every prepared layout of this view is invalidated at once, and each file
+   * currently presenting it re-runs `matches` and `layout`. Files on raw diff
+   * or on another view do no work. The previously prepared rows stay on screen
+   * until the replacement resolves, so a refresh never flashes back to raw
+   * diff; a re-layout that declines, throws, or times out falls back to raw
+   * exactly like any other failed layout, with the same single warning.
+   *
+   * Pass `{ fileId }` when the state that changed belongs to one file — a fold
+   * or an edit buffer the view keeps per file. Only that file's prepared layout
+   * for this view is invalidated; the other files presenting the view keep
+   * their rows and do no work, which matters because a view can be presenting
+   * every matching file in the changeset at once. A `fileId` no reviewed file
+   * carries invalidates nothing and warns about nothing: ids can race a reload.
+   *
+   * Bare ids address the calling extension's own view, `"<extensionId>:<viewId>"`
+   * addresses any registered one, and an unknown id warns and does nothing —
+   * the same resolution and refusal `select` uses.
+   */
+  refresh(viewId: string, options?: { fileId?: string }): void;
 }
 
 /**

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -428,6 +428,7 @@ export function App({
   const {
     applyBulkTarget: applyFilePresentationToAllMatching,
     availableSelections: availableFileViewSelectionState,
+    epochs: fileViewEpochs,
     bulkTarget: selectedFileViewBulkTarget,
     createControls: createFileViewControls,
     menuEntries: selectedFileViewEntries,
@@ -830,6 +831,7 @@ export function App({
     useFilePresentationRendering({
       files: filteredFiles,
       selections: availableFileViewSelectionState,
+      epochs: fileViewEpochs,
       views: sessionFileViews,
       width: diffContentWidth,
       onIssue: showSessionNotice,

--- a/src/ui/AppHost.file-views.test.tsx
+++ b/src/ui/AppHost.file-views.test.tsx
@@ -96,6 +96,88 @@ function createBulkFileViewExtension() {
   return { extension, root };
 }
 
+/** Write a stateful preview whose layout only changes when the extension asks for a refresh. */
+function createStatefulFileViewExtension() {
+  const root = mkdtempSync(join(tmpdir(), "hunk-apphost-stateful-view-"));
+  tempDirs.push(root);
+  const extension = join(root, "stateful-view");
+  mkdirSync(extension, { recursive: true });
+  writeFileSync(
+    join(extension, "package.json"),
+    JSON.stringify({ name: "stateful-view", private: true, hunk: { extensions: ["./index.ts"] } }),
+  );
+  writeFileSync(
+    join(extension, "index.ts"),
+    `export default function (hunk) {
+  let expanded = false;
+  let pending = false;
+  const marked = new Set();
+  hunk.registerFileView({
+    id: "stateful",
+    title: "Stateful view",
+    matches: () => true,
+    layout: ({ file }) => ({
+      rows: [
+        {
+          id: "state",
+          spans: [
+            {
+              text:
+                (expanded ? "STATE EXPANDED" : "STATE COLLAPSED") +
+                (marked.has(file.id) ? " MARKED" : "") +
+                (pending ? " PENDING" : ""),
+            },
+          ],
+        },
+      ],
+      hunkRows: (file.hunks ?? []).map(() => ({ startRow: 0, endRow: 0 })),
+    }),
+  });
+  hunk.registerCommand(
+    { id: "toggle-stateful", title: "Toggle stateful view", key: "f8" },
+    (ctx) => ctx.fileViews.toggle("stateful"),
+  );
+  hunk.registerCommand(
+    { id: "expand-stateful", title: "Expand stateful view", key: "f9" },
+    (ctx) => {
+      expanded = !expanded;
+      ctx.fileViews.refresh("stateful");
+    },
+  );
+  hunk.registerCommand(
+    { id: "mark-stateful", title: "Mark this file", key: "f6" },
+    (ctx) => {
+      const fileId = ctx.selection.file?.id;
+      if (!fileId) return;
+      marked.add(fileId);
+      ctx.fileViews.refresh("stateful", { fileId });
+    },
+  );
+  hunk.registerCommand(
+    { id: "refresh-unknown", title: "Refresh unknown view", key: "f7" },
+    (ctx) => ctx.fileViews.refresh("not-a-view"),
+  );
+  hunk.registerCommand(
+    { id: "refresh-unknown-file", title: "Refresh a file the review does not carry", key: "f4" },
+    (ctx) => {
+      pending = true;
+      ctx.fileViews.refresh("stateful", { fileId: "no-such-file" });
+    },
+  );
+  hunk.registerCommand(
+    { id: "mark-hidden", title: "Mark the changeset's second file", key: "f3" },
+    (ctx) => {
+      // A reviewed id the command names directly, so it can target a file the filter hides.
+      marked.add("beta");
+      ctx.fileViews.refresh("stateful", { fileId: "beta" });
+    },
+  );
+}
+`,
+  );
+  return { extension, root };
+}
+
 /** Build the separated changes that exercise public summaries and cross-hunk selection. */
 function createTwoHunkFile() {
   const beforeLines = Array.from(
@@ -131,6 +213,17 @@ async function waitForFrame(
     if (predicate(frame)) return frame;
   }
   throw new Error(`Timed out waiting for AppHost frame:\n${setup.captureCharFrame()}`);
+}
+
+/** Paint a fixed number of frames and return the last, for asserting that nothing changed. */
+async function renderFrames(setup: Awaited<ReturnType<typeof testRender>>, frames: number) {
+  for (let attempt = 0; attempt < frames; attempt += 1) {
+    await act(async () => {
+      await setup.renderOnce();
+      await Bun.sleep(20);
+    });
+  }
+  return setup.captureCharFrame();
 }
 
 describe("AppHost file views", () => {
@@ -180,6 +273,119 @@ describe("AppHost file views", () => {
       ]);
     } finally {
       console.error = originalConsoleError;
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+
+  test("re-lays out a stateful view on view-wide and file-scoped refresh, warning for an unknown view id", async () => {
+    const { extension, root } = createStatefulFileViewExtension();
+    const extensions = await loadStartupExtensions({
+      cliExtensionPaths: [extension],
+      cwd: root,
+      env: { XDG_CONFIG_HOME: root } as NodeJS.ProcessEnv,
+      extensions: { enabled: true, extensionConfigs: {}, paths: [], repoPaths: [] },
+    });
+    expect(extensions.issues).toEqual([]);
+    const bootstrap = createTestVcsAppBootstrap({
+      changesetId: "changeset:stateful-view",
+      files: [createTestDiffFile({ id: "stateful", path: "stateful.ts" })],
+      initialMode: "stack",
+      inputMode: "stack",
+      vcsOptions: { extensionPaths: [extension] },
+    });
+    bootstrap.extensions = extensions;
+    const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={() => {}} />, {
+      width: 120,
+      height: 24,
+    });
+
+    try {
+      await waitForFrame(setup, (frame) => frame.includes("stateful.ts"));
+      await act(async () => setup.mockInput.pressKey("F8"));
+      await waitForFrame(setup, (frame) => frame.includes("STATE COLLAPSED"));
+
+      // Neither the file nor the width changed, so only the refresh can re-derive these rows.
+      await act(async () => setup.mockInput.pressKey("F9"));
+      await waitForFrame(setup, (frame) => frame.includes("STATE EXPANDED"));
+
+      // The same re-derivation, scoped to the reviewed file whose state the command changed.
+      await act(async () => setup.mockInput.pressKey("F6"));
+      await waitForFrame(setup, (frame) => frame.includes("STATE EXPANDED MARKED"));
+
+      await act(async () => setup.mockInput.pressKey("F7"));
+      const warned = await waitForFrame(setup, (frame) =>
+        frame.includes('targeted unknown file view "not-a-view"'),
+      );
+      // An unknown id refuses without disturbing the presentation the user is looking at.
+      expect(warned).toContain("STATE EXPANDED MARKED");
+
+      // A scope naming a file the review does not carry could only invalidate a layout that does
+      // not exist, so the host stores no epoch for it and nothing re-lays out.
+      await act(async () => setup.mockInput.pressKey("F4"));
+      const unchanged = await renderFrames(setup, 12);
+      expect(unchanged).toContain("STATE EXPANDED MARKED");
+      expect(unchanged).not.toContain("PENDING");
+
+      // The state the ignored refresh left behind is genuinely live: the next real invalidation
+      // picks it up, so the frames above were quiet for want of an epoch, not want of a change.
+      await act(async () => setup.mockInput.pressKey("F9"));
+      await waitForFrame(setup, (frame) => frame.includes("STATE COLLAPSED MARKED PENDING"));
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+
+  test("honors a file-scoped refresh for a file the current filter hides", async () => {
+    const { extension, root } = createStatefulFileViewExtension();
+    const extensions = await loadStartupExtensions({
+      cliExtensionPaths: [extension],
+      cwd: root,
+      env: { XDG_CONFIG_HOME: root } as NodeJS.ProcessEnv,
+      extensions: { enabled: true, extensionConfigs: {}, paths: [], repoPaths: [] },
+    });
+    expect(extensions.issues).toEqual([]);
+    const bootstrap = createTestVcsAppBootstrap({
+      changesetId: "changeset:hidden-refresh",
+      files: [
+        createTestDiffFile({ id: "alpha", path: "alpha.ts" }),
+        createTestDiffFile({ id: "beta", path: "beta.ts" }),
+      ],
+      initialMode: "split",
+      inputMode: "split",
+      vcsOptions: { extensionPaths: [extension] },
+    });
+    bootstrap.extensions = extensions;
+    const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={() => {}} />, {
+      width: 220,
+      height: 24,
+    });
+
+    try {
+      await waitForFrame(setup, (frame) => frame.includes("alpha.ts"));
+      // Put both files on the stateful view so the hidden one has a prepared layout to retire.
+      await act(async () => setup.mockInput.pressKey("F8"));
+      await act(async () => setup.mockInput.typeText("."));
+      await act(async () => setup.mockInput.pressKey("F8"));
+      await waitForFrame(setup, (frame) => frame.split("STATE COLLAPSED").length === 3);
+
+      await act(async () => setup.mockInput.pressTab());
+      await waitForFrame(setup, (frame) => frame.toLowerCase().includes("filter"));
+      await act(async () => setup.mockInput.typeText("alpha"));
+      await waitForFrame(setup, (frame) => !frame.includes("beta.ts"));
+      await act(async () => setup.mockInput.pressTab());
+
+      // Filtering hides a file without un-reviewing it, so its scoped epoch must still be recorded.
+      await act(async () => setup.mockInput.pressKey("F3"));
+      await act(async () => setup.mockInput.pressTab());
+      await waitForFrame(setup, (frame) => frame.includes("filter: alpha"));
+      await act(async () => setup.mockInput.pressEscape());
+      // Both files present the view again once the unhidden one finishes re-preparing.
+      const restored = await waitForFrame(
+        setup,
+        (frame) => frame.split("STATE COLLAPSED").length === 3,
+      );
+      expect(restored).toContain("STATE COLLAPSED MARKED");
+    } finally {
       await act(async () => setup.renderer.destroy());
     }
   });

--- a/src/ui/fileViews/state.test.ts
+++ b/src/ui/fileViews/state.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type { ExtensionDiffFile } from "../../extension-api/types";
 import type { RegisteredFileView } from "../../extensions/types";
 import {
+  bumpFileViewEpoch,
+  fileViewLayoutEpoch,
+  reconcileFileViewEpochs,
   reconcileFileViewSelections,
   registeredFileViewKey,
   resolveBulkFileViewTarget,
@@ -89,6 +92,77 @@ describe("file-view selection state", () => {
     });
     expect(selectFileViewForFiles(selected, ["first", "second"], "preview:new")).toBe(selected);
     expect(selectFileViewForFiles(current, [], "preview:new")).toBe(current);
+  });
+
+  test("counts refreshes per view from an implicit zero and always changes map identity", () => {
+    const first = bumpFileViewEpoch(new Map(), "preview:rendered");
+    expect(fileViewLayoutEpoch(first, "preview:rendered", "readme")).toBe(1);
+
+    const second = bumpFileViewEpoch(first, "preview:rendered");
+    expect(second).not.toBe(first);
+    expect(fileViewLayoutEpoch(second, "preview:rendered", "readme")).toBe(2);
+    // One view's invalidation never disturbs another's prepared layouts.
+    const other = bumpFileViewEpoch(second, "other:view");
+    expect(fileViewLayoutEpoch(other, "preview:rendered", "readme")).toBe(2);
+  });
+
+  test("scopes a refresh to one file without disturbing the view's other presentations", () => {
+    const viewWide = bumpFileViewEpoch(new Map(), "preview:rendered");
+    const scoped = bumpFileViewEpoch(viewWide, "preview:rendered", "readme");
+
+    expect(fileViewLayoutEpoch(scoped, "preview:rendered", "readme")).toBe(2);
+    // The other file presenting the same view keeps the epoch its prepared layout is retained under.
+    expect(fileViewLayoutEpoch(scoped, "preview:rendered", "other")).toBe(
+      fileViewLayoutEpoch(viewWide, "preview:rendered", "other"),
+    );
+    // Either kind of bump always moves the composed epoch, whichever order they arrive in.
+    expect(
+      fileViewLayoutEpoch(
+        bumpFileViewEpoch(scoped, "preview:rendered"),
+        "preview:rendered",
+        "other",
+      ),
+    ).toBe(2);
+    expect(fileViewLayoutEpoch(new Map(), "preview:rendered", "readme")).toBe(0);
+  });
+
+  test("keeps arbitrary view ids distinct from file-scoped epoch keys", () => {
+    const controlCharacterView = "preview:bad\0view";
+    const similarlyShapedView = "preview:bad";
+    const current = bumpFileViewEpoch(new Map(), controlCharacterView);
+    const scoped = bumpFileViewEpoch(current, similarlyShapedView, "view");
+
+    expect(fileViewLayoutEpoch(scoped, controlCharacterView, "other")).toBe(1);
+    expect(fileViewLayoutEpoch(scoped, similarlyShapedView, "view")).toBe(1);
+    expect(fileViewLayoutEpoch(scoped, similarlyShapedView, "other")).toBe(0);
+  });
+
+  test("drops epochs for views and files a reload removed while preserving identity otherwise", () => {
+    const current = bumpFileViewEpoch(
+      bumpFileViewEpoch(
+        bumpFileViewEpoch(bumpFileViewEpoch(new Map(), "preview:rendered"), "gone:view"),
+        "preview:rendered",
+        "readme",
+      ),
+      "preview:rendered",
+      "deleted",
+    );
+    const kept = reconcileFileViewEpochs(current, ["readme"], new Set(["preview:rendered"]));
+
+    expect(fileViewLayoutEpoch(kept, "preview:rendered", "readme")).toBe(2);
+    // A scoped entry outlives neither its view nor the file it names.
+    expect(fileViewLayoutEpoch(kept, "preview:rendered", "deleted")).toBe(1);
+    expect(fileViewLayoutEpoch(kept, "gone:view", "readme")).toBe(0);
+
+    expect(
+      reconcileFileViewEpochs(
+        current,
+        ["readme", "deleted"],
+        new Set(["preview:rendered", "gone:view"]),
+      ),
+    ).toBe(current);
+    const empty = new Map<string, number>();
+    expect(reconcileFileViewEpochs(empty, [], new Set())).toBe(empty);
   });
 
   test("allows an extension view id named raw because only null is the raw sentinel", () => {

--- a/src/ui/fileViews/state.ts
+++ b/src/ui/fileViews/state.ts
@@ -21,6 +21,99 @@ export function resolveRegisteredFileView(
   return views.find((view) => registeredFileViewKey(view) === key);
 }
 
+/**
+ * Layout invalidation counters for one session, in two kinds of key.
+ *
+ * One encoded tuple kind counts view-wide invalidation; another includes a
+ * reviewed file id and scopes invalidation to that file's presentation. One
+ * map holds both so preparation has a single place to consult, and
+ * `fileViewLayoutEpoch` is the only thing that knows how the two compose.
+ *
+ * Absent means zero: a view only earns an entry once something invalidates it,
+ * so the common session never carries any epoch state at all.
+ */
+export type FileViewEpochState = ReadonlyMap<string, number>;
+
+/** Encode a view-wide or file-scoped epoch key without constraining extension-owned ids. */
+function fileViewEpochKey(viewKey: string, fileId?: string) {
+  // JSON string tuples stay unambiguous even when a registered id contains control characters.
+  return JSON.stringify(fileId === undefined ? [viewKey] : [viewKey, fileId]);
+}
+
+/** Decode an internally generated epoch key, ignoring malformed external map entries. */
+function parseFileViewEpochKey(key: string): readonly [viewKey: string, fileId?: string] | null {
+  try {
+    const parsed: unknown = JSON.parse(key);
+    if (
+      !Array.isArray(parsed) ||
+      (parsed.length !== 1 && parsed.length !== 2) ||
+      !parsed.every((part) => typeof part === "string")
+    ) {
+      return null;
+    }
+    return parsed as [string, string?];
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The invalidation epoch one `(file, view)` preparation is retained under.
+ *
+ * View-wide and file-scoped counters are summed rather than compared, so
+ * bumping either always moves the result and neither can mask the other
+ * whatever order they arrive in. Both only ever count up.
+ */
+export function fileViewLayoutEpoch(epochs: FileViewEpochState, viewKey: string, fileId: string) {
+  return (
+    (epochs.get(fileViewEpochKey(viewKey)) ?? 0) +
+    (epochs.get(fileViewEpochKey(viewKey, fileId)) ?? 0)
+  );
+}
+
+/**
+ * Invalidate prepared layouts by bumping one epoch.
+ *
+ * Without `fileId` this retires every prepared layout of the view; with one it
+ * retires only that file's, leaving the other presenting files untouched.
+ */
+export function bumpFileViewEpoch(
+  current: FileViewEpochState,
+  viewKey: string,
+  fileId?: string,
+): FileViewEpochState {
+  const key = fileViewEpochKey(viewKey, fileId);
+  // A fresh map identity is the signal preparation watches; mutating in place would be invisible.
+  const next = new Map(current);
+  next.set(key, (current.get(key) ?? 0) + 1);
+  return next;
+}
+
+/**
+ * Drop epochs a reload orphaned, keeping map identity when nothing changed.
+ *
+ * A scoped entry outlives neither its view nor the file it names: a reload that
+ * drops either retires the entry with it.
+ */
+export function reconcileFileViewEpochs(
+  current: FileViewEpochState,
+  fileIds: readonly string[],
+  viewKeys: ReadonlySet<string>,
+): FileViewEpochState {
+  if (current.size === 0) return current;
+  const validFileIds = new Set(fileIds);
+  const next = new Map<string, number>();
+  for (const [key, epoch] of current) {
+    const parsed = parseFileViewEpochKey(key);
+    if (!parsed) continue;
+    const [viewKey, fileId] = parsed;
+    if (viewKeys.has(viewKey) && (fileId === undefined || validFileIds.has(fileId))) {
+      next.set(key, epoch);
+    }
+  }
+  return next.size === current.size ? current : next;
+}
+
 /** Reconcile per-file selections after filtering/reload removes files or views. */
 export function reconcileFileViewSelections(
   current: FileViewSelectionState,

--- a/src/ui/fileViews/useFilePresentationController.ts
+++ b/src/ui/fileViews/useFilePresentationController.ts
@@ -6,18 +6,23 @@ import type { ExtensionFileViewControls, RegisteredFileView } from "../../extens
 import type { MenuEntry } from "../components/chrome/menu";
 import { availableFileViewSelections, fileViewUnavailableReason } from "./availability";
 import {
+  bumpFileViewEpoch,
+  reconcileFileViewEpochs,
   reconcileFileViewSelections,
   registeredFileViewKey,
   resolveBulkFileViewTarget,
   resolveRegisteredFileView,
   selectFileView,
   selectFileViewForFiles,
+  type FileViewEpochState,
   type FileViewSelectionState,
 } from "./state";
 
 export interface FilePresentationController {
   /** Stored choices with temporarily unavailable files omitted for rendering. */
   availableSelections: FileViewSelectionState;
+  /** Layout invalidation epochs requested by stateful extension views. */
+  epochs: FileViewEpochState;
   bulkTarget: { readonly title: string } | null;
   menuEntries: readonly MenuEntry[];
   /** Build live host-owned file-presentation controls for one extension command. */
@@ -54,10 +59,16 @@ export function useFilePresentationController({
 }): FilePresentationController {
   // Raw is implicit, so an empty state is the guaranteed default and fallback.
   const [selections, setSelections] = useState<FileViewSelectionState>({});
+  // A registration replacement already invalidates prepared layouts; these counters cover state
+  // changes inside one stable registration for the lifetime of this controller.
+  const [epochs, setEpochs] = useState<FileViewEpochState>(() => new Map<string, number>());
   const selectionsRef = useRef(selections);
   selectionsRef.current = selections;
   const viewsRef = useRef(views);
   viewsRef.current = views;
+  const fileIds = useMemo(() => new Set(files.map((file) => file.id)), [files]);
+  const fileIdsRef = useRef<ReadonlySet<string>>(fileIds);
+  fileIdsRef.current = fileIds;
 
   const unavailableReasons = useMemo(() => {
     const reasons = new Map<string, string>();
@@ -77,14 +88,10 @@ export function useFilePresentationController({
 
   useEffect(() => {
     const viewKeys = new Set(views.map(registeredFileViewKey));
-    setSelections((current) =>
-      reconcileFileViewSelections(
-        current,
-        files.map((file) => file.id),
-        viewKeys,
-      ),
-    );
-  }, [files, views]);
+    const reviewedFileIds = [...fileIds];
+    setSelections((current) => reconcileFileViewSelections(current, reviewedFileIds, viewKeys));
+    setEpochs((current) => reconcileFileViewEpochs(current, reviewedFileIds, viewKeys));
+  }, [fileIds, views]);
 
   /** Select raw or one registered presentation for a file. */
   const select = useCallback((fileId: string, viewKey: string | null) => {
@@ -158,6 +165,19 @@ export function useFilePresentationController({
             selectionsRef.current[fileId] === registeredFileViewKey(registered),
           );
         },
+        refresh(viewId: string, options?: { fileId?: string }) {
+          const registered = resolve(viewId);
+          if (!registered) {
+            showNotice(`Extension ${extensionId} targeted unknown file view "${viewId}"`);
+            return;
+          }
+          const fileId = typeof options?.fileId === "string" ? options.fileId : undefined;
+          // A stale id can race a reload. It invalidates nothing and does not warn the extension.
+          if (fileId !== undefined && !fileIdsRef.current.has(fileId)) return;
+          setEpochs((current) =>
+            bumpFileViewEpoch(current, registeredFileViewKey(registered), fileId),
+          );
+        },
       };
     },
     [getExtensionSelection, getSelectedFileId, select, showNotice],
@@ -229,6 +249,7 @@ export function useFilePresentationController({
 
   return {
     availableSelections,
+    epochs,
     bulkTarget,
     menuEntries,
     createControls,

--- a/src/ui/fileViews/useFilePresentationRendering.test.tsx
+++ b/src/ui/fileViews/useFilePresentationRendering.test.tsx
@@ -30,6 +30,7 @@ async function renderPresentation() {
   const views = [view];
   const selected = { [file.id]: key };
   const raw = {};
+  const epochs = new Map<string, number>();
   const warnings: string[] = [];
   const ignoreIssue = () => {};
   const collectWarning = (message: string) => warnings.push(message);
@@ -42,6 +43,7 @@ async function renderPresentation() {
     rendering = useFilePresentationRendering({
       files,
       selections: enabled ? selected : raw,
+      epochs,
       views,
       width: 80,
       onIssue: ignoreIssue,

--- a/src/ui/fileViews/useFilePresentationRendering.ts
+++ b/src/ui/fileViews/useFilePresentationRendering.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { DiffFile } from "../../core/types";
 import type { RegisteredFileView } from "../../extensions/types";
-import type { FileViewSelectionState } from "./state";
+import type { FileViewEpochState, FileViewSelectionState } from "./state";
 import type { FileViewRowFailure } from "./types";
 import { useFileViewLayouts } from "./useFileViews";
 
@@ -17,6 +17,7 @@ export interface FilePresentationRendering {
 export function useFilePresentationRendering({
   files,
   selections,
+  epochs,
   views,
   width,
   onIssue,
@@ -24,12 +25,13 @@ export function useFilePresentationRendering({
 }: {
   files: readonly DiffFile[];
   selections: Readonly<FileViewSelectionState>;
+  epochs: FileViewEpochState;
   views: readonly RegisteredFileView[];
   width: number;
   onIssue: (message: string) => void;
   onWarning: (message: string) => void;
 }): FilePresentationRendering {
-  const layouts = useFileViewLayouts({ files, selections, views, width, onIssue });
+  const layouts = useFileViewLayouts({ files, selections, views, width, epochs, onIssue });
   const reportedRowFailuresRef = useRef(
     new Map<string, { fileId: string; layoutGeneration: number }>(),
   );

--- a/src/ui/fileViews/useFileViews.test.tsx
+++ b/src/ui/fileViews/useFileViews.test.tsx
@@ -3,7 +3,7 @@ import { testRender } from "@opentui/react/test-utils";
 import { act, createElement, useState } from "react";
 import { createTestDiffFile, createTestSourceFetcher } from "../../../test/helpers/diff-helpers";
 import type { RegisteredFileView } from "../../extensions/types";
-import { registeredFileViewKey } from "./state";
+import { bumpFileViewEpoch, registeredFileViewKey, type FileViewEpochState } from "./state";
 import {
   FILE_VIEW_LAYOUT_CACHE_MAX_ENTRIES,
   FILE_VIEW_LAYOUT_RESIZE_DEBOUNCE_MS,
@@ -702,6 +702,295 @@ describe("file-view layout cache identity", () => {
       expect([matchesCalls, layoutCalls]).toEqual([2, 2]);
       expect(latest.get(file.id)?.registrationIdentity).not.toBe(first?.registrationIdentity);
       expect(latest.get(file.id)?.layoutGeneration).not.toBe(first?.layoutGeneration);
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+});
+
+describe("file-view layout invalidation", () => {
+  test("re-runs matches and layout for the same file and width after a refresh", async () => {
+    let matchesCalls = 0;
+    let generation = 0;
+    const view = createTestView(({ file: inputFile }) => ({
+      rows: [{ id: "row", spans: [{ text: `generation ${generation}` }] }],
+      hunkRows: (inputFile.hunks ?? []).map(() => ({ startRow: 0, endRow: 0 })),
+    }));
+    view.view.matches = () => {
+      matchesCalls += 1;
+      return true;
+    };
+    const key = registeredFileViewKey(view);
+    const selections = { [file.id]: key };
+    const views = [view];
+    let refresh = () => {};
+    let latest: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
+
+    function Harness() {
+      const [epochs, setEpochs] = useState<FileViewEpochState>(() => new Map());
+      refresh = () => setEpochs((current) => bumpFileViewEpoch(current, key));
+      latest = useFileViewLayouts({
+        files,
+        selections,
+        views,
+        width: 80,
+        epochs,
+        onIssue: ignoreIssue,
+      });
+      return null;
+    }
+
+    const setup = await testRender(createElement(Harness), { width: 10, height: 2 });
+    const settleAt = async (expected: string) => {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          await setup.renderOnce();
+        });
+        if (latest.get(file.id)?.layout.rows[0]?.spans[0]?.text === expected) return;
+      }
+      throw new Error(`layout did not settle at "${expected}"`);
+    };
+
+    try {
+      await settleAt("generation 0");
+      const first = latest.get(file.id);
+      expect(matchesCalls).toBe(1);
+
+      generation = 1;
+      await act(async () => {
+        refresh();
+        await setup.renderOnce();
+      });
+      await settleAt("generation 1");
+      // The refreshed pass re-consults the extension rather than reusing the cached tree.
+      expect(matchesCalls).toBe(2);
+      expect(latest.get(file.id)?.layoutGeneration).not.toBe(first?.layoutGeneration);
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+
+  test("keeps the previous layout visible until the refreshed layout resolves", async () => {
+    let layoutCalls = 0;
+    let resolveRefreshed:
+      | ((layout: ReturnType<RegisteredFileView["view"]["layout"]>) => void)
+      | undefined;
+    const view = createTestView(({ file: inputFile }) => {
+      layoutCalls += 1;
+      if (layoutCalls > 1) {
+        return new Promise((resolve) => {
+          resolveRefreshed = resolve;
+        });
+      }
+      return {
+        rows: [{ id: "row", spans: [{ text: "before refresh" }] }],
+        hunkRows: (inputFile.hunks ?? []).map(() => ({ startRow: 0, endRow: 0 })),
+      };
+    });
+    const key = registeredFileViewKey(view);
+    const selections = { [file.id]: key };
+    const views = [view];
+    let refresh = () => {};
+    let latest: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
+
+    function Harness() {
+      const [epochs, setEpochs] = useState<FileViewEpochState>(() => new Map());
+      refresh = () => setEpochs((current) => bumpFileViewEpoch(current, key));
+      latest = useFileViewLayouts({
+        files,
+        selections,
+        views,
+        width: 80,
+        epochs,
+        onIssue: ignoreIssue,
+      });
+      return null;
+    }
+
+    const setup = await testRender(createElement(Harness), { width: 10, height: 2 });
+    const rowText = () => latest.get(file.id)?.layout.rows[0]?.spans[0]?.text;
+
+    try {
+      for (let attempt = 0; attempt < 20 && latest.size === 0; attempt += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          await setup.renderOnce();
+        });
+      }
+      expect(rowText()).toBe("before refresh");
+
+      await act(async () => {
+        refresh();
+        await setup.renderOnce();
+      });
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          await setup.renderOnce();
+        });
+        // Never a flash back to raw diff while the replacement is still pending.
+        expect(rowText()).toBe("before refresh");
+      }
+      expect(resolveRefreshed).toBeDefined();
+
+      resolveRefreshed?.({
+        rows: [{ id: "row", spans: [{ text: "after refresh" }] }],
+        hunkRows: file.metadata.hunks.map(() => ({ startRow: 0, endRow: 0 })),
+      });
+      for (let attempt = 0; attempt < 20 && rowText() !== "after refresh"; attempt += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          await setup.renderOnce();
+        });
+      }
+      expect(rowText()).toBe("after refresh");
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+
+  test("does no work for an unselected view and re-prepares it when selected again", async () => {
+    let layoutCalls = 0;
+    const view = createTestView(({ file: inputFile }) => {
+      layoutCalls += 1;
+      return {
+        rows: [{ id: "row", spans: [{ text: `layout ${layoutCalls}` }] }],
+        hunkRows: (inputFile.hunks ?? []).map(() => ({ startRow: 0, endRow: 0 })),
+      };
+    });
+    const key = registeredFileViewKey(view);
+    const views = [view];
+    // Stable identities: the hook keys its preparation effect on the selections object itself.
+    const selectedSelections = { [file.id]: key };
+    const rawSelections: Record<string, string> = {};
+    let selectView = (_selected: boolean) => {};
+    let refresh = () => {};
+    let latest: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
+
+    function Harness() {
+      const [selected, setSelected] = useState(true);
+      const [epochs, setEpochs] = useState<FileViewEpochState>(() => new Map());
+      selectView = setSelected;
+      refresh = () => setEpochs((current) => bumpFileViewEpoch(current, key));
+      latest = useFileViewLayouts({
+        files,
+        selections: selected ? selectedSelections : rawSelections,
+        views,
+        width: 80,
+        epochs,
+        onIssue: ignoreIssue,
+      });
+      return null;
+    }
+
+    const setup = await testRender(createElement(Harness), { width: 10, height: 2 });
+    const settle = async () => {
+      for (let attempt = 0; attempt < 20 && latest.size === 0; attempt += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          await setup.renderOnce();
+        });
+      }
+    };
+
+    try {
+      await settle();
+      expect(layoutCalls).toBe(1);
+
+      await act(async () => {
+        selectView(false);
+        await setup.renderOnce();
+      });
+      await act(async () => {
+        refresh();
+        await setup.renderOnce();
+        await Promise.resolve();
+      });
+      // Raw diff everywhere: an invalidated view that nothing presents costs no extension work.
+      expect(layoutCalls).toBe(1);
+
+      await act(async () => {
+        selectView(true);
+        await setup.renderOnce();
+      });
+      await settle();
+      expect(layoutCalls).toBe(2);
+      expect(latest.get(file.id)?.layout.rows[0]?.spans[0]?.text).toBe("layout 2");
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+
+  test("re-lays out only the named file for a scoped refresh and both for a view-wide one", async () => {
+    const other = createTestDiffFile({
+      id: "sibling",
+      path: "sibling.ts",
+      before: "old\n",
+      after: "new\n",
+    });
+    const bothFiles = [file, other];
+    const layoutCalls = new Map<string, number>();
+    const view = createTestView(({ file: inputFile }) => {
+      const calls = (layoutCalls.get(inputFile.id) ?? 0) + 1;
+      layoutCalls.set(inputFile.id, calls);
+      return {
+        rows: [{ id: "row", spans: [{ text: `${inputFile.id} layout ${calls}` }] }],
+        hunkRows: (inputFile.hunks ?? []).map(() => ({ startRow: 0, endRow: 0 })),
+      };
+    });
+    const key = registeredFileViewKey(view);
+    // One view presenting every matching file, as the bulk "apply to all matching files" action leaves it.
+    const selections = { [file.id]: key, [other.id]: key };
+    const views = [view];
+    let refresh = (_fileId?: string) => {};
+    let latest: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
+
+    function Harness() {
+      const [epochs, setEpochs] = useState<FileViewEpochState>(() => new Map());
+      refresh = (fileId) => setEpochs((current) => bumpFileViewEpoch(current, key, fileId));
+      latest = useFileViewLayouts({
+        files: bothFiles,
+        selections,
+        views,
+        width: 80,
+        epochs,
+        onIssue: ignoreIssue,
+      });
+      return null;
+    }
+
+    const setup = await testRender(createElement(Harness), { width: 10, height: 2 });
+    const settleAt = async (fileId: string, expected: string) => {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        await act(async () => {
+          await Promise.resolve();
+          await setup.renderOnce();
+        });
+        if (latest.get(fileId)?.layout.rows[0]?.spans[0]?.text === expected) return;
+      }
+      throw new Error(`layout for ${fileId} did not settle at "${expected}"`);
+    };
+
+    try {
+      await settleAt(file.id, "request layout 1");
+      await settleAt(other.id, "sibling layout 1");
+
+      await act(async () => {
+        refresh(file.id);
+        await setup.renderOnce();
+      });
+      await settleAt(file.id, "request layout 2");
+      // The sibling's prepared tree is still retained under its own unchanged epoch.
+      expect(layoutCalls.get(other.id)).toBe(1);
+      expect(latest.get(other.id)?.layout.rows[0]?.spans[0]?.text).toBe("sibling layout 1");
+
+      await act(async () => {
+        refresh();
+        await setup.renderOnce();
+      });
+      await settleAt(file.id, "request layout 3");
+      await settleAt(other.id, "sibling layout 2");
     } finally {
       await act(async () => setup.renderer.destroy());
     }

--- a/src/ui/fileViews/useFileViews.ts
+++ b/src/ui/fileViews/useFileViews.ts
@@ -12,7 +12,7 @@ import {
   validateFileViewSourceRanges,
   type ValidatedFileViewLayout,
 } from "./layout";
-import { registeredFileViewKey } from "./state";
+import { fileViewLayoutEpoch, registeredFileViewKey, type FileViewEpochState } from "./state";
 
 /** Bound asynchronous third-party layout work so raw diff never waits indefinitely. */
 export const FILE_VIEW_LAYOUT_TIMEOUT_MS = 1_500;
@@ -26,6 +26,7 @@ export const FILE_VIEW_LAYOUT_CACHE_MAX_ENTRIES = 64;
 export const FILE_VIEW_LAYOUT_ISSUE_MAX_ENTRIES = 256;
 
 const EMPTY_RESOLVED_FILE_VIEW_LAYOUTS: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
+const EMPTY_FILE_VIEW_EPOCHS: FileViewEpochState = new Map();
 
 export interface ResolvedFileViewLayout extends ValidatedFileViewLayout {
   key: string;
@@ -62,8 +63,13 @@ function recordBoundedIssue(keys: Set<string>, key: string) {
   return true;
 }
 
-/** Remove superseded widths for one registration before reading or preparing its current width. */
-function selectCacheWidthVariant(
+/**
+ * Remove superseded variants for one file/registration before reading or preparing the current one.
+ *
+ * A variant is one `(width, epoch)` combination of the same prepared tree, so this is what retires
+ * both a resized geometry and an epoch an extension has invalidated.
+ */
+function selectCacheVariant(
   entries: Map<string, CacheEntry>,
   cacheKey: string,
   file: DiffFile,
@@ -204,18 +210,25 @@ function hasSelectedFileViews(
  * Raw diff remains visible while preparation is pending or declines the file. A
  * cancellation never reaches an extension as an error toast: resizes, reloads,
  * and changing the selected view are normal control flow.
+ *
+ * `epochs` carries extension-requested invalidation: bumping a view's epoch makes every
+ * prepared tree of that view a stale cache variant, so the files presenting it re-prepare.
+ * A file-scoped bump moves the same retention key for one file only, leaving the rest of
+ * that view's presenting files on their prepared trees.
  */
 export function useFileViewLayouts({
   files,
   selections,
   views,
   width,
+  epochs = EMPTY_FILE_VIEW_EPOCHS,
   onIssue,
 }: {
   files: readonly DiffFile[];
   selections: Readonly<Record<string, string>>;
   views: readonly RegisteredFileView[];
   width: number;
+  epochs?: FileViewEpochState;
   onIssue: (message: string) => void;
 }) {
   const cache = useRef(new Map<string, CacheEntry>());
@@ -264,8 +277,8 @@ export function useFileViewLayouts({
       const registered = byKey.get(key);
       if (!registered) return;
 
-      const cacheKey = `${file.id}:${key}:${width}`;
-      const cached = selectCacheWidthVariant(cache.current, cacheKey, file, registered);
+      const cacheKey = `${file.id}:${key}:${width}:${fileViewLayoutEpoch(epochs, key, file.id)}`;
+      const cached = selectCacheVariant(cache.current, cacheKey, file, registered);
       // A valid registration-aware cache hit bypasses even matches(), whose extension code may be
       // expensive or stateful. A reload replaces the registration object and invalidates it.
       if (cached?.file === file && cached.registered === registered) {
@@ -360,7 +373,7 @@ export function useFileViewLayouts({
       if (startTimer) clearTimeout(startTimer);
       controller.abort();
     };
-  }, [files, hasSelectedViews, onIssue, selections, views, width]);
+  }, [epochs, files, hasSelectedViews, onIssue, selections, views, width]);
 
   return useMemo(() => {
     if (!hasSelectedViews) return EMPTY_RESOLVED_FILE_VIEW_LAYOUTS;
@@ -382,6 +395,9 @@ export function useFileViewLayouts({
     }
     // Effects clean up after render. Exact per-file filtering synchronously declines stale geometry
     // while preserving unaffected files across filtering and another file's selection change.
+    // Epoch is deliberately absent from this filter: an invalidated layout still describes the same
+    // file at the same width, so it stays on screen until its replacement resolves rather than
+    // flashing back to raw diff.
     return current.size > 0 ? current : EMPTY_RESOLVED_FILE_VIEW_LAYOUTS;
   }, [files, hasSelectedViews, resolved, selections, views, width]);
 }

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -97,6 +97,7 @@ The handler fires when the key is pressed outside modal UI (dialogs, menus, and 
 
 - `ctx.sidebars.open(viewId)` / `close(viewId)` / `toggle(viewId)` / `isOpen(viewId)` — a bare id names your own view, `"files"` the built-in file navigation, `"<extensionId>:<viewId>"` any registered view. Opening also reveals a hidden sidebar area.
 - `ctx.fileViews.select(viewId)` / `toggle(viewId)` / `isActive(viewId)` — controls a matching [file preview](/docs/extend/file-previews/) for the current file; `select(null)` restores raw diff.
+- `ctx.fileViews.refresh(viewId, options?)` — marks that view's prepared layouts stale so a stateful view re-derives; every file presenting it re-lays out, keeping its current rows visible until the replacement resolves. Pass `{ fileId }` to scope the invalidation to one reviewed file's presentation of the view.
 - `ctx.selection` — where the review was pointing when the command fired.
 - `ctx.navigation` — moves the review stream.
 - `ctx.dialogs` — asks the user, below.

--- a/website/src/content/docs/docs/extend/file-previews.md
+++ b/website/src/content/docs/docs/extend/file-previews.md
@@ -27,6 +27,8 @@ hunk.registerCommand({ id: "toggle-preview", title: "Toggle preview", key: "f8" 
 
 `ctx.fileViews.select("preview")` selects a view, `select(null)` returns to raw diff, and `isActive("preview")` reports the current selection. A bare id names the calling extension's view; `"other-extension:preview"` addresses another registered view. These controls intentionally target only the current file; applying a view across the changeset remains a host-owned View-menu action.
 
+`ctx.fileViews.refresh("preview")` invalidates that view's prepared layouts. Hunk treats `layout` as a pure derivation of `(file, width)` and reuses its result until one of those changes, so a view holding its own state — a fold, a toggled overlay — flips that state and then asks for the re-derivation. Refresh defaults to view-wide: every file presenting the view re-runs `matches` and `layout`, while files on raw diff or another view do no work. The rows already on screen stay visible until their replacement resolves, so a refresh never flashes back to raw diff. When the state that changed belongs to one file — a fold, a per-file edit buffer — pass `refresh("preview", { fileId })` so only that file re-lays out and the other presenting files keep their prepared rows. A `fileId` no reviewed file carries invalidates nothing.
+
 ## Register a view
 
 A view has an id, a title, a cheap file matcher, and a layout function:


### PR DESCRIPTION
**PR 1 of 3** in the extension interactive-surfaces stack (this → workspace reads/writes → interactive file-view modes). Merges independently.

## What

Adds `fileViews.refresh(viewId, options?)` to the extension command context's file-view controls.

## Why

The host treats a file view's `layout(input)` as a pure derivation of `(file, width)`: results are cached and only re-run when the file, width, or registration changes. A stateful view — a fold control, a toggled overlay, a future inline editor — has no such change to announce, so it had no way to redraw. `refresh` is that announcement.

## How

- A session-scoped per-view epoch (`src/ui/fileViews/state.ts`) joins the layout-preparation cache key in `useFileViewLayouts`, so bumping it makes every prepared tree of that view a stale cache variant.
- Files currently presenting the view re-run `matches` + `layout`; files on raw diff or another view do no work.
- **Optional `{ fileId }` scopes the invalidation to one reviewed file** — per-file state (a fold, an edit buffer) shouldn't re-run third-party `layout` for every file presenting the view, which the bulk-apply path can make the whole changeset. The effective epoch is the sum of the view-wide and file-scoped counters, composed in exactly one helper (`fileViewLayoutEpoch`).
- The previous rows deliberately stay visible until the replacement resolves — a refresh never flashes back to raw diff. A re-layout that declines, throws, or times out falls back to raw exactly like any other failed layout.
- Unknown ids warn and do nothing, with the same bare/qualified id resolution as `select`; a `fileId` no review carries invalidates nothing (ids can race a reload).
- Epochs are reconciled away with dead registrations and dead files on reload.

## Testing

- Hook-level: re-runs layout for same (file, width) after refresh; stale layout stays visible while pending; unselected views do no work; a scoped refresh re-runs only the named file while a view-wide one re-runs all presenting files (`src/ui/fileViews/useFileViews.test.tsx`).
- Pure helpers: epoch bump/scope/composition/reconcile (`src/ui/fileViews/state.test.ts`).
- App-level: a real stateful extension view exercised with both view-wide and file-scoped refresh end-to-end, plus the unknown-id warning (`src/ui/AppHost.file-views.test.tsx`).
- Full suite green: typecheck, `bun run test`, PTY integration, lint, `check:pack` (doc examples compile, including a scoped-refresh snippet), `check:docs`.

Docs updated in `docs/extensions.md`, `docs/extension-architecture.md`, and the website extension pages; changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aJpBUupsP9L7Wtd7MEzmU