### PR TITLE
fix(session): report daemon reachability in session list JSON

### DIFF
--- a/.changeset/session-list-daemon-status.md
+++ b/.changeset/session-list-daemon-status.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Report whether the session daemon is reachable in `hunk session list --json` so callers can tell a down daemon from an empty session set.

--- a/src/session/agent/commands.daemon.test.ts
+++ b/src/session/agent/commands.daemon.test.ts
@@ -56,7 +56,7 @@ describe("resolveDaemonAvailability with no daemon listening", () => {
       action: "list",
       output: "json",
     } satisfies SessionCommandInput);
-    expect(JSON.parse(output)).toEqual({ sessions: [] });
+    expect(JSON.parse(output)).toEqual({ sessions: [], daemon: { available: false } });
   });
 
   probeTest(

--- a/src/session/agent/commands.test.ts
+++ b/src/session/agent/commands.test.ts
@@ -951,6 +951,50 @@ describe("session command compatibility checks", () => {
     expect(output).toBe("No active Hunk sessions.\n");
   });
 
+  // Intent: the JSON list value must distinguish a down daemon (available: false) from a healthy
+  // daemon with zero sessions (available: true). Text output stays unchanged in both states.
+  test("list reports daemon unavailable in JSON when no daemon is present", async () => {
+    setSessionCommandTestHooks({
+      createClient: () => {
+        throw new Error("list should not create a client without a daemon");
+      },
+      resolveDaemonAvailability: async () => false,
+    });
+
+    const output = await runSessionCommand({
+      kind: "session",
+      action: "list",
+      output: "json",
+    } satisfies SessionCommandInput);
+
+    expect(JSON.parse(output)).toEqual({
+      sessions: [],
+      daemon: { available: false },
+    });
+  });
+
+  test("list reports daemon available in JSON when a daemon is present", async () => {
+    setSessionCommandTestHooks({
+      createClient: () =>
+        createClient({
+          listSessions: async () => [createTestListedSession("session-1")],
+        }),
+      resolveDaemonAvailability: async () => true,
+    });
+
+    const output = await runSessionCommand({
+      kind: "session",
+      action: "list",
+      output: "json",
+    } satisfies SessionCommandInput);
+
+    const parsed = JSON.parse(output);
+    expect(parsed.daemon).toEqual({ available: true });
+    expect(parsed).toMatchObject({
+      sessions: [{ sessionId: "session-1" }],
+    });
+  });
+
   // Intent: remaining command branches dispatch to the daemon and keep text output stable.
   test("routes remaining session actions through the daemon and formats text output", async () => {
     const selector: SessionSelectorInput = { sessionId: "session-1" };

--- a/src/session/agent/commands.ts
+++ b/src/session/agent/commands.ts
@@ -176,7 +176,11 @@ export async function runSessionCommand(input: SessionCommandInput) {
     input.action,
   ) ?? resolveDaemonAvailability(input.action));
   if (!daemonAvailable && input.action === "list") {
-    return renderOutput(input.output, { sessions: [] }, () => formatListOutput([]));
+    // Report daemon reachability in the JSON value so callers can tell a down daemon from a
+    // healthy daemon with zero sessions — both otherwise render an empty session list.
+    return renderOutput(input.output, { sessions: [], daemon: { available: false } }, () =>
+      formatListOutput([]),
+    );
   }
 
   const normalizedSelector = "selector" in input ? normalizeSessionSelector(input.selector) : null;
@@ -188,7 +192,9 @@ export async function runSessionCommand(input: SessionCommandInput) {
   switch (input.action) {
     case "list": {
       const sessions = await client.listSessions();
-      return renderOutput(input.output, { sessions }, () => formatListOutput(sessions));
+      return renderOutput(input.output, { sessions, daemon: { available: true } }, () =>
+        formatListOutput(sessions),
+      );
     }
     case "get": {
       const session = await client.getSession(normalizedSelector!);


### PR DESCRIPTION
Fixes #527

## Summary
`hunk session list --json` now includes a `daemon` object alongside `sessions` so callers can distinguish an unreachable daemon from a healthy daemon with zero sessions — both previously printed the byte-identical `{ "sessions": [] }` with exit 0.

- Daemon unreachable: `{ "sessions": [], "daemon": { "available": false } }`
- Daemon reachable: `{ "sessions": [...], "daemon": { "available": true } }`

Text-mode `hunk session list` output and the exit code are unchanged in both states, and existing JSON consumers that read `.sessions` keep working (purely additive, non-breaking).

## Root cause
In `runSessionCommand`, the daemon-down `list` branch returned `renderOutput(input.output, { sessions: [] }, …)` and the daemon-up `list` branch returned `renderOutput(input.output, { sessions }, …)`. `renderOutput` serializes the value object as the JSON body, so both produced `{ "sessions": … }` — the reachability boolean from `resolveDaemonAvailability` was discarded before it reached the output, collapsing "daemon down" and "daemon up, zero sessions" into the same bytes.

## Changes
- `src/session/agent/commands.ts` — pass `daemon: { available }` inside the `value` to `renderOutput` for the `list` action in both branches (`available: false` on the down path, `available: true` on the up path). No other action is affected; the return type stays `string`; `src/main.tsx`, exit codes, and CLI flags are untouched.
- `src/session/agent/commands.daemon.test.ts` — update the real-probe strict `toEqual` to the new shape `{ sessions: [], daemon: { available: false } }`.
- `src/session/agent/commands.test.ts` — add two hook-based regression tests (daemon-unavailable and daemon-available JSON shapes).
- `.changeset/session-list-daemon-status.md` — `hunkdiff` / `patch` changeset.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run test:theme-contrast`
- [x] `bun run test` (1940 pass / 0 fail, incl. `src/session/agent/commands.test.ts` and `commands.daemon.test.ts`)
- [x] `bun run test:tty-smoke`
- [x] `bun run test:integration` (91 pass / 6 fail — the 6 failures are pre-existing TUI/extension tests that reproduce identically on the clean base `c4739ef` and are caused by the local worktree environment, not this change; the full unit + session suite is green)
- [x] manual: `HUNK_MCP_PORT=<free-port> hunk session list --json` now emits `daemon.available: false` with text-mode and exit code unchanged
- [x] macOS arm64 (Bun 1.3.14)
- [ ] Linux / Windows (the `windows-compat` CI job exercises these unit/session tests)

Co-authored-by: Claude <noreply@anthropic.com>
