### PR TITLE
feat(extensions): expose public Hunk command execution

### DIFF
--- a/.changeset/public-extension-command-controls.md
+++ b/.changeset/public-extension-command-controls.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Let extensions invoke public Hunk review commands with atomic movement counts.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -174,8 +174,17 @@ menu-specific wording and checkbox state, and the controls help dialog
 (`src/ui/lib/helpContent.ts`) declares curated rows the same way — both render
 their key text from resolved `keyLabels` and run entries through
 `executeAppCommand`. A few commands ship with `defaultKeys: []` because they
-exist for a menu item; they never match a key but remain bindable by id. The
-**Extensions** menu is generated from the registered extension commands, one
+exist for a menu item; they never match a key but remain bindable by id.
+
+Command handlers receive guarded `ctx.commands` controls built by
+`src/ui/lib/extensionCommandControls.ts`. They resolve the live App command table on every call,
+then expose only built-ins carrying explicit public metadata. Counted movement reaches the same
+command callback once with a normalized delta; it is never implemented as repeated synchronous
+dispatch. Current-line alignment is also semantic: App raises an alignment request and `DiffPane`
+resolves it against its private row geometry, so no renderer or scrollbox leaks into the API.
+Extension commands remain private to prevent recursion and cross-extension execution.
+
+The **Extensions** menu is generated from the registered extension commands, one
 item per command grouped by extension, and is absent entirely when there are
 none — which is why the visible menu list is derived from the menus record
 (`buildMenuSpecs` in `src/ui/components/chrome/menu.ts`) rather than fixed.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -192,7 +192,7 @@ cannot mutate the registry mid-session.
 
 ### `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `2`). Branch on it if you want
+The API generation this Hunk speaks (currently `3`). Branch on it if you want
 one file to support several Hunk versions.
 
 ### `hunk.registerTheme(theme)`
@@ -1043,6 +1043,33 @@ selected hunk, and `null` whenever `file` is — or when the file has no hunks t
 select. The values are captured when the command fires: a handler that awaits
 still sees the selection it was run from, not wherever the user navigated to
 meanwhile.
+
+`ctx.commands` invokes Hunk's documented semantic commands through the exact same live command
+table used by the keyboard, menus, and help:
+
+```ts
+hunk.registerCommand({ id: "skip-three", title: "Skip three hunks", key: "ctrl+j" }, (ctx) => {
+  if (ctx.commands.isEnabled("hunk.review.nextHunk")) {
+    ctx.commands.execute("hunk.review.nextHunk", { count: 3 });
+  }
+});
+```
+
+Only explicitly public built-in `hunk.*` commands can be invoked. Unknown, disabled,
+extension-owned, or stale-session commands return `false`; an extension cannot recursively invoke
+itself or another extension. `isEnabled` also returns `false` for malformed ids, while malformed
+`execute` ids, options, and counts throw as extension programming errors. The public ids are the built-ins listed in
+[keybindings](keybindings.md), including the unbound
+`hunk.review.alignCurrentLineTop`, `hunk.review.alignCurrentLineCenter`, and
+`hunk.review.alignCurrentLineBottom` commands.
+
+`count` defaults to `1` and must be a positive safe integer no greater than `10,000`. Relative
+line, viewport, horizontal, file, hunk, and annotated navigation applies the count atomically in
+one host transition. Absolute positioning and one-shot commands run once. This avoids stale React
+state without exposing scroll boxes, renderer refs, or coordinates. Both methods read live command
+state, so they remain valid after an `await` or an ordinary content soft reload that retains the
+extension registry. Controls retained across an extension-registry reload or App remount return
+`false`.
 
 `ctx.navigation` moves the review stream: `selectFile(fileId)` and
 `selectHunk(fileId, hunkIndex)`, the same guarded navigation a sidebar's

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -39,56 +39,62 @@ byte; named Tab and Enter events stay distinct.
 
 The built-in commands and the keys they ship with:
 
-| Command id                          | Does                                     | Default keys                 |
-| ----------------------------------- | ---------------------------------------- | ---------------------------- |
-| `hunk.app.quit`                     | Quit                                     | `q`                          |
-| `hunk.app.refresh`                  | Refresh the review                       | `r`                          |
-| `hunk.app.toggleHelp`               | Toggle help                              | `?`                          |
-| `hunk.app.toggleFocusArea`          | Switch focus between files and filter    | `tab`                        |
-| `hunk.app.openAgentSkill`           | Show agent skill                         | _(none)_                     |
-| `hunk.review.focusFilter`           | Focus the file filter                    | `/`                          |
-| `hunk.review.startNote`             | Add a review note                        | `c`                          |
-| `hunk.review.editSelectedFile`      | Open the selected file in your editor    | `e`                          |
-| `hunk.review.nextHunk`              | Next hunk                                | `]`                          |
-| `hunk.review.previousHunk`          | Previous hunk                            | `[`                          |
-| `hunk.review.nextFile`              | Next file                                | `.`                          |
-| `hunk.review.previousFile`          | Previous file                            | `,`                          |
-| `hunk.review.nextAnnotatedHunk`     | Next annotated hunk                      | `}`                          |
-| `hunk.review.previousAnnotatedHunk` | Previous annotated hunk                  | `{`                          |
-| `hunk.review.nextAnnotatedFile`     | Next annotated file                      | _(none)_                     |
-| `hunk.review.previousAnnotatedFile` | Previous annotated file                  | _(none)_                     |
-| `hunk.review.toggleHunkGap`         | Expand or collapse the selected context  | `z`                          |
-| `hunk.review.pageDown`              | Scroll down one page                     | `pagedown`, `space`, `f`     |
-| `hunk.review.pageUp`                | Scroll up one page                       | `pageup`, `b`, `shift+space` |
-| `hunk.review.halfPageDown`          | Scroll down half a page                  | `d`                          |
-| `hunk.review.halfPageUp`            | Scroll up half a page                    | `u`                          |
-| `hunk.review.stepDown`              | Scroll down one row                      | `down`, `j`                  |
-| `hunk.review.stepUp`                | Scroll up one row                        | `up`, `k`                    |
-| `hunk.review.jumpToTop`             | Jump to start                            | `g`, `home`                  |
-| `hunk.review.jumpToBottom`          | Jump to end                              | `G`, `end`                   |
-| `hunk.review.scrollCodeLeft`        | Scroll code left (shifted scrolls fast)  | `left`, `shift+left`         |
-| `hunk.review.scrollCodeRight`       | Scroll code right (shifted scrolls fast) | `right`, `shift+right`       |
-| `hunk.view.toggleSidebar`           | Toggle sidebar                           | `s`                          |
-| `hunk.view.toggleMenuBar`           | Toggle menu bar                          | `M`                          |
-| `hunk.view.toggleHunkHeaders`       | Toggle hunk headers                      | `m`                          |
-| `hunk.view.toggleLineNumbers`       | Toggle line numbers                      | `l`                          |
-| `hunk.view.toggleLineWrap`          | Toggle line wrapping                     | `w`                          |
-| `hunk.view.toggleAgentNotes`        | Toggle agent notes                       | `a`                          |
-| `hunk.view.toggleCopyDecorations`   | Toggle copy decorations                  | _(none)_                     |
-| `hunk.view.openThemeSelector`       | Choose theme                             | `t`                          |
-| `hunk.view.layoutSplit`             | Split layout                             | `1`                          |
-| `hunk.view.layoutStack`             | Stack layout                             | `2`                          |
-| `hunk.view.layoutAuto`              | Auto layout                              | `0`                          |
-| `hunk.view.cursorLineRow`           | Highlight the current row                | _(none)_                     |
-| `hunk.view.cursorLineNumber`        | Mark the current line number             | _(none)_                     |
-| `hunk.view.cursorLineOff`           | Hide the current-line marker             | _(none)_                     |
+| Command id                                     | Does                                           | Default keys                 |
+| ---------------------------------------------- | ---------------------------------------------- | ---------------------------- |
+| `hunk.review.jumpToBottom`                     | Jump to end                                    | `G`, `end`                   |
+| `hunk.review.jumpToTop`                        | Jump to start                                  | `g`, `home`                  |
+| `hunk.app.quit`                                | Quit                                           | `q`                          |
+| `hunk.app.toggleHelp`                          | Toggle help                                    | `?`                          |
+| `hunk.app.openAgentSkill`                      | Show agent skill                               | _(none)_                     |
+| `hunk.app.toggleFocusArea`                     | Switch focus between files and filter          | `tab`                        |
+| `hunk.review.focusFilter`                      | Focus the file filter                          | `/`                          |
+| `hunk.review.startNote`                        | Add a review note                              | `c`                          |
+| `hunk.review.pageDown`                         | Scroll down one page                           | `pagedown`, `space`, `f`     |
+| `hunk.review.pageUp`                           | Scroll up one page                             | `pageup`, `b`, `shift+space` |
+| `hunk.review.halfPageDown`                     | Scroll down half a page                        | `d`                          |
+| `hunk.review.halfPageUp`                       | Scroll up half a page                          | `u`                          |
+| `hunk.review.stepDown`                         | Scroll down one row                            | `down`, `j`                  |
+| `hunk.review.stepUp`                           | Scroll up one row                              | `up`, `k`                    |
+| `hunk.review.scrollCodeLeft`                   | Scroll code left (shifted scrolls fast)        | `left`, `shift+left`         |
+| `hunk.review.scrollCodeRight`                  | Scroll code right (shifted scrolls fast)       | `right`, `shift+right`       |
+| `hunk.review.alignCurrentLineTop`              | Align current line to viewport top             | _(none)_                     |
+| `hunk.review.alignCurrentLineCenter`           | Center current line in viewport                | _(none)_                     |
+| `hunk.review.alignCurrentLineBottom`           | Align current line to viewport bottom          | _(none)_                     |
+| `hunk.view.cursorLineRow`                      | Highlight the current row                      | _(none)_                     |
+| `hunk.view.cursorLineNumber`                   | Mark the current line number                   | _(none)_                     |
+| `hunk.view.cursorLineOff`                      | Hide the current-line marker                   | _(none)_                     |
+| `hunk.view.layoutSplit`                        | Split layout                                   | `1`                          |
+| `hunk.view.layoutStack`                        | Stack layout                                   | `2`                          |
+| `hunk.view.layoutAuto`                         | Auto layout                                    | `0`                          |
+| `hunk.view.applyFilePresentationToAllMatching` | Apply current file presentation to all matches | _(none)_                     |
+| `hunk.view.toggleSidebar`                      | Toggle sidebar                                 | `s`                          |
+| `hunk.app.refresh`                             | Refresh the review                             | `r`                          |
+| `hunk.view.openThemeSelector`                  | Choose theme                                   | `t`                          |
+| `hunk.view.toggleAgentNotes`                   | Toggle agent notes                             | `a`                          |
+| `hunk.view.toggleLineNumbers`                  | Toggle line numbers                            | `l`                          |
+| `hunk.view.toggleLineWrap`                     | Toggle line wrapping                           | `w`                          |
+| `hunk.view.toggleMenuBar`                      | Toggle menu bar                                | `M`                          |
+| `hunk.view.toggleHunkHeaders`                  | Toggle hunk headers                            | `m`                          |
+| `hunk.view.toggleCopyDecorations`              | Toggle copy decorations                        | _(none)_                     |
+| `hunk.review.toggleHunkGap`                    | Expand or collapse the selected context        | `z`                          |
+| `hunk.review.editSelectedFile`                 | Open the selected file in your editor          | `e`                          |
+| `hunk.review.previousHunk`                     | Previous hunk                                  | `[`                          |
+| `hunk.review.nextHunk`                         | Next hunk                                      | `]`                          |
+| `hunk.review.previousFile`                     | Previous file                                  | `,`                          |
+| `hunk.review.nextFile`                         | Next file                                      | `.`                          |
+| `hunk.review.previousAnnotatedHunk`            | Previous annotated hunk                        | `{`                          |
+| `hunk.review.nextAnnotatedHunk`                | Next annotated hunk                            | `}`                          |
+| `hunk.review.previousAnnotatedFile`            | Previous annotated file                        | _(none)_                     |
+| `hunk.review.nextAnnotatedFile`                | Next annotated file                            | _(none)_                     |
 
-Commands marked _(none)_ ship without a key: they are menu items today, and
-binding one gives it a shortcut like any other.
+Commands marked _(none)_ ship without a key: they remain callable by command id
+and can be assigned a shortcut through `[keybindings]`. Some also appear in a
+menu, while semantic commands such as current-line alignment do not need a menu
+entry.
 
