### PR TITLE
fix(ui): bound current-line navigation costs

### DIFF
--- a/.changeset/famous-birds-kneel.md
+++ b/.changeset/famous-birds-kneel.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep current-line highlighting responsive and memory-efficient across large reviews and long wrapped rows.

--- a/src/ui/AppHost.cursor-line.test.tsx
+++ b/src/ui/AppHost.cursor-line.test.tsx
@@ -105,6 +105,33 @@ async function renderCursorLineApp(
   return setup;
 }
 
+/** Render a long wrapped CJK addition through the split-row chunk path. */
+async function renderWrappedCursorLineApp(cursorLine: CursorLine) {
+  const content = `export const message = "${"日本語".repeat(80)}";\n`;
+  const bootstrap = {
+    ...createTestVcsAppBootstrap({
+      files: [
+        createTestDiffFile({
+          id: "wrapped",
+          path: "wrapped.ts",
+          before: "",
+          after: content,
+          context: 3,
+        }),
+      ],
+      initialMode: "split",
+      initialWrapLines: true,
+    }),
+    initialCursorLine: cursorLine,
+  };
+  const setup = await testRender(<AppHost bootstrap={bootstrap as never} />, {
+    width: 120,
+    height: 16,
+  });
+  await flush(setup);
+  return setup;
+}
+
 describe("current line highlight", () => {
   test("marks the current row apart from the rows around it", async () => {
     const setup = await renderCursorLineApp("row");
@@ -199,6 +226,22 @@ describe("current line highlight", () => {
     } finally {
       await act(async () => {
         setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("marks a wrapped CJK row through the chunk renderer", async () => {
+    const marked = await renderWrappedCursorLineApp("row");
+    const plain = await renderWrappedCursorLineApp("off");
+
+    try {
+      expect(rowBackground(marked, "日本語日本語")).not.toEqual(
+        rowBackground(plain, "日本語日本語"),
+      );
+    } finally {
+      await act(async () => {
+        marked.renderer.destroy();
+        plain.renderer.destroy();
       });
     }
   });

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -21,7 +21,6 @@ import type {
   LayoutMode,
   UserNoteLineTarget,
 } from "../../../core/types";
-import type { LineCursor } from "../../lib/lineCursors";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
 import type { CursorHighlight } from "../../diff/renderRows";
@@ -41,6 +40,8 @@ import {
   buildLineCursors,
   clampLineCursorToViewport,
   EMPTY_LINE_CURSORS,
+  firstLineCursorInHunk,
+  type LineCursor,
   type LineCursorBoundsLookup,
 } from "../../lib/lineCursors";
 import {
@@ -923,18 +924,26 @@ export function DiffPane({
     return resolveCopySelectionSide(copySelectionDrag.anchor.column, layout, diffContentWidth);
   }, [copySelectionDrag, diffContentWidth, layout]);
 
+  // Display the selected hunk's first line on the initial mount while the controller adopts the
+  // measured cursor list. Because both paths reuse the same cursor object, the follow-up state
+  // publication does not invalidate and repaint an expensive wrapped row.
+  const renderedLineCursor = useMemo(
+    () => lineCursor ?? firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex),
+    [lineCursor, lineCursors, selectedFileId, selectedHunkIndex],
+  );
+
   // One object per cursor move, so the section and row memos below only see a new reference when
   // the current line actually moves.
   const cursorHighlight = useMemo(
     () =>
-      cursorLine === "off" || !lineCursor
+      cursorLine === "off" || !renderedLineCursor
         ? undefined
         : ({
-            stableKey: lineCursor.stableKey,
+            stableKey: renderedLineCursor.stableKey,
             style: cursorLine,
-            side: lineCursor.target.side,
+            side: renderedLineCursor.target.side,
           } satisfies CursorHighlight),
-    [cursorLine, lineCursor],
+    [cursorLine, renderedLineCursor],
   );
 
   const copySelectedRowKeysByFile = useMemo(
@@ -2107,7 +2116,9 @@ export function DiffPane({
                       selectedHunkIndex={file.id === selectedFileId ? selectedHunkIndex : -1}
                       copySelectedRowRanges={copySelectedRowKeysByFile.get(file.id)}
                       copySelectedSide={copySelectionSide}
-                      cursorHighlight={file.id === lineCursor?.fileId ? cursorHighlight : undefined}
+                      cursorHighlight={
+                        file.id === renderedLineCursor?.fileId ? cursorHighlight : undefined
+                      }
                       shouldLoadHighlight={
                         (!wrapLines || initialWrappedRenderWindowWarmed) &&
                         highlightPrefetchFileIds.has(file.id)

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -272,15 +272,18 @@ function styledTextFromSpanNodes(nodes: ReactNode[]) {
   return new StyledText(chunks);
 }
 
-/** Append an unselected fixed-width inline span plan directly to StyledText chunks. */
+/** Append a fixed-width inline span plan directly to StyledText chunks. */
 function appendFixedInlineChunks(
   chunks: TextChunk[],
   spans: RenderSpan[],
   width: number,
   fallbackColor: string,
   fallbackBg: string,
+  highlightBg?: (baseBg: string) => string,
 ) {
   const { spans: trimmed, usedWidth } = sliceSpansWindow(spans, 0, width);
+  const renderedBackground = (background: string) =>
+    highlightBg ? highlightBg(background) : background;
   const paddingAmount = Math.max(0, width - usedWidth);
   const lastSpan = trimmed.at(-1);
   let paddingMerged = false;
@@ -299,7 +302,7 @@ function appendFixedInlineChunks(
       __isChunk: true,
       text: span.text,
       fg: styledTextColor(span.fg ?? fallbackColor),
-      bg: styledTextColor(span.bg ?? fallbackBg),
+      bg: styledTextColor(renderedBackground(span.bg ?? fallbackBg)),
     });
   }
   if (!paddingMerged && paddingAmount > 0) {
@@ -307,12 +310,17 @@ function appendFixedInlineChunks(
       __isChunk: true,
       text: " ".repeat(paddingAmount),
       fg: styledTextColor(fallbackColor),
-      bg: styledTextColor(fallbackBg),
+      bg: styledTextColor(renderedBackground(fallbackBg)),
     });
   }
 }
 
-/** Append one unselected wrapped cell without constructing intermediate React span elements. */
+/** Report whether a wrapped highlight can paint existing chunks without slicing token spans. */
+function isChunkCompatibleWrappedHighlight(highlight: RowHighlight | undefined) {
+  return !highlight?.colRange || highlight.colRange === FULL_ROW_COL_RANGE;
+}
+
+/** Append one wrapped cell without constructing intermediate React span elements. */
 function appendWrappedCellChunks(
   chunks: TextChunk[],
   line: WrappedCellLine,
@@ -320,19 +328,23 @@ function appendWrappedCellChunks(
   contentWidth: number,
   theme: AppTheme,
   prefix: { text: string; fg: string; bg: string },
+  highlight?: RowHighlight,
 ) {
+  const renderedBackground = (background: string) =>
+    highlight ? highlight.bg(background) : background;
+  const contentHighlightBg = highlight?.colRange === FULL_ROW_COL_RANGE ? highlight.bg : undefined;
   chunks.push(
     {
       __isChunk: true,
       text: prefix.text,
       fg: styledTextColor(prefix.fg),
-      bg: styledTextColor(prefix.bg),
+      bg: styledTextColor(renderedBackground(prefix.bg)),
     },
     {
       __isChunk: true,
       text: line.gutterText,
       fg: styledTextColor(palette.numberColor),
-      bg: styledTextColor(palette.gutterBg),
+      bg: styledTextColor(renderedBackground(palette.gutterBg)),
     },
   );
   appendFixedInlineChunks(
@@ -341,6 +353,7 @@ function appendWrappedCellChunks(
     contentWidth,
     theme.syntaxColors.default,
     palette.contentBg,
+    contentHighlightBg,
   );
 }
 
@@ -366,7 +379,19 @@ function renderInlineSpans(
     horizontalOffset,
     width,
   );
-  const needsBlending = highlightBg && selectionColRange;
+  // A whole-row cursor covers this complete rendered window, so it can recolor each existing span
+  // directly. Treating it like a partial copy selection would remeasure and split every token — a
+  // particularly expensive duplicate width pass for long wrapped CJK lines.
+  const fullHighlightBg =
+    highlightBg &&
+    selectionColRange &&
+    selectionColRange.start <= 0 &&
+    selectionColRange.end >= width
+      ? highlightBg
+      : undefined;
+  const needsBlending = !fullHighlightBg && highlightBg && selectionColRange;
+  const renderedBackground = (background: string) =>
+    fullHighlightBg ? fullHighlightBg(background) : background;
   const paddingAmount = Math.max(0, width - usedWidth);
   let paddingMerged = false;
   const lastSpan = trimmed.at(-1);
@@ -394,7 +419,7 @@ function renderInlineSpans(
         <span
           key={`${keyPrefix}:${elementIndex++}`}
           fg={span.fg ?? fallbackColor}
-          bg={span.bg ?? fallbackBg}
+          bg={renderedBackground(span.bg ?? fallbackBg)}
         >
           {span.text}
         </span>,
@@ -526,7 +551,7 @@ function renderInlineSpans(
   } else if (!paddingMerged && paddingAmount > 0) {
     // Keep a separate padding span when the final content style differs from the cell fallback.
     elements.push(
-      <span key={`${keyPrefix}:pad`} fg={fallbackColor} bg={fallbackBg}>
+      <span key={`${keyPrefix}:pad`} fg={fallbackColor} bg={renderedBackground(fallbackBg)}>
         {" ".repeat(paddingAmount)}
       </span>,
     );
@@ -1903,7 +1928,10 @@ function renderRow(
 
             const showBadgeOnLine = showAddNoteBadge && index === 0;
             let styledRow: StyledText;
-            if (leftHighlight || rightHighlight) {
+            if (
+              !isChunkCompatibleWrappedHighlight(leftHighlight) ||
+              !isChunkCompatibleWrappedHighlight(rightHighlight)
+            ) {
               styledRow = styledTextFromSpanNodes([
                 renderWrappedSplitCellLine(
                   leftLine,
@@ -1940,6 +1968,7 @@ function renderRow(
                 leftContentWidth,
                 theme,
                 leftPrefix,
+                leftHighlight,
               );
               appendWrappedCellChunks(
                 chunks,
@@ -1948,6 +1977,7 @@ function renderRow(
                 rightContentWidth,
                 theme,
                 rightPrefix,
+                rightHighlight,
               );
               if (guideOnNewSide) {
                 chunks.push({
@@ -2078,22 +2108,44 @@ function renderRow(
         <box id={anchorId} style={{ width: "100%", flexDirection: "column" }}>
           {layout.lines.map((line, index) => {
             const showBadgeOnLine = showAddNoteBadge && index === 0;
-            const styledRow = styledTextFromSpanNodes([
-              renderWrappedStackCellLine(
+            let styledRow: StyledText;
+            if (isChunkCompatibleWrappedHighlight(cellHighlight)) {
+              const chunks: TextChunk[] = [];
+              appendWrappedCellChunks(
+                chunks,
                 line,
                 layout.palette,
                 wrappedContentWidth,
                 theme,
-                `${row.key}:stack:${index}`,
                 prefix,
                 cellHighlight,
-              ),
-              guideOnNewSide ? (
-                <span key={`${row.key}:note-guide:${index}`} fg={theme.noteBorder}>
-                  │
-                </span>
-              ) : null,
-            ]);
+              );
+              if (guideOnNewSide) {
+                chunks.push({
+                  __isChunk: true,
+                  text: "│",
+                  fg: styledTextColor(theme.noteBorder),
+                });
+              }
+              styledRow = new StyledText(chunks);
+            } else {
+              styledRow = styledTextFromSpanNodes([
+                renderWrappedStackCellLine(
+                  line,
+                  layout.palette,
+                  wrappedContentWidth,
+                  theme,
+                  `${row.key}:stack:${index}`,
+                  prefix,
+                  cellHighlight,
+                ),
+                guideOnNewSide ? (
+                  <span key={`${row.key}:note-guide:${index}`} fg={theme.noteBorder}>
+                    │
+                  </span>
+                ) : null,
+              ]);
+            }
 
             return (
               <box

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -254,6 +254,28 @@ describe("useReviewController", () => {
     }
   });
 
+  test("keeps review stream identities stable across selection-only navigation", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const initialVisibleFiles = expectValue(controllerRef.current).visibleFiles;
+
+      await act(async () => {
+        expectValue(controllerRef.current).selectHunk("alpha", 1);
+      });
+      await flush(setup);
+
+      const controller = expectValue(controllerRef.current);
+      expect(controller.selectedHunkIndex).toBe(1);
+      expect(controller.visibleFiles).toBe(initialVisibleFiles);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("moves through visible files with clamped file-header alignment", async () => {
     const controllerRef: { current: ReviewController | null } = { current: null };
     const setup = await testRender(

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -54,10 +54,11 @@ import { agentNoteMarkupWidth } from "../lib/agentNoteGeometry";
 import { reviewNoteSource } from "../lib/agentAnnotations";
 import { STML_REFERENCE_WIDTH, validateStmlMarkup } from "../lib/stml/layout";
 import {
-  buildReviewState,
+  buildReviewStreamState,
   buildSelectedHunkSummary,
   findNextAnnotatedFile,
   resolveReviewNavigationTarget,
+  resolveSelectedFile,
 } from "../lib/reviewState";
 
 /** Add or remove one gap key from a file's expansion set. */
@@ -320,25 +321,20 @@ export function useReviewController({
 
   const deferredFilter = useDeferredValue(filter);
 
-  const { allFiles, visibleFiles, selectedFile, selectedHunk, hunkCursors, annotatedHunkCursors } =
-    useMemo(
-      () =>
-        buildReviewState({
-          files,
-          liveCommentsByFileId: mergeAnnotationMaps(liveCommentsByFileId, userNotesByFileId),
-          filterQuery: deferredFilter,
-          selectedFileId,
-          selectedHunkIndex,
-        }),
-      [
-        deferredFilter,
+  const { allFiles, visibleFiles, hunkCursors, annotatedHunkCursors } = useMemo(
+    () =>
+      buildReviewStreamState({
         files,
-        liveCommentsByFileId,
-        selectedFileId,
-        selectedHunkIndex,
-        userNotesByFileId,
-      ],
-    );
+        liveCommentsByFileId: mergeAnnotationMaps(liveCommentsByFileId, userNotesByFileId),
+        filterQuery: deferredFilter,
+      }),
+    [deferredFilter, files, liveCommentsByFileId, userNotesByFileId],
+  );
+  const selectedFile = useMemo(
+    () => resolveSelectedFile(allFiles, visibleFiles, selectedFileId),
+    [allFiles, selectedFileId, visibleFiles],
+  );
+  const selectedHunk = selectedFile?.metadata.hunks[selectedHunkIndex];
 
   /** Update the selection and reveal intent together so diff scrolling stays explicit. */
   const selectHunk = useCallback(

--- a/src/ui/lib/reviewState.ts
+++ b/src/ui/lib/reviewState.ts
@@ -18,19 +18,15 @@ import {
   type HunkCursor,
 } from "./hunks";
 
-export interface BuildReviewStateOptions {
+export interface BuildReviewStreamStateOptions {
   files: DiffFile[];
   liveCommentsByFileId: Record<string, AgentAnnotation[]>;
   filterQuery: string;
-  selectedFileId: string;
-  selectedHunkIndex: number;
 }
 
-export interface ReviewState {
+export interface ReviewStreamState {
   allFiles: DiffFile[];
   visibleFiles: DiffFile[];
-  selectedFile: DiffFile | undefined;
-  selectedHunk: DiffFile["metadata"]["hunks"][number] | undefined;
   hunkCursors: HunkCursor[];
   annotatedHunkCursors: HunkCursor[];
 }
@@ -41,23 +37,18 @@ export interface ReviewNavigationTarget {
   scrollToNote: boolean;
 }
 
-/** Build the derived review stream state from files, filter text, and selection. */
-export function buildReviewState({
+/** Build selection-independent review stream state from files and filter text. */
+export function buildReviewStreamState({
   files,
   liveCommentsByFileId,
   filterQuery,
-  selectedFileId,
-  selectedHunkIndex,
-}: BuildReviewStateOptions): ReviewState {
+}: BuildReviewStreamStateOptions): ReviewStreamState {
   const allFiles = mergeFileAnnotationsByFileId(files, liveCommentsByFileId);
   const visibleFiles = filterReviewFiles(allFiles, filterQuery);
-  const selectedFile = resolveSelectedFile(allFiles, visibleFiles, selectedFileId);
 
   return {
     allFiles,
     visibleFiles,
-    selectedFile,
-    selectedHunk: selectedFile?.metadata.hunks[selectedHunkIndex],
     hunkCursors: buildHunkCursors(visibleFiles),
     annotatedHunkCursors: buildAnnotatedHunkCursors(visibleFiles),
   };


### PR DESCRIPTION
## Summary

- keep selection-only navigation from rebuilding review-stream files, geometry, and line cursors
- seed the initially measured current-line cursor synchronously to avoid a duplicate first-frame repaint
- retain the direct `StyledText` chunk path for wrapped gutter and full-row highlights instead of converting every visual line into React spans
- add identity and wrapped-CJK cursor regression coverage

## Benchmark evidence

Five-sample medians from the release benchmark fixtures:

- navigation heap after six hunk moves: about 171 MB → 135.9 MB
- pathological wrapped-CJK long-line mount: about 35–42 ms → 20.1 ms in the focused run (22.05 ms when run with the broader benchmark group)
- wrapped content remained present on the initial, immediate-scroll, and settled frames

The broader 518-physical-line mount metric remains above the older stable baseline and is not claimed as fixed here. The pathological long-line regression and navigation retention regression that motivated this change are resolved.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:pack`
- focused controller, current-line, row-style, and copy-selection tests
- `bun run test:integration` — 97 passing
- `bun run test:tty-smoke` — 9 passing
- real-TTY wrapped-CJK diff smoke run
- independent review: no blockers

*This PR description was generated by Pi using OpenAI GPT-5.6-sol*
