### PR TITLE
test(git): isolate fixture repos from the developer's Git config

### DIFF
--- a/.changeset/isolate-test-git-config.md
+++ b/.changeset/isolate-test-git-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Run Git-backed tests against an empty Git config so the machine's `diff.*` settings cannot change the patch text they assert on.

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+GIT_CONFIG_GLOBAL=/dev/null
+GIT_CONFIG_SYSTEM=/dev/null


### PR DESCRIPTION
Git-backed tests build temp repos but inherit the machine's global and system gitconfigs, so ambient settings such as `diff.noPrefix` and `diff.colorMoved` rewrite the patch text they assert on.

Point Git at config files that do not exist for the duration of a test run to make the tests hermetic. Repo-local config still applies, so fixtures keep full control, and the tests that want a specific prefix mode still ask for it explicitly.