### PR TITLE
feat(ui): show changed-file count in menu bar

### DIFF
--- a/.changeset/common-carpets-fail.md
+++ b/.changeset/common-carpets-fail.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Show the changed-file count alongside addition and deletion totals in the menu bar.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1838,6 +1838,8 @@ export function App({
     event?.stopPropagation();
   };
 
+  const changedFileCount = bootstrap.changeset.files.length;
+  const changedFileLabel = changedFileCount === 1 ? "file" : "files";
   const totalAdditions = bootstrap.changeset.files.reduce(
     (sum, file) => sum + file.stats.additions,
     0,
@@ -1846,7 +1848,7 @@ export function App({
     (sum, file) => sum + file.stats.deletions,
     0,
   );
-  const topTitle = `${bootstrap.changeset.title}  +${totalAdditions}  -${totalDeletions}`;
+  const topTitle = `${bootstrap.changeset.title}  ${changedFileCount} ${changedFileLabel}  +${totalAdditions}  -${totalDeletions}`;
   const diffHeaderStatsWidth = maxFileHeaderStatsWidth(filteredFiles);
   const diffHeaderLabelWidth = Math.max(0, diffContentWidth - diffHeaderStatsWidth - 1);
   const diffSeparatorWidth = Math.max(0, diffContentWidth - 2);

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -751,6 +751,22 @@ describe("App interactions", () => {
     }
   });
 
+  test("menu bar summarizes changed files, additions, and deletions", async () => {
+    const setup = await testRender(<AppHost bootstrap={createBootstrap()} />, {
+      width: 240,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+      expect(setup.captureCharFrame()).toContain("repo working tree  2 files  +3  -2");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("Shift-M hides the menu bar without disabling F10 menus", async () => {
     const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
       width: 240,


### PR DESCRIPTION
## Summary

- show the changed-file count beside addition and deletion totals in the menu bar
- preserve correct singular and plural labels
- add render-level regression coverage and a patch changeset

Fixes #561.

## Validation

- `bun test src/ui/AppHost.interactions.test.tsx --test-name-pattern "menu bar summarizes"`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run test:integration` — 97 passed
- `bun run test:tty-smoke` — 9 passed
- real source TTY smoke confirming the `1 file` summary

## Notes

- `bun test` reached 2040 passing tests and 18 skips, but exited nonzero because Bun collected two website Playwright specs outside the Playwright runner.

*This PR description was generated by Pi using OpenAI GPT-5.6*
