### PR TITLE
fix(pager): keep Git colors in non-diff output for captured pager hosts

### DIFF
--- a/.changeset/preserve-captured-pager-color.md
+++ b/.changeset/preserve-captured-pager-color.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep Git's colors in non-diff `hunk pager` output for captured pager hosts, so LazyGit's branch log renders in its normal per-branch palette instead of a single color.

--- a/src/app/startup.test.ts
+++ b/src/app/startup.test.ts
@@ -135,7 +135,8 @@ describe("startup planning", () => {
       },
     });
 
-    expect(plan).toEqual({ kind: "passthrough", text });
+    // Captured hosts draw this text themselves, so Git's colors have to survive.
+    expect(plan).toEqual({ kind: "passthrough", text, preserveColor: true });
     expect(loaded).toBe(false);
   });
 
@@ -155,7 +156,8 @@ describe("startup planning", () => {
       },
     });
 
-    expect(plan).toEqual({ kind: "passthrough", text });
+    // A genuinely dumb terminal would print the escape sequences as literal text.
+    expect(plan).toEqual({ kind: "passthrough", text, preserveColor: false });
     expect(loaded).toBe(false);
   });
 
@@ -216,13 +218,14 @@ describe("startup planning", () => {
       readStdinText: async () => patchText,
       looksLikePatchInputImpl: () => true,
       stdoutIsTTY: false,
+      env: { TERM: "xterm-256color" },
       loadAppBootstrapImpl: async () => {
         loaded = true;
         throw new Error("unreachable");
       },
     });
 
-    expect(plan).toEqual({ kind: "passthrough", text: patchText });
+    expect(plan).toEqual({ kind: "passthrough", text: patchText, preserveColor: false });
     expect(loaded).toBe(false);
   });
 
@@ -242,7 +245,7 @@ describe("startup planning", () => {
       },
     });
 
-    expect(plan).toEqual({ kind: "passthrough", text: patchText });
+    expect(plan).toEqual({ kind: "passthrough", text: patchText, preserveColor: false });
     expect(loaded).toBe(false);
   });
 

