### PR TITLE
fix(ui): keep the menu bar inside the app's gutter

### DIFF
--- a/.changeset/lucky-moons-smash.md
+++ b/.changeset/lucky-moons-smash.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep the top menu bar inside the same one-column margin as the rest of the app instead of painting its background into the outer gutter.

--- a/src/ui/components/chrome/MenuBar.tsx
+++ b/src/ui/components/chrome/MenuBar.tsx
@@ -21,38 +21,50 @@ export function MenuBar({
   onToggleMenu: (menuId: MenuId) => void;
 }) {
   return (
+    // The outer row paints the app background so the bar keeps the same
+    // one-column gutter the body panes have; only the inner band is chrome.
     <box
       style={{
         height: 1,
-        backgroundColor: theme.panelAlt,
+        backgroundColor: theme.background,
         flexDirection: "row",
         alignItems: "center",
         paddingLeft: 1,
         paddingRight: 1,
       }}
     >
-      {menuSpecs.map((menu) => {
-        const active = activeMenuId === menu.id;
-        return (
-          <box
-            key={menu.id}
-            style={{
-              width: menu.width,
-              height: 1,
-              backgroundColor: active ? theme.accentMuted : theme.panelAlt,
-            }}
-            onMouseUp={() => onToggleMenu(menu.id)}
-            onMouseOver={() => onHoverMenu(menu.id)}
-          >
-            <text fg={active ? theme.text : theme.muted}>{` ${menu.label} `}</text>
-          </box>
-        );
-      })}
+      <box
+        style={{
+          flexGrow: 1,
+          height: 1,
+          backgroundColor: theme.panelAlt,
+          flexDirection: "row",
+          alignItems: "center",
+        }}
+      >
+        {menuSpecs.map((menu) => {
+          const active = activeMenuId === menu.id;
+          return (
+            <box
+              key={menu.id}
+              style={{
+                width: menu.width,
+                height: 1,
+                backgroundColor: active ? theme.accentMuted : theme.panelAlt,
+              }}
+              onMouseUp={() => onToggleMenu(menu.id)}
+              onMouseOver={() => onHoverMenu(menu.id)}
+            >
+              <text fg={active ? theme.text : theme.muted}>{` ${menu.label} `}</text>
+            </box>
+          );
+        })}
 
-      <box style={{ flexGrow: 1, height: 1, alignItems: "center", justifyContent: "flex-end" }}>
-        <text
-          fg={theme.muted}
-        >{` ${fitText(topTitle, menuBarTitleWidth(menuSpecs, terminalWidth))}`}</text>
+        <box style={{ flexGrow: 1, height: 1, alignItems: "center", justifyContent: "flex-end" }}>
+          <text
+            fg={theme.muted}
+          >{` ${fitText(topTitle, menuBarTitleWidth(menuSpecs, terminalWidth))}`}</text>
+        </box>
       </box>
     </box>
   );

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createPtyHarness } from "./harness";
+import { createPtyHarness, lineIndexOf, rowCellBackgrounds } from "./harness";
 
 const harness = createPtyHarness();
 
@@ -319,6 +319,36 @@ describe("PTY chrome", () => {
 
       expect(stacked).not.toMatch(/▌.*▌/);
       expect(stacked).toContain("1   -  export const alpha = 1;");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("the menu bar leaves the same one-column gutter the body panes leave", async () => {
+    const fixture = harness.createTwoFileRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff"],
+      cwd: fixture.dir,
+      cols: 100,
+      rows: 20,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+
+      const menuRow = rowCellBackgrounds(session, 0);
+      const bodyRow = rowCellBackgrounds(session, lineIndexOf(initial, "export const alpha"));
+      const lastColumn = menuRow.length - 1;
+
+      // Outer gutters match the body, so the app keeps one continuous margin.
+      expect(menuRow[0]).toBe(bodyRow[0]);
+      expect(menuRow[lastColumn]).toBe(bodyRow[bodyRow.length - 1]);
+
+      // The menu bar's own chrome band still fills everything between them.
+      expect(menuRow[1]).not.toBe(menuRow[0]);
+      expect(menuRow[lastColumn - 1]).not.toBe(menuRow[lastColumn]);
     } finally {
       session.close();
     }

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -142,6 +142,21 @@ export function rightmostColumnOf(text: string, needle: string) {
   );
 }
 
+/**
+ * Expand one rendered row into its per-cell background colors.
+ *
+ * Chrome rows and body rows only line up visually when their gutter cells paint
+ * the same background, which plain text snapshots cannot show.
+ */
+export function rowCellBackgrounds(session: Session, row: number) {
+  const line = session.getTerminalData().lines[row];
+  if (!line) {
+    throw new Error(`rowCellBackgrounds: row ${row} is not on screen.`);
+  }
+
+  return line.spans.flatMap((span) => [...span.text].map(() => span.bg));
+}
+
 /** Locate a visible terminal row containing text so mouse tests can target rendered content. */
 export function lineIndexOf(text: string, needle: string) {
   return text.split("\n").findIndex((line) => line.includes(needle));


### PR DESCRIPTION
The top menu bar painted its chrome background into the two outer gutter columns, so it didn't line up with the panes below — the app's one-column margin ran down the whole UI except the top row.

`MenuBar` was one full-width box with `paddingLeft`/`paddingRight: 1` and `backgroundColor: theme.panelAlt`, so the padding cells were chrome. This moves the band into an inner `flexGrow: 1` box and lets the outer row paint `theme.background`.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/modem-dev/hunk/assets/pr-693-menu-bar-gutter/menubar-before.png) | ![after](https://raw.githubusercontent.com/modem-dev/hunk/assets/pr-693-menu-bar-gutter/menubar-after.png) |

Real PTY captures at 90 columns, rendered cell-for-cell from the colors the terminal received. The zooms magnify the edge columns: before, the band runs to the very edge on the menu row; after, the dark gutter is continuous down both sides.

**Column positions are unchanged** — labels still start at column 1, so `MenuSpec.left`, `MenuDropdown` anchoring, and `menuBarTitleWidth` all still hold.

Adds a PTY regression test asserting the menu bar's edge cells match the body's, plus a `rowCellBackgrounds` harness helper — text snapshots can't see this bug, only the cell background differs. Confirmed the test fails without the fix.

`typecheck`, `lint`, `test/pty/chrome.test.ts`, and `test:tty-smoke` are clean. ⚠️ The full `bun test` has 5 failures in `extensions-integration` and `file-views-integration`; they fail identically on the unmodified baseline, so they're pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