-The menus and the controls help dialog (`?`) show the keys each command is
-currently on, so remapping something changes what they advertise. A command you
-unbind keeps its menu item and simply stops showing a key.
+The menus and the controls help dialog (`?`) show the keys for the commands they
+present, so remapping something changes what they advertise. Unbinding a menu
+command keeps its menu item and simply stops showing a key.
 
 Extension commands are named `<extensionId>.<commandId>` and remap the same way
 (see [docs/extensions.md](extensions.md)). Keys that belong to a dialog,

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -41,51 +41,51 @@ The built-in commands and the keys they ship with:
 
 | Command id                                     | Does                                           | Default keys                 |
 | ---------------------------------------------- | ---------------------------------------------- | ---------------------------- |
-| `hunk.review.jumpToBottom`                     | Jump to end                                    | `G`, `end`                   |
-| `hunk.review.jumpToTop`                        | Jump to start                                  | `g`, `home`                  |
-| `hunk.app.quit`                                | Quit                                           | `q`                          |
-| `hunk.app.toggleHelp`                          | Toggle help                                    | `?`                          |
 | `hunk.app.openAgentSkill`                      | Show agent skill                               | _(none)_                     |
+| `hunk.app.quit`                                | Quit                                           | `q`                          |
+| `hunk.app.refresh`                             | Refresh the review                             | `r`                          |
 | `hunk.app.toggleFocusArea`                     | Switch focus between files and filter          | `tab`                        |
+| `hunk.app.toggleHelp`                          | Toggle help                                    | `?`                          |
+| `hunk.review.alignCurrentLineBottom`           | Align current line to viewport bottom          | _(none)_                     |
+| `hunk.review.alignCurrentLineCenter`           | Center current line in viewport                | _(none)_                     |
+| `hunk.review.alignCurrentLineTop`              | Align current line to viewport top             | _(none)_                     |
+| `hunk.review.editSelectedFile`                 | Open the selected file in your editor          | `e`                          |
 | `hunk.review.focusFilter`                      | Focus the file filter                          | `/`                          |
-| `hunk.review.startNote`                        | Add a review note                              | `c`                          |
-| `hunk.review.pageDown`                         | Scroll down one page                           | `pagedown`, `space`, `f`     |
-| `hunk.review.pageUp`                           | Scroll up one page                             | `pageup`, `b`, `shift+space` |
 | `hunk.review.halfPageDown`                     | Scroll down half a page                        | `d`                          |
 | `hunk.review.halfPageUp`                       | Scroll up half a page                          | `u`                          |
-| `hunk.review.stepDown`                         | Scroll down one row                            | `down`, `j`                  |
-| `hunk.review.stepUp`                           | Scroll up one row                              | `up`, `k`                    |
+| `hunk.review.jumpToBottom`                     | Jump to end                                    | `G`, `end`                   |
+| `hunk.review.jumpToTop`                        | Jump to start                                  | `g`, `home`                  |
+| `hunk.review.nextAnnotatedFile`                | Next annotated file                            | _(none)_                     |
+| `hunk.review.nextAnnotatedHunk`                | Next annotated hunk                            | `}`                          |
+| `hunk.review.nextFile`                         | Next file                                      | `.`                          |
+| `hunk.review.nextHunk`                         | Next hunk                                      | `]`                          |
+| `hunk.review.pageDown`                         | Scroll down one page                           | `pagedown`, `space`, `f`     |
+| `hunk.review.pageUp`                           | Scroll up one page                             | `pageup`, `b`, `shift+space` |
+| `hunk.review.previousAnnotatedFile`            | Previous annotated file                        | _(none)_                     |
+| `hunk.review.previousAnnotatedHunk`            | Previous annotated hunk                        | `{`                          |
+| `hunk.review.previousFile`                     | Previous file                                  | `,`                          |
+| `hunk.review.previousHunk`                     | Previous hunk                                  | `[`                          |
 | `hunk.review.scrollCodeLeft`                   | Scroll code left (shifted scrolls fast)        | `left`, `shift+left`         |
 | `hunk.review.scrollCodeRight`                  | Scroll code right (shifted scrolls fast)       | `right`, `shift+right`       |
-| `hunk.review.alignCurrentLineTop`              | Align current line to viewport top             | _(none)_                     |
-| `hunk.review.alignCurrentLineCenter`           | Center current line in viewport                | _(none)_                     |
-| `hunk.review.alignCurrentLineBottom`           | Align current line to viewport bottom          | _(none)_                     |
-| `hunk.view.cursorLineRow`                      | Highlight the current row                      | _(none)_                     |
+| `hunk.review.startNote`                        | Add a review note                              | `c`                          |
+| `hunk.review.stepDown`                         | Scroll down one row                            | `down`, `j`                  |
+| `hunk.review.stepUp`                           | Scroll up one row                              | `up`, `k`                    |
+| `hunk.review.toggleHunkGap`                    | Expand or collapse the selected context        | `z`                          |
+| `hunk.view.applyFilePresentationToAllMatching` | Apply current file presentation to all matches | _(none)_                     |
 | `hunk.view.cursorLineNumber`                   | Mark the current line number                   | _(none)_                     |
 | `hunk.view.cursorLineOff`                      | Hide the current-line marker                   | _(none)_                     |
+| `hunk.view.cursorLineRow`                      | Highlight the current row                      | _(none)_                     |
+| `hunk.view.layoutAuto`                         | Auto layout                                    | `0`                          |
 | `hunk.view.layoutSplit`                        | Split layout                                   | `1`                          |
 | `hunk.view.layoutStack`                        | Stack layout                                   | `2`                          |
-| `hunk.view.layoutAuto`                         | Auto layout                                    | `0`                          |
-| `hunk.view.applyFilePresentationToAllMatching` | Apply current file presentation to all matches | _(none)_                     |
-| `hunk.view.toggleSidebar`                      | Toggle sidebar                                 | `s`                          |
-| `hunk.app.refresh`                             | Refresh the review                             | `r`                          |
 | `hunk.view.openThemeSelector`                  | Choose theme                                   | `t`                          |
 | `hunk.view.toggleAgentNotes`                   | Toggle agent notes                             | `a`                          |
+| `hunk.view.toggleCopyDecorations`              | Toggle copy decorations                        | _(none)_                     |
+| `hunk.view.toggleHunkHeaders`                  | Toggle hunk headers                            | `m`                          |
 | `hunk.view.toggleLineNumbers`                  | Toggle line numbers                            | `l`                          |
 | `hunk.view.toggleLineWrap`                     | Toggle line wrapping                           | `w`                          |
 | `hunk.view.toggleMenuBar`                      | Toggle menu bar                                | `M`                          |
-| `hunk.view.toggleHunkHeaders`                  | Toggle hunk headers                            | `m`                          |
-| `hunk.view.toggleCopyDecorations`              | Toggle copy decorations                        | _(none)_                     |
-| `hunk.review.toggleHunkGap`                    | Expand or collapse the selected context        | `z`                          |
-| `hunk.review.editSelectedFile`                 | Open the selected file in your editor          | `e`                          |
-| `hunk.review.previousHunk`                     | Previous hunk                                  | `[`                          |
-| `hunk.review.nextHunk`                         | Next hunk                                      | `]`                          |
-| `hunk.review.previousFile`                     | Previous file                                  | `,`                          |
-| `hunk.review.nextFile`                         | Next file                                      | `.`                          |
-| `hunk.review.previousAnnotatedHunk`            | Previous annotated hunk                        | `{`                          |
-| `hunk.review.nextAnnotatedHunk`                | Next annotated hunk                            | `}`                          |
-| `hunk.review.previousAnnotatedFile`            | Previous annotated file                        | _(none)_                     |
-| `hunk.review.nextAnnotatedFile`                | Next annotated file                            | _(none)_                     |
+| `hunk.view.toggleSidebar`                      | Toggle sidebar                                 | `s`                          |
 
 Commands marked _(none)_ ship without a key: they remain callable by command id
 and can be assigned a shortcut through `[keybindings]`. Some also appear in a