--- a/src/app/startup.ts
+++ b/src/app/startup.ts
@@ -46,6 +46,7 @@ export type StartupPlan =
   | {
       kind: "passthrough";
       text: string;
+      preserveColor: boolean;
     }
   | {
       kind: "static-diff-pager";
@@ -154,6 +155,7 @@ export async function prepareStartupPlan(
   if (parsedCliInput.kind === "pager") {
     const stdinText = await readStdinText();
     const pagerOptions = parsedCliInput.options;
+    const capturedPagerHost = isCapturedPagerHost(env);
     const staticPagerPlan = () => {
       const staticPatchInput: CliInput = {
         kind: "patch",
@@ -179,13 +181,18 @@ export async function prepareStartupPlan(
         : staticPlan;
     };
 
+    // Captured hosts render Hunk's stdout in their own panel, so passed-through text keeps
+    // the color Git already put in it.
+    const passthroughPlan = {
+      kind: "passthrough" as const,
+      text: stdinText,
+      preserveColor: capturedPagerHost,
+    };
+
     if (!looksLikePatchInputImpl(stdinText)) {
       // Dumb-terminal and captured pager hosts cannot safely own an interactive text pager.
       if (env.TERM === "dumb") {
-        return {
-          kind: "passthrough",
-          text: stdinText,
-        };
+        return passthroughPlan;
       }
 
       return {
@@ -195,22 +202,16 @@ export async function prepareStartupPlan(
     }
 
     if (!stdoutIsTTY) {
-      return {
-        kind: "passthrough",
-        text: stdinText,
-      };
+      return passthroughPlan;
     }
 
-    if (env.TERM === "dumb" && !isCapturedPagerHost(env)) {
-      return {
-        kind: "passthrough",
-        text: stdinText,
-      };
+    if (env.TERM === "dumb" && !capturedPagerHost) {
+      return passthroughPlan;
     }
 
     // Captured pager hosts like LazyGit can provide a PTY while advertising TERM=dumb.
     // In that mode, emit static colored diff output instead of launching the TUI.
-    if (isCapturedPagerHost(env)) {
+    if (capturedPagerHost) {
       return staticPagerPlan();
     }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,7 +49,9 @@ async function main() {
   }
 
   if (startupPlan.kind === "passthrough") {
-    process.stdout.write(sanitizeTerminalText(startupPlan.text));
+    process.stdout.write(
+      sanitizeTerminalText(startupPlan.text, { preserveAnsiStyle: startupPlan.preserveColor }),
+    );
     process.exit(0);
   }
 

--- a/test/cli/entrypoint.test.ts
+++ b/test/cli/entrypoint.test.ts
@@ -18,6 +18,15 @@ function git(cwd: string, ...args: string[]) {
   }
 }
 
+/** Drop the ambient markers that would make Hunk treat this run as a captured pager host. */
+function uncapturedPagerEnv() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key]) => key !== "LV" && key !== "GIT_PAGER" && !key.startsWith("LAZYGIT"),
+    ),
+  );
+}
+
 describe("CLI entrypoint contracts", () => {
   test("bare hunk prints standard help without terminal takeover sequences", () => {
     const proc = Bun.spawnSync(["bun", "run", "src/main.tsx"], {
@@ -223,6 +232,40 @@ describe("CLI entrypoint contracts", () => {
     expect(stdout).toContain("feature/demo");
     expect(stdout).not.toContain("View  Navigate  Agent  Help");
     expect(stdout).not.toContain("\u001b[?1049h");
+  });
+
+  test("general pager mode keeps Git colors in non-diff stdin for captured pager hosts", () => {
+    const coloredLog = "\u001b[33m*\u001b[m \u001b[32mabc1234\u001b[m feat: thing\n";
+    const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "pager"], {
+      cwd: process.cwd(),
+      stdin: Buffer.from(coloredLog),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...uncapturedPagerEnv(), TERM: "dumb", LAZYGIT_NEW_DIR_FILE: "/tmp/lazygit-dir" },
+    });
+
+    const stdout = Buffer.from(proc.stdout).toString("utf8");
+
+    expect(proc.exitCode).toBe(0);
+    expect(Buffer.from(proc.stderr).toString("utf8")).toBe("");
+    expect(stdout).toBe(coloredLog);
+  });
+
+  test("general pager mode strips colors from non-diff stdin outside captured pager hosts", () => {
+    const coloredLog = "\u001b[33m*\u001b[m \u001b[32mabc1234\u001b[m feat: thing\n";
+    const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "pager"], {
+      cwd: process.cwd(),
+      stdin: Buffer.from(coloredLog),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...uncapturedPagerEnv(), TERM: "dumb" },
+    });
+
+    const stdout = Buffer.from(proc.stdout).toString("utf8");
+
+    expect(proc.exitCode).toBe(0);
+    expect(Buffer.from(proc.stderr).toString("utf8")).toBe("");
+    expect(stdout).toBe("* abc1234 feat: thing\n");
   });
 
   test("general pager mode passes diff stdin through when stdout is not a terminal", () => {


### PR DESCRIPTION
Fixes #702.

Captured pager hosts like LazyGit advertise `TERM=dumb` while rendering ANSI in their own panel. Hunk already knows this for diffs — `isCapturedPagerHost` is what routes those hosts to the static colored renderer instead of launching the TUI. Non-diff input returns `passthrough` before reaching that check, and passthrough stripped SGR unconditionally, so LazyGit's branch log rendered in a single color.

This reuses that same predicate rather than adding a second heuristic: the fact that already tells the diff path "this host renders ANSI" now also decides whether passthrough preserves it.

```ts
const passthroughPlan = {
  kind: "passthrough" as const,
  text: stdinText,
  preserveColor: capturedPagerHost,
};
```

#381 fixed the same symptom for interactive terminals via `pagePlainText`, but captured hosts never reach `pagePlainText` — `TERM=dumb` sends them down passthrough first.

### Before / after

| released 0.18.0 | this branch |
|---|---|
| ![branch log with no color](https://raw.githubusercontent.com/DanielCarmingham/hunk/assets/lazygit-nondiff-color/assets/lazygit-released-0.18.0-no-color.png) | ![branch log with color preserved](https://raw.githubusercontent.com/DanielCarmingham/hunk/assets/lazygit-nondiff-color/assets/lazygit-patched-color-preserved.png) |

Same repo, same commit, same terminal size — only the pager binary differs.

### Verification

- `bun run typecheck` clean; `bun test` shows an identical failure set to `main` on the same base (no regressions, +2 new passing tests)
- Reverting only the source change while keeping the new tests fails 5 of them, so the tests do detect the fix
- Real `git log --graph --color=always` through `hunk pager`: **0 → 468** escape sequences under a LazyGit environment, and still **0** for a plain `TERM=dumb` terminal, so genuinely dumb terminals are unaffected
- Confirmed end to end by driving real LazyGit 0.64.0 in a PTY (screenshots above)