--- a/examples/extensions/review-triage/README.md
+++ b/examples/extensions/review-triage/README.md
@@ -12,14 +12,14 @@ Or copy the directory to your Hunk extensions directory and keep its `package.js
 
 ## Use
 
-Open **Extensions → Toggle review triage** (`y`). The right sidebar lists each visible file's hunks; click a hunk to navigate the review stream. Use **Extensions → Mark selected hunk…** (`x`) to choose a status and enter an optional rationale. **Set review focus…** and **Clear triage decisions** are menu-only commands.
+Open **Extensions → Toggle review triage** (`y`). The right sidebar lists each visible file's hunks; click a hunk to navigate the review stream. Use **Extensions → Mark selected hunk…** (`x`) to choose a status and enter an optional rationale. **Center current review line**, **Set review focus…**, and **Clear triage decisions** are menu-only commands.
 
 The board intentionally keeps state only for the running Hunk session. Reloading reconciles decisions against the newly parsed hunks and drops entries that no longer match, rather than silently transferring a decision to changed code.
 
 ## API surface exercised
 
 - `registerSidebarView` renders public file/hunk summaries and navigates with sidebar actions.
-- `registerCommand` supplies the Extensions-menu items and user-remappable defaults.
+- `registerCommand` supplies the Extensions-menu items and user-remappable defaults; `ctx.commands.execute` delegates the dedicated centering action to Hunk's public semantic command.
 - `dialogs.select`, `dialogs.input`, and `dialogs.confirm` implement the review decision and clear flows.
 - Lifecycle handlers track changeset loads, reloads, selection, viewed hunks, Hunk notes, filters, and pending watch reloads through a `useSyncExternalStore` bridge.
 - `hunk.events` publishes decisions and listens for `review-triage:open`, so another extension can reveal the board without importing its state.

--- a/examples/extensions/review-triage/index.tsx
+++ b/examples/extensions/review-triage/index.tsx
@@ -236,6 +236,12 @@ export default function registerReviewTriage(hunk: HunkExtensionAPI) {
     ctx.sidebars.toggle("triage"),
   );
 
+  hunk.registerCommand({ id: "center", title: "Center current review line" }, (ctx) => {
+    if (!ctx.commands.execute("hunk.review.alignCurrentLineCenter")) {
+      ctx.notify("Enable the current-line marker before centering it", "warning");
+    }
+  });
+
   hunk.registerCommand({ id: "mark", title: "Mark selected hunk…", key: "x" }, async (ctx) => {
     const { file, hunkIndex } = ctx.selection;
     if (!file || hunkIndex === null) {

--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -23,6 +23,8 @@ import {
 } from "hunkdiff/extension";
 import type {
   ExtensionChangeset,
+  ExtensionCommandControls,
+  ExtensionCommandExecutionOptions,
   ExtensionFileViewRow,
   ExtensionFileViewRowComponentProps,
   ExtensionFileViewSourceRange,
@@ -98,6 +100,14 @@ export default function (hunk: HunkExtensionAPI) {
     },
   });
   hunk.registerCommand({ id: "raw-view", title: "Raw view" }, (ctx) => {
+    const commandControls: ExtensionCommandControls = ctx.commands;
+    const execution: ExtensionCommandExecutionOptions = { count: 2 };
+    if (commandControls.isEnabled("hunk.review.nextHunk")) {
+      const executed: boolean = commandControls.execute("hunk.review.nextHunk", execution);
+      hunk.log(executed ? "moved" : "not moved");
+    }
+    // @ts-expect-error Count must be numeric.
+    commandControls.execute("hunk.review.nextHunk", { count: "two" });
     ctx.fileViews.select("raw");
     ctx.fileViews.select(null);
     ctx.fileViews.refresh("raw");

--- a/skills/hunk-extensions/SKILL.md
+++ b/skills/hunk-extensions/SKILL.md
@@ -94,7 +94,7 @@ bad or duplicate id is skipped with a startup notice.
 | React to loads, selection, viewed files, notes, reloads | `hunk.on(event, handler)`                    |
 | Coordinate with another loaded extension                | `hunk.events.emit` / `hunk.events.on`        |
 | Read user-supplied settings                             | `hunk.config` (`[extension.<id>]` table)     |
-| Branch on the API generation (currently `2`)            | `hunk.apiVersion`                            |
+| Branch on the API generation (currently `3`)            | `hunk.apiVersion`                            |
 
 Registration is only valid while the factory runs — Hunk seals the API object
 afterwards.
@@ -109,7 +109,8 @@ transform — gets `ctx.cwd` and `ctx.notify(message, type?)`. A file view's
   any view) and `ctx.events.emit`.
 - **Command handlers** get `ctx.sidebars`, `ctx.fileViews` (select/toggle/isActive/
   refresh/enterMode/exitMode), `ctx.selection` (a snapshot of file + hunk index),
-  `ctx.navigation` (live, guarded `selectFile`/`selectHunk`), `ctx.dialogs`
+  `ctx.navigation` (live, guarded `selectFile`/`selectHunk`), `ctx.commands`
+  (`isEnabled`/`execute` for public semantic `hunk.*` commands), `ctx.dialogs`
   (`confirm`/`select`/`input`, queued and attributed), and `ctx.workspace`
   (`readDocument`, `canWriteDocument`, `writeDocument` with consent).
 - **Sidebar components** get props: `files` (frozen, filtered, review order, each
@@ -164,6 +165,11 @@ Most extension bugs are one of these:
 - **Chords are defaults.** Users remap by command id in `[keybindings]`; built-ins
   win conflicts, refused one chord at a time. Bind the character shift produces
   (`"!"`, not `"shift+1"`).
+- **`ctx.commands` invokes Hunk, not other extensions.** Probe with
+  `isEnabled("hunk.review.nextHunk")`, then call `execute(id, { count })` for an
+  explicitly public built-in. Counts are positive whole numbers up to 10,000,
+  applied atomically to movement; one-shot actions run once. Unknown, disabled,
+  private, extension-owned, or stale commands return `false`.
 - **Repo config can set `[extension.<id>]` for a globally installed extension.**
   Treat `hunk.config` as untrusted for anything exec-adjacent (binary paths,
   shell commands, module loading).

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -65,6 +65,8 @@ export type {
   ExtensionFactory,
   ExtensionCommand,
   ExtensionCommandContext,
+  ExtensionCommandControls,
+  ExtensionCommandExecutionOptions,
   ExtensionCommandHandler,
   ExtensionReviewSelection,
   ExtensionConfirmOptions,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -21,7 +21,7 @@
  * Extensions can branch on `hunk.apiVersion` so a newer Hunk can keep loading
  * older extensions without guessing at their expectations.
  */
-export const HUNK_EXTENSION_API_VERSION = 2;
+export const HUNK_EXTENSION_API_VERSION = 3;
 export type HunkExtensionApiVersion = typeof HUNK_EXTENSION_API_VERSION;
 
 export type ExtensionNotifyType = "info" | "warning" | "error";
@@ -995,6 +995,31 @@ export interface ExtensionCommand {
   key?: string | readonly string[];
 }
 
+/** Options for invoking one public Hunk command from an extension command. */
+export interface ExtensionCommandExecutionOptions {
+  /**
+   * Positive whole-number magnitude for commands that support counted movement.
+   *
+   * Counts are applied atomically by the host rather than by repeatedly dispatching the command.
+   * Commands without count semantics run once. Values above 10,000 or outside the safe positive
+   * integer range are rejected as extension programming errors.
+   */
+  count?: number;
+}
+
+/** Inspect and invoke the public semantic commands owned by Hunk. */
+export interface ExtensionCommandControls {
+  /** Report whether one public `hunk.*` command exists and can run right now; malformed ids return false. */
+  isEnabled(commandId: string): boolean;
+  /**
+   * Invoke one enabled public `hunk.*` command through Hunk's normal command table.
+   *
+   * Returns `false` for unknown, disabled, non-public, extension-owned, or stale commands.
+   * Malformed ids, options, and counts are extension programming errors and throw.
+   */
+  execute(commandId: string, options?: ExtensionCommandExecutionOptions): boolean;
+}
+
 /** Open, close, and inspect sidebar views from a command handler. */
 export interface ExtensionSidebarControls {
   /**
@@ -1305,6 +1330,8 @@ export interface ExtensionWorkspace {
 
 /** What a command handler receives when its key fires. */
 export interface ExtensionCommandContext extends ExtensionContext {
+  /** Live access to the public built-in command table. */
+  readonly commands: ExtensionCommandControls;
   sidebars: ExtensionSidebarControls;
   /** Host-owned selection controls for alternate file presentations. */
   fileViews: ExtensionFileViewControls;

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -27,6 +27,8 @@ export type {
   ExtensionChangeset,
   ExtensionCommand,
   ExtensionCommandContext,
+  ExtensionCommandControls,
+  ExtensionCommandExecutionOptions,
   ExtensionCommandHandler,
   ExtensionConfirmOptions,
   ExtensionContext,

--- a/src/ui/App.extension-command-controls.test.tsx
+++ b/src/ui/App.extension-command-controls.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act, StrictMode, useState } from "react";
+import { createTestVcsAppBootstrap } from "../../test/helpers/app-bootstrap";
+import { createTestDiffFile } from "../../test/helpers/diff-helpers";
+import type { AppBootstrap } from "../core/types";
+import type { ExtensionCommandControls } from "../extension-api/types";
+import { createEmptyExtensionLoadResult } from "../extensions/types";
+import { App } from "./App";
+
+/** Build one bootstrap with a caller-supplied extension authority. */
+function createBootstrap(extensions = createEmptyExtensionLoadResult("/repo")): AppBootstrap {
+  return {
+    ...createTestVcsAppBootstrap({
+      changesetId: "changeset:command-controls",
+      files: [createTestDiffFile({ id: "alpha", path: "alpha.ts" })],
+      initialMode: "stack",
+    }),
+    extensions,
+  };
+}
+
+/** Settle React effects and OpenTUI rendering. */
+async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
+  await act(async () => {
+    await setup.renderOnce();
+    await Bun.sleep(0);
+    await setup.renderOnce();
+  });
+}
+
+describe("extension command control authority", () => {
+  test("retires captured controls only when a soft reload replaces the extension registry", async () => {
+    let capturedControls: ExtensionCommandControls | null = null;
+    const initial = createBootstrap();
+    initial.extensions!.registry.commands.push({
+      extensionId: "probe",
+      command: { id: "capture", title: "Capture controls", key: "y" },
+      handler(ctx) {
+        capturedControls = ctx.commands;
+      },
+    });
+    let replaceBootstrap: (next: AppBootstrap) => void = () => {};
+
+    function Harness() {
+      const [bootstrap, setBootstrap] = useState(initial);
+      replaceBootstrap = setBootstrap;
+      return (
+        <App
+          bootstrap={bootstrap}
+          onReloadSession={async () => ({
+            sessionId: "test",
+            inputKind: bootstrap.input.kind,
+            title: bootstrap.changeset.title,
+            sourceLabel: bootstrap.changeset.sourceLabel,
+            fileCount: bootstrap.changeset.files.length,
+            selectedHunkIndex: 0,
+          })}
+        />
+      );
+    }
+
+    const setup = await testRender(
+      <StrictMode>
+        <Harness />
+      </StrictMode>,
+      { width: 140, height: 24 },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flush(setup);
+      expect(capturedControls).not.toBeNull();
+      expect(capturedControls!.isEnabled("hunk.review.nextHunk")).toBe(true);
+
+      // Ordinary content reloads retain the extension registry and its async authority.
+      await act(async () => {
+        replaceBootstrap({ ...createBootstrap(), extensions: initial.extensions });
+      });
+      await flush(setup);
+      expect(capturedControls!.isEnabled("hunk.review.nextHunk")).toBe(true);
+
+      // AppHost closes the old registry before its async replacement load finishes.
+      // Captured controls lose authority at that boundary, before App receives new props.
+      initial.extensions!.registry.eventBusPhase = "closed";
+      expect(capturedControls!.isEnabled("hunk.review.nextHunk")).toBe(false);
+      expect(capturedControls!.execute("hunk.review.nextHunk")).toBe(false);
+
+      // Reloading extensions then swaps the registry without remounting App. The
+      // retired controls must stay stale against the replacement command table.
+      await act(async () => {
+        replaceBootstrap(createBootstrap());
+      });
+      await flush(setup);
+      expect(capturedControls!.isEnabled("hunk.review.nextHunk")).toBe(false);
+      expect(capturedControls!.execute("hunk.review.nextHunk")).toBe(false);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+});

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -5,7 +5,17 @@ import {
 } from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { writeFile } from "node:fs/promises";
-import { Fragment, Suspense, lazy, useCallback, useEffect, useMemo, useState, useRef } from "react";
+import {
+  Fragment,
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   diffPersistedViewPreferences,
   saveGlobalViewPreferences,
@@ -73,10 +83,13 @@ import {
   buildAppCommands,
   builtinCommandKeyDefaults,
   builtinCommandMatchProbes,
+  type AppCommand,
 } from "./lib/appCommands";
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
+import { createExtensionCommandControls } from "./lib/extensionCommandControls";
 import { createGuardedReviewNavigation } from "./lib/extensionNavigation";
+import type { CurrentLineAlignment } from "./lib/hunkScroll";
 import type { LineCursor } from "./lib/lineCursors";
 import { buildExtensionReviewSelection } from "./lib/extensionSelection";
 import { useFilePresentationController } from "./fileViews/useFilePresentationController";
@@ -228,6 +241,10 @@ export function App({
   const [copyDecorations, setCopyDecorations] = useState(bootstrap.initialCopyDecorations ?? false);
   const [codeHorizontalOffset, setCodeHorizontalOffset] = useState(0);
   const [cursorLine, setCursorLine] = useState<CursorLine>(bootstrap.initialCursorLine ?? "row");
+  const [lineCursorAlignmentRequest, setLineCursorAlignmentRequest] = useState<{
+    id: number;
+    alignment: CurrentLineAlignment;
+  }>({ id: 0, alignment: "center" });
   const [showHunkHeaders, setShowHunkHeaders] = useState(bootstrap.initialShowHunkHeaders ?? true);
   const [showMenuBar, setShowMenuBar] = useState(bootstrap.initialShowMenuBar ?? true);
   const [themeSelectorState, setThemeSelectorState] = useState<ThemeSelectorState>({
@@ -406,12 +423,31 @@ export function App({
   // warning instead of validating against the dead instance's file list or
   // driving a controller whose state updates no longer render.
   const appAliveForNavigationRef = useRef(true);
-  useEffect(
-    () => () => {
+  const extensionHostCommandsRef = useRef<readonly AppCommand[]>([]);
+  // A soft extension reload keeps App mounted but replaces the authority that
+  // created each handler. Retain the current registry separately so controls
+  // captured by a retired async handler cannot drive the replacement registry.
+  const activeExtensionRegistryRef = useRef(extensions?.registry);
+  useLayoutEffect(() => {
+    activeExtensionRegistryRef.current = extensions?.registry;
+  }, [extensions?.registry]);
+  const extensionCommandControls = useMemo(() => {
+    const owningRegistry = extensions?.registry;
+    return createExtensionCommandControls({
+      getCommands: () => extensionHostCommandsRef.current,
+      isLive: () =>
+        appAliveForNavigationRef.current &&
+        owningRegistry?.eventBusPhase !== "closed" &&
+        activeExtensionRegistryRef.current === owningRegistry,
+    });
+  }, [extensions?.registry]);
+  useEffect(() => {
+    // StrictMode replays setup/cleanup/setup while the same App remains mounted.
+    appAliveForNavigationRef.current = true;
+    return () => {
       appAliveForNavigationRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
 
   /** Build the selection snapshot a command handler receives, at invocation. */
   const getExtensionSelection = useCallback(() => {
@@ -749,6 +785,7 @@ export function App({
       };
       const ctx: ExtensionCommandContext = {
         cwd: extensions?.context.cwd ?? process.cwd(),
+        commands: extensionCommandControls,
         notify: (message, type) => extensions?.context.notify(message, type),
         sidebars: createSidebarControls(registered.extensionId),
         fileViews: createFileViewControls(registered.extensionId),
@@ -797,6 +834,7 @@ export function App({
       createExtensionDialogs,
       createFileViewControls,
       createSidebarControls,
+      extensionCommandControls,
       createWorkspaceControls,
       extensions,
       getExtensionSelection,
@@ -1067,6 +1105,14 @@ export function App({
     }
     diffScrollRef.current?.scrollBy(delta, unit);
   };
+
+  /** Ask DiffPane to align the current rendered line using its authoritative row geometry. */
+  const alignCurrentLine = useCallback((alignment: CurrentLineAlignment) => {
+    setLineCursorAlignmentRequest((current) => ({
+      id: current.id + 1,
+      alignment,
+    }));
+  }, []);
 
   /** Step one line: move the current line, or scroll the viewport when there is no marker. */
   const stepDiffLine = (delta: number) => {
@@ -1675,8 +1721,10 @@ export function App({
   // win a key and extension order follows load order.
   const appCommands = [
     ...buildAppCommands({
+      canAlignCurrentLine: cursorLine !== "off" && review.lineCursor !== null,
       canApplyFilePresentationToAllMatching: selectedFileViewBulkTarget !== null,
       canRefreshCurrentInput,
+      alignCurrentLine,
       applyFilePresentationToAllMatching,
       focusFilter,
       moveToAnnotatedFile,
@@ -1708,6 +1756,7 @@ export function App({
     }),
     ...extensionAppCommands.commands,
   ];
+  extensionHostCommandsRef.current = appCommands;
 
   // Menus name commands rather than repeating them: every item's key hint and
   // action come from the table above, so a remapped shortcut shows its new key
@@ -2006,6 +2055,7 @@ export function App({
           cursorLine={cursorLine}
           lineCursor={review.lineCursor}
           lineCursorRevealRequestId={review.lineCursorRevealRequestId}
+          lineCursorAlignmentRequest={lineCursorAlignmentRequest}
           theme={activeTheme}
           width={diffPaneWidth}
           onActiveAddNoteAffordanceChange={setActiveAddNoteTarget}

--- a/src/ui/AppHost.extension-navigation.test.tsx
+++ b/src/ui/AppHost.extension-navigation.test.tsx
@@ -32,7 +32,7 @@ function createTempDir(prefix: string) {
   return dir;
 }
 
-/** Create a Git checkout with two committed files carrying working-tree changes. */
+/** Create a Git checkout with three committed files carrying working-tree changes. */
 function createTestRepo(prefix: string) {
   const repo = createTempDir(prefix);
   execSync("git init && git config user.email test@test && git config user.name test", {
@@ -41,9 +41,11 @@ function createTestRepo(prefix: string) {
   });
   writeFileSync(join(repo, "alpha.txt"), "one\n");
   writeFileSync(join(repo, "beta.txt"), "one\n");
+  writeFileSync(join(repo, "gamma.txt"), "one\n");
   execSync("git add . && git commit -m init", { cwd: repo, stdio: "ignore" });
   writeFileSync(join(repo, "alpha.txt"), "one\ntwo\n");
   writeFileSync(join(repo, "beta.txt"), "one\ntwo\n");
+  writeFileSync(join(repo, "gamma.txt"), "one\ntwo\n");
   return repo;
 }
 
@@ -120,6 +122,54 @@ async function withAppHost(
 }
 
 describe("extension command navigation", () => {
+  test("public command controls execute counted navigation and refuse extension commands", async () => {
+    const repo = createTestRepo("hunk-ext-command-controls-");
+    const extDir = createTempDir("hunk-ext-command-controls-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `let fileIds = [];\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.on("changeset_loaded", ({ changeset }) => {\n` +
+        `    fileIds = changeset.files.map((file) => file.id);\n` +
+        `  });\n` +
+        `  hunk.on("selection_changed", ({ fileId, hunkIndex }) => {\n` +
+        `    const label = fileId === fileIds[2] ? "third" : "other";\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "selected " + label + " " + hunkIndex + "\\n");\n` +
+        `  });\n` +
+        `  hunk.registerCommand({ id: "probe", title: "Probe", key: "y" }, (ctx) => {\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "enabled " + ctx.commands.isEnabled("hunk.review.nextHunk") + "\\n");\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "own " + ctx.commands.execute("ext.probe") + "\\n");\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "move " + ctx.commands.execute("hunk.review.nextHunk", { count: 2 }) + "\\n");\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "align " + ctx.commands.execute("hunk.review.alignCurrentLineCenter") + "\\n");\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("alpha.txt"),
+        "the review to render",
+      );
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("selected third 0"),
+        "the counted command to land directly on the third hunk",
+      );
+
+      expect(readProbeLog(logPath)).toEqual(
+        expect.arrayContaining(["enabled true", "align true", "own false", "move true"]),
+      );
+    });
+  });
+
   test("a command handler jumps the review stream through ctx.navigation", async () => {
     const repo = createTestRepo("hunk-ext-nav-jump-");
     // Outside the repo, so the fixture and its log never join the review.

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -34,7 +34,12 @@ import {
   computeRapidScrollOverscanRows,
   RAPID_SCROLL_OVERSCAN_IDLE_MS,
 } from "../../lib/adaptiveScrollOverscan";
-import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "../../lib/hunkScroll";
+import {
+  computeHunkRevealScrollTop,
+  computeLineAlignmentScrollTop,
+  computeLineRevealScrollTop,
+  type CurrentLineAlignment,
+} from "../../lib/hunkScroll";
 import { inlineNoteStableKey } from "../../diff/reviewRenderPlan";
 import {
   buildLineCursors,
@@ -209,6 +214,7 @@ export function DiffPane({
   cursorLine = "off",
   lineCursor = null,
   lineCursorRevealRequestId = 0,
+  lineCursorAlignmentRequest = { id: 0, alignment: "center" },
   scrollToNote = false,
   draftNote = null,
   draftNoteFocused = false,
@@ -265,6 +271,7 @@ export function DiffPane({
   cursorLine?: CursorLine;
   lineCursor?: LineCursor | null;
   lineCursorRevealRequestId?: number;
+  lineCursorAlignmentRequest?: { id: number; alignment: CurrentLineAlignment };
   scrollToNote?: boolean;
   draftNote?: DraftReviewNote | null;
   draftNoteFocused?: boolean;
@@ -1549,6 +1556,21 @@ export function DiffPane({
   const prevSelectedAnchorIdRef = useRef<string | null>(null);
   const prevPinnedHeaderFileIdRef = useRef<string | null>(null);
   const pendingSelectionSettleRef = useRef(false);
+  const pendingSelectionRevealTimeoutsRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  /** Clear scheduled selection-reveal retries without changing the resettle policy. */
+  const clearPendingSelectionRevealTimers = useCallback(() => {
+    for (const timeout of pendingSelectionRevealTimeoutsRef.current) {
+      clearTimeout(timeout);
+    }
+    pendingSelectionRevealTimeoutsRef.current = [];
+  }, []);
+
+  /** Retire selection reveal work once an explicit line alignment becomes authoritative. */
+  const supersedePendingSelectionReveal = useCallback(() => {
+    clearPendingSelectionRevealTimers();
+    pendingSelectionSettleRef.current = false;
+  }, [clearPendingSelectionRevealTimers]);
 
   /** Clear any pending "selected file to top" follow-up. */
   const clearPendingFileTopAlign = useCallback(() => {
@@ -1940,24 +1962,23 @@ export function DiffPane({
 
     // Run after this pane renders the selected section/hunk, then retry once on the next task
     // after the mounted row bounds settle.
+    clearPendingSelectionRevealTimers();
     suppressViewportSelectionSync();
     scrollSelectionIntoView();
     pendingSelectionSettleRef.current = shouldTrackPinnedHeaderResettle;
-    const retryDelays = [0];
-    const timeouts = retryDelays.map((delay) => setTimeout(scrollSelectionIntoView, delay));
-    const settleReset = shouldTrackPinnedHeaderResettle
-      ? setTimeout(() => {
+    const timeouts = [setTimeout(scrollSelectionIntoView, 0)];
+    if (shouldTrackPinnedHeaderResettle) {
+      timeouts.push(
+        setTimeout(() => {
           pendingSelectionSettleRef.current = false;
-        }, 120)
-      : null;
-    return () => {
-      timeouts.forEach((timeout) => clearTimeout(timeout));
-      if (settleReset) {
-        clearTimeout(settleReset);
-      }
-    };
+        }, 120),
+      );
+    }
+    pendingSelectionRevealTimeoutsRef.current = timeouts;
+    return clearPendingSelectionRevealTimers;
   }, [
     clampReviewScrollTop,
+    clearPendingSelectionRevealTimers,
     pinnedHeaderFileId,
     scrollRef,
     scrollViewport.height,
@@ -2013,6 +2034,55 @@ export function DiffPane({
     lineCursorRevealRequestId,
     scrollRef,
     scrollViewport.height,
+    suppressViewportSelectionSync,
+  ]);
+
+  const previousLineCursorAlignmentRequestIdRef = useRef(lineCursorAlignmentRequest.id);
+
+  useLayoutEffect(() => {
+    if (previousLineCursorAlignmentRequestIdRef.current === lineCursorAlignmentRequest.id) {
+      return;
+    }
+
+    const scrollBox = scrollRef.current;
+    if (
+      !scrollBox ||
+      !lineCursor ||
+      lineCursor.fileId !== selectedFileId ||
+      lineCursor.hunkIndex !== selectedHunkIndex
+    ) {
+      return;
+    }
+    const bounds = lineCursorBoundsOf(lineCursor);
+    if (!bounds) return;
+
+    const viewportHeight = scrollBox.viewport.height || scrollViewport.height;
+    const desiredTop = computeLineAlignmentScrollTop({
+      alignment: lineCursorAlignmentRequest.alignment,
+      lineTop: bounds.top,
+      lineHeight: bounds.height,
+      viewportHeight,
+    });
+    // Explicit alignment is the final scroll policy for a composed semantic
+    // command sequence; selection/file reveal retries must not overwrite it.
+    supersedePendingSelectionReveal();
+    clearPendingFileTopAlign();
+    suppressViewportSelectionSync();
+    scrollBox.scrollTo(clampReviewScrollTop(desiredTop, viewportHeight));
+    // Consume only after the selected cursor was measured and aligned. A
+    // navigation command may update selection before cursor reconciliation.
+    previousLineCursorAlignmentRequestIdRef.current = lineCursorAlignmentRequest.id;
+  }, [
+    clampReviewScrollTop,
+    clearPendingFileTopAlign,
+    lineCursor,
+    lineCursorAlignmentRequest,
+    lineCursorBoundsOf,
+    scrollRef,
+    scrollViewport.height,
+    selectedFileId,
+    selectedHunkIndex,
+    supersedePendingSelectionReveal,
     suppressViewportSelectionSync,
   ]);
 

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1,7 +1,7 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
-import { act, createRef, useCallback, useEffect, useState, type ReactNode } from "react";
+import { act, createRef, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type { AppBootstrap, DiffFile } from "../../core/types";
 import { createTestVcsAppBootstrap } from "../../../test/helpers/app-bootstrap";
 import { capturedTestColorToHex } from "../../../test/helpers/test-color-helpers";
@@ -17,6 +17,8 @@ import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildFileSectionLayouts, buildInStreamFileHeaderHeights } from "../lib/fileSectionLayout";
 import { builtinCommandKeyDefaults, builtinCommandMatchProbes } from "../lib/appCommands";
 import { resolveCommandKeys } from "../lib/keymap";
+import type { CurrentLineAlignment } from "../lib/hunkScroll";
+import type { LineCursor } from "../lib/lineCursors";
 
 const { AppHost } = await import("../AppHost");
 const { toReadOnlyFileViews } = await import("../../extensions/events");
@@ -1176,6 +1178,184 @@ describe("UI components", () => {
       expect(frame).not.toContain("2 + export const line2 = 200;");
       expect(frame).not.toContain("intro.ts");
       expect(frame).not.toContain("@@ -1,3 +1,3 @@");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("DiffPane aligns the current rendered line to top, center, and bottom", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const files = [createTallDiffFile("target", "target.ts", 100)];
+    const scrollRef = createRef<ScrollBoxRenderable>();
+    let requestAlignment: (alignment: CurrentLineAlignment) => void = () => {};
+    let targetReady = false;
+
+    function LineAlignmentHarness() {
+      const [lineCursor, setLineCursor] = useState<LineCursor | null>(null);
+      const [request, setRequest] = useState<{
+        id: number;
+        alignment: CurrentLineAlignment;
+      }>({ id: 0, alignment: "center" });
+      requestAlignment = (alignment) =>
+        setRequest((current) => ({ id: current.id + 1, alignment }));
+
+      return (
+        <DiffPane
+          {...createDiffPaneProps(files, theme, {
+            cursorLine: "row",
+            diffContentWidth: 96,
+            lineCursor,
+            lineCursorAlignmentRequest: request,
+            scrollRef,
+            selectedHunkRevealRequestId: 0,
+            separatorWidth: 92,
+            width: 100,
+          })}
+          onLineCursorsChange={(cursors) => {
+            if (lineCursor || cursors.length === 0) return;
+            const target = cursors[Math.floor(cursors.length / 2)];
+            if (!target) return;
+            targetReady = true;
+            setLineCursor(target);
+          }}
+        />
+      );
+    }
+
+    const setup = await testRender(<LineAlignmentHarness />, {
+      width: 104,
+      height: 14,
+    });
+
+    try {
+      for (let attempt = 0; attempt < 10 && !targetReady; attempt += 1) {
+        await settleDiffPane(setup);
+      }
+      expect(targetReady).toBe(true);
+      expect(scrollRef.current?.viewport.height ?? 0).toBeGreaterThan(0);
+
+      const positions = {} as Record<CurrentLineAlignment, number>;
+      for (const alignment of ["top", "center", "bottom"] as const) {
+        await act(async () => {
+          requestAlignment(alignment);
+          await setup.renderOnce();
+          await Bun.sleep(0);
+          await setup.renderOnce();
+        });
+        positions[alignment] = scrollRef.current?.scrollTop ?? 0;
+      }
+
+      // For one row well inside a tall stream, putting it at the viewport top
+      // requires the greatest scroll, followed by center and then bottom.
+      expect(positions.top).toBeGreaterThan(positions.center);
+      expect(positions.center).toBeGreaterThan(positions.bottom);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("DiffPane defers command alignment until navigation reconciles the current line", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const files = [createWideTwoHunkDiffFile("target", "target.ts")];
+    const scrollRef = createRef<ScrollBoxRenderable>();
+    let requestNavigationAndAlignment = () => {};
+    let reconcileCurrentLine = () => {};
+    let cursorsReady = false;
+
+    function DeferredAlignmentHarness() {
+      const [selectedHunkIndex, setSelectedHunkIndex] = useState(0);
+      const [selectedHunkRevealRequestId, setSelectedHunkRevealRequestId] = useState(0);
+      const [lineCursor, setLineCursor] = useState<LineCursor | null>(null);
+      const [request, setRequest] = useState<{
+        id: number;
+        alignment: CurrentLineAlignment;
+      }>({ id: 0, alignment: "top" });
+      const targetCursorRef = useRef<LineCursor | null>(null);
+
+      requestNavigationAndAlignment = () => {
+        setSelectedHunkIndex(1);
+        setSelectedHunkRevealRequestId((current) => current + 1);
+        setRequest((current) => ({ id: current.id + 1, alignment: "top" }));
+      };
+      reconcileCurrentLine = () => {
+        if (targetCursorRef.current) setLineCursor(targetCursorRef.current);
+      };
+
+      return (
+        <DiffPane
+          {...createDiffPaneProps(files, theme, {
+            cursorLine: "row",
+            diffContentWidth: 96,
+            lineCursor,
+            lineCursorAlignmentRequest: request,
+            scrollRef,
+            selectedHunkIndex,
+            selectedHunkRevealRequestId,
+            separatorWidth: 92,
+            width: 100,
+          })}
+          onLineCursorsChange={(cursors) => {
+            const initialCursor = cursors.find((cursor) => cursor.hunkIndex === 0);
+            targetCursorRef.current = cursors.find((cursor) => cursor.hunkIndex === 1) ?? null;
+            if (!initialCursor || !targetCursorRef.current) return;
+            cursorsReady = true;
+            if (!lineCursor) setLineCursor(initialCursor);
+          }}
+        />
+      );
+    }
+
+    const setup = await testRender(<DeferredAlignmentHarness />, {
+      width: 104,
+      height: 14,
+    });
+
+    try {
+      for (let attempt = 0; attempt < 10 && !cursorsReady; attempt += 1) {
+        await settleDiffPane(setup);
+      }
+      expect(cursorsReady).toBe(true);
+      const scrollBox = scrollRef.current;
+      expect(scrollBox).not.toBeNull();
+      const scrollToSpy = spyOn(scrollBox!, "scrollTo");
+      scrollToSpy.mockClear();
+
+      await act(async () => {
+        requestNavigationAndAlignment();
+        await setup.renderOnce();
+        await setup.renderOnce();
+      });
+      expect(scrollToSpy).toHaveBeenCalled();
+      const selectionRevealCallCount = scrollToSpy.mock.calls.length;
+      const selectionRevealTarget = scrollToSpy.mock.calls.at(-1)?.[0];
+      expect(typeof selectionRevealTarget).toBe("number");
+      const selectionRevealScrollTop =
+        typeof selectionRevealTarget === "number" ? selectionRevealTarget : 0;
+
+      await act(async () => {
+        // Reconcile before the selection reveal's zero-delay retry fires. The
+        // successful explicit alignment must supersede that scheduled work.
+        reconcileCurrentLine();
+        await setup.renderOnce();
+      });
+      expect(scrollToSpy.mock.calls.length).toBeGreaterThan(selectionRevealCallCount);
+      const alignedTarget = scrollToSpy.mock.calls.at(-1)?.[0];
+      expect(typeof alignedTarget).toBe("number");
+      const alignedScrollTop = typeof alignedTarget === "number" ? alignedTarget : 0;
+      expect(alignedScrollTop).toBeGreaterThan(selectionRevealScrollTop);
+
+      const alignedCallCount = scrollToSpy.mock.calls.length;
+      await act(async () => {
+        await Bun.sleep(150);
+        await setup.renderOnce();
+      });
+      expect(scrollToSpy).toHaveBeenCalledTimes(alignedCallCount);
+      expect(scrollBox?.scrollTop ?? 0).toBe(alignedScrollTop);
+      scrollToSpy.mockRestore();
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -48,6 +48,20 @@ function createTwoHunkFile() {
   return createDiffFile("alpha", "alpha.ts", lines(...beforeLines), lines(...afterLines));
 }
 
+/** Build one file with three separated hunks for counted navigation coverage. */
+function createThreeHunkFile() {
+  const beforeLines = Array.from(
+    { length: 30 },
+    (_, index) => `export const line${index + 1} = ${index + 1};`,
+  );
+  const afterLines = [...beforeLines];
+  afterLines[0] = "export const line1 = 100;";
+  afterLines[14] = "export const line15 = 1500;";
+  afterLines[29] = "export const line30 = 3000;";
+
+  return createDiffFile("alpha", "alpha.ts", lines(...beforeLines), lines(...afterLines));
+}
+
 /** Build the same file id with only one hunk so stale hunk indices must clamp. */
 function createSingleHunkFile() {
   const beforeLines = Array.from(
@@ -360,6 +374,34 @@ describe("useReviewController", () => {
       controller = expectValue(controllerRef.current);
       expect(controller.selectedFile?.path).toBe("alpha.ts");
       expect(controller.selectedFileTopAlignRequestId).toBe(4);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("moves across several files in one counted selection request", async () => {
+    const { controllerRef, setup } = await renderReviewController([
+      createAlphaFile(),
+      createDiffFile("beta", "beta.ts", "export const beta = 1;\n", "export const beta = 2;\n"),
+      createDiffFile("gamma", "gamma.ts", "export const gamma = 1;\n", "export const gamma = 2;\n"),
+      createDiffFile("delta", "delta.ts", "export const delta = 1;\n", "export const delta = 2;\n"),
+    ]);
+
+    try {
+      await flush(setup);
+      const initialAlignRequest = expectValue(controllerRef.current).selectedFileTopAlignRequestId;
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToFile(3);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).selectedFile?.path).toBe("delta.ts");
+      expect(expectValue(controllerRef.current).selectedFileTopAlignRequestId).toBe(
+        initialAlignRequest + 1,
+      );
     } finally {
       await act(async () => {
         setup.renderer.destroy();
@@ -1478,6 +1520,50 @@ describe("useReviewController", () => {
     }
   });
 
+  test("moves several rendered lines with one reveal request", async () => {
+    const file = createTwoHunkFile();
+    const expectedCursors = buildLineCursors(
+      [file],
+      [
+        measureDiffSectionGeometry(
+          file,
+          "stack",
+          true,
+          resolveTheme("github-dark-default", null),
+          [],
+          0,
+          true,
+          false,
+        ),
+      ],
+    );
+    const { controllerRef, setup } = await renderReviewController([file]);
+
+    try {
+      await flush(setup);
+      const initial = expectValue(expectValue(controllerRef.current).lineCursor);
+      const initialIndex = expectedCursors.findIndex(
+        (cursor) => cursor.stableKey === initial.stableKey && cursor.fileId === initial.fileId,
+      );
+      const expected = expectValue(expectedCursors[initialIndex + 4]);
+      const initialRequestId = expectValue(controllerRef.current).lineCursorRevealRequestId;
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveLineCursor(4);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).lineCursor).toEqual(expected);
+      expect(expectValue(controllerRef.current).lineCursorRevealRequestId).toBe(
+        initialRequestId + 1,
+      );
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("carries hunk selection along as the current line crosses a hunk boundary", async () => {
     const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
 
@@ -1520,6 +1606,31 @@ describe("useReviewController", () => {
         target: { side: "new", line: 12 },
       });
       expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("moves across several hunks with one reveal request", async () => {
+    const { controllerRef, setup } = await renderReviewController([createThreeHunkFile()]);
+
+    try {
+      await flush(setup);
+      expect(expectValue(controllerRef.current).selectedFile?.metadata.hunks).toHaveLength(3);
+      const initialRequestId = expectValue(controllerRef.current).selectedHunkRevealRequestId;
+
+      await act(async () => {
+        expectValue(controllerRef.current).moveToHunk(2);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(2);
+      expect(expectValue(expectValue(controllerRef.current).lineCursor).hunkIndex).toBe(2);
+      expect(expectValue(controllerRef.current).selectedHunkRevealRequestId).toBe(
+        initialRequestId + 1,
+      );
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -204,15 +204,16 @@ describe("built-in commands under user keybindings", () => {
 });
 
 describe("builtinCommandKeyDefaults", () => {
-  test("keeps the documented command-id table identical to the runtime catalog", () => {
+  test("keeps the documented command-id table sorted and identical to the runtime catalog", () => {
     const markdown = readFileSync(resolve(import.meta.dir, "../../../docs/keybindings.md"), "utf8");
     const documentedIds = Array.from(
       markdown.matchAll(/^\| `(hunk\.[^`]+)`\s+\|/gm),
       (match) => match[1],
     );
     const { commands } = createTestCommands();
+    const sortedRuntimeIds = commands.map((command) => command.id).toSorted();
 
-    expect(documentedIds).toEqual(commands.map((command) => command.id));
+    expect(documentedIds).toEqual(sortedRuntimeIds);
   });
 
   test("reports every built-in command with the chords it ships with", () => {

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { KeyEvent, type ParsedKey } from "@opentui/core";
 import {
@@ -36,8 +38,10 @@ function createTestCommands(resolvedKeys?: ResolvedCommandKeys) {
       ran.push(args.length > 0 ? `${name}:${args.join(",")}` : name);
     };
   const options: BuildAppCommandsOptions = {
+    canAlignCurrentLine: true,
     canApplyFilePresentationToAllMatching: false,
     canRefreshCurrentInput: true,
+    alignCurrentLine: record("alignCurrentLine"),
     applyFilePresentationToAllMatching: record("applyFilePresentationToAllMatching"),
     focusFilter: record("focusFilter"),
     moveToAnnotatedFile: record("moveToAnnotatedFile"),
@@ -200,11 +204,23 @@ describe("built-in commands under user keybindings", () => {
 });
 
 describe("builtinCommandKeyDefaults", () => {
+  test("keeps the documented command-id table identical to the runtime catalog", () => {
+    const markdown = readFileSync(resolve(import.meta.dir, "../../../docs/keybindings.md"), "utf8");
+    const documentedIds = Array.from(
+      markdown.matchAll(/^\| `(hunk\.[^`]+)`\s+\|/gm),
+      (match) => match[1],
+    );
+    const { commands } = createTestCommands();
+
+    expect(documentedIds).toEqual(commands.map((command) => command.id));
+  });
+
   test("reports every built-in command with the chords it ships with", () => {
     const defaults = builtinCommandKeyDefaults();
     const { commands } = createTestCommands();
 
     expect(defaults.map((entry) => entry.id)).toEqual(commands.map((command) => command.id));
+    expect(commands.every((command) => command.publicToExtensions)).toBe(true);
     expect(defaults.find((entry) => entry.id === "hunk.review.pageDown")?.defaultKeys).toEqual([
       "pagedown",
       "space",
@@ -218,6 +234,9 @@ describe("builtinCommandKeyDefaults", () => {
         .sort(),
     ).toEqual([
       "hunk.app.openAgentSkill",
+      "hunk.review.alignCurrentLineBottom",
+      "hunk.review.alignCurrentLineCenter",
+      "hunk.review.alignCurrentLineTop",
       "hunk.review.nextAnnotatedFile",
       "hunk.review.previousAnnotatedFile",
       "hunk.view.applyFilePresentationToAllMatching",
@@ -267,12 +286,36 @@ describe("executeAppCommand", () => {
     expect(ran).toEqual(["requestQuit", "openAgentSkill"]);
   });
 
-  test("passes the command's own first chord to handlers that read the event", () => {
+  test("uses shipped semantics rather than a remapped chord for programmatic execution", () => {
+    const { keys } = resolveCommandKeys({
+      defaults: builtinCommandKeyDefaults(),
+      userBindings: { "hunk.review.scrollCodeLeft": "shift+left" },
+    });
+    const { commands, ran } = createTestCommands(keys);
+
+    // Invoking by id moves ordinary columns even when the user's only key is the fast shifted form.
+    expect(executeAppCommand(commands, "hunk.review.scrollCodeLeft", { count: 3 })).toBe(true);
+    // Keyboard Shift+Left retains its accelerated behavior.
+    expect(dispatchAppCommand(commands, keyEvent({ name: "left", shift: true }))?.id).toBe(
+      "hunk.review.scrollCodeLeft",
+    );
+    expect(ran).toEqual(["scrollCodeHorizontally:-3", "scrollCodeHorizontally:-8"]);
+  });
+
+  test("applies movement counts in one semantic callback", () => {
     const { commands, ran } = createTestCommands();
 
-    // The shifted arrow scrolls further; invoked by name it takes the plain form.
-    expect(executeAppCommand(commands, "hunk.review.scrollCodeLeft")).toBe(true);
-    expect(ran).toEqual(["scrollCodeHorizontally:-1"]);
+    expect(executeAppCommand(commands, "hunk.review.nextHunk", { count: 3 })).toBe(true);
+    expect(executeAppCommand(commands, "hunk.review.stepUp", { count: 4 })).toBe(true);
+    expect(executeAppCommand(commands, "hunk.review.pageDown", { count: 2 })).toBe(true);
+    expect(ran).toEqual(["moveToHunk:3", "stepDiffLine:-4", "scrollDiff:2,viewport"]);
+  });
+
+  test("runs one-shot commands once regardless of count", () => {
+    const { commands, ran } = createTestCommands();
+
+    expect(executeAppCommand(commands, "hunk.app.toggleHelp", { count: 9 })).toBe(true);
+    expect(ran).toEqual(["toggleHelp"]);
   });
 
   test("refuses a disabled command and an id nobody registered", () => {

--- a/src/ui/lib/appCommands.ts
+++ b/src/ui/lib/appCommands.ts
@@ -1,5 +1,6 @@
 import type { KeyEvent } from "@opentui/core";
 import type { CursorLine, LayoutMode } from "../../core/types";
+import type { ExtensionCommandExecutionOptions } from "../../extension-api/types";
 import {
   matchesAnyKeyChord,
   parseKeyChordOrUndefined,
@@ -24,6 +25,8 @@ const FAST_CODE_HORIZONTAL_SCROLL_COLUMNS = 8;
  * structure of the widget that owns them, not shortcuts a user rebinds or an
  * extension extends.
  */
+export const MAX_APP_COMMAND_COUNT = 10_000;
+
 export interface AppCommand {
   /**
    * Stable identifier, always namespaced by whoever owns the command.
@@ -40,8 +43,8 @@ export interface AppCommand {
   /**
    * The chords this command currently answers to, after user keybindings.
    *
-   * Empty means the command is unbound: it never matches a key, and is reached
-   * only by name through `executeAppCommand` (a menu entry, say).
+   * Empty means the command is unbound: it never matches a key, but remains
+   * callable by id through `executeAppCommand` and may also appear in a menu.
    */
   keys: readonly string[];
   /** Display form of `keys`, for menus, help, and conflict messages. */
@@ -58,7 +61,10 @@ export interface AppCommand {
   /** Report whether the command may run right now; skipped when false. */
   isEnabled?: () => boolean;
   match: (key: KeyEvent) => boolean;
-  run: (key: KeyEvent) => void;
+  /** True when extension command controls may invoke this host command by id. */
+  publicToExtensions: boolean;
+  /** Run once with a host-normalized positive movement count. */
+  run: (key: KeyEvent, count: number) => void;
   /** Close an open dropdown menu after running. */
   closesMenu?: boolean;
 }
@@ -70,14 +76,16 @@ interface BuiltinCommandSpec {
   /** Chords the command ships with; the user's config may replace them. */
   defaultKeys: readonly string[];
   isEnabled?: () => boolean;
-  run: (key: KeyEvent) => void;
+  run: (key: KeyEvent, count: number) => void;
   closesMenu?: boolean;
 }
 
 /** The callbacks the built-in command set drives; App supplies its own handlers. */
 export interface BuildAppCommandsOptions {
+  canAlignCurrentLine: boolean;
   canApplyFilePresentationToAllMatching: boolean;
   canRefreshCurrentInput: boolean;
+  alignCurrentLine: (alignment: "top" | "center" | "bottom") => void;
   applyFilePresentationToAllMatching: () => void;
   focusFilter: () => void;
   moveToAnnotatedFile: (delta: number) => void;
@@ -120,10 +128,58 @@ export interface BuildAppCommandsOptions {
  * as the old cascade of if-statements was, so entries keep the old cascade's
  * relative order where it mattered (uppercase before lowercase forms).
  *
- * A few commands ship with no chords at all. They exist because the menus name
- * them: an action reachable by mouse is a command like any other, and declaring
- * it here is what makes it bindable from `[keybindings]` and dispatchable by id.
+ * A few commands ship with no chords at all. Declaring them here keeps semantic
+ * actions bindable from `[keybindings]` and dispatchable by id whether or not a
+ * menu currently presents them.
  */
+const PUBLIC_EXTENSION_COMMAND_IDS = new Set([
+  "hunk.review.jumpToBottom",
+  "hunk.review.jumpToTop",
+  "hunk.app.quit",
+  "hunk.app.toggleHelp",
+  "hunk.app.openAgentSkill",
+  "hunk.app.toggleFocusArea",
+  "hunk.review.focusFilter",
+  "hunk.review.startNote",
+  "hunk.review.pageDown",
+  "hunk.review.pageUp",
+  "hunk.review.halfPageDown",
+  "hunk.review.halfPageUp",
+  "hunk.review.stepDown",
+  "hunk.review.stepUp",
+  "hunk.review.scrollCodeLeft",
+  "hunk.review.scrollCodeRight",
+  "hunk.review.alignCurrentLineTop",
+  "hunk.review.alignCurrentLineCenter",
+  "hunk.review.alignCurrentLineBottom",
+  "hunk.view.cursorLineRow",
+  "hunk.view.cursorLineNumber",
+  "hunk.view.cursorLineOff",
+  "hunk.view.layoutSplit",
+  "hunk.view.layoutStack",
+  "hunk.view.layoutAuto",
+  "hunk.view.applyFilePresentationToAllMatching",
+  "hunk.view.toggleSidebar",
+  "hunk.app.refresh",
+  "hunk.view.openThemeSelector",
+  "hunk.view.toggleAgentNotes",
+  "hunk.view.toggleLineNumbers",
+  "hunk.view.toggleLineWrap",
+  "hunk.view.toggleMenuBar",
+  "hunk.view.toggleHunkHeaders",
+  "hunk.view.toggleCopyDecorations",
+  "hunk.review.toggleHunkGap",
+  "hunk.review.editSelectedFile",
+  "hunk.review.previousHunk",
+  "hunk.review.nextHunk",
+  "hunk.review.previousFile",
+  "hunk.review.nextFile",
+  "hunk.review.previousAnnotatedHunk",
+  "hunk.review.nextAnnotatedHunk",
+  "hunk.review.previousAnnotatedFile",
+  "hunk.review.nextAnnotatedFile",
+]);
+
 function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSpec[] {
   return [
     {
@@ -181,37 +237,37 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       id: "hunk.review.pageDown",
       title: "Scroll down one page",
       defaultKeys: ["pagedown", "space", "f"],
-      run: () => options.scrollDiff(1, "viewport"),
+      run: (_key, count) => options.scrollDiff(count, "viewport"),
     },
     {
       id: "hunk.review.pageUp",
       title: "Scroll up one page",
       defaultKeys: ["pageup", "b", "shift+space"],
-      run: () => options.scrollDiff(-1, "viewport"),
+      run: (_key, count) => options.scrollDiff(-count, "viewport"),
     },
     {
       id: "hunk.review.halfPageDown",
       title: "Scroll down half a page",
       defaultKeys: ["d"],
-      run: () => options.scrollDiff(1, "half"),
+      run: (_key, count) => options.scrollDiff(count, "half"),
     },
     {
       id: "hunk.review.halfPageUp",
       title: "Scroll up half a page",
       defaultKeys: ["u"],
-      run: () => options.scrollDiff(-1, "half"),
+      run: (_key, count) => options.scrollDiff(-count, "half"),
     },
     {
       id: "hunk.review.stepDown",
       title: "Scroll down one row",
       defaultKeys: ["down", "j"],
-      run: () => options.stepDiffLine(1),
+      run: (_key, count) => options.stepDiffLine(count),
     },
     {
       id: "hunk.review.stepUp",
       title: "Scroll up one row",
       defaultKeys: ["up", "k"],
-      run: () => options.stepDiffLine(-1),
+      run: (_key, count) => options.stepDiffLine(-count),
     },
     {
       id: "hunk.review.scrollCodeLeft",
@@ -219,15 +275,40 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       // Both chords run the same command; the shifted one scrolls further, so
       // the handler reads the event rather than splitting into two commands.
       defaultKeys: ["left", "shift+left"],
-      run: (key) =>
-        options.scrollCodeHorizontally(key.shift ? -FAST_CODE_HORIZONTAL_SCROLL_COLUMNS : -1),
+      run: (key, count) =>
+        options.scrollCodeHorizontally(
+          (key.shift ? -FAST_CODE_HORIZONTAL_SCROLL_COLUMNS : -1) * count,
+        ),
     },
     {
       id: "hunk.review.scrollCodeRight",
       title: "Scroll code right",
       defaultKeys: ["right", "shift+right"],
-      run: (key) =>
-        options.scrollCodeHorizontally(key.shift ? FAST_CODE_HORIZONTAL_SCROLL_COLUMNS : 1),
+      run: (key, count) =>
+        options.scrollCodeHorizontally(
+          (key.shift ? FAST_CODE_HORIZONTAL_SCROLL_COLUMNS : 1) * count,
+        ),
+    },
+    {
+      id: "hunk.review.alignCurrentLineTop",
+      title: "Align current line to top",
+      defaultKeys: [],
+      isEnabled: () => options.canAlignCurrentLine,
+      run: () => options.alignCurrentLine("top"),
+    },
+    {
+      id: "hunk.review.alignCurrentLineCenter",
+      title: "Align current line to center",
+      defaultKeys: [],
+      isEnabled: () => options.canAlignCurrentLine,
+      run: () => options.alignCurrentLine("center"),
+    },
+    {
+      id: "hunk.review.alignCurrentLineBottom",
+      title: "Align current line to bottom",
+      defaultKeys: [],
+      isEnabled: () => options.canAlignCurrentLine,
+      run: () => options.alignCurrentLine("bottom"),
     },
     {
       id: "hunk.view.cursorLineRow",
@@ -361,56 +442,56 @@ function builtinCommandSpecs(options: BuildAppCommandsOptions): BuiltinCommandSp
       id: "hunk.review.previousHunk",
       title: "Previous hunk",
       defaultKeys: ["["],
-      run: () => options.moveToHunk(-1),
+      run: (_key, count) => options.moveToHunk(-count),
       closesMenu: true,
     },
     {
       id: "hunk.review.nextHunk",
       title: "Next hunk",
       defaultKeys: ["]"],
-      run: () => options.moveToHunk(1),
+      run: (_key, count) => options.moveToHunk(count),
       closesMenu: true,
     },
     {
       id: "hunk.review.previousFile",
       title: "Previous file",
       defaultKeys: [","],
-      run: () => options.moveToFile(-1),
+      run: (_key, count) => options.moveToFile(-count),
       closesMenu: true,
     },
     {
       id: "hunk.review.nextFile",
       title: "Next file",
       defaultKeys: ["."],
-      run: () => options.moveToFile(1),
+      run: (_key, count) => options.moveToFile(count),
       closesMenu: true,
     },
     {
       id: "hunk.review.previousAnnotatedHunk",
       title: "Previous annotated hunk",
       defaultKeys: ["{"],
-      run: () => options.moveToAnnotatedHunk(-1),
+      run: (_key, count) => options.moveToAnnotatedHunk(-count),
       closesMenu: true,
     },
     {
       id: "hunk.review.nextAnnotatedHunk",
       title: "Next annotated hunk",
       defaultKeys: ["}"],
-      run: () => options.moveToAnnotatedHunk(1),
+      run: (_key, count) => options.moveToAnnotatedHunk(count),
       closesMenu: true,
     },
     {
       id: "hunk.review.previousAnnotatedFile",
       title: "Previous annotated file",
       defaultKeys: [],
-      run: () => options.moveToAnnotatedFile(-1),
+      run: (_key, count) => options.moveToAnnotatedFile(-count),
       closesMenu: true,
     },
     {
       id: "hunk.review.nextAnnotatedFile",
       title: "Next annotated file",
       defaultKeys: [],
-      run: () => options.moveToAnnotatedFile(1),
+      run: (_key, count) => options.moveToAnnotatedFile(count),
       closesMenu: true,
     },
   ];
@@ -433,6 +514,7 @@ function toAppCommand(spec: BuiltinCommandSpec, resolvedKeys?: ResolvedCommandKe
     keys,
     keyLabels: keys.map(formatKeyChord),
     isEnabled: spec.isEnabled,
+    publicToExtensions: PUBLIC_EXTENSION_COMMAND_IDS.has(spec.id),
     match: matchesAnyKeyChord(keys),
     run: spec.run,
     closesMenu: spec.closesMenu,
@@ -447,8 +529,10 @@ export function buildAppCommands(options: BuildAppCommandsOptions): AppCommand[]
 const NOOP_COMMAND_OPTIONS: BuildAppCommandsOptions = (() => {
   const noop = () => {};
   return {
+    canAlignCurrentLine: false,
     canApplyFilePresentationToAllMatching: false,
     canRefreshCurrentInput: true,
+    alignCurrentLine: noop,
     applyFilePresentationToAllMatching: noop,
     focusFilter: noop,
     moveToAnnotatedFile: noop,
@@ -553,7 +637,7 @@ export function dispatchAppCommand(
     }
 
     key.preventDefault();
-    command.run(key);
+    command.run(key, 1);
     return command;
   }
 
@@ -564,16 +648,43 @@ export function dispatchAppCommand(
  * A key event standing in for "the user asked for this command by name".
  *
  * Commands reached without a keypress still take one, because `run` is written
- * against the event a chord produced. Synthesizing the command's own first
- * chord keeps the two paths identical for the handful of commands that read the
- * event (the shifted arrow scrolls further); an unbound command has no chord to
- * synthesize, so it gets a neutral event with no modifiers set.
+ * against the event a chord produced. Synthesize from the command's shipped
+ * first chord rather than the user's resolved binding: invoking a semantic
+ * command by id must not change behavior when that command is remapped. An
+ * unbound command gets a neutral event with no modifiers set.
  */
 function commandInvocationEvent(command: AppCommand): KeyEvent {
-  const parsed = command.keys.map(parseKeyChordOrUndefined).find((chord) => chord !== undefined);
+  const parsed = (command.defaultKeys ?? [])
+    .map(parseKeyChordOrUndefined)
+    .find((chord) => chord !== undefined);
   return parsed
     ? synthesizeKeyEvent(parsed)
-    : synthesizeKeyEvent({ base: "", ctrl: false, meta: false, option: false, shift: false });
+    : synthesizeKeyEvent({
+        base: "",
+        ctrl: false,
+        meta: false,
+        option: false,
+        shift: false,
+      });
+}
+
+/** Validate and normalize a programmatic command count once at the dispatch boundary. */
+export function normalizeAppCommandCount(options?: ExtensionCommandExecutionOptions): number {
+  if (
+    options !== undefined &&
+    (options === null || typeof options !== "object" || Array.isArray(options))
+  ) {
+    throw new TypeError("Command execution options must be an object.");
+  }
+
+  const count = options?.count ?? 1;
+  if (!Number.isSafeInteger(count) || count < 1 || count > MAX_APP_COMMAND_COUNT) {
+    throw new RangeError(
+      `Command execution count must be a positive safe integer no greater than ${MAX_APP_COMMAND_COUNT}.`,
+    );
+  }
+
+  return count;
 }
 
 /**
@@ -584,12 +695,25 @@ function commandInvocationEvent(command: AppCommand): KeyEvent {
  * a menu item and its shortcut can never drift apart. Reports whether a command
  * ran — an id nobody registered, or one whose `isEnabled` says no, does nothing.
  */
-export function executeAppCommand(commands: readonly AppCommand[], id: string): boolean {
+export function executeAppCommand(
+  commands: readonly AppCommand[],
+  id: string,
+  options?: ExtensionCommandExecutionOptions,
+): boolean {
+  return executeAppCommandWithCount(commands, id, normalizeAppCommandCount(options));
+}
+
+/** Execute one command after the caller has normalized its count exactly once. */
+export function executeAppCommandWithCount(
+  commands: readonly AppCommand[],
+  id: string,
+  count: number,
+): boolean {
   const command = commands.find((candidate) => candidate.id === id);
   if (!command || !isCommandEnabled(command)) {
     return false;
   }
 
-  command.run(commandInvocationEvent(command));
+  command.run(commandInvocationEvent(command), count);
   return true;
 }

--- a/src/ui/lib/appMenus.test.ts
+++ b/src/ui/lib/appMenus.test.ts
@@ -37,8 +37,10 @@ function createTestCommands(overrides: Partial<BuildAppCommandsOptions> = {}) {
     };
   const noop = () => {};
   const commands = buildAppCommands({
+    canAlignCurrentLine: true,
     canApplyFilePresentationToAllMatching: false,
     canRefreshCurrentInput: true,
+    alignCurrentLine: record("alignCurrentLine"),
     applyFilePresentationToAllMatching: record("applyFilePresentationToAllMatching"),
     focusFilter: noop,
     moveToAnnotatedFile: record("moveToAnnotatedFile"),

--- a/src/ui/lib/extensionCommandControls.test.ts
+++ b/src/ui/lib/extensionCommandControls.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import type { AppCommand } from "./appCommands";
+import { MAX_APP_COMMAND_COUNT } from "./appCommands";
+import { createExtensionCommandControls } from "./extensionCommandControls";
+
+/** Build one host command without coupling these capability tests to App callbacks. */
+function testCommand({
+  id = "hunk.review.nextHunk",
+  enabled = true,
+  publicToExtensions = true,
+  run = () => {},
+}: {
+  id?: string;
+  enabled?: boolean;
+  publicToExtensions?: boolean;
+  run?: AppCommand["run"];
+} = {}): AppCommand {
+  return {
+    id,
+    title: id,
+    keys: [],
+    keyLabels: [],
+    defaultKeys: [],
+    publicToExtensions,
+    isEnabled: () => enabled,
+    match: () => false,
+    run,
+  };
+}
+
+describe("extension command controls", () => {
+  test("executes an enabled public Hunk command with one normalized count", () => {
+    const counts: number[] = [];
+    const command = testCommand({ run: (_key, count) => counts.push(count) });
+    const controls = createExtensionCommandControls({
+      getCommands: () => [command],
+      isLive: () => true,
+    });
+
+    expect(controls.isEnabled(command.id)).toBe(true);
+    expect(controls.execute(command.id, { count: 7 })).toBe(true);
+    expect(controls.execute(command.id, { count: MAX_APP_COMMAND_COUNT })).toBe(true);
+    expect(counts).toEqual([7, MAX_APP_COMMAND_COUNT]);
+  });
+
+  test("resolves the live table on every call", () => {
+    let commands: readonly AppCommand[] = [testCommand({ enabled: false })];
+    const controls = createExtensionCommandControls({
+      getCommands: () => commands,
+      isLive: () => true,
+    });
+
+    expect(controls.isEnabled("hunk.review.nextHunk")).toBe(false);
+    commands = [testCommand()];
+    expect(controls.isEnabled("hunk.review.nextHunk")).toBe(true);
+  });
+
+  test("refuses unknown, disabled, private, extension-owned, and stale commands", () => {
+    let live = true;
+    const enabled = testCommand();
+    const commands = [
+      enabled,
+      testCommand({ id: "hunk.app.refresh", enabled: false }),
+      testCommand({ id: "hunk.internal.probe", publicToExtensions: false }),
+      testCommand({ id: "example.run" }),
+    ];
+    const controls = createExtensionCommandControls({
+      getCommands: () => commands,
+      isLive: () => live,
+    });
+
+    expect(controls.isEnabled("hunk.missing")).toBe(false);
+    expect(controls.execute("hunk.missing")).toBe(false);
+    expect(controls.isEnabled("hunk.app.refresh")).toBe(false);
+    expect(controls.execute("hunk.app.refresh")).toBe(false);
+    expect(controls.isEnabled("hunk.internal.probe")).toBe(false);
+    expect(controls.execute("hunk.internal.probe")).toBe(false);
+    expect(controls.isEnabled("example.run")).toBe(false);
+    expect(controls.execute("example.run")).toBe(false);
+    live = false;
+    expect(controls.isEnabled(enabled.id)).toBe(false);
+    expect(controls.execute(enabled.id)).toBe(false);
+  });
+
+  test("keeps probes non-throwing while execution rejects malformed input even when stale", () => {
+    const controls = createExtensionCommandControls({
+      getCommands: () => [testCommand()],
+      isLive: () => true,
+    });
+
+    expect(controls.isEnabled("" as never)).toBe(false);
+    expect(controls.isEnabled(null as never)).toBe(false);
+    expect(controls.isEnabled(42 as never)).toBe(false);
+    expect(() => controls.execute("")).toThrow("non-empty command id");
+    expect(() => controls.execute("hunk.review.nextHunk", null as never)).toThrow(
+      "options must be an object",
+    );
+    expect(() => controls.execute("hunk.unknown", null as never)).toThrow(
+      "options must be an object",
+    );
+    for (const count of [0, -1, 1.5, Number.NaN, MAX_APP_COMMAND_COUNT + 1]) {
+      expect(() => controls.execute("hunk.review.nextHunk", { count })).toThrow(
+        `no greater than ${MAX_APP_COMMAND_COUNT}`,
+      );
+    }
+
+    const staleControls = createExtensionCommandControls({
+      getCommands: () => [testCommand()],
+      isLive: () => false,
+    });
+    expect(() => staleControls.execute("hunk.review.nextHunk", { count: 0 })).toThrow(
+      `no greater than ${MAX_APP_COMMAND_COUNT}`,
+    );
+  });
+});

--- a/src/ui/lib/extensionCommandControls.ts
+++ b/src/ui/lib/extensionCommandControls.ts
@@ -1,0 +1,66 @@
+import type {
+  ExtensionCommandControls,
+  ExtensionCommandExecutionOptions,
+} from "../../extension-api/types";
+import {
+  executeAppCommandWithCount,
+  isCommandEnabled,
+  normalizeAppCommandCount,
+  type AppCommand,
+} from "./appCommands";
+
+/** Validate an execution id passed by JavaScript despite the TypeScript contract. */
+function requireCommandId(commandId: unknown): string {
+  if (typeof commandId !== "string" || commandId.trim().length === 0) {
+    throw new TypeError("Extension command controls require a non-empty command id.");
+  }
+  return commandId;
+}
+
+/** Read a probe id without turning malformed input into an extension failure. */
+function commandIdForProbe(commandId: unknown): string | undefined {
+  return typeof commandId === "string" && commandId.trim().length > 0 ? commandId : undefined;
+}
+
+/** Find one explicitly public host command in the current live command table. */
+function findPublicCommand(commands: readonly AppCommand[], commandId: string) {
+  return commands.find(
+    (command) =>
+      command.id === commandId && command.id.startsWith("hunk.") && command.publicToExtensions,
+  );
+}
+
+/**
+ * Build live, renderer-free command controls for an extension command handler.
+ *
+ * The table is read for every operation so an async handler resumes against current App state.
+ * Liveness prevents a handler retained across an App remount from driving callbacks owned by the
+ * retired tree.
+ */
+export function createExtensionCommandControls({
+  getCommands,
+  isLive,
+}: {
+  getCommands: () => readonly AppCommand[];
+  isLive: () => boolean;
+}): ExtensionCommandControls {
+  return Object.freeze({
+    isEnabled(commandId: string) {
+      const id = commandIdForProbe(commandId);
+      if (!id || !isLive()) return false;
+      const command = findPublicCommand(getCommands(), id);
+      return Boolean(command && isCommandEnabled(command));
+    },
+    execute(commandId: string, options?: ExtensionCommandExecutionOptions) {
+      const id = requireCommandId(commandId);
+      // Validate before liveness and lookup so programming errors stay visible
+      // even when a handler resumes after its App instance retired.
+      const count = normalizeAppCommandCount(options);
+      if (!isLive()) return false;
+      const commands = getCommands();
+      const command = findPublicCommand(commands, id);
+      if (!command) return false;
+      return executeAppCommandWithCount([command], id, count);
+    },
+  });
+}

--- a/src/ui/lib/extensionCommands.test.ts
+++ b/src/ui/lib/extensionCommands.test.ts
@@ -34,6 +34,7 @@ describe("buildExtensionAppCommands", () => {
     // Both are listed for the Extensions menu; only the bound one has a key.
     expect(commands.map((command) => command.id)).toEqual(["meta.toggle", "meta.silent"]);
     expect(commands.map((command) => command.keyLabels)).toEqual([["y"], []]);
+    expect(commands.every((command) => !command.publicToExtensions)).toBe(true);
     expect(dispatchAppCommand(commands, chordEvent("y"))?.id).toBe("meta.toggle");
     expect(ran).toEqual(["meta.toggle"]);
   });

--- a/src/ui/lib/extensionCommands.ts
+++ b/src/ui/lib/extensionCommands.ts
@@ -110,6 +110,7 @@ export function buildExtensionAppCommands(
       title: command.title,
       keys: bound.map((binding) => binding.chord),
       keyLabels: bound.map((binding) => formatKeyChord(binding.chord)),
+      publicToExtensions: false,
       match: (key) => bound.some((binding) => binding.match(key)),
       run: () => options.runCommand(registered),
       closesMenu: true,

--- a/src/ui/lib/hunkScroll.test.ts
+++ b/src/ui/lib/hunkScroll.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { computeHunkRevealScrollTop, computeLineRevealScrollTop } from "./hunkScroll";
+import {
+  computeHunkRevealScrollTop,
+  computeLineAlignmentScrollTop,
+  computeLineRevealScrollTop,
+} from "./hunkScroll";
 
 describe("computeHunkRevealScrollTop", () => {
   test("keeps a fitting hunk fully visible when the preferred padding would clip the end", () => {
@@ -55,6 +59,34 @@ describe("computeHunkRevealScrollTop", () => {
         viewportHeight: 0,
       }),
     ).toBe(19);
+  });
+});
+
+describe("computeLineAlignmentScrollTop", () => {
+  test("aligns a rendered line to the top, center, and bottom", () => {
+    const input = { lineTop: 20, lineHeight: 2, viewportHeight: 10 };
+    expect(computeLineAlignmentScrollTop({ ...input, alignment: "top" })).toBe(20);
+    expect(computeLineAlignmentScrollTop({ ...input, alignment: "center" })).toBe(16);
+    expect(computeLineAlignmentScrollTop({ ...input, alignment: "bottom" })).toBe(12);
+  });
+
+  test("clamps alignment at the start and handles rows taller than the viewport", () => {
+    expect(
+      computeLineAlignmentScrollTop({
+        alignment: "center",
+        lineTop: 2,
+        lineHeight: 1,
+        viewportHeight: 20,
+      }),
+    ).toBe(0);
+    expect(
+      computeLineAlignmentScrollTop({
+        alignment: "bottom",
+        lineTop: 10,
+        lineHeight: 20,
+        viewportHeight: 8,
+      }),
+    ).toBe(22);
   });
 });
 

--- a/src/ui/lib/hunkScroll.ts
+++ b/src/ui/lib/hunkScroll.ts
@@ -34,6 +34,29 @@ export function computeHunkRevealScrollTop({
   return desiredTop;
 }
 
+export type CurrentLineAlignment = "top" | "center" | "bottom";
+
+/** Place the current rendered line at one semantic viewport edge or center. */
+export function computeLineAlignmentScrollTop({
+  alignment,
+  lineTop,
+  lineHeight,
+  viewportHeight,
+}: {
+  alignment: CurrentLineAlignment;
+  lineTop: number;
+  lineHeight: number;
+  viewportHeight: number;
+}) {
+  const top = Math.max(0, lineTop);
+  const height = Math.max(1, lineHeight);
+  const viewport = Math.max(1, viewportHeight);
+
+  if (alignment === "top") return top;
+  if (alignment === "bottom") return Math.max(0, top + height - viewport);
+  return Math.max(0, top - Math.floor((viewport - height) / 2));
+}
+
 /**
  * Pick a scroll target that brings the current line just into view.
  *

--- a/src/ui/lib/hunks.test.ts
+++ b/src/ui/lib/hunks.test.ts
@@ -46,6 +46,17 @@ describe("hunk navigation", () => {
     expect(findNextHunkCursor(cursors, "alpha", 1, -1)).toEqual({ fileId: "alpha", hunkIndex: 0 });
   });
 
+  test("applies multi-step movement atomically and clamps at the target", () => {
+    expect(findNextHunkCursor(cursors, "alpha", 0, 2)).toEqual({
+      fileId: "beta",
+      hunkIndex: 0,
+    });
+    expect(findNextHunkCursor(cursors, "beta", 0, -2)).toEqual({
+      fileId: "alpha",
+      hunkIndex: 0,
+    });
+  });
+
   test("clamps at the ends of the review stream", () => {
     expect(findNextHunkCursor(cursors, "alpha", 0, -1)).toEqual({ fileId: "alpha", hunkIndex: 0 });
     expect(findNextHunkCursor(cursors, "beta", 0, 1)).toEqual({ fileId: "beta", hunkIndex: 0 });
@@ -192,6 +203,10 @@ describe("annotated hunk navigation", () => {
     expect(findNextHunkCursor(annotatedCursors, "beta", 0, -1, streamCursors)).toEqual({
       fileId: "alpha",
       hunkIndex: 1,
+    });
+    expect(findNextHunkCursor(annotatedCursors, "alpha", 0, 2, streamCursors)).toEqual({
+      fileId: "gamma",
+      hunkIndex: 0,
     });
     expect(findNextHunkCursor(annotatedCursors, "alpha", 0, 1, streamCursors)).toEqual({
       fileId: "alpha",

--- a/src/ui/lib/hunks.ts
+++ b/src/ui/lib/hunks.ts
@@ -80,17 +80,19 @@ function findNearestCursorIndex(
 
   // Comment navigation is non-cyclic like normal hunk navigation, so positions outside
   // the annotated span clamp to the nearest annotated edge instead of wrapping.
+  const remainingSteps = Math.max(0, Math.abs(delta) - 1);
   if (delta >= 0) {
     const nextCursor = indexedCursors.find(({ streamIndex }) => streamIndex > currentStreamIndex);
-    return nextCursor?.index ?? indexedCursors[indexedCursors.length - 1]!.index;
+    const nearestIndex = nextCursor?.index ?? indexedCursors[indexedCursors.length - 1]!.index;
+    return Math.min(nearestIndex + remainingSteps, cursors.length - 1);
   }
 
   for (let index = indexedCursors.length - 1; index >= 0; index -= 1) {
     const indexedCursor = indexedCursors[index]!;
     if (indexedCursor.streamIndex < currentStreamIndex) {
-      return indexedCursor.index;
+      return Math.max(0, indexedCursor.index - remainingSteps);
     }
   }
 
-  return indexedCursors[0]!.index;
+  return 0;
 }

--- a/src/ui/lib/reviewState.ts
+++ b/src/ui/lib/reviewState.ts
@@ -93,7 +93,9 @@ export function findNextAnnotatedFile(
 
   const currentIndex = annotatedFiles.findIndex((file) => file.id === currentFileId);
   const normalizedIndex = currentIndex >= 0 ? currentIndex : 0;
-  const nextIndex = (normalizedIndex + delta + annotatedFiles.length) % annotatedFiles.length;
+  const nextIndex =
+    (((normalizedIndex + delta) % annotatedFiles.length) + annotatedFiles.length) %
+    annotatedFiles.length;
   return annotatedFiles[nextIndex] ?? null;
 }
 

--- a/test/pty/extensions-integration.test.ts
+++ b/test/pty/extensions-integration.test.ts
@@ -359,7 +359,7 @@ describe("PTY extensions", () => {
       args: ["diff", "--mode", "stack", "--extension", REVIEW_TRIAGE_EXTENSION],
       cwd: fixture.dir,
       cols: 140,
-      rows: 24,
+      rows: 30,
       env: { XDG_CONFIG_HOME: configHome },
     });
 
@@ -391,6 +391,7 @@ describe("PTY extensions", () => {
       expect(menu).not.toBeNull();
       expect(menu!).toMatch(/Toggle review triage\s+y/);
       expect(menu).toMatch(/Mark selected hunk…\s+x/);
+      expect(menu).toContain("Center current review line");
       expect(menu).toContain("Set review focus…");
       expect(menu).toContain("Clear triage decisions");
     } finally {

--- a/website/src/content/docs/docs/configure/keybindings.md
+++ b/website/src/content/docs/docs/configure/keybindings.md
@@ -29,7 +29,7 @@ Chords join `ctrl`, `alt`/`option`, `cmd`/`meta`, and `shift` with `+` around a 
 
 ## Find command ids
 
-The menus and the in-app help (`?`) always show the keys each command currently holds, so a remap changes what they advertise. The full table of built-in command ids and their default keys lives in [`docs/keybindings.md`](https://github.com/modem-dev/hunk/blob/main/docs/keybindings.md) in the repository. Commands listed without a default key are menu items today; binding one gives it a shortcut like any other.
+The menus and the in-app help (`?`) show the keys for the commands they present, so a remap changes what they advertise. The full table of built-in command ids and their default keys lives in [`docs/keybindings.md`](https://github.com/modem-dev/hunk/blob/main/docs/keybindings.md) in the repository. Commands listed without a default key remain callable by id and can be assigned a shortcut; some also appear in menus.
 
 Keys owned by a dialog, menu, or focused text input — `Esc`, `Enter`, `Ctrl-S` while writing a note — belong to those widgets and are not remappable.
 

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -7,7 +7,7 @@ The extension factory receives one API object. Registration calls are only valid
 
 ## `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `2`). Branch on it if you want one file to support several Hunk versions. Version 2 adds the experimental file-view contract and its command controls.
+The API generation this Hunk speaks (currently `3`). Branch on it if you want one file to support several Hunk versions. Version 3 adds live execution of public Hunk commands from extension command handlers.
 
 ## `hunk.registerTheme(theme)`
 
@@ -95,6 +95,7 @@ Registered commands are also listed in the menu bar's **Extensions** menu under 
 
 The handler fires when the key is pressed outside modal UI (dialogs, menus, and focused text inputs own their keys). It receives the standard context plus:
 
+- `ctx.commands.isEnabled(commandId)` / `execute(commandId, { count? })` — probes or invokes an explicitly public built-in `hunk.*` command through the same live table as keyboard and menu actions. Relative movement applies counts atomically; extension-owned and cross-extension commands return `false`.
 - `ctx.sidebars.open(viewId)` / `close(viewId)` / `toggle(viewId)` / `isOpen(viewId)` — a bare id names your own view, `"files"` the built-in file navigation, `"<extensionId>:<viewId>"` any registered view. Opening also reveals a hidden sidebar area.
 - `ctx.fileViews.select(viewId)` / `toggle(viewId)` / `isActive(viewId)` — controls a matching [file preview](/docs/extend/file-previews/) for the current file; `select(null)` restores raw diff.
 - `ctx.fileViews.refresh(viewId, options?)` — marks that view's prepared layouts stale so a stateful view re-derives; every file presenting it re-lays out, keeping its current rows visible until the replacement resolves. Pass `{ fileId }` to scope the invalidation to one reviewed file's presentation of the view.
@@ -122,6 +123,8 @@ hunk.registerCommand(
 `selection.file` is a frozen view, identical to a sidebar's `files` entries; it is `null` only when no files are visible. `selection.hunkIndex` is `null` whenever `file` is, or when the file has no hunks. The values are captured when the command fires, so an async handler keeps the selection it started from.
 
 `ctx.navigation.selectFile(fileId)` and `selectHunk(fileId, hunkIndex)` route through the same guarded review controller as a sidebar's `actions` — the stream scrolls, selection updates, `selection_changed` fires. Unlike `selection` it is live: a handler that awaits a dialog and then navigates still works.
+
+All built-ins listed in the [keybindings reference](https://github.com/modem-dev/hunk/blob/main/docs/keybindings.md) are public to command handlers. This includes the unbound `hunk.review.alignCurrentLineTop`, `hunk.review.alignCurrentLineCenter`, and `hunk.review.alignCurrentLineBottom` commands. `count` defaults to `1`, is capped at `10,000`, and scales relative row, viewport, horizontal, file, hunk, and annotated navigation in one host transition. Absolute and one-shot commands run once. Unknown, disabled, non-public, extension-owned, or stale commands return `false`. `isEnabled` also returns `false` for a malformed id; malformed `execute` ids, options, and counts throw into normal extension failure containment.
 
 A handler may be async; a failure becomes a warning naming your extension.
 
@@ -267,7 +270,7 @@ const patterns = (hunk.config.patterns as string[] | undefined) ?? ["*.lock"];
 
 ## `ctx.notify(message, type?)`
 
-Every handler and transform receives a context with `cwd` and `notify`; event and bus handlers add `sidebars` and `events.emit`, command handlers add `sidebars`, `fileViews`, `selection`, `navigation`, and `dialogs`. `notify` shows one transient line at the bottom of the app; `type` is `"info"` (default), `"warning"`, or `"error"`. Messages raised before the UI mounts are buffered, so a `startup` handler can notify safely.
+Every handler and transform receives a context with `cwd` and `notify`; event and bus handlers add `sidebars` and `events.emit`, command handlers add `commands`, `sidebars`, `fileViews`, `selection`, `navigation`, and `dialogs`. `notify` shows one transient line at the bottom of the app; `type` is `"info"` (default), `"warning"`, or `"error"`. Messages raised before the UI mounts are buffered, so a `startup` handler can notify safely.
 
 ## `hunk.log(message)`
 


### PR DESCRIPTION
## Summary

- publish API v3 command controls so extension handlers can probe and execute explicitly public built-in `hunk.*` commands
- support validated atomic movement counts and renderer-owned current-line top/center/bottom alignment
- keep extension-owned commands private and retire captured controls safely across App and extension-registry lifecycles
- document the command catalog and update package checks, the bundled extension skill, and the review-triage example

This intentionally delivers semantic command execution only; it does not add global keyboard modes or Vim key routing.

## Test plan

- `bun run test` — 2,000 passed, 9 skipped
- `bun run test:integration` — 101 passed
- `bun run test:tty-smoke` — 9 passed
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:docs`
- `bun run check:pack`

*This PR description was generated by Pi using gpt-5.6-sol*
