### PR TITLE
feat(extensions): support guided review workflows

### DIFF
--- a/.changeset/guided-extension-workflows.md
+++ b/.changeset/guided-extension-workflows.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add extension APIs for transient sessions and observing or navigating guided review workflows.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -42,8 +42,9 @@ load issue and costs only that extension. The rules themselves are stated in
 
 ## One registry, one apply path
 
-Registrations (themes, file languages, VCS adapters, changeset transforms,
-panes, commands, lifecycle/UI events, and bus listeners) collect into one
+Registrations (session behavior, themes, file languages, VCS adapters,
+changeset transforms, panes, commands, lifecycle/UI events, and inter-extension
+bus listeners) collect into one
 `ExtensionRegistry` (`src/extensions/types.ts`) and are resolved/applied
 through `src/extensions/apply.ts` on both startup and reload. Staged external-VCS
 bootstrap retains the provisional candidate/config snapshot: a final pass that
@@ -191,6 +192,13 @@ stepping's minimum-distance scroll and the top-padded position hunk, note, and
 `revealLine` reveals share. Extensions name a target; they never name a scroll
 position.
 
+After any named command runs in the terminal host, App emits `command_executed`
+with its stable id. The event decorates the assembled terminal command table, so
+keyboard dispatch, menus, and extension command controls share one observation
+path. Browser/session review actions lower through `ReviewIntent` instead; they
+are semantic effects rather than terminal command invocations. Widget-owned
+modal keys also remain outside the table and therefore outside the event.
+
 `ctx.dialogs` is the one place extension code can interrupt the user, so its
 ordering and settlement live outside React in
 `src/ui/lib/extensionDialogs.ts` — one FIFO queue per App instance, minting a
@@ -206,9 +214,19 @@ dialogs below Hunk's own app-critical prompts (repo trust, save-on-quit) and
 above menus, help, the theme selector, focused inputs, file-view modes, session
 keyboard modes, and the command table: an extension may
 interrupt review navigation, never a decision about the session itself. The
-frame always carries an `ext <id>` attribution row — the toast marker — because
-the title is extension-authored and a prompt must not be able to impersonate
-Hunk.
+frame carries an `ext <id>` attribution row — the toast marker — for every
+user-installed extension, because its title is extension-authored and a prompt
+must not be able to impersonate Hunk. The host derives the extension's trusted
+bundled origin from registry metadata and omits the redundant marker only for
+Hunk-owned bundled UI.
+
+Lifecycle and bus handlers receive that same attributed dialog queue plus the
+same guarded live navigation commands use. `App` installs both through the
+per-extension event-context provider; headless or pre-mount delivery resolves
+dialogs to their cancel values and refuses navigation with a warning. Session
+behavior requests are registry data too: `configureSession({ viewPreferences:
+"transient" })` makes practice and presentation view changes ephemeral without
+teaching `App` about any particular extension id.
 
 `src/ui/lib/extensionWorkspace.ts` owns the policy for `ctx.workspace`. Reads
 resolve reviewed file ids through the existing source fetcher, which retains

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -192,8 +192,10 @@ stepping's minimum-distance scroll and the top-padded position hunk, note, and
 `revealLine` reveals share. Extensions name a target; they never name a scroll
 position.
 
-After any named command runs in the terminal host, App emits `command_executed`
-with its stable id. The event decorates the assembled terminal command table, so
+After any named command dispatches in the terminal host, App emits
+`command_executed` with its stable id. This observes the accepted action after
+synchronous `AppCommand.run`, not settlement of detached extension promises.
+The event decorates the assembled terminal command table, so
 keyboard dispatch, menus, and extension command controls share one observation
 path. Browser/session review actions lower through `ReviewIntent` instead; they
 are semantic effects rather than terminal command invocations. Widget-owned
@@ -218,15 +220,26 @@ frame carries an `ext <id>` attribution row — the toast marker — for every
 user-installed extension, because its title is extension-authored and a prompt
 must not be able to impersonate Hunk. The host derives the extension's trusted
 bundled origin from registry metadata and omits the redundant marker only for
-Hunk-owned bundled UI.
+Hunk-owned bundled UI. `src/ui/lib/modalGeometry.ts` clamps the frame before
+extension text is wrapped or windowed, so measurement and rendering use the
+same terminal width; body/options yield rows to a pinned mouse-clickable action
+footer on short terminals.
 
 Lifecycle and bus handlers receive that same attributed dialog queue plus the
 same guarded live navigation commands use. `App` installs both through the
-per-extension event-context provider; headless or pre-mount delivery resolves
-dialogs to their cancel values and refuses navigation with a warning. Session
-behavior requests are registry data too: `configureSession({ viewPreferences:
-"transient" })` makes practice and presentation view changes ephemeral without
-teaching `App` about any particular extension id.
+per-extension event-context provider, while `AppHost` publishes mounted
+lifecycle order (`startup`, then `changeset_loaded`; reloads add
+`session_reload`) only after the matching child commit. Headless or pre-mount delivery resolves
+dialogs to their cancel values and refuses navigation with a warning.
+`src/ui/lib/extensionCapabilityLease.ts` binds retained pane, navigation,
+dialog, and workspace controls to one App, extension registry, and review
+generation. Soft
+reload or registry retirement therefore makes old host-mediated capabilities
+inert before shutdown begins. Session behavior requests are registry data too:
+`resolveExtensionSessionOptions` applies the shared policy that any
+`configureSession({ viewPreferences: "transient" })` request makes practice and
+presentation view changes ephemeral without teaching `App` about an extension
+id.
 
 `src/ui/lib/extensionWorkspace.ts` owns the policy for `ctx.workspace`. Reads
 resolve reviewed file ids through the existing source fetcher, which retains

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1607,12 +1607,16 @@ one focused welcome question and navigate to its first example, while a
 `changeset_loaded` handler can reveal a pane when it finds something worth
 showing — no keypress required. Dialog calls made before the mounted app is
 ready resolve to their cancel value with a warning rather than opening later.
+Controls retained across a review or extension-registry replacement expire:
+navigation and pane mutations warn and do nothing, dialogs resolve to their
+normal cancel value, and workspace reads/writes return `null`/`unavailable`
+instead of acting on replacement content.
 
 | Event                  | Payload                 | When                                                      |
 | ---------------------- | ----------------------- | --------------------------------------------------------- |
 | `startup`              | `{ cwd }`               | once per loaded instance, after its review UI mounts      |
 | `changeset_loaded`     | `{ changeset }`         | first load and every reload                               |
-| `command_executed`     | `{ commandId }`         | whenever a named built-in or extension command runs       |
+| `command_executed`     | `{ commandId }`         | after a named command dispatches in this terminal host    |
 | `selection_changed`    | `{ fileId, hunkIndex }` | when the review selection settles (debounced ~150ms)      |
 | `file_viewed`          | `{ file, hunkIndex }`   | when selection settles on a file or a reload replaces it  |
 | `filter_changed`       | `{ filter }`            | whenever the file-filter query changes                    |
@@ -1624,14 +1628,21 @@ ready resolve to their cancel value with a warning rather than opening later.
 | `session_reload`       | `{ changeset, reason }` | on every session reload                                   |
 | `shutdown`             | `{}`                    | before instance replacement or exit, with a short timeout |
 
+A newly mounted extension instance receives `startup` before its first
+`changeset_loaded`; reloads then deliver `changeset_loaded` before
+`session_reload` once the matching review generation has committed.
+
 `selection_changed` is trailing-debounced on purpose: holding `[`/`]` retargets
 the selection many times a second, and handlers only care where the user landed.
 `fileId` and `hunkIndex` are `null` when nothing is selected.
 
-`command_executed` reports the stable command id after its handler is invoked, whether the user
-reached it through a key, a menu, or another host-owned command surface. Listen for ids rather
-than key chords so behavior follows the user's live `[keybindings]` table. Modal widget keys such
-as Escape, Enter, note-editor Ctrl-S, and F10 menu navigation are not commands and do not emit it.
+`command_executed` reports the stable command id after the terminal dispatcher invokes it,
+whether the user reached it through a key, a menu, or `ctx.commands.execute`. Extension commands
+may still have detached async work in flight; this event observes the accepted user action, not
+promise settlement. Listen for ids rather than key chords so behavior follows the user's live
+`[keybindings]` table. Browser/session actions lower to shared review intents rather than terminal
+commands and do not emit this event. Modal widget keys such as Escape, Enter, note-editor Ctrl-S,
+and F10 menu navigation are also not commands.
 
 `session_reload`'s `reason` is `"watch"` (the watcher saw the source change),
 `"daemon"` (an agent command through the session broker), or `"manual"` (the
@@ -1646,6 +1657,8 @@ here this session", not a complete review record; present it as such.
 
 `shutdown` handlers get a short window (250ms) to finish before Hunk replaces
 the extension registry or exits anyway, so make cleanup prompt and idempotent.
+Host-mediated UI authority is already revoked when shutdown begins: use the
+event to release extension-owned resources, not to navigate or open dialogs.
 The replacement instance receives `startup` after its review is mounted.
 
 ### `hunk.events`

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -278,10 +278,27 @@ new instances and run that shutdown/startup pair around the replacement.
 
 ### `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `5`). Version 5 adds line
-highlighters and line-granular navigation (`revealLine`); version 4 added
-keyboard modes and docked panes, with API-v3 sidebar names remaining as
-deprecated aliases.
+The API generation this Hunk speaks (currently `6`). Branch on it if you want
+one file to support several Hunk versions. Version 6 adds session behavior,
+terminal-command observation, and live navigation/dialogs in event handlers;
+version 5 added line highlighters and line-granular navigation (`revealLine`);
+version 4 added keyboard modes and docked panes, with API-v3 sidebar names
+remaining as deprecated aliases.
+
+### `hunk.configureSession(options)`
+
+Request host-level behavior for the review session loading the extension. Use
+`{ viewPreferences: "transient" }` for training, demos, and presentations that
+deliberately exercise view controls but must never offer to save their final
+practice state into the user's config. If any loaded extension requests it, the
+shared session skips the save-view-preferences prompt on quit.
+
+```ts
+hunk.configureSession({ viewPreferences: "transient" });
+```
+
+The default is `{ viewPreferences: "default" }`. Like every registration-time
+call, this must run synchronously while the factory is loading.
 
 ### `hunk.registerTheme(theme)`
 
@@ -1461,8 +1478,9 @@ hunk.registerCommand({ id: "pick-hunk", title: "Pick a hunk", key: "ctrl+k" }, a
 ```
 
 Hunk draws the dialog, not you: your text fills the title, body, and choices,
-and the frame carries an `ext <your-id>` attribution line — the same marker
-`notify` toasts use — so a prompt can never present itself as Hunk asking.
+and dialogs from installed extensions carry an `ext <your-id>` attribution line
+— the same marker `notify` toasts use — so a third-party prompt can never present
+itself as Hunk asking. Hunk's own bundled extensions omit that redundant marker.
 
 One dialog is on screen at a time. Concurrent requests queue in call order,
 across extensions too, so a second question waits its turn instead of replacing
@@ -1582,14 +1600,19 @@ the metadata actually parses to.
 
 Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks
 the UI waiting for one. Alongside `cwd` and `notify`, every handler receives
-`ctx.panes`, the same open/close/toggle controls command handlers receive.
-That means a `changeset_loaded` handler can reveal its extension's pane when
-it finds something worth showing — no keypress required.
+`ctx.panes`, live `ctx.navigation`, and attributed `ctx.dialogs`, the same
+controls command handlers receive. `ctx.sidebars` is a deprecated alias for
+`ctx.panes`. That means a `startup` handler can present
+one focused welcome question and navigate to its first example, while a
+`changeset_loaded` handler can reveal a pane when it finds something worth
+showing — no keypress required. Dialog calls made before the mounted app is
+ready resolve to their cancel value with a warning rather than opening later.
 
 | Event                  | Payload                 | When                                                      |
 | ---------------------- | ----------------------- | --------------------------------------------------------- |
 | `startup`              | `{ cwd }`               | once per loaded instance, after its review UI mounts      |
 | `changeset_loaded`     | `{ changeset }`         | first load and every reload                               |
+| `command_executed`     | `{ commandId }`         | whenever a named built-in or extension command runs       |
 | `selection_changed`    | `{ fileId, hunkIndex }` | when the review selection settles (debounced ~150ms)      |
 | `file_viewed`          | `{ file, hunkIndex }`   | when selection settles on a file or a reload replaces it  |
 | `filter_changed`       | `{ filter }`            | whenever the file-filter query changes                    |
@@ -1604,6 +1627,11 @@ it finds something worth showing — no keypress required.
 `selection_changed` is trailing-debounced on purpose: holding `[`/`]` retargets
 the selection many times a second, and handlers only care where the user landed.
 `fileId` and `hunkIndex` are `null` when nothing is selected.
+
+`command_executed` reports the stable command id after its handler is invoked, whether the user
+reached it through a key, a menu, or another host-owned command surface. Listen for ids rather
+than key chords so behavior follows the user's live `[keybindings]` table. Modal widget keys such
+as Escape, Enter, note-editor Ctrl-S, and F10 menu navigation are not commands and do not emit it.
 
 `session_reload`'s `reason` is `"watch"` (the watcher saw the source change),
 `"daemon"` (an agent command through the session broker), or `"manual"` (the
@@ -1625,8 +1653,10 @@ The replacement instance receives `startup` after its review is mounted.
 `hunk.events` is a small bus shared by every loaded extension. Use it to
 coordinate extensions without coupling them through a command or global state.
 Names are open-ended, so namespace them with your extension id. Listeners get
-the same `ctx.panes` controls as lifecycle handlers; delivery is fire-and-forget
-and one listener's failure is reported without stopping the others. Events an
+the same `ctx.panes`, `ctx.navigation`, and `ctx.dialogs` controls as lifecycle
+handlers; `ctx.sidebars` remains a deprecated pane alias. Delivery is
+fire-and-forget and one listener's failure is reported without stopping the
+others. Events an
 extension emits while factories are loading are queued until every extension
 has had a chance to subscribe.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1556,9 +1556,12 @@ has moved or become unsafe.
 
 `writeDocument` verifies the target, asks for consent through the attributed
 `ctx.dialogs` queue, then verifies it again before writing. The second check
-prevents deletion and symlink-swap races while the dialog is open. A successful
-write starts a session reload; the write promise may settle before that reload
-finishes.
+prevents deletion and symlink-swap races while the dialog is open. Authority is
+checked immediately before the filesystem call; once that irreversible write
+starts, its actual success or failure wins even if another reload happens, and
+graceful shutdown waits for it to settle. A successful write queues
+reconciliation of the review then active, and the write promise may settle
+before that reload finishes.
 
 A declined prompt returns `cancelled`, an ineligible or unsafe target returns
 `unavailable`, and an attempted write failure returns `failed` with a
@@ -1609,8 +1612,10 @@ showing — no keypress required. Dialog calls made before the mounted app is
 ready resolve to their cancel value with a warning rather than opening later.
 Controls retained across a review or extension-registry replacement expire:
 navigation and pane mutations warn and do nothing, dialogs resolve to their
-normal cancel value, and workspace reads/writes return `null`/`unavailable`
-instead of acting on replacement content.
+normal cancel value, and workspace reads or not-yet-started writes return
+`null`/`unavailable` instead of acting on replacement content. Once a consented
+filesystem write starts, it reports its actual outcome and success reconciles
+the review then active.
 
 | Event                  | Payload                 | When                                                      |
 | ---------------------- | ----------------------- | --------------------------------------------------------- |

--- a/packages/session-broker/src/connection.test.ts
+++ b/packages/session-broker/src/connection.test.ts
@@ -21,12 +21,14 @@ type TestServerMessage = SessionServerMessage<"annotate", { summary: string }>;
 class TestSocket implements SessionBrokerSocketLike {
   readyState = 0;
   sent: string[] = [];
+  throwOnSend = false;
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: unknown }) => void) | null = null;
   onclose: ((event: { code: number; reason: string }) => void) | null = null;
   onerror: (() => void) | null = null;
 
   send(data: string) {
+    if (this.throwOnSend) throw new Error("socket exploded");
     this.sent.push(data);
   }
 
@@ -104,6 +106,35 @@ describe("session broker connection", () => {
       updatedAt: "2026-04-15T00:00:01.000Z",
       state: { selectedIndex: 1 },
     });
+  });
+
+  test("keeps the previous registration when replacement send throws", () => {
+    const socket = new TestSocket();
+    const registration = createRegistration();
+    const connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration,
+      snapshot: createSnapshot(),
+    });
+    connection.start();
+    socket.emitOpen();
+    socket.throwOnSend = true;
+
+    expect(() =>
+      connection.replaceSession(
+        { ...registration, sessionId: "session-2" },
+        { ...createSnapshot(), state: { selectedIndex: 2 } },
+      ),
+    ).toThrow("socket exploded");
+    expect(connection.getRegistration()).toBe(registration);
+    connection.stop();
   });
 
   test("queues broker commands until the app bridge is ready", async () => {

--- a/packages/session-broker/src/connection.ts
+++ b/packages/session-broker/src/connection.ts
@@ -104,15 +104,16 @@ export class SessionBrokerConnection<
   }
 
   replaceSession(registration: SessionRegistration<Info>, snapshot: SessionSnapshot<State>) {
-    this.registration = registration;
-    this.snapshot = snapshot;
     // Re-register instead of sending only a snapshot because selectors like cwd, repoRoot, and the
-    // session id itself live in the registration envelope.
+    // session id itself live in the registration envelope. Send before committing local state so
+    // a throwing socket keeps the previous registration and snapshot coherent.
     this.send({
       type: "register",
       registration,
       snapshot,
     });
+    this.registration = registration;
+    this.snapshot = snapshot;
   }
 
   updateSnapshot(snapshot: SessionSnapshot<State>) {

--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -37,6 +37,7 @@ import type {
   ExtensionPaneProps,
   ExtensionPaneSize,
   ExtensionReviewSelection,
+  ExtensionSessionOptions,
   ExtensionVerticalPane,
   ExtensionVcsAdapter,
   ExtensionVcsDiffInput,
@@ -48,6 +49,8 @@ import type {
 } from "hunkdiff/extension";
 
 export default function (hunk: HunkExtensionAPI) {
+  const sessionOptions: ExtensionSessionOptions = { viewPreferences: "transient" };
+  hunk.configureSession(sessionOptions);
   const noSelection: ExtensionReviewSelection = { file: null, hunkIndex: null };
   hunk.log(noSelection.file === null ? "nothing selected" : noSelection.file.path);
 
@@ -290,8 +293,14 @@ export default function (hunk: HunkExtensionAPI) {
     files: changeset.files.filter((file) => !file.path.endsWith(".lock")),
   }));
 
-  hunk.on("startup", (event, ctx) => {
+  hunk.on("startup", async (event, ctx) => {
     ctx.notify(\`started in \${event.cwd}\`, "info");
+    if (await ctx.dialogs.confirm({ title: "Reveal the first line?" })) {
+      ctx.navigation.revealLine("file-id", "new", 1);
+    }
+  });
+  hunk.on("command_executed", ({ commandId }) => {
+    hunk.log(\`terminal command \${commandId}\`);
   });
   hunk.on("changeset_loaded", (event) => {
     hunk.log(\`loaded \${event.changeset.files.length} files\`);

--- a/skills/hunk-extensions/SKILL.md
+++ b/skills/hunk-extensions/SKILL.md
@@ -93,22 +93,22 @@ bad or duplicate id is skipped with a startup notice.
 
 ## Pick the touchpoint
 
-| To do this                                               | Call                                               |
-| -------------------------------------------------------- | -------------------------------------------------- |
-| Keep demo/training view settings temporary               | `hunk.configureSession(options)`                   |
-| Add a selectable color theme                             | `hunk.registerTheme(theme)`                        |
-| Highlight an unrecognized file extension                 | `hunk.registerFileLanguage(ext, lang)`             |
-| Support another VCS (`git`/`jj`/`sl` are reserved)       | `hunk.registerVcsAdapter(adapter)`                 |
-| Add a navigation/list/status pane beside the review      | `hunk.registerPane(pane)`                          |
-| Present a file as something other than a raw diff        | `hunk.registerFileView(view)` (experimental)       |
-| Mark character ranges inside diff lines                  | `hunk.registerLineHighlighter(highlighter)`        |
-| Interpret review keys as a temporary global mode         | `hunk.registerKeyboardMode(mode)`                  |
-| Bind a key / add an Extensions-menu entry                | `hunk.registerCommand(command, handler)`           |
-| Hide, reorder, retitle files before review               | `hunk.transformChangeset(fn)`                      |
-| React to loads, selection, view movement, notes, reloads | `hunk.on(event, handler)`                          |
-| Coordinate with another loaded extension                 | `hunk.events.emit` / `hunk.events.on`              |
-| Read user-supplied settings                              | `hunk.config` (`[extension.<id>]` table)           |
-| Branch on the API generation (currently `6`)             | `hunk.apiVersion`                                  |
+| To do this                                               | Call                                         |
+| -------------------------------------------------------- | -------------------------------------------- |
+| Keep demo/training view settings temporary               | `hunk.configureSession(options)`             |
+| Add a selectable color theme                             | `hunk.registerTheme(theme)`                  |
+| Highlight an unrecognized file extension                 | `hunk.registerFileLanguage(ext, lang)`       |
+| Support another VCS (`git`/`jj`/`sl` are reserved)       | `hunk.registerVcsAdapter(adapter)`           |
+| Add a navigation/list/status pane beside the review      | `hunk.registerPane(pane)`                    |
+| Present a file as something other than a raw diff        | `hunk.registerFileView(view)` (experimental) |
+| Mark character ranges inside diff lines                  | `hunk.registerLineHighlighter(highlighter)`  |
+| Interpret review keys as a temporary global mode         | `hunk.registerKeyboardMode(mode)`            |
+| Bind a key / add an Extensions-menu entry                | `hunk.registerCommand(command, handler)`     |
+| Hide, reorder, retitle files before review               | `hunk.transformChangeset(fn)`                |
+| React to loads, selection, view movement, notes, reloads | `hunk.on(event, handler)`                    |
+| Coordinate with another loaded extension                 | `hunk.events.emit` / `hunk.events.on`        |
+| Read user-supplied settings                              | `hunk.config` (`[extension.<id>]` table)     |
+| Branch on the API generation (currently `6`)             | `hunk.apiVersion`                            |
 
 Registration is only valid while the factory runs — Hunk seals the API object
 afterwards.
@@ -176,6 +176,10 @@ Most extension bugs are one of these:
 - **Handler state must live outside the component.** Panes unmount when closed;
   bridge module-level state into React with `useSyncExternalStore` and immutable
   snapshots (`review-triage/index.tsx` is the working version).
+- **Retained review controls expire on reload.** An old handler cannot control
+  replacement content: pane/navigation calls become inert, dialogs cancel, and
+  workspace reads/writes return `null`/`unavailable`. `shutdown` runs after that
+  revocation, so use it only to release extension-owned resources.
 - **A reload keeps your factory and renames the files.** Factories re-run only
   after a trust grant or a cwd change, so module state survives — but a file's
   `id` encodes its position in the changeset, so a reload that adds or drops a

--- a/skills/hunk-extensions/SKILL.md
+++ b/skills/hunk-extensions/SKILL.md
@@ -93,21 +93,22 @@ bad or duplicate id is skipped with a startup notice.
 
 ## Pick the touchpoint
 
-| To do this                                              | Call                                         |
-| ------------------------------------------------------- | -------------------------------------------- |
-| Add a selectable color theme                            | `hunk.registerTheme(theme)`                  |
-| Highlight an unrecognized file extension                | `hunk.registerFileLanguage(ext, lang)`       |
-| Support another VCS (`git`/`jj`/`sl` are reserved)      | `hunk.registerVcsAdapter(adapter)`           |
-| Add a navigation/list/status pane beside the review     | `hunk.registerPane(pane)`                    |
-| Present a file as something other than a raw diff       | `hunk.registerFileView(view)` (experimental) |
-| Mark character ranges inside diff lines                 | `hunk.registerLineHighlighter(highlighter)`  |
-| Interpret review keys as a temporary global mode        | `hunk.registerKeyboardMode(mode)`            |
-| Bind a key / add an Extensions-menu entry               | `hunk.registerCommand(command, handler)`     |
-| Hide, reorder, retitle files before review              | `hunk.transformChangeset(fn)`                |
-| React to loads, selection, viewed files, notes, reloads | `hunk.on(event, handler)`                    |
-| Coordinate with another loaded extension                | `hunk.events.emit` / `hunk.events.on`        |
-| Read user-supplied settings                             | `hunk.config` (`[extension.<id>]` table)     |
-| Branch on the API generation (currently `5`)            | `hunk.apiVersion`                            |
+| To do this                                               | Call                                               |
+| -------------------------------------------------------- | -------------------------------------------------- |
+| Keep demo/training view settings temporary               | `hunk.configureSession(options)`                   |
+| Add a selectable color theme                             | `hunk.registerTheme(theme)`                        |
+| Highlight an unrecognized file extension                 | `hunk.registerFileLanguage(ext, lang)`             |
+| Support another VCS (`git`/`jj`/`sl` are reserved)       | `hunk.registerVcsAdapter(adapter)`                 |
+| Add a navigation/list/status pane beside the review      | `hunk.registerPane(pane)`                          |
+| Present a file as something other than a raw diff        | `hunk.registerFileView(view)` (experimental)       |
+| Mark character ranges inside diff lines                  | `hunk.registerLineHighlighter(highlighter)`        |
+| Interpret review keys as a temporary global mode         | `hunk.registerKeyboardMode(mode)`                  |
+| Bind a key / add an Extensions-menu entry                | `hunk.registerCommand(command, handler)`           |
+| Hide, reorder, retitle files before review               | `hunk.transformChangeset(fn)`                      |
+| React to loads, selection, view movement, notes, reloads | `hunk.on(event, handler)`                          |
+| Coordinate with another loaded extension                 | `hunk.events.emit` / `hunk.events.on`              |
+| Read user-supplied settings                              | `hunk.config` (`[extension.<id>]` table)           |
+| Branch on the API generation (currently `6`)             | `hunk.apiVersion`                                  |
 
 Registration is only valid while the factory runs — Hunk seals the API object
 afterwards.
@@ -119,7 +120,8 @@ transform — gets `ctx.cwd` and `ctx.notify(message, type?)`. A file view's
 `matches` and `layout` get no context at all. Beyond that:
 
 - **Event and bus handlers** also get `ctx.panes` (open/close/toggle/isOpen on
-  any pane) and `ctx.events.emit`.
+  any pane), live `ctx.navigation`, attributed `ctx.dialogs`, and
+  `ctx.events.emit`. `ctx.sidebars` is a deprecated alias for `ctx.panes`.
 - **Command handlers** get `ctx.panes`, `ctx.fileViews` (select/toggle/isActive/
   refresh/enterMode/exitMode), `ctx.highlights` (refresh prepared line marks,
   whole or `{ fileId }`-scoped), `ctx.selection` (a snapshot of file + hunk index),

--- a/skills/hunk-extensions/SKILL.md
+++ b/skills/hunk-extensions/SKILL.md
@@ -178,8 +178,11 @@ Most extension bugs are one of these:
   snapshots (`review-triage/index.tsx` is the working version).
 - **Retained review controls expire on reload.** An old handler cannot control
   replacement content: pane/navigation calls become inert, dialogs cancel, and
-  workspace reads/writes return `null`/`unavailable`. `shutdown` runs after that
-  revocation, so use it only to release extension-owned resources.
+  workspace reads or not-yet-started writes return `null`/`unavailable`. A
+  consented write already in progress reports its real outcome, holds graceful
+  exit until it settles, and reconciles the active review on success. `shutdown`
+  runs after revocation, so use it only
+  to release extension-owned resources.
 - **A reload keeps your factory and renames the files.** Factories re-run only
   after a trust grant or a cwd change, so module state survives — but a file's
   `id` encodes its position in the changeset, so a reload that adds or drops a

--- a/src/app/extensionBootstrap.test.ts
+++ b/src/app/extensionBootstrap.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import type { HunkConfigResolution } from "../core/config";
+import type { CliInput } from "../core/types";
+import { createEmptyExtensionLoadResult } from "../extensions/types";
+import { resolveConfiguredExtensions } from "./extensionBootstrap";
+import { getBundledVcsCatalog } from "./vcsCatalog";
+
+/** Build the normalized config needed before extension discovery starts. */
+function createTestConfig(input: CliInput): HunkConfigResolution {
+  return {
+    input,
+    customThemes: [],
+    extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+    keybindings: {},
+  };
+}
+
+describe("resolveConfiguredExtensions", () => {
+  test("retires provisional authority when the loader rejects before returning it", async () => {
+    const input: CliInput = { kind: "vcs", staged: false, options: { vcs: "git" } };
+    const provisional = createEmptyExtensionLoadResult("/repo");
+    let shutdowns = 0;
+    let published = false;
+    provisional.registry.eventHandlers.shutdown.push({
+      extensionId: "probe",
+      handler: () => {
+        shutdowns += 1;
+      },
+    });
+
+    await expect(
+      resolveConfiguredExtensions(
+        {
+          runtimeInput: input,
+          configured: createTestConfig(input),
+          cwd: "/repo",
+          baseVcsCatalog: getBundledVcsCatalog(),
+          onProvisionalLoad: (result) => {
+            published = result === provisional;
+          },
+        },
+        {
+          loadStartupExtensionsImpl: async (options) => {
+            options.onProvisionalLoad?.(provisional);
+            throw new Error("load exploded");
+          },
+        },
+      ),
+    ).rejects.toThrow("load exploded");
+
+    expect(published).toBe(true);
+    expect(provisional.registry.eventBusPhase).toBe("closed");
+    expect(shutdowns).toBe(1);
+  });
+
+  test("stops before a later staged registry after the caller becomes inactive", async () => {
+    const input: CliInput = { kind: "vcs", staged: false, options: { vcs: "git" } };
+    const configured = createTestConfig(input);
+    const provisional = createEmptyExtensionLoadResult("/repo");
+    provisional.registry.vcsAdapters.push({
+      extensionId: "probe",
+      adapter: { id: "probe", name: "Probe", detect: () => null, operations: {} },
+    });
+    let active = true;
+    let loads = 0;
+
+    await expect(
+      resolveConfiguredExtensions(
+        {
+          runtimeInput: input,
+          configured,
+          cwd: "/repo",
+          baseVcsCatalog: getBundledVcsCatalog(),
+          assertActive: () => {
+            if (!active) throw new Error("caller retired");
+          },
+        },
+        {
+          findProjectRootCandidateImpl: () => "/recognized",
+          loadStartupExtensionsImpl: async (options) => {
+            loads += 1;
+            options.onProvisionalLoad?.(provisional);
+            active = false;
+            return provisional;
+          },
+        },
+      ),
+    ).rejects.toThrow("caller retired");
+
+    expect(loads).toBe(1);
+    expect(provisional.registry.eventBusPhase).toBe("closed");
+  });
+
+  test("retires distinct first and second pass registries when the second loader rejects", async () => {
+    const input: CliInput = { kind: "vcs", staged: false, options: { vcs: "git" } };
+    const configured = createTestConfig(input);
+    const first = createEmptyExtensionLoadResult("/repo");
+    const second = createEmptyExtensionLoadResult("/repo");
+    const shutdowns: string[] = [];
+    first.registry.vcsAdapters.push({
+      extensionId: "probe",
+      adapter: { id: "probe", name: "Probe", detect: () => null, operations: {} },
+    });
+    first.registry.eventHandlers.shutdown.push({
+      extensionId: "first",
+      handler: () => {
+        shutdowns.push("first");
+      },
+    });
+    second.registry.eventHandlers.shutdown.push({
+      extensionId: "second",
+      handler: () => {
+        shutdowns.push("second");
+      },
+    });
+    let loads = 0;
+
+    await expect(
+      resolveConfiguredExtensions(
+        {
+          runtimeInput: input,
+          configured,
+          cwd: "/repo",
+          baseVcsCatalog: getBundledVcsCatalog(),
+        },
+        {
+          findProjectRootCandidateImpl: () => "/recognized",
+          resolveConfiguredCliInputImpl: () => ({
+            ...configured,
+            projectRoot: "/recognized",
+          }),
+          loadStartupExtensionsImpl: async (options) => {
+            loads += 1;
+            const provisional = loads === 1 ? first : second;
+            options.onProvisionalLoad?.(provisional);
+            if (loads === 2) throw new Error("second pass exploded");
+            return provisional;
+          },
+        },
+      ),
+    ).rejects.toThrow("second pass exploded");
+
+    expect(loads).toBe(2);
+    expect(first.registry.eventBusPhase).toBe("closed");
+    expect(second.registry.eventBusPhase).toBe("closed");
+    expect(shutdowns.sort()).toEqual(["first", "second"]);
+  });
+});

--- a/src/app/extensionBootstrap.ts
+++ b/src/app/extensionBootstrap.ts
@@ -19,6 +19,10 @@ export interface ResolveConfiguredExtensionsOptions {
   /** Adapters already known before this load, such as the current live-session catalog. */
   discoveryCatalog?: VcsCatalog;
   notifications?: ExtensionNotificationHub;
+  /** Publish provisional ownership before imports or asynchronous factories can suspend. */
+  onProvisionalLoad?: (result: ExtensionLoadResult) => void;
+  /** Throw when the caller's lifetime ended so no later staged registry can be created. */
+  assertActive?: () => void;
 }
 
 export interface ResolveConfiguredExtensionsDeps {
@@ -54,7 +58,14 @@ export async function resolveConfiguredExtensions(
     });
 
   let extensions: ExtensionLoadResult | undefined;
+  let provisionalExtensions: ExtensionLoadResult | undefined;
+  /** Retain loader ownership locally before forwarding it to a caller that may also suspend. */
+  const ownProvisionalLoad = (result: ExtensionLoadResult) => {
+    provisionalExtensions = result;
+    options.onProvisionalLoad?.(result);
+  };
   try {
+    options.assertActive?.();
     extensions = await loadStartupExtensionsImpl({
       extensions: configured.extensions,
       cwd: options.cwd,
@@ -64,8 +75,10 @@ export async function resolveConfiguredExtensions(
       reservedExtensionIds: options.baseVcsCatalog.reservedIds,
       notifications: options.notifications,
       deferEventBusBinding: true,
+      onProvisionalLoad: ownProvisionalLoad,
     });
 
+    options.assertActive?.();
     const provisionalAdapters = resolveExtensionVcsAdapters(
       extensions.registry,
       options.baseVcsCatalog,
@@ -79,6 +92,7 @@ export async function resolveConfiguredExtensions(
         env: options.env,
         vcsCatalog: provisionalCatalog,
       });
+      options.assertActive?.();
       extensions = await loadStartupExtensionsImpl({
         extensions: configured.extensions,
         cwd: options.cwd,
@@ -88,14 +102,22 @@ export async function resolveConfiguredExtensions(
         reservedExtensionIds: options.baseVcsCatalog.reservedIds,
         notifications: extensions.notifications,
         previousLoad: extensions,
+        onProvisionalLoad: ownProvisionalLoad,
       });
     } else {
       bindExtensionEventBus(extensions);
     }
 
+    options.assertActive?.();
     return { configured, extensions };
   } catch (error) {
-    await retireExtensionLoadResult(extensions);
+    // A staged loader can reject after publishing a new registry but before
+    // assigning its result. Retire the latest provisional wrapper first, then
+    // any distinct earlier pass; registry-global retirement deduplicates aliases.
+    await retireExtensionLoadResult(provisionalExtensions);
+    if (extensions?.registry !== provisionalExtensions?.registry) {
+      await retireExtensionLoadResult(extensions);
+    }
     throw error;
   }
 }

--- a/src/app/review/producer.test.ts
+++ b/src/app/review/producer.test.ts
@@ -89,6 +89,64 @@ describe("review producer generations", () => {
     expect(files).toHaveLength(1);
   });
 
+  test("prepares a generation without advancing until a non-throwing commit", () => {
+    const { producer } = createProducer();
+    const before = producer.getPublication();
+    const prepared = producer.preparePublication({
+      files: [createTestDiffFile({ before: BEFORE, after: lines("alpha", "BETA!") })],
+      sourceLabel: "/repo",
+    });
+
+    expect(producer.getPublication()).toBe(before);
+    expect(parseReviewGeneration(prepared.publication.generation)?.sequence).toBe(1);
+
+    expect(producer.reservePublication(prepared).commit()).toBe(prepared.publication);
+    expect(producer.getPublication()).toBe(prepared.publication);
+  });
+
+  test("can detach the previous store until a prepared generation mounts", () => {
+    const { producer } = createProducer();
+    producer.attachStore(createReviewStore(producer.getPublication().document));
+    const prepared = producer.preparePublication({
+      files: [createTestDiffFile({ before: BEFORE, after: AFTER })],
+      sourceLabel: "/repo",
+    });
+
+    producer.reservePublication(prepared).commit({ detachStore: true });
+
+    expect(producer.getReviewState()).toBeUndefined();
+    expect(() => producer.applyIntent({ type: "filter/set", filter: "stale" })).toThrow(
+      "no review state",
+    );
+  });
+
+  test("refuses stale, foreign, active, and reused publication preparations", () => {
+    const { producer } = createProducer();
+    const other = new ReviewProducer({ files: [] }, { producerId: "other" });
+    const first = producer.preparePublication({ files: [] });
+    const competing = producer.preparePublication({ files: [] });
+
+    expect(() => other.reservePublication(first)).toThrow("another producer");
+    const reservation = producer.reservePublication(first);
+    expect(() => producer.reservePublication(competing)).toThrow("another reservation is active");
+    reservation.commit();
+    expect(() => producer.reservePublication(competing)).toThrow("stale");
+    expect(() => producer.reservePublication(first)).toThrow("more than once");
+  });
+
+  test("cancels a reservation without advancing and cannot reuse its preparation", () => {
+    const { producer } = createProducer();
+    const before = producer.getPublication();
+    const prepared = producer.preparePublication({ files: [] });
+    const reservation = producer.reservePublication(prepared);
+
+    reservation.cancel();
+    reservation.commit();
+
+    expect(producer.getPublication()).toBe(before);
+    expect(() => producer.reservePublication(prepared)).toThrow("more than once");
+  });
+
   test("retires the previous generation's resources", async () => {
     const { producer } = createProducer();
     const stale = producer.getPublication();

--- a/src/app/review/producer.ts
+++ b/src/app/review/producer.ts
@@ -81,6 +81,34 @@ export interface PublishReviewInput {
   sourceLabel?: string;
 }
 
+/** Fully validated next generation that can be reserved without changing current publication. */
+export interface PreparedReviewPublication {
+  readonly identity: ReviewGenerationIdentity;
+  readonly publication: ReviewPublication;
+  readonly resourceStore: ReviewResourceStore;
+}
+
+export interface ReviewPublicationCommitOptions {
+  detachStore?: boolean;
+}
+
+/** One producer-owned reservation whose final commit is synchronous and non-throwing. */
+export interface ReservedReviewPublication {
+  commit(options?: ReviewPublicationCommitOptions): ReviewPublication;
+  cancel(): void;
+}
+
+interface PreparedReviewPublicationOwnership {
+  producer: ReviewProducer;
+  baseGeneration: string;
+  state: "prepared" | "reserved" | "settled";
+}
+
+const preparedReviewPublicationOwnership = new WeakMap<
+  PreparedReviewPublication,
+  PreparedReviewPublicationOwnership
+>();
+
 /** How many resource ids one bulk request may name at once. */
 export const MAX_REVIEW_RESOURCE_BATCH = 512;
 
@@ -91,6 +119,7 @@ export class ReviewProducer {
   private publication: ReviewPublication;
   private resourceStore: ReviewResourceStore;
   private store: ReviewStore | undefined;
+  private publicationReservation: object | undefined;
 
   constructor(input: PublishReviewInput, options: ReviewProducerOptions = {}) {
     this.digest = options.digest ?? nodeReviewDigest;
@@ -117,6 +146,81 @@ export class ReviewProducer {
     };
   }
 
+  /** Validate and materialize the next generation without changing what this producer serves. */
+  preparePublication(input: PublishReviewInput): PreparedReviewPublication {
+    const previous = this.getPublicationAddress();
+    const identity = nextReviewGeneration(this.identity);
+    const generation = formatReviewGeneration(identity);
+    // A new generation restarts revisions, so the check is about the generation step; the
+    // contract states that revisions are only comparable within one.
+    assertReviewPublicationAdvance(previous, { generation, stateRevision: 0 });
+
+    const publication = buildReviewPublication({
+      files: input.files,
+      generation,
+      ...(input.sourceLabel !== undefined ? { sourceLabel: input.sourceLabel } : {}),
+    });
+    const prepared: PreparedReviewPublication = {
+      identity,
+      publication,
+      resourceStore: this.createResourceStore(publication),
+    };
+    preparedReviewPublicationOwnership.set(prepared, {
+      producer: this,
+      baseGeneration: previous.generation,
+      state: "prepared",
+    });
+    return prepared;
+  }
+
+  /** Reserve one owned, current preparation before a caller exposes it through a transport. */
+  reservePublication(prepared: PreparedReviewPublication): ReservedReviewPublication {
+    const ownership = preparedReviewPublicationOwnership.get(prepared);
+    if (!ownership || ownership.producer !== this) {
+      throw new Error("Cannot reserve a review publication prepared by another producer.");
+    }
+    if (ownership.state !== "prepared") {
+      throw new Error("Cannot reserve a review publication more than once.");
+    }
+    if (this.publicationReservation) {
+      throw new Error("Cannot reserve a review publication while another reservation is active.");
+    }
+    if (ownership.baseGeneration !== this.publication.generation) {
+      throw new Error("Cannot reserve a stale review publication.");
+    }
+
+    const reservation = {};
+    this.publicationReservation = reservation;
+    ownership.state = "reserved";
+    let settled = false;
+
+    /** Settle this exact reservation once, optionally publishing its prepared generation. */
+    const settle = (
+      commit: boolean,
+      options: ReviewPublicationCommitOptions = {},
+    ): ReviewPublication => {
+      if (settled) return this.publication;
+      settled = true;
+      ownership.state = "settled";
+      if (this.publicationReservation !== reservation) return this.publication;
+      this.publicationReservation = undefined;
+      if (!commit) return this.publication;
+
+      this.identity = prepared.identity;
+      this.publication = prepared.publication;
+      this.resourceStore = prepared.resourceStore;
+      if (options.detachStore) this.store = undefined;
+      return this.publication;
+    };
+
+    return {
+      commit: (options) => settle(true, options),
+      cancel: () => {
+        settle(false);
+      },
+    };
+  }
+
   /**
    * Publish the next generation of this review.
    *
@@ -126,21 +230,8 @@ export class ReviewProducer {
    * describe a review nobody is looking at any more.
    */
   publish(input: PublishReviewInput): ReviewPublication {
-    const previous = this.getPublicationAddress();
-    const identity = nextReviewGeneration(this.identity);
-    const generation = formatReviewGeneration(identity);
-    // A new generation restarts revisions, so the check is about the generation step; the
-    // contract states that revisions are only comparable within one.
-    assertReviewPublicationAdvance(previous, { generation, stateRevision: 0 });
-
-    this.identity = identity;
-    this.publication = buildReviewPublication({
-      files: input.files,
-      generation,
-      ...(input.sourceLabel !== undefined ? { sourceLabel: input.sourceLabel } : {}),
-    });
-    this.resourceStore = this.createResourceStore();
-    return this.publication;
+    const prepared = this.preparePublication(input);
+    return this.reservePublication(prepared).commit();
   }
 
   /**
@@ -232,10 +323,10 @@ export class ReviewProducer {
     return this.resourceStore.materializeAll(resourceIds);
   }
 
-  /** Build the resource store that belongs to the current generation. */
-  private createResourceStore() {
+  /** Build the resource store that belongs to one prepared or current generation. */
+  private createResourceStore(publication = this.publication) {
     return new ReviewResourceStore({
-      publication: this.publication,
+      publication,
       digest: this.digest,
       ...(this.resourceConcurrency !== undefined ? { concurrency: this.resourceConcurrency } : {}),
     });

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -83,6 +83,7 @@ export type {
   ExtensionDialogs,
   ExtensionInputOptions,
   ExtensionSelectOptions,
+  ExtensionSessionOptions,
   ExtensionNotifyType,
   ExtensionPaintTheme,
   ExtensionPane,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -1553,9 +1553,13 @@ export interface ExtensionWorkspace {
    * On success Hunk reloads the session the same way the refresh key does, so
    * the review an extension sees afterwards reflects what it wrote. That holds
    * for every write that can happen: a session whose review could not be
-   * rebuilt refuses writes rather than accepting one it would then hide. The
-   * returned promise settles on the write itself, not on the reload — a handler
-   * that resumes immediately is looking at the changeset it was called with.
+   * rebuilt refuses writes rather than accepting one it would then hide.
+   * Authority is checked immediately before the filesystem call; once that
+   * irreversible write starts, the promise reports its actual outcome even if
+   * another reload wins meanwhile, and success reconciles the review then active.
+   * Graceful shutdown waits for a started write to settle. The promise settles
+   * on the write itself, not on its follow-up reload — a handler that
+   * resumes immediately is looking at the changeset it was called with.
    *
    * A filesystem that refuses the write resolves `"failed"` with a
    * human-readable `detail`. The promise **rejects** only for a malformed
@@ -1621,8 +1625,10 @@ export interface ExtensionCommandContext extends ExtensionContext {
    * user's consent.
    *
    * Host-mediated on purpose: the file is named by review id, a write asks the
-   * user first, and the review reloads after a successful write. Retained
-   * controls expire with this review generation (`null`/`"unavailable"`).
+   * user first, and the review reloads after a successful write. Retained reads
+   * and writes that have not started expire with this review generation
+   * (`null`/`"unavailable"`); an irreversible write already in progress reports
+   * its real filesystem outcome.
    */
   readonly workspace: ExtensionWorkspace;
 }

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -21,7 +21,7 @@
  * Extensions can branch on `hunk.apiVersion` so a newer Hunk can keep loading
  * older extensions without guessing at their expectations.
  */
-export const HUNK_EXTENSION_API_VERSION = 5;
+export const HUNK_EXTENSION_API_VERSION = 6;
 export type HunkExtensionApiVersion = typeof HUNK_EXTENSION_API_VERSION;
 
 export type ExtensionNotifyType = "info" | "warning" | "error";
@@ -1611,8 +1611,9 @@ export interface ExtensionCommandContext extends ExtensionContext {
   /**
    * Ask the user a question and await the answer.
    *
-   * Valid for the whole life of the handler's promise, so a handler may open
-   * several dialogs in sequence with work in between.
+   * Valid for the handler's promise while this review generation remains
+   * current, so a handler may open several dialogs in sequence with work in
+   * between. A reload expires retained controls and returns cancel values.
    */
   readonly dialogs: ExtensionDialogs;
   /**
@@ -1620,7 +1621,8 @@ export interface ExtensionCommandContext extends ExtensionContext {
    * user's consent.
    *
    * Host-mediated on purpose: the file is named by review id, a write asks the
-   * user first, and the review reloads after a successful write.
+   * user first, and the review reloads after a successful write. Retained
+   * controls expire with this review generation (`null`/`"unavailable"`).
    */
   readonly workspace: ExtensionWorkspace;
 }
@@ -1648,7 +1650,7 @@ export interface ExtensionEventBus {
   emit<Payload = unknown>(event: string, payload: Payload): void;
 }
 
-/** Context lifecycle and bus listeners receive, including live host controls. */
+/** Context lifecycle and bus listeners receive, with controls scoped to this review generation. */
 export interface ExtensionEventContext extends ExtensionContext {
   panes: ExtensionPaneControls;
   /** @deprecated Use panes. */
@@ -1693,7 +1695,7 @@ export interface ExtensionReviewNote {
 export interface ExtensionEventPayloads {
   startup: { cwd: string };
   changeset_loaded: { changeset: ExtensionChangeset };
-  /** A named built-in or extension command was invoked by key, menu, or another host surface. */
+  /** A named built-in or extension command was dispatched in this terminal host. */
   command_executed: { commandId: string };
   selection_changed: { fileId: string | null; hunkIndex: number | null };
   /** The review stream settled on a different file. */

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -1410,12 +1410,12 @@ export interface ExtensionInputOptions {
 /**
  * Ask the user questions from a command handler, one modal at a time.
  *
- * Every dialog is drawn by Hunk, not by the extension, and carries an
- * attribution line naming the extension that raised it — a prompt cannot
- * present itself as Hunk asking. Only one dialog is on screen at a time:
+ * Every dialog is drawn by Hunk, not by the extension. Dialogs from installed
+ * extensions carry an attribution line naming their source, so a third-party
+ * prompt cannot present itself as Hunk asking; Hunk-owned bundled extensions
+ * omit that redundant marker. Only one dialog is on screen at a time:
  * concurrent requests queue in call order (FIFO), including across extensions,
- * so a second question waits for the first to be answered rather than
- * replacing it.
+ * so a second question waits for the first to be answered rather than replacing it.
  *
  * Escape always cancels, resolving the cancel value (`false`, or `null`).
  * Enter accepts: the confirm action, the highlighted option, or the typed text.
@@ -1566,6 +1566,18 @@ export interface ExtensionWorkspace {
   writeDocument(request: ExtensionWorkspaceWriteRequest): Promise<ExtensionWorkspaceWriteResult>;
 }
 
+/** Host-level behavior one extension may request for the current review session. */
+export interface ExtensionSessionOptions {
+  /**
+   * Treat view-setting changes as temporary practice or presentation state.
+   *
+   * When `"transient"`, Hunk never offers to write the session's final view
+   * settings into the user's config on quit. Any extension requesting
+   * transient behavior makes the shared session transient.
+   */
+  viewPreferences?: "default" | "transient";
+}
+
 /** What a command handler receives when its key fires. */
 export interface ExtensionCommandContext extends ExtensionContext {
   /** Live access to the public built-in command table. */
@@ -1636,11 +1648,15 @@ export interface ExtensionEventBus {
   emit<Payload = unknown>(event: string, payload: Payload): void;
 }
 
-/** Context lifecycle and bus listeners receive, including live pane controls. */
+/** Context lifecycle and bus listeners receive, including live host controls. */
 export interface ExtensionEventContext extends ExtensionContext {
   panes: ExtensionPaneControls;
   /** @deprecated Use panes. */
   sidebars: ExtensionSidebarControls;
+  /** Navigate the live review from lifecycle-driven guides and coordinators. */
+  readonly navigation: ExtensionReviewNavigation;
+  /** Ask attributed, FIFO-queued questions from lifecycle and bus handlers. */
+  readonly dialogs: ExtensionDialogs;
   events: Pick<ExtensionEventBus, "emit">;
 }
 
@@ -1677,6 +1693,8 @@ export interface ExtensionReviewNote {
 export interface ExtensionEventPayloads {
   startup: { cwd: string };
   changeset_loaded: { changeset: ExtensionChangeset };
+  /** A named built-in or extension command was invoked by key, menu, or another host surface. */
+  command_executed: { commandId: string };
   selection_changed: { fileId: string | null; hunkIndex: number | null };
   /** The review stream settled on a different file. */
   file_viewed: { file: ExtensionDiffFile; hunkIndex: number | null };
@@ -1716,6 +1734,8 @@ export type ExtensionEventHandler<Event extends ExtensionEventName = ExtensionEv
  */
 export interface HunkExtensionAPI {
   readonly apiVersion: HunkExtensionApiVersion;
+  /** Configure host-level behavior for the review session loading this extension. */
+  configureSession(options: ExtensionSessionOptions): void;
   /** Contribute one selectable theme. */
   registerTheme(theme: ExtensionThemeConfig): void;
   /** Map one file extension (with or without a leading dot) to a highlight language. */

--- a/src/extensions/apply.test.ts
+++ b/src/extensions/apply.test.ts
@@ -23,6 +23,7 @@ import {
   resolveExtensionKeyboardModes,
   resolveExtensionLineHighlighters,
   resolveExtensionPanes,
+  resolveExtensionSessionOptions,
   resolveExtensionVcsAdapters,
   resolveSessionVcsId,
 } from "./apply";
@@ -114,6 +115,20 @@ describe("extension file languages", () => {
 
     expect(applyExtensionFileLanguages(result.registry)).toEqual([]);
     expect(fileLanguageForPath("sample.hunkfixture")).toBe("ruby");
+  });
+});
+
+describe("extension session options", () => {
+  test("lets any transient request win for the shared review session", () => {
+    const result = createEmptyExtensionLoadResult("/repo");
+    result.registry.sessionOptions.push(
+      { extensionId: "default", options: { viewPreferences: "default" } },
+      { extensionId: "guide", options: { viewPreferences: "transient" } },
+    );
+
+    expect(resolveExtensionSessionOptions(result.registry)).toEqual({
+      transientViewPreferences: true,
+    });
   });
 });
 

--- a/src/extensions/apply.ts
+++ b/src/extensions/apply.ts
@@ -299,6 +299,23 @@ export function resolveExtensionCommands(registry: ExtensionRegistry): ResolvedE
   return { commands, issues };
 }
 
+/** Host-level behavior resolved across every extension in one shared session. */
+export interface ResolvedExtensionSessionOptions {
+  /** Any transient request wins so a guide cannot accidentally persist practice state. */
+  transientViewPreferences: boolean;
+}
+
+/** Resolve extension session requests through their documented shared-session policy. */
+export function resolveExtensionSessionOptions(
+  registry: ExtensionRegistry,
+): ResolvedExtensionSessionOptions {
+  return {
+    transientViewPreferences: registry.sessionOptions.some(
+      ({ options }) => options.viewPreferences === "transient",
+    ),
+  };
+}
+
 /** Everything one load pass contributes to the loading pipeline, plus refused registrations. */
 export interface AppliedExtensionRegistrations {
   /** Accepted user adapters, retained for notices and extension-facing UI state. */

--- a/src/extensions/events.test.ts
+++ b/src/extensions/events.test.ts
@@ -190,7 +190,7 @@ describe("extension event dispatch", () => {
         notify: () => {},
         panes,
         sidebars: panes,
-        navigation: { selectFile: () => {}, selectHunk: () => {} },
+        navigation: { selectFile: () => {}, selectHunk: () => {}, revealLine: () => {} },
         dialogs: {
           confirm: async () => false,
           select: async () => null,
@@ -248,6 +248,33 @@ describe("extension event bus", () => {
 
     releaseShutdown();
     await retirement;
+  });
+
+  test("drops ordinary lifecycle events after revocation and runs shutdown once", async () => {
+    const seen: string[] = [];
+    const { result } = createTestLoadResult([
+      {
+        extensionId: "probe",
+        event: "selection_changed",
+        handler: () => {
+          seen.push("selection");
+        },
+      },
+      {
+        extensionId: "probe",
+        event: "shutdown",
+        handler: () => {
+          seen.push("shutdown");
+        },
+      },
+    ]);
+    bindExtensionEventBus(result);
+
+    await retireExtensionLoadResult(result);
+    emitExtensionEvent(result, "selection_changed", { fileId: null, hunkIndex: null });
+    await retireExtensionLoadResult(result);
+
+    expect(seen).toEqual(["shutdown"]);
   });
 
   test("delivers a namespaced event to every listener and isolates failures", async () => {

--- a/src/extensions/events.test.ts
+++ b/src/extensions/events.test.ts
@@ -63,6 +63,24 @@ describe("extension event dispatch", () => {
     expect(seen).toEqual(["first:/repo:/repo", "second"]);
   });
 
+  test("reports named command execution with an immutable payload", () => {
+    let seen: { commandId: string } | undefined;
+    const { result } = createTestLoadResult([
+      {
+        extensionId: "coach",
+        event: "command_executed",
+        handler: (payload) => {
+          seen = payload as { commandId: string };
+        },
+      },
+    ]);
+
+    emitExtensionEvent(result, "command_executed", { commandId: "hunk.review.nextHunk" });
+
+    expect(seen).toEqual({ commandId: "hunk.review.nextHunk" });
+    expect(Object.isFrozen(seen)).toBe(true);
+  });
+
   test("isolates a throwing handler and keeps dispatching the rest", () => {
     const seen: string[] = [];
     const { result, notices } = createTestLoadResult([
@@ -172,6 +190,12 @@ describe("extension event dispatch", () => {
         notify: () => {},
         panes,
         sidebars: panes,
+        navigation: { selectFile: () => {}, selectHunk: () => {} },
+        dialogs: {
+          confirm: async () => false,
+          select: async () => null,
+          input: async () => null,
+        },
         events: { emit: () => {} },
       };
     };

--- a/src/extensions/events.test.ts
+++ b/src/extensions/events.test.ts
@@ -250,6 +250,28 @@ describe("extension event bus", () => {
     await retirement;
   });
 
+  test("shares one retirement completion while shutdown is still pending", async () => {
+    const { result } = createTestLoadResult();
+    let releaseShutdown!: () => void;
+    result.registry.eventHandlers.shutdown.push({
+      extensionId: "probe",
+      handler: () => new Promise<void>((resolve) => (releaseShutdown = resolve)),
+    });
+    bindExtensionEventBus(result);
+
+    const first = retireExtensionLoadResult(result);
+    const second = retireExtensionLoadResult({ ...result });
+    expect(second).toBe(first);
+
+    let settled = false;
+    void second.then(() => (settled = true));
+    await Bun.sleep(0);
+    expect(settled).toBe(false);
+
+    releaseShutdown();
+    await Promise.all([first, second]);
+  });
+
   test("drops ordinary lifecycle events after revocation and runs shutdown once", async () => {
     const seen: string[] = [];
     const { result } = createTestLoadResult([

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -472,6 +472,7 @@ export function bindExtensionEventBus(result: ExtensionLoadResult | undefined) {
   }
 
   const { registry } = result;
+  if (registry.eventBusPhase === "closed") return false;
   registry.emitCustomEvent = (event, payload) => {
     emitExtensionCustomEvent(result, event, payload);
   };
@@ -482,6 +483,7 @@ export function bindExtensionEventBus(result: ExtensionLoadResult | undefined) {
   for (const { event, payload } of registry.pendingCustomEvents.splice(0)) {
     emitExtensionCustomEvent(result, event, payload);
   }
+  return true;
 }
 
 /**
@@ -550,13 +552,13 @@ export function revokeExtensionLoadResult(result: ExtensionLoadResult | undefine
   return true;
 }
 
-/** Shut down one retired extension runtime after synchronously revoking its authority. */
-export async function retireExtensionLoadResult(
-  result: ExtensionLoadResult | undefined,
-): Promise<void> {
-  if (!revokeExtensionLoadResult(result)) {
-    return;
-  }
+/** Shut down one retired extension runtime through the registry's shared completion. */
+export function retireExtensionLoadResult(result: ExtensionLoadResult | undefined): Promise<void> {
+  if (!result) return Promise.resolve();
+  const { registry } = result;
+  if (registry.retirementPromise) return registry.retirementPromise;
+  if (!revokeExtensionLoadResult(result)) return Promise.resolve();
 
-  await emitExtensionEventBounded(result, "shutdown", {});
+  registry.retirementPromise = emitExtensionEventBounded(result, "shutdown", {});
+  return registry.retirementPromise;
 }

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -320,7 +320,7 @@ function unavailableReviewNavigation(
       `Extension ${extensionId} cannot navigate the review before the app is ready`,
       "warning",
     );
-  return { selectFile: unavailable, selectHunk: unavailable };
+  return { selectFile: unavailable, selectHunk: unavailable, revealLine: unavailable };
 }
 
 /** Dialog controls used before the mounted app has installed its modal queue. */
@@ -386,6 +386,12 @@ function runExtensionEventHandlers<Event extends ExtensionEventName>(
 ): Promise<void>[] {
   const handlers = result.registry.eventHandlers[event];
   const settled: Promise<void>[] = [];
+
+  // Revocation closes ordinary lifecycle delivery synchronously. Retirement is
+  // the sole exception: shutdown runs once after authority has become inert.
+  if (result.registry.eventBusPhase === "closed" && event !== "shutdown") {
+    return settled;
+  }
 
   if (handlers.length === 0) {
     return settled;

--- a/src/extensions/events.ts
+++ b/src/extensions/events.ts
@@ -8,8 +8,10 @@ import type {
 import type { Hunk } from "@pierre/diffs";
 import type {
   ExtensionDiffHunk,
+  ExtensionDialogs,
   ExtensionEventContext,
   ExtensionPaneControls,
+  ExtensionReviewNavigation,
   ExtensionVcsFileChangeType,
 } from "../extension-api/types";
 import { summarizeHunk } from "../core/hunkSummary";
@@ -308,6 +310,42 @@ function unavailablePaneControls(
   };
 }
 
+/** Navigation controls used before the mounted app can safely move a review. */
+function unavailableReviewNavigation(
+  result: ExtensionLoadResult,
+  extensionId: string,
+): ExtensionReviewNavigation {
+  const unavailable = () =>
+    result.context.notify(
+      `Extension ${extensionId} cannot navigate the review before the app is ready`,
+      "warning",
+    );
+  return { selectFile: unavailable, selectHunk: unavailable };
+}
+
+/** Dialog controls used before the mounted app has installed its modal queue. */
+function unavailableDialogs(result: ExtensionLoadResult, extensionId: string): ExtensionDialogs {
+  const unavailable = () =>
+    result.context.notify(
+      `Extension ${extensionId} cannot open a dialog before the app is ready`,
+      "warning",
+    );
+  return {
+    confirm: async () => {
+      unavailable();
+      return false;
+    },
+    select: async () => {
+      unavailable();
+      return null;
+    },
+    input: async () => {
+      unavailable();
+      return null;
+    },
+  };
+}
+
 /** Build the runtime event context for one owning extension. */
 function createEventContext(
   result: ExtensionLoadResult,
@@ -324,6 +362,8 @@ function createEventContext(
     ...result.context,
     panes,
     sidebars: panes,
+    navigation: unavailableReviewNavigation(result, extensionId),
+    dialogs: unavailableDialogs(result, extensionId),
     events: {
       emit(event, payload) {
         emitExtensionCustomEvent(result, event, payload);

--- a/src/extensions/host.test.ts
+++ b/src/extensions/host.test.ts
@@ -6,12 +6,14 @@ import type { Changeset } from "../core/types";
 import { getVcsOperation } from "../core/vcs";
 import type { VcsAdapter } from "../core/vcs/types";
 import { discoverExtensions } from "./discovery";
+import { retireExtensionLoadResult } from "./events";
 import { loadExtensions } from "./host";
 import { createExtensionNotificationHub } from "./notifications";
 import {
   deriveExtensionId,
   HUNK_EXTENSION_API_VERSION,
   type ExtensionCandidate,
+  type ExtensionFactory,
   type ExtensionOrigin,
 } from "./types";
 
@@ -61,6 +63,71 @@ afterEach(() => {
 });
 
 describe("extension host", () => {
+  test("publishes provisional ownership before the first module import settles", async () => {
+    const dir = createTempDir("hunk-host-provisional-");
+    const candidate = createTestExtension(dir, "delayed.ts", "export default function () {}\n");
+    let finishImport!: (module: unknown) => void;
+    const imported = new Promise<unknown>((resolve) => {
+      finishImport = resolve;
+    });
+    let provisional: Awaited<ReturnType<typeof loadExtensions>> | undefined;
+
+    const loading = loadExtensions({
+      candidates: [candidate],
+      cwd: dir,
+      importExtensionModuleImpl: () => imported,
+      onProvisionalLoad: (result) => {
+        provisional = result;
+      },
+    });
+
+    expect(provisional?.registry.eventBusPhase).toBe("loading");
+    finishImport({ default: () => {} });
+    expect(await loading).toBe(provisional!);
+  });
+
+  test("keeps retirement terminal when an asynchronous factory resumes late", async () => {
+    const dir = createTempDir("hunk-host-retired-factory-");
+    const candidate = createTestExtension(dir, "delayed.ts", "export default function () {}\n");
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let shutdowns = 0;
+    const factory: ExtensionFactory = async (hunk) => {
+      hunk.on("shutdown", () => {
+        shutdowns += 1;
+      });
+      markStarted();
+      await barrier;
+      hunk.registerTheme({ id: "too-late", label: "Too late", background: "#000000" });
+    };
+    let provisional: Awaited<ReturnType<typeof loadExtensions>> | undefined;
+    const loading = loadExtensions({
+      candidates: [candidate],
+      cwd: dir,
+      importExtensionModuleImpl: async () => ({ default: factory }),
+      onProvisionalLoad: (result) => {
+        provisional = result;
+      },
+    });
+    await started;
+
+    const retirement = retireExtensionLoadResult(provisional);
+    release();
+    const result = await loading;
+    await retirement;
+
+    expect(shutdowns).toBe(1);
+    expect(result.registry.eventBusPhase).toBe("closed");
+    expect(result.registry.themes).toEqual([]);
+    expect(result.registry.extensions).toEqual([]);
+  });
+
   test("collects registrations from a TypeScript extension on disk", async () => {
     const dir = createTempDir("hunk-host-register-");
     const candidate = createTestExtension(

--- a/src/extensions/host.ts
+++ b/src/extensions/host.ts
@@ -15,6 +15,7 @@ import {
   type ExtensionLoadIssue,
   type ExtensionLoadResult,
   type ExtensionMetadata,
+  type ExtensionRegistry,
 } from "./types";
 
 export interface LoadExtensionsOptions {
@@ -42,6 +43,13 @@ export interface LoadExtensionsOptions {
   resolveRepoTrustImpl?: (repoRoot: string, options: ExtensionTrustOptions) => ExtensionTrustState;
   /** Module loader seam; defaults to a plain dynamic import of the absolute path. */
   importExtensionModuleImpl?: (path: string) => Promise<unknown>;
+  /** Publish provisional ownership before imports or asynchronous factories can suspend. */
+  onProvisionalLoad?: (result: ExtensionLoadResult) => void;
+}
+
+/** Read durable retirement without letting control-flow narrowing hide asynchronous revocation. */
+function registryRetired(registry: ExtensionRegistry) {
+  return registry.eventBusPhase === "closed";
 }
 
 /** Import one extension entry file by absolute path, cross-platform. */
@@ -186,7 +194,25 @@ export async function loadExtensions(options: LoadExtensionsOptions): Promise<Ex
   // imports resolve to the host's own instances rather than the filesystem.
   registerHostRuntimeModules(accepted.map((candidate) => candidate.path));
   const registry = options.previousLoad?.registry ?? createEmptyExtensionRegistry();
-  registry.eventBusPhase = "loading";
+  if (!registryRetired(registry)) registry.eventBusPhase = "loading";
+  const notifications =
+    options.notifications ??
+    options.previousLoad?.notifications ??
+    createExtensionNotificationHub();
+  const context = createExtensionContext(options.cwd, notifications.notify);
+  const result: ExtensionLoadResult = {
+    registry,
+    issues,
+    loaded: [...registry.extensions],
+    context,
+    notifications,
+    loadState: {
+      candidates: [...(options.allCandidates ?? options.candidates)],
+      extensionConfigs: structuredClone(options.extensionConfigs ?? {}),
+    },
+  };
+  options.onProvisionalLoad?.(result);
+  if (registryRetired(registry)) return result;
   const importModule = options.importExtensionModuleImpl ?? importExtensionModule;
   const resolveTrust = options.resolveRepoTrustImpl ?? resolveRepoTrust;
   const trustOptions: ExtensionTrustOptions = { env: options.env };
@@ -207,6 +233,7 @@ export async function loadExtensions(options: LoadExtensionsOptions): Promise<Ex
   };
 
   for (const candidate of accepted) {
+    if (registryRetired(registry)) break;
     if (candidate.origin === "repo") {
       const trust = resolveRepoTrustState();
       if (trust !== "trusted") {
@@ -228,6 +255,7 @@ export async function loadExtensions(options: LoadExtensionsOptions): Promise<Ex
       // Importing is the host's half of loading: it is the part that differs
       // from the bundled tier, which has its factories statically in hand.
       factory = readExtensionFactory(await importModule(candidate.path));
+      if (registryRetired(registry)) break;
     } catch (error) {
       issues.push({
         extensionId: candidate.id,
@@ -245,24 +273,18 @@ export async function loadExtensions(options: LoadExtensionsOptions): Promise<Ex
       factory,
       config: options.extensionConfigs?.[candidate.id],
     });
+    if (registryRetired(registry)) break;
   }
 
-  const notifications =
-    options.notifications ??
-    options.previousLoad?.notifications ??
-    createExtensionNotificationHub();
-  const context = createExtensionContext(options.cwd, notifications.notify);
   // `registry.extensions` already holds exactly the extensions whose factories
   // completed, in load order, so the loaded list is a copy of it rather than a
   // second tally that could drift.
-  const loaded = [...registry.extensions];
-  const loadState = {
-    candidates: [...(options.allCandidates ?? options.candidates)],
-    extensionConfigs: structuredClone(options.extensionConfigs ?? {}),
-  };
-  const result: ExtensionLoadResult = pendingTrustRepoRoot
-    ? { registry, issues, loaded, context, notifications, loadState, pendingTrustRepoRoot }
-    : { registry, issues, loaded, context, notifications, loadState };
+  result.loaded = [...registry.extensions];
+  if (pendingTrustRepoRoot) {
+    result.pendingTrustRepoRoot = pendingTrustRepoRoot;
+  } else {
+    delete result.pendingTrustRepoRoot;
+  }
   if (!options.deferEventBusBinding) {
     bindExtensionEventBus(result);
   }

--- a/src/extensions/publicApiRobustness.test.ts
+++ b/src/extensions/publicApiRobustness.test.ts
@@ -560,6 +560,7 @@ describe("factories that misbehave outright", () => {
     });
 
     for (const method of [
+      "configureSession",
       "registerTheme",
       "registerFileLanguage",
       "registerVcsAdapter",

--- a/src/extensions/runExtension.test.ts
+++ b/src/extensions/runExtension.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { resolveExtensionPanes } from "./apply";
 import { runExtensionFactory, toInternalVcsAdapter } from "./runExtension";
-import { createEmptyExtensionRegistry, type ExtensionLoadIssue } from "./types";
+import {
+  createEmptyExtensionRegistry,
+  HUNK_EXTENSION_API_VERSION,
+  type ExtensionLoadIssue,
+} from "./types";
 
 /** Build the metadata one bundled-style extension would load under. */
 function bundledMetadata(id: string) {
@@ -12,6 +16,7 @@ describe("runExtensionFactory", () => {
   test("applies a synchronous factory before returning, with nothing to await", () => {
     const registry = createEmptyExtensionRegistry();
     const issues: ExtensionLoadIssue[] = [];
+    let apiVersion: number | undefined;
 
     // The bundled tier depends on this: adapter resolution is synchronous, so a
     // static factory has to be fully applied by the time this call returns.
@@ -20,11 +25,13 @@ describe("runExtensionFactory", () => {
       registry,
       issues,
       factory: (hunk) => {
+        apiVersion = hunk.apiVersion;
         hunk.registerFileLanguage(".demo", "demo");
       },
     });
 
     expect(pending).toBeUndefined();
+    expect(apiVersion).toBe(HUNK_EXTENSION_API_VERSION);
     expect(issues).toEqual([]);
     expect(registry.extensions.map((extension) => extension.id)).toEqual(["demo"]);
     expect(registry.fileLanguages.map((entry) => entry.extension)).toEqual(["demo"]);
@@ -228,6 +235,43 @@ describe("registerPane", () => {
 
     expect(registry.panes).toEqual([]);
     expect(issues.map((issue) => issue.extensionId)).toEqual(["half-pane"]);
+  });
+});
+
+describe("configureSession", () => {
+  test("records transient view preferences under the owning extension", () => {
+    const registry = createEmptyExtensionRegistry();
+    const issues: ExtensionLoadIssue[] = [];
+
+    runExtensionFactory({
+      metadata: bundledMetadata("trainer"),
+      registry,
+      issues,
+      factory: (hunk) => hunk.configureSession({ viewPreferences: "transient" }),
+    });
+
+    expect(issues).toEqual([]);
+    expect(registry.sessionOptions).toEqual([
+      { extensionId: "trainer", options: { viewPreferences: "transient" } },
+    ]);
+  });
+
+  test("rejects unknown policy values and rolls back earlier requests", () => {
+    const registry = createEmptyExtensionRegistry();
+    const issues: ExtensionLoadIssue[] = [];
+
+    runExtensionFactory({
+      metadata: bundledMetadata("broken-trainer"),
+      registry,
+      issues,
+      factory: (hunk) => {
+        hunk.configureSession({ viewPreferences: "transient" });
+        hunk.configureSession({ viewPreferences: "forever" } as never);
+      },
+    });
+
+    expect(registry.sessionOptions).toEqual([]);
+    expect(issues[0]?.message).toContain('"default" or "transient"');
   });
 });
 

--- a/src/extensions/runExtension.test.ts
+++ b/src/extensions/runExtension.test.ts
@@ -85,6 +85,27 @@ describe("runExtensionFactory", () => {
     expect(issues.map((issue) => issue.message)).toEqual(["late failure"]);
   });
 
+  test("isolates a factory result whose then getter throws", () => {
+    const registry = createEmptyExtensionRegistry();
+    const issues: ExtensionLoadIssue[] = [];
+
+    const pending = runExtensionFactory({
+      metadata: bundledMetadata("hostile-thenable"),
+      registry,
+      issues,
+      factory: () =>
+        Object.defineProperty({}, ["th", "en"].join(""), {
+          get() {
+            throw new Error("then exploded");
+          },
+        }) as Promise<void>,
+    });
+
+    expect(pending).toBeUndefined();
+    expect(registry.extensions).toEqual([]);
+    expect(issues.map((issue) => issue.message)).toEqual(["then exploded"]);
+  });
+
   test("seals the API so a deferred callback cannot register later", async () => {
     const registry = createEmptyExtensionRegistry();
     const issues: ExtensionLoadIssue[] = [];

--- a/src/extensions/runExtension.ts
+++ b/src/extensions/runExtension.ts
@@ -13,6 +13,7 @@ import {
   type ExtensionRegistry,
   type ExtensionPane,
   type ExtensionSidebarView,
+  type ExtensionSessionOptions,
   type ExtensionFileView,
   type ExtensionKeyboardMode,
   type ExtensionLineHighlighter,
@@ -216,6 +217,7 @@ interface ExtensionApiHandle {
 
 /** Registration counts captured before one extension runs, for failure rollback. */
 interface RegistrySnapshot {
+  sessionOptions: number;
   themes: number;
   fileLanguages: number;
   vcsAdapters: number;
@@ -238,6 +240,7 @@ function snapshotRegistry(registry: ExtensionRegistry): RegistrySnapshot {
   }
 
   return {
+    sessionOptions: registry.sessionOptions.length,
     themes: registry.themes.length,
     fileLanguages: registry.fileLanguages.length,
     vcsAdapters: registry.vcsAdapters.length,
@@ -260,6 +263,7 @@ function snapshotRegistry(registry: ExtensionRegistry): RegistrySnapshot {
  * not stay in the registry. Collected logs are kept as failure diagnostics.
  */
 function rollbackRegistry(registry: ExtensionRegistry, snapshot: RegistrySnapshot) {
+  registry.sessionOptions.length = snapshot.sessionOptions;
   registry.themes.length = snapshot.themes;
   registry.fileLanguages.length = snapshot.fileLanguages;
   registry.vcsAdapters.length = snapshot.vcsAdapters;
@@ -328,6 +332,21 @@ export function createExtensionApi(
     apiVersion: HUNK_EXTENSION_API_VERSION,
     config,
     events,
+    configureSession(options: ExtensionSessionOptions) {
+      assertOpen("configureSession");
+      if (!isPlainObject(options)) {
+        throw new Error("configureSession requires an options object.");
+      }
+      if (
+        options.viewPreferences !== undefined &&
+        options.viewPreferences !== "default" &&
+        options.viewPreferences !== "transient"
+      ) {
+        throw new Error('configureSession viewPreferences must be "default" or "transient".');
+      }
+
+      registry.sessionOptions.push({ extensionId: metadata.id, options: { ...options } });
+    },
     registerTheme(theme: ExtensionThemeConfig) {
       assertOpen("registerTheme");
       assertNonEmptyString(theme?.id, "registerTheme requires a theme with a non-empty id.");

--- a/src/extensions/runExtension.ts
+++ b/src/extensions/runExtension.ts
@@ -293,9 +293,9 @@ export function createExtensionApi(
 ): ExtensionApiHandle {
   let sealed = false;
 
-  /** Guard one registration call against use after the load pass finished. */
+  /** Guard one registration call against use after the load pass finished or retired. */
   const assertOpen = (method: string) => {
-    if (sealed) {
+    if (sealed || registry.eventBusPhase === "closed") {
       throw new Error(
         `${metadata.id}: hunk.${method}() can only be called while the extension is loading.`,
       );
@@ -629,19 +629,38 @@ export function runExtensionFactory({
     return;
   }
 
-  if (!isThenable(pending)) {
+  let thenable: boolean;
+  try {
+    thenable = isThenable(pending);
+  } catch (error) {
     seal();
-    registry.extensions.push(metadata);
+    fail(error);
     return;
   }
 
-  return pending.then(
+  if (!thenable) {
+    seal();
+    if (registry.eventBusPhase !== "closed") registry.extensions.push(metadata);
+    return;
+  }
+
+  // Promise assimilation turns a throwing or otherwise hostile `then` access
+  // into the ordinary rejection path instead of leaking out of the load pass.
+  return Promise.resolve(pending).then(
     () => {
       seal();
+      if (registry.eventBusPhase === "closed") {
+        rollbackRegistry(registry, snapshot);
+        return;
+      }
       registry.extensions.push(metadata);
     },
     (error: unknown) => {
       seal();
+      if (registry.eventBusPhase === "closed") {
+        rollbackRegistry(registry, snapshot);
+        return;
+      }
       fail(error);
     },
   );

--- a/src/extensions/startup.ts
+++ b/src/extensions/startup.ts
@@ -36,6 +36,8 @@ export interface LoadStartupExtensionsOptions {
   previousLoad?: ExtensionLoadResult;
   /** Keep factory bus events queued for a possible staged continuation. */
   deferEventBusBinding?: boolean;
+  /** Publish provisional ownership before imports or asynchronous factories can suspend. */
+  onProvisionalLoad?: (result: ExtensionLoadResult) => void;
   /** Test seams forwarded to the host loader. */
   hostOverrides?: Pick<
     LoadExtensionsOptions,
@@ -135,6 +137,7 @@ export async function loadStartupExtensions(
     repoRoot: options.projectRoot ?? options.hostOverrides?.repoRoot,
     reservedExtensionIds: options.reservedExtensionIds,
     deferEventBusBinding: options.deferEventBusBinding,
+    onProvisionalLoad: options.onProvisionalLoad,
   });
 }
 

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -202,6 +202,8 @@ export interface ExtensionRegistry {
   eventBusPhase: "loading" | "ready" | "closed";
   /** Bound after loading so hunk.events.emit can dispatch at runtime. */
   emitCustomEvent?: (event: string, payload: unknown) => void;
+  /** Shared completion for the one terminal retirement of this registry. */
+  retirementPromise?: Promise<void>;
   logs: ExtensionLogEntry[];
 }
 

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -13,6 +13,7 @@ import type {
   ExtensionLineHighlighter,
   ExtensionNotifyType,
   ExtensionPane,
+  ExtensionSessionOptions,
   ExtensionThemeConfig,
 } from "../extension-api/types";
 import { createExtensionNotificationHub, type ExtensionNotificationHub } from "./notifications";
@@ -52,6 +53,7 @@ export type {
   ExtensionPane,
   ExtensionPaneControls,
   ExtensionSidebarView,
+  ExtensionSessionOptions,
   ExtensionThemeConfig,
   ExtensionVcsAdapter,
   ExtensionWorkspace,
@@ -145,6 +147,12 @@ export interface RegisteredCommand {
   handler: ExtensionCommandHandler;
 }
 
+/** One extension's host-level behavior request for the current session. */
+export interface RegisteredSessionOptions {
+  extensionId: string;
+  options: ExtensionSessionOptions;
+}
+
 export interface RegisteredEventHandler<Event extends ExtensionEventName = ExtensionEventName> {
   extensionId: string;
   handler: ExtensionEventHandler<Event>;
@@ -176,6 +184,7 @@ export type ExtensionEventHandlerMap = {
 /** Everything extensions registered, in load order, for the rest of the app to consume. */
 export interface ExtensionRegistry {
   extensions: ExtensionMetadata[];
+  sessionOptions: RegisteredSessionOptions[];
   themes: RegisteredTheme[];
   fileLanguages: RegisteredFileLanguage[];
   vcsAdapters: RegisteredVcsAdapter[];
@@ -261,6 +270,7 @@ export function deriveExtensionId(entryPath: string) {
 export function createEmptyExtensionRegistry(): ExtensionRegistry {
   return {
     extensions: [],
+    sessionOptions: [],
     themes: [],
     fileLanguages: [],
     vcsAdapters: [],
@@ -273,6 +283,7 @@ export function createEmptyExtensionRegistry(): ExtensionRegistry {
     eventHandlers: {
       startup: [],
       changeset_loaded: [],
+      command_executed: [],
       selection_changed: [],
       file_viewed: [],
       filter_changed: [],

--- a/src/session/broker/brokerClient.test.ts
+++ b/src/session/broker/brokerClient.test.ts
@@ -76,6 +76,24 @@ afterEach(() => {
 });
 
 describe("Hunk session daemon client", () => {
+  test("keeps its previous registration when the live connection rejects replacement", () => {
+    const registration = createRegistration();
+    const client = new SessionBrokerClient(registration, createSnapshot());
+    (client as any).connection = {
+      replaceSession() {
+        throw new Error("connection exploded");
+      },
+    };
+
+    expect(() =>
+      client.replaceSession(
+        { ...registration, sessionId: "replacement-session" },
+        createSnapshot(),
+      ),
+    ).toThrow("connection exploded");
+    expect(client.getRegistration()).toBe(registration);
+  });
+
   test("logs one actionable warning when the session daemon is configured for a non-loopback host without opt-in", async () => {
     process.env.HUNK_MCP_HOST = "0.0.0.0";
     process.env.HUNK_MCP_PORT = "47657";

--- a/src/session/broker/brokerClient.ts
+++ b/src/session/broker/brokerClient.ts
@@ -109,9 +109,11 @@ export class SessionBrokerClient<
   }
 
   replaceSession(registration: SessionRegistration<Info>, snapshot: SessionSnapshot<State>) {
+    // Let the connection validate/send first. If it throws, the client keeps
+    // serving the previous registration and snapshot as one coherent pair.
+    this.connection?.replaceSession(registration, snapshot);
     this.registration = registration;
     this.snapshot = snapshot;
-    this.connection?.replaceSession(registration, snapshot);
   }
 
   private resolveConfig() {

--- a/src/ui/App.extension-command-controls.test.tsx
+++ b/src/ui/App.extension-command-controls.test.tsx
@@ -4,7 +4,7 @@ import { act, StrictMode, useState } from "react";
 import { createTestVcsAppBootstrap } from "../../test/helpers/app-bootstrap";
 import { createTestDiffFile } from "../../test/helpers/diff-helpers";
 import type { AppBootstrap } from "../app/types";
-import type { ExtensionCommandControls } from "../extension-api/types";
+import type { ExtensionCommandControls, ExtensionWorkspace } from "../extension-api/types";
 import { createEmptyExtensionLoadResult } from "../extensions/types";
 import { App } from "./App";
 
@@ -32,12 +32,14 @@ async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
 describe("extension command control authority", () => {
   test("retires captured controls only when a soft reload replaces the extension registry", async () => {
     let capturedControls: ExtensionCommandControls | null = null;
+    let capturedWorkspace: ExtensionWorkspace | null = null;
     const initial = createBootstrap();
     initial.extensions!.registry.commands.push({
       extensionId: "probe",
       command: { id: "capture", title: "Capture controls", key: "y" },
       handler(ctx) {
         capturedControls = ctx.commands;
+        capturedWorkspace = ctx.workspace;
       },
     });
     let replaceBootstrap: (next: AppBootstrap) => void = () => {};
@@ -76,12 +78,21 @@ describe("extension command control authority", () => {
       expect(capturedControls).not.toBeNull();
       expect(capturedControls!.isEnabled("hunk.review.nextHunk")).toBe(true);
 
-      // Ordinary content reloads retain the extension registry and its async authority.
+      // Runtime-level command controls survive a content reload, while
+      // review-bound workspace authority expires with the old generation.
       await act(async () => {
         replaceBootstrap({ ...createBootstrap(), extensions: initial.extensions });
       });
       await flush(setup);
       expect(capturedControls!.isEnabled("hunk.review.nextHunk")).toBe(true);
+      expect(capturedWorkspace).not.toBeNull();
+      expect(
+        await capturedWorkspace!.writeDocument({ fileId: "alpha", text: "replacement" }),
+      ).toEqual({
+        ok: false,
+        reason: "unavailable",
+        detail: "The review reloaded before this extension operation could finish.",
+      });
 
       // AppHost closes the old registry before its async replacement load finishes.
       // Captured controls lose authority at that boundary, before App receives new props.

--- a/src/ui/App.extension-command-controls.test.tsx
+++ b/src/ui/App.extension-command-controls.test.tsx
@@ -50,6 +50,7 @@ describe("extension command control authority", () => {
       return (
         <App
           bootstrap={bootstrap}
+          onRegisterWorkspaceRefreshRequest={() => () => {}}
           onReloadSession={async () => ({
             sessionId: "test",
             inputKind: bootstrap.input.kind,
@@ -58,6 +59,11 @@ describe("extension command control authority", () => {
             fileCount: bootstrap.changeset.files.length,
             selectedHunkIndex: 0,
           })}
+          onWorkspaceWriteCompleted={() => {}}
+          runWorkspaceWrite={async (write) => {
+            await write();
+            return true;
+          }}
         />
       );
     }

--- a/src/ui/App.extension-trust.test.tsx
+++ b/src/ui/App.extension-trust.test.tsx
@@ -39,6 +39,7 @@ function createTrustHarness(initial: AppBootstrap) {
     return (
       <App
         bootstrap={bootstrap}
+        onRegisterWorkspaceRefreshRequest={() => () => {}}
         onReloadSession={async () => ({
           sessionId: "test",
           inputKind: bootstrap.input.kind,
@@ -47,6 +48,11 @@ function createTrustHarness(initial: AppBootstrap) {
           fileCount: bootstrap.changeset.files.length,
           selectedHunkIndex: 0,
         })}
+        onWorkspaceWriteCompleted={() => {}}
+        runWorkspaceWrite={async (write) => {
+          await write();
+          return true;
+        }}
       />
     );
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -693,6 +693,21 @@ export function App({
     [extensions, setPaneOpen],
   );
 
+  /** Build live, guarded review navigation for one extension-owned handler. */
+  const createExtensionNavigation = useCallback(
+    (extensionId: string) =>
+      createGuardedReviewNavigation({
+        extensionId,
+        getFiles: () => extensionSelectionInputsRef.current.filteredFiles,
+        isLive: () => appAliveForNavigationRef.current,
+        notify: (message, type) => extensions?.context.notify(message, type),
+        onSelectFile: (fileId) => extensionCommandNavigationRef.current.onSelectFile(fileId),
+        onSelectHunk: (fileId, hunkIndex) =>
+          extensionCommandNavigationRef.current.onSelectHunk(fileId, hunkIndex),
+      }),
+    [extensions],
+  );
+
   /**
    * Reveal the sidebar area, assigned each render once the responsive layout
    * is known (the controls above are created before it is computed).
@@ -709,7 +724,7 @@ export function App({
   const {
     accept: acceptExtensionDialog,
     cancel: cancelExtensionDialog,
-    createDialogs: createExtensionDialogs,
+    createDialogs: createQueuedExtensionDialogs,
     inputValue: extensionDialogInputValue,
     moveSelection: moveExtensionDialogSelection,
     pickOption: setExtensionDialogSelectedIndex,
@@ -717,6 +732,17 @@ export function App({
     selectedIndex: extensionDialogSelectedIndex,
     updateInput: setExtensionDialogInputValue,
   } = useExtensionDialogController({ reviewGeneration: bootstrap });
+
+  /** Keep third-party dialog attribution while presenting bundled extensions as native Hunk UI. */
+  const createExtensionDialogs = useCallback(
+    (extensionId: string) => {
+      const bundled = extensions?.registry.extensions.some(
+        (metadata) => metadata.id === extensionId && metadata.origin === "bundled",
+      );
+      return createQueuedExtensionDialogs(extensionId, { showAttribution: !bundled });
+    },
+    [createQueuedExtensionDialogs, extensions],
+  );
 
   /** Build host-mediated reviewed-document read and write controls for one extension command. */
   const createWorkspaceControls = useCallback(
@@ -820,8 +846,8 @@ export function App({
     [createExtensionDialogs],
   );
 
-  // Lifecycle and bus listeners receive the same pane controls as commands,
-  // so an extension can react to loaded content by revealing its own pane.
+  // Lifecycle and bus listeners receive the same pane, navigation, and dialog
+  // controls as commands, so onboarding can stay entirely in the public API.
   if (extensions) {
     extensions.eventContextProvider = (extensionId): ExtensionEventContext => {
       const panes = createPaneControls(extensionId);
@@ -830,6 +856,8 @@ export function App({
         notify: (message, type) => extensions.context.notify(message, type),
         panes,
         sidebars: panes,
+        navigation: createExtensionNavigation(extensionId),
+        dialogs: createExtensionDialogs(extensionId),
         events: {
           emit(event, payload) {
             emitExtensionCustomEvent(extensions, event, payload);
@@ -875,19 +903,7 @@ export function App({
         // the same focus/jump callbacks a sidebar row click runs, so a handler
         // that awaits a dialog before navigating still acts on the current
         // review — validated, clamped, and warned exactly like sidebar actions.
-        navigation: createGuardedReviewNavigation({
-          extensionId: registered.extensionId,
-          getFiles: () => extensionSelectionInputsRef.current.filteredFiles,
-          // Extensions outlive App remounts, so the notify sink stays valid
-          // even after this instance dies and `isLive` starts refusing calls.
-          isLive: () => appAliveForNavigationRef.current,
-          notify: (message, type) => extensions?.context.notify(message, type),
-          onSelectFile: (fileId) => extensionCommandNavigationRef.current.onSelectFile(fileId),
-          onSelectHunk: (fileId, hunkIndex) =>
-            extensionCommandNavigationRef.current.onSelectHunk(fileId, hunkIndex),
-          onRevealLine: (fileId, side, line) =>
-            extensionCommandNavigationRef.current.onRevealLine(fileId, side, line),
-        }),
+        navigation: createExtensionNavigation(registered.extensionId),
       };
 
       try {
@@ -904,6 +920,7 @@ export function App({
     // do not rebuild on every `[`/`]` press.
     [
       createExtensionDialogs,
+      createExtensionNavigation,
       createFileViewControls,
       createKeyboardModeControls,
       createLineHighlightControls,
@@ -1701,8 +1718,12 @@ export function App({
 
   /** Leave the app through the shared shutdown path, prompting before discarding view changes. */
   const requestQuit = useCallback(() => {
+    const transientViewPreferences = extensions?.registry.sessionOptions.some(
+      ({ options }) => options.viewPreferences === "transient",
+    );
     if (
       !pagerMode &&
+      !transientViewPreferences &&
       bootstrap.input.options.promptSaveViewPreferences !== false &&
       hasUnsavedViewPreferences
     ) {
@@ -1714,6 +1735,7 @@ export function App({
     onQuit();
   }, [
     bootstrap.input.options.promptSaveViewPreferences,
+    extensions,
     hasUnsavedViewPreferences,
     onQuit,
     pagerMode,
@@ -1915,7 +1937,13 @@ export function App({
       triggerRefreshCurrentInput,
     }),
     ...extensionAppCommands.commands,
-  ];
+  ].map((command) => ({
+    ...command,
+    run: (...args: Parameters<typeof command.run>) => {
+      command.run(...args);
+      emitExtensionEvent(extensions, "command_executed", { commandId: command.id });
+    },
+  }));
   extensionHostCommandsRef.current = appCommands;
 
   // Menus name commands rather than repeating them: every item's key hint and

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -101,10 +101,7 @@ import {
 } from "./lib/appCommands";
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
-import {
-  createExtensionCapabilityLease,
-  runWithExtensionCapabilityLease,
-} from "./lib/extensionCapabilityLease";
+import { createExtensionCapabilityLease } from "./lib/extensionCapabilityLease";
 import { createExtensionCommandControls } from "./lib/extensionCommandControls";
 import {
   applyExtensionCurrentLinePaintUpdate,
@@ -214,27 +211,55 @@ function withCurrentViewOptions(
   };
 }
 
+/** Current mounted review descriptor AppHost dereferences when reconciling a completed write. */
+export interface WorkspaceRefreshRequest {
+  nextInput: CliInput;
+  sourcePath?: string;
+}
+
+/** Filesystem write implementation used by the host-mediated extension workspace. */
+export type WorkspaceFileWriter = (absolutePath: string, text: string) => Promise<void>;
+
+/** Host-owned boundary that tracks irreversible writes through graceful shutdown. */
+export type WorkspaceWriteRunner = (write: () => Promise<void>) => Promise<boolean>;
+
+/** Write UTF-8 text through the production filesystem implementation. */
+const writeWorkspaceFile: WorkspaceFileWriter = async (absolutePath, text) => {
+  await writeFile(absolutePath, text, "utf8");
+};
+
 /** Orchestrate global app state, layout, navigation, and pane coordination. */
 export function App({
   bootstrap,
   hostClient,
   noticeText,
   onQuit = () => process.exit(0),
+  onRegisterWorkspaceRefreshRequest,
   onReloadSession,
+  onWorkspaceWriteCompleted,
   reviewProducer,
+  runWorkspaceWrite,
   watchRuntime,
+  workspaceFileWriter = writeWorkspaceFile,
 }: {
   bootstrap: AppBootstrap;
   hostClient?: HunkSessionBrokerClient;
   noticeText?: string | null;
   onQuit?: () => void;
+  /** Register the mounted review descriptor AppHost should reconcile after a completed write. */
+  onRegisterWorkspaceRefreshRequest: (request: WorkspaceRefreshRequest) => () => void;
   onReloadSession: (
     nextInput: CliInput,
     options?: ReloadSessionOptions,
   ) => Promise<ReloadedSessionResult>;
+  /** Reconcile the currently mounted review after a consented filesystem write succeeds. */
+  onWorkspaceWriteCompleted: () => void;
   /** The producer publishing this review's generations, when the host mounted one. */
   reviewProducer?: ReviewProducer;
+  /** Start and track one irreversible write, or refuse it once graceful shutdown begins. */
+  runWorkspaceWrite: WorkspaceWriteRunner;
   watchRuntime?: WatchedInputRuntime;
+  workspaceFileWriter?: WorkspaceFileWriter;
 }) {
   const SIDEBAR_MIN_WIDTH = 22;
   const DIFF_MIN_WIDTH = 48;
@@ -261,11 +286,11 @@ export function App({
   });
   // The producer plans brokered actions against the store this controller owns, so a
   // remote action and a key press reach the same state through the same intent path.
-  // Attached before any command can arrive: the session bridge is installed by a later
-  // effect, so nothing can be dispatched into the producer until this has run.
-  useEffect(() => {
+  // AppHost detaches the previous store while committing a reload; this child layout
+  // effect installs the matching store before parent lifecycle handlers can use it.
+  useLayoutEffect(() => {
     reviewProducer?.attachStore(review.store);
-  }, [review.store, reviewProducer]);
+  }, [bootstrap.changeset, review.store, reviewProducer]);
   // Note-layer visibility is shared review state, so it lives in the review store
   // alongside the notes it governs rather than in local app state.
   const showAgentNotes = review.showAgentNotes;
@@ -752,13 +777,6 @@ export function App({
    */
   const revealSidebarAreaRef = useRef<() => void>(() => {});
 
-  /**
-   * Reload the review after a host-mediated write, assigned each render because
-   * the refresh callback is built further down the component than the extension
-   * controls that trigger it.
-   */
-  const reloadAfterWorkspaceWriteRef = useRef<() => void>(() => {});
-
   const {
     accept: acceptExtensionDialog,
     cancel: cancelExtensionDialog,
@@ -815,11 +833,8 @@ export function App({
           // Every failure the fetcher can raise — a missing side, a read error,
           // the host's source-size cap — is the same "no document" answer. Recheck
           // after the fetch so a retired generation cannot publish stale text.
-          return runWithExtensionCapabilityLease(
-            lease,
-            () => (read ? read().catch(() => null) : Promise.resolve(null)),
-            () => null,
-          );
+          const document = read ? await read().catch(() => null) : null;
+          return lease.isLive() ? document : null;
         },
         canWriteDocument(fileId: string) {
           // The probe answers for anything, including an id that is not even a
@@ -880,36 +895,39 @@ export function App({
             return { ok: false, reason: "unavailable", detail: changedTargetRefusal };
           }
 
-          const writeFailure = await runWithExtensionCapabilityLease(
-            lease,
-            async (): Promise<ExtensionWorkspaceWriteResult | null> => {
-              try {
-                await writeFile(target.absolutePath, text, "utf8");
-                return null;
-              } catch (error) {
-                return {
-                  ok: false,
-                  reason: "failed",
-                  detail: `Failed to write ${target.path} • ${
-                    error instanceof Error ? error.message || error.name : String(error)
-                  }`,
-                };
-              }
-            },
-            expired,
-          );
-          if (writeFailure) return writeFailure;
+          // This is the final revocable boundary. Once the irreversible write
+          // starts, its real filesystem outcome wins even if the review changes.
+          if (!lease.isLive()) return expired();
+          try {
+            const started = await runWorkspaceWrite(() =>
+              workspaceFileWriter(target.absolutePath, text),
+            );
+            if (!started) return expired();
+          } catch (error) {
+            return {
+              ok: false,
+              reason: "failed",
+              detail: `Failed to write ${target.path} • ${
+                error instanceof Error ? error.message || error.name : String(error)
+              }`,
+            };
+          }
 
-          // Fire-and-forget the reload so the result settles on the write
-          // itself. In a `--watch` session the watcher sees the same write and
-          // reloads too; a reload replaces the review silently, so a second one
-          // costs a rebuild rather than a duplicated notice.
-          reloadAfterWorkspaceWriteRef.current();
+          // AppHost dereferences the mounted review descriptor only when this
+          // reconciliation reaches the reload queue, so a retired App cannot
+          // restore the source or view options it started from.
+          onWorkspaceWriteCompleted();
           return { ok: true };
         },
       };
     },
-    [createExtensionDialogs, createReviewCapabilityLease],
+    [
+      createExtensionDialogs,
+      createReviewCapabilityLease,
+      onWorkspaceWriteCompleted,
+      runWorkspaceWrite,
+      workspaceFileWriter,
+    ],
   );
 
   // Lifecycle and bus listeners receive the same pane, navigation, and dialog
@@ -1568,15 +1586,11 @@ export function App({
 
   const canRefreshCurrentInput = canReloadInput(bootstrap.input);
   const watchEnabled = Boolean(bootstrap.input.options.watch && canRefreshCurrentInput);
+  const workspaceRefreshRequest = useMemo<WorkspaceRefreshRequest | null>(() => {
+    if (!canRefreshCurrentInput) return null;
 
-  /** Rebuild the current diff source while preserving the active app view options. */
-  const refreshCurrentInput = useCallback(
-    async (options?: Pick<ReloadSessionOptions, "reason" | "reloadExtensions">) => {
-      if (!canRefreshCurrentInput) {
-        return;
-      }
-
-      const nextInput = withCurrentViewOptions(bootstrap.input, {
+    return {
+      nextInput: withCurrentViewOptions(bootstrap.input, {
         layoutMode,
         themeId,
         showAgentNotes,
@@ -1584,27 +1598,39 @@ export function App({
         showLineNumbers,
         showMenuBar,
         wrapLines,
-      });
+      }),
+      sourcePath: isVcsReviewInput(bootstrap.input) ? bootstrap.changeset.sourceLabel : undefined,
+    };
+  }, [
+    bootstrap.changeset.sourceLabel,
+    bootstrap.input,
+    canRefreshCurrentInput,
+    layoutMode,
+    showAgentNotes,
+    showHunkHeaders,
+    showLineNumbers,
+    showMenuBar,
+    themeId,
+    wrapLines,
+  ]);
 
-      await onReloadSession(nextInput, {
+  useLayoutEffect(() => {
+    if (!workspaceRefreshRequest) return;
+    return onRegisterWorkspaceRefreshRequest(workspaceRefreshRequest);
+  }, [onRegisterWorkspaceRefreshRequest, workspaceRefreshRequest]);
+
+  /** Rebuild the current diff source while preserving the active app view options. */
+  const refreshCurrentInput = useCallback(
+    async (options?: Pick<ReloadSessionOptions, "reason" | "reloadExtensions">) => {
+      if (!workspaceRefreshRequest) return;
+
+      await onReloadSession(workspaceRefreshRequest.nextInput, {
         ...options,
         resetApp: false,
-        sourcePath: isVcsReviewInput(bootstrap.input) ? bootstrap.changeset.sourceLabel : undefined,
+        sourcePath: workspaceRefreshRequest.sourcePath,
       });
     },
-    [
-      bootstrap.changeset.sourceLabel,
-      bootstrap.input,
-      canRefreshCurrentInput,
-      layoutMode,
-      onReloadSession,
-      showAgentNotes,
-      showHunkHeaders,
-      showLineNumbers,
-      showMenuBar,
-      themeId,
-      wrapLines,
-    ],
+    [onReloadSession, workspaceRefreshRequest],
   );
 
   const triggerRefreshCurrentInput = useCallback(() => {
@@ -1612,10 +1638,6 @@ export function App({
       console.error("Failed to reload the current diff.", error);
     });
   }, [refreshCurrentInput]);
-
-  // A completed extension write is a source change the user did not make in an
-  // editor, so it reloads through exactly the path the refresh key takes.
-  reloadAfterWorkspaceWriteRef.current = triggerRefreshCurrentInput;
 
   /** Reload because the watcher saw the reviewed source change on disk. */
   const refreshWatchedInput = useCallback(

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -101,7 +101,10 @@ import {
 } from "./lib/appCommands";
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
-import { createExtensionCapabilityLease } from "./lib/extensionCapabilityLease";
+import {
+  createExtensionCapabilityLease,
+  runWithExtensionCapabilityLease,
+} from "./lib/extensionCapabilityLease";
 import { createExtensionCommandControls } from "./lib/extensionCommandControls";
 import {
   applyExtensionCurrentLinePaintUpdate,
@@ -810,8 +813,13 @@ export function App({
             side,
           });
           // Every failure the fetcher can raise — a missing side, a read error,
-          // the host's source-size cap — is the same "no document" answer.
-          return read ? read().catch(() => null) : null;
+          // the host's source-size cap — is the same "no document" answer. Recheck
+          // after the fetch so a retired generation cannot publish stale text.
+          return runWithExtensionCapabilityLease(
+            lease,
+            () => (read ? read().catch(() => null) : Promise.resolve(null)),
+            () => null,
+          );
         },
         canWriteDocument(fileId: string) {
           // The probe answers for anything, including an id that is not even a
@@ -872,17 +880,25 @@ export function App({
             return { ok: false, reason: "unavailable", detail: changedTargetRefusal };
           }
 
-          try {
-            await writeFile(target.absolutePath, text, "utf8");
-          } catch (error) {
-            return {
-              ok: false,
-              reason: "failed",
-              detail: `Failed to write ${target.path} • ${
-                error instanceof Error ? error.message || error.name : String(error)
-              }`,
-            };
-          }
+          const writeFailure = await runWithExtensionCapabilityLease(
+            lease,
+            async (): Promise<ExtensionWorkspaceWriteResult | null> => {
+              try {
+                await writeFile(target.absolutePath, text, "utf8");
+                return null;
+              } catch (error) {
+                return {
+                  ok: false,
+                  reason: "failed",
+                  detail: `Failed to write ${target.path} • ${
+                    error instanceof Error ? error.message || error.name : String(error)
+                  }`,
+                };
+              }
+            },
+            expired,
+          );
+          if (writeFailure) return writeFailure;
 
           // Fire-and-forget the reload so the result settles on the write
           // itself. In a `--watch` session the watcher sees the same write and

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -38,6 +38,7 @@ import {
   resolveExtensionFileViews,
   resolveExtensionKeyboardModes,
   resolveExtensionLineHighlighters,
+  resolveExtensionSessionOptions,
 } from "../extensions/apply";
 import {
   emitExtensionCustomEvent,
@@ -95,10 +96,12 @@ import {
   buildAppCommands,
   builtinCommandKeyDefaults,
   builtinCommandMatchProbes,
+  observeAppCommandDispatch,
   type AppCommand,
 } from "./lib/appCommands";
 import { buildAppMenus } from "./lib/appMenus";
 import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/extensionCommands";
+import { createExtensionCapabilityLease } from "./lib/extensionCapabilityLease";
 import { createExtensionCommandControls } from "./lib/extensionCommandControls";
 import {
   applyExtensionCurrentLinePaintUpdate,
@@ -452,6 +455,13 @@ export function App({
     () => (extensions ? resolveExtensionLineHighlighters(extensions.registry).highlighters : []),
     [extensions],
   );
+  const extensionSessionOptions = useMemo(
+    () =>
+      extensions
+        ? resolveExtensionSessionOptions(extensions.registry)
+        : { transientViewPreferences: false },
+    [extensions],
+  );
   // The one conversion of the visible review files into the frozen views every
   // extension surface sees: sidebar props and command-handler selection both
   // read from this list, so they can never describe the review differently.
@@ -510,19 +520,33 @@ export function App({
   // created each handler. Retain the current registry separately so controls
   // captured by a retired async handler cannot drive the replacement registry.
   const activeExtensionRegistryRef = useRef(extensions?.registry);
+  const activeReviewGenerationRef = useRef(bootstrap);
   useLayoutEffect(() => {
     activeExtensionRegistryRef.current = extensions?.registry;
-  }, [extensions?.registry]);
+    activeReviewGenerationRef.current = bootstrap;
+  }, [bootstrap, extensions?.registry]);
   const extensionCommandControls = useMemo(() => {
-    const owningRegistry = extensions?.registry;
+    const lease = createExtensionCapabilityLease({
+      owningRegistry: extensions?.registry,
+      getActiveRegistry: () => activeExtensionRegistryRef.current,
+      isAppAlive: () => appAliveForNavigationRef.current,
+    });
     return createExtensionCommandControls({
       getCommands: () => extensionHostCommandsRef.current,
-      isLive: () =>
-        appAliveForNavigationRef.current &&
-        owningRegistry?.eventBusPhase !== "closed" &&
-        activeExtensionRegistryRef.current === owningRegistry,
+      isLive: lease.isLive,
     });
   }, [extensions?.registry]);
+  /** Mint controls that expire with their runtime, App instance, or review generation. */
+  const createReviewCapabilityLease = useCallback(
+    () =>
+      createExtensionCapabilityLease({
+        owningRegistry: extensions?.registry,
+        getActiveRegistry: () => activeExtensionRegistryRef.current,
+        isAppAlive: () => appAliveForNavigationRef.current,
+        isReviewCurrent: () => activeReviewGenerationRef.current === bootstrap,
+      }),
+    [bootstrap, extensions?.registry],
+  );
   useEffect(() => {
     // StrictMode replays setup/cleanup/setup while the same App remains mounted.
     appAliveForNavigationRef.current = true;
@@ -629,12 +653,6 @@ export function App({
     };
   }, []);
 
-  useEffect(() => {
-    // Every load produces a fresh changeset object, so this covers the first
-    // review plus soft reloads; hard reloads remount App and land here again.
-    emitExtensionEvent(extensions, "changeset_loaded", { changeset: bootstrap.changeset });
-  }, [bootstrap.changeset, extensions]);
-
   const setPaneOpen = useCallback((key: string, nextOpen: boolean | "toggle") => {
     setPaneOpenState((current) => {
       const isOpen = current.open.includes(key);
@@ -650,6 +668,15 @@ export function App({
   /** Build the canonical pane controls; deprecated sidebar controls share this object. */
   const createPaneControls = useCallback(
     (extensionId: string): ExtensionPaneControls => {
+      const lease = createReviewCapabilityLease();
+      const hasAuthority = (method: string) => {
+        if (lease.isLive()) return true;
+        extensions?.context.notify(
+          `Extension ${extensionId} ${method} ignored — the review session was reloaded`,
+          "warning",
+        );
+        return false;
+      };
       const resolve = (method: string, id: string) => {
         const key = resolvePaneKey(sessionPanesRef.current, extensionId, id);
         if (!key)
@@ -666,6 +693,7 @@ export function App({
       };
       return {
         open(id) {
+          if (!hasAuthority("panes.open")) return;
           const key = resolve("panes.open", id);
           if (key) {
             setPaneOpen(key, true);
@@ -673,10 +701,12 @@ export function App({
           }
         },
         close(id) {
+          if (!hasAuthority("panes.close")) return;
           const key = resolve("panes.close", id);
           if (key) setPaneOpen(key, false);
         },
         toggle(id) {
+          if (!hasAuthority("panes.toggle")) return;
           const key = resolve("panes.toggle", id);
           if (key) {
             const opens = !paneOpenStateRef.current.open.includes(key);
@@ -685,27 +715,32 @@ export function App({
           }
         },
         isOpen(id) {
+          if (!lease.isLive()) return false;
           const key = resolvePaneKey(sessionPanesRef.current, extensionId, id);
           return key !== undefined && paneOpenStateRef.current.open.includes(key);
         },
       };
     },
-    [extensions, setPaneOpen],
+    [createReviewCapabilityLease, extensions, setPaneOpen],
   );
 
   /** Build live, guarded review navigation for one extension-owned handler. */
   const createExtensionNavigation = useCallback(
-    (extensionId: string) =>
-      createGuardedReviewNavigation({
+    (extensionId: string) => {
+      const lease = createReviewCapabilityLease();
+      return createGuardedReviewNavigation({
         extensionId,
         getFiles: () => extensionSelectionInputsRef.current.filteredFiles,
-        isLive: () => appAliveForNavigationRef.current,
+        isLive: lease.isLive,
         notify: (message, type) => extensions?.context.notify(message, type),
         onSelectFile: (fileId) => extensionCommandNavigationRef.current.onSelectFile(fileId),
         onSelectHunk: (fileId, hunkIndex) =>
           extensionCommandNavigationRef.current.onSelectHunk(fileId, hunkIndex),
-      }),
-    [extensions],
+        onRevealLine: (fileId, side, line) =>
+          extensionCommandNavigationRef.current.onRevealLine(fileId, side, line),
+      });
+    },
+    [createReviewCapabilityLease, extensions],
   );
 
   /**
@@ -736,17 +771,27 @@ export function App({
   /** Keep third-party dialog attribution while presenting bundled extensions as native Hunk UI. */
   const createExtensionDialogs = useCallback(
     (extensionId: string) => {
+      const lease = createReviewCapabilityLease();
       const bundled = extensions?.registry.extensions.some(
         (metadata) => metadata.id === extensionId && metadata.origin === "bundled",
       );
-      return createQueuedExtensionDialogs(extensionId, { showAttribution: !bundled });
+      return createQueuedExtensionDialogs(extensionId, {
+        isLive: lease.isLive,
+        showAttribution: !bundled,
+      });
     },
-    [createQueuedExtensionDialogs, extensions],
+    [createQueuedExtensionDialogs, createReviewCapabilityLease, extensions],
   );
 
   /** Build host-mediated reviewed-document read and write controls for one extension command. */
   const createWorkspaceControls = useCallback(
     (extensionId: string): ExtensionWorkspace => {
+      const lease = createReviewCapabilityLease();
+      const expired = (): ExtensionWorkspaceWriteResult => ({
+        ok: false,
+        reason: "unavailable",
+        detail: "The review reloaded before this extension operation could finish.",
+      });
       const resolveTarget = (fileId: string) =>
         resolveExtensionWorkspaceWriteTarget({
           fileId,
@@ -755,6 +800,7 @@ export function App({
 
       return {
         async readDocument(fileId: string, side: ExtensionFileSide) {
+          if (!lease.isLive()) return null;
           // Unlike a write, a read asks nothing of the user and nothing of the
           // review kind: it hands back the document the review is already
           // showing. Only a malformed side throws, from inside the policy.
@@ -771,7 +817,7 @@ export function App({
           // The probe answers for anything, including an id that is not even a
           // string: an affordance question should not throw at a caller who is
           // only deciding whether to offer the action.
-          return typeof fileId === "string" && resolveTarget(fileId).writable;
+          return lease.isLive() && typeof fileId === "string" && resolveTarget(fileId).writable;
         },
         async writeDocument(
           request: ExtensionWorkspaceWriteRequest,
@@ -779,6 +825,7 @@ export function App({
           // Throws rather than resolving a reason: a malformed request is a bug
           // in the extension, not an answer about this review.
           const { fileId, text } = normalizeWorkspaceWriteRequest(request);
+          if (!lease.isLive()) return expired();
           const target = resolveTarget(fileId);
           if (!target.writable) {
             return { ok: false, reason: "unavailable", detail: target.detail };
@@ -797,6 +844,7 @@ export function App({
               root,
             });
           const refusal = await verifyTarget();
+          if (!lease.isLive()) return expired();
           if (refusal) {
             return { ok: false, reason: "unavailable", detail: refusal };
           }
@@ -809,6 +857,7 @@ export function App({
             body: `Extension ${extensionId} will replace this file's contents on disk.`,
             confirmLabel: "write",
           });
+          if (!lease.isLive()) return expired();
           if (!confirmed) {
             return {
               ok: false,
@@ -818,6 +867,7 @@ export function App({
           }
 
           const changedTargetRefusal = await verifyTarget();
+          if (!lease.isLive()) return expired();
           if (changedTargetRefusal) {
             return { ok: false, reason: "unavailable", detail: changedTargetRefusal };
           }
@@ -843,7 +893,7 @@ export function App({
         },
       };
     },
-    [createExtensionDialogs],
+    [createExtensionDialogs, createReviewCapabilityLease],
   );
 
   // Lifecycle and bus listeners receive the same pane, navigation, and dialog
@@ -1718,12 +1768,9 @@ export function App({
 
   /** Leave the app through the shared shutdown path, prompting before discarding view changes. */
   const requestQuit = useCallback(() => {
-    const transientViewPreferences = extensions?.registry.sessionOptions.some(
-      ({ options }) => options.viewPreferences === "transient",
-    );
     if (
       !pagerMode &&
-      !transientViewPreferences &&
+      !extensionSessionOptions.transientViewPreferences &&
       bootstrap.input.options.promptSaveViewPreferences !== false &&
       hasUnsavedViewPreferences
     ) {
@@ -1735,7 +1782,7 @@ export function App({
     onQuit();
   }, [
     bootstrap.input.options.promptSaveViewPreferences,
-    extensions,
+    extensionSessionOptions.transientViewPreferences,
     hasUnsavedViewPreferences,
     onQuit,
     pagerMode,
@@ -1904,46 +1951,43 @@ export function App({
   // One dispatch table for every app-level shortcut: the built-in commands
   // over App's live callbacks, then extension commands, so built-ins always
   // win a key and extension order follows load order.
-  const appCommands = [
-    ...buildAppCommands({
-      canAlignCurrentLine: cursorLine !== "off" && review.lineCursor !== null,
-      canApplyFilePresentationToAllMatching: selectedFileViewBulkTarget !== null,
-      canRefreshCurrentInput,
-      alignCurrentLine,
-      applyFilePresentationToAllMatching,
-      focusFilter,
-      moveSelection: review.moveSelection,
-      openAgentSkill,
-      openThemeSelector,
-      requestQuit,
-      resolvedKeys: resolvedCommandKeys,
-      scrollCodeHorizontally,
-      scrollDiff,
-      stepDiffLine,
-      selectCursorLine: setCursorLine,
-      selectLayoutMode,
-      startUserNote: () => startUserNote(),
-      toggleAgentNotes,
-      toggleCopyDecorations,
-      toggleFocusArea,
-      toggleGapForSelectedHunk: review.toggleSelectedHunkGap,
-      toggleHelp,
-      toggleHunkHeaders,
-      toggleLineNumbers,
-      toggleLineWrap,
-      toggleMenuBar,
-      toggleSidebar,
-      triggerEditSelectedFile,
-      triggerRefreshCurrentInput,
-    }),
-    ...extensionAppCommands.commands,
-  ].map((command) => ({
-    ...command,
-    run: (...args: Parameters<typeof command.run>) => {
-      command.run(...args);
-      emitExtensionEvent(extensions, "command_executed", { commandId: command.id });
-    },
-  }));
+  const appCommands = observeAppCommandDispatch(
+    [
+      ...buildAppCommands({
+        canAlignCurrentLine: cursorLine !== "off" && review.lineCursor !== null,
+        canApplyFilePresentationToAllMatching: selectedFileViewBulkTarget !== null,
+        canRefreshCurrentInput,
+        alignCurrentLine,
+        applyFilePresentationToAllMatching,
+        focusFilter,
+        moveSelection: review.moveSelection,
+        openAgentSkill,
+        openThemeSelector,
+        requestQuit,
+        resolvedKeys: resolvedCommandKeys,
+        scrollCodeHorizontally,
+        scrollDiff,
+        stepDiffLine,
+        selectCursorLine: setCursorLine,
+        selectLayoutMode,
+        startUserNote: () => startUserNote(),
+        toggleAgentNotes,
+        toggleCopyDecorations,
+        toggleFocusArea,
+        toggleGapForSelectedHunk: review.toggleSelectedHunkGap,
+        toggleHelp,
+        toggleHunkHeaders,
+        toggleLineNumbers,
+        toggleLineWrap,
+        toggleMenuBar,
+        toggleSidebar,
+        triggerEditSelectedFile,
+        triggerRefreshCurrentInput,
+      }),
+      ...extensionAppCommands.commands,
+    ],
+    (commandId) => emitExtensionEvent(extensions, "command_executed", { commandId }),
+  );
   extensionHostCommandsRef.current = appCommands;
 
   // Menus name commands rather than repeating them: every item's key hint and

--- a/src/ui/AppHost.extension-dialogs.test.tsx
+++ b/src/ui/AppHost.extension-dialogs.test.tsx
@@ -160,6 +160,7 @@ async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>, quits: () => number) => Promise<void>,
   hostClient?: HunkSessionBrokerClient,
+  dimensions: { width: number; height: number } = { width: 140, height: 30 },
 ) {
   let quitCount = 0;
   const setup = await testRender(
@@ -170,7 +171,7 @@ async function withAppHost(
         quitCount += 1;
       }}
     />,
-    { width: 140, height: 30 },
+    dimensions,
   );
 
   try {
@@ -181,6 +182,16 @@ async function withAppHost(
       setup.renderer.destroy();
     });
   }
+}
+
+/** Find the first terminal coordinate occupied by one rendered text fragment. */
+function findTextPosition(frame: string, text: string) {
+  const lines = frame.split("\n");
+  for (let y = 0; y < lines.length; y += 1) {
+    const x = lines[y]!.indexOf(text);
+    if (x >= 0) return { x, y };
+  }
+  return null;
 }
 
 /**
@@ -264,6 +275,40 @@ describe("extension dialogs", () => {
     });
   });
 
+  test("keeps confirm actions visible when wrapped prose exceeds a short terminal", async () => {
+    const repo = createTestRepo("hunk-ext-dialog-short-confirm-");
+    const extDir = createTempDir("hunk-ext-dialog-short-confirm-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeDialogFixture(
+      extPath,
+      logPath,
+      `ctx.dialogs.confirm({ title: "Short terminal", body: "This deliberately long explanation wraps across many rows but must never displace the primary actions from the modal footer." })`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await act(async () => {
+          await setup.mockInput.typeText("y");
+        });
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("Short terminal"),
+          "the short confirm dialog to open",
+        );
+
+        const frame = setup.captureCharFrame();
+        expect(frame).toContain("…");
+        expect(frame).toContain("enter/y");
+        expect(frame).toContain("esc/n");
+      },
+      undefined,
+      { width: 50, height: 12 },
+    );
+  });
+
   test("escape resolves a confirm dialog as false", async () => {
     const repo = createTestRepo("hunk-ext-dialog-escape-");
     const extDir = createTempDir("hunk-ext-dialog-escape-ext-");
@@ -345,6 +390,41 @@ describe("extension dialogs", () => {
     });
   });
 
+  test("clicking a select option accepts that exact row", async () => {
+    const repo = createTestRepo("hunk-ext-dialog-select-mouse-");
+    const extDir = createTempDir("hunk-ext-dialog-select-mouse-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeDialogFixture(
+      extPath,
+      logPath,
+      `ctx.dialogs.select({ title: "Mouse target?", options: ["staging", "production", "canary"] })`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("production"),
+        "the mouse select dialog to open",
+      );
+
+      const target = findTextPosition(setup.captureCharFrame(), "production");
+      expect(target).not.toBeNull();
+      await act(async () => {
+        await setup.mockMouse.click(target!.x, target!.y);
+      });
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("answer production"),
+        "the clicked option to resolve",
+      );
+    });
+  });
+
   test("an input dialog resolves the typed text", async () => {
     const repo = createTestRepo("hunk-ext-dialog-input-");
     const extDir = createTempDir("hunk-ext-dialog-input-ext-");
@@ -385,13 +465,15 @@ describe("extension dialogs", () => {
       );
       expect(quits()).toBe(0);
 
+      const submit = findTextPosition(setup.captureCharFrame(), "submit");
+      expect(submit).not.toBeNull();
       await act(async () => {
-        await setup.mockInput.pressEnter();
+        await setup.mockMouse.click(submit!.x, submit!.y);
       });
       await flushUntil(
         setup,
         () => readProbeLog(logPath).includes("answer quick-fix"),
-        "the handler to resolve the typed text",
+        "the mouse action to submit the typed text",
       );
     });
   });
@@ -426,9 +508,7 @@ describe("extension dialogs", () => {
         // The daemon path reaches reloadSession without the refresh key's
         // wrapper, so this is the reload that would leave the question
         // standing if cancellation hung off any single call site.
-        await act(async () => {
-          await broker.reload({ kind: "vcs", staged: false, options: {} });
-        });
+        const reload = broker.reload({ kind: "vcs", staged: false, options: {} });
         await flushUntil(
           setup,
           () => {
@@ -437,6 +517,7 @@ describe("extension dialogs", () => {
           },
           "the reload to close the dialog over the replacement review",
         );
+        await reload;
         await flushUntil(
           setup,
           () => readProbeLog(logPath).includes("answer false"),

--- a/src/ui/AppHost.extension-dialogs.test.tsx
+++ b/src/ui/AppHost.extension-dialogs.test.tsx
@@ -527,4 +527,53 @@ describe("extension dialogs", () => {
       broker.client,
     );
   });
+
+  test("keeps a dialog opened by the replacement generation's reload lifecycle", async () => {
+    const repo = createTestRepo("hunk-ext-dialog-reload-lifecycle-");
+    const extDir = createTempDir("hunk-ext-dialog-reload-lifecycle-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.on("session_reload", async (_payload, ctx) => {\n` +
+        `    const answer = await ctx.dialogs.confirm({ title: "Review reloaded" });\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "answer " + String(answer) + "\\n");\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const broker = createTestBrokerClient();
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("alpha.txt"),
+          "the initial review to render",
+        );
+
+        const reload = broker.reload({ kind: "vcs", staged: false, options: {} });
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("Review reloaded"),
+          "the replacement lifecycle dialog to remain open",
+        );
+        await reload;
+        expect(readProbeLog(logPath)).toEqual([]);
+
+        await act(async () => {
+          await setup.mockInput.pressEnter();
+        });
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("answer true"),
+          "the replacement lifecycle dialog to resolve normally",
+        );
+      },
+      broker.client,
+    );
+  });
 });

--- a/src/ui/AppHost.extensions.test.tsx
+++ b/src/ui/AppHost.extensions.test.tsx
@@ -425,6 +425,73 @@ describe("reload keeps launch extension authority", () => {
   });
 });
 
+describe("mounted lifecycle ordering", () => {
+  test("delivers same-runtime reload events after the new review commits", async () => {
+    const repo = createTestRepo("hunk-apphost-lifecycle-order-");
+    const logPath = join(repo, "lifecycle.log");
+    const extPath = join(repo, "lifecycle.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `export default function (hunk) {\n` +
+        `  const log = (line) => appendFileSync(${JSON.stringify(logPath)}, line + "\\n");\n` +
+        `  hunk.on("startup", () => log("lifecycle:startup"));\n` +
+        `  hunk.on("changeset_loaded", () => log("lifecycle:changeset_loaded"));\n` +
+        `  hunk.on("session_reload", ({ changeset }, ctx) => {\n` +
+        `    log("lifecycle:session_reload");\n` +
+        `    const added = changeset.files.find((file) => file.path === "gamma.txt");\n` +
+        `    if (added) ctx.navigation.selectFile(added.id);\n` +
+        `  });\n` +
+        `  hunk.on("file_viewed", ({ file }) => log("viewed:" + file.path));\n` +
+        `}\n`,
+    );
+    useTempConfigHome();
+
+    const bootstrap = await loadAppBootstrap(
+      { kind: "vcs", staged: false, options: { mode: "stack", extensionPaths: [extPath] } },
+      { cwd: repo },
+    );
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: repo,
+      cliExtensionPaths: [extPath],
+    });
+    expect(bootstrap.extensions.issues).toEqual([]);
+    const broker = createTestBrokerClient();
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("lifecycle:changeset_loaded"),
+          "the initial mounted lifecycle",
+        );
+        expect(readProbeLog(logPath).slice(0, 2)).toEqual([
+          "lifecycle:startup",
+          "lifecycle:changeset_loaded",
+        ]);
+
+        writeFileSync(join(repo, "gamma.txt"), "new file\n");
+        await broker.reload({ kind: "vcs", staged: false, options: {} }, repo);
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("viewed:gamma.txt"),
+          "the committed review to accept lifecycle navigation",
+        );
+
+        expect(readProbeLog(logPath).filter((line) => line.startsWith("lifecycle:"))).toEqual([
+          "lifecycle:startup",
+          "lifecycle:changeset_loaded",
+          "lifecycle:changeset_loaded",
+          "lifecycle:session_reload",
+        ]);
+      },
+      broker.client,
+    );
+  });
+});
+
 describe("file_viewed events", () => {
   test("fires again when a soft reload replaces the selected file with the same id", async () => {
     const repo = createTestRepo("hunk-apphost-file-viewed-");
@@ -619,6 +686,62 @@ describe("startup for extensions loaded mid-session", () => {
       },
       broker.client,
     );
+  });
+
+  test("revokes retained panes and dialogs before a soft replacement shuts down", async () => {
+    const repo = createTestRepo("hunk-apphost-retired-controls-");
+    const logPath = join(repo, "retired.log");
+    const extPath = join(repo, "retired.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `import { createElement } from "react";\n` +
+        `export default function (hunk) {\n` +
+        `  const paneText = ["RETIRED", "CONTROL", "PANE"].join(" ");\n` +
+        `  const dialogTitle = ["RETIRED", "CONTROL", "DIALOG"].join(" ");\n` +
+        `  hunk.registerPane({\n` +
+        `    id: "retired", title: "Retired", placement: "right", width: { preferred: 20, min: 10, max: 40 },\n` +
+        `    component: () => createElement("text", { content: paneText }),\n` +
+        `  });\n` +
+        `  hunk.on("startup", () => appendFileSync(${JSON.stringify(logPath)}, "startup\\n"));\n` +
+        `  hunk.on("shutdown", async (_payload, ctx) => {\n` +
+        `    ctx.panes.open("retired");\n` +
+        `    ctx.navigation.selectFile("retired-file");\n` +
+        `    const answer = await ctx.dialogs.confirm({ title: dialogTitle });\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "shutdown:" + answer + "\\n");\n` +
+        `  });\n` +
+        `}\n`,
+    );
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+    expect(bootstrap.extensions.issues).toEqual([]);
+
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("startup"),
+        "the retiring extension to receive startup",
+      );
+      await act(async () => {
+        await setup.mockInput.typeText("r");
+      });
+      await flushUntil(
+        setup,
+        () => readProbeLog(logPath).includes("shutdown:false"),
+        "retired shutdown controls to resolve without entering replacement UI",
+      );
+
+      const frame = setup.captureCharFrame();
+      expect(frame).not.toContain("RETIRED CONTROL DIALOG");
+      expect(frame).not.toContain("RETIRED CONTROL PANE");
+      expect(frame).toContain("ignored — the review session was reloaded");
+    });
   });
 
   test("shuts down and starts each replacement extension instance", async () => {

--- a/src/ui/AppHost.extensions.test.tsx
+++ b/src/ui/AppHost.extensions.test.tsx
@@ -1,11 +1,19 @@
 import { execSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
 import { removeTestDirectory } from "../../test/helpers/filesystem";
+import { ReviewProducer } from "../app/review/producer";
 import type { AppBootstrap } from "../app/types";
 import { getBundledVcsCatalog } from "../app/vcsCatalog";
 import { loadAppBootstrap as loadCoreAppBootstrap } from "../core/changesetLoaders";
@@ -139,6 +147,68 @@ function writeProbeExtension(path: string, logPath: string) {
   );
 }
 
+/** Write a probe whose replacement transform waits until the test releases its commit gate. */
+function writeDelayedReplacementExtension(path: string, logPath: string, releasePath: string) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(
+    path,
+    `import { appendFileSync, existsSync } from "node:fs";\n` +
+      `export default function (hunk) {\n` +
+      `  const replacement = existsSync(${JSON.stringify(logPath)});\n` +
+      `  appendFileSync(${JSON.stringify(logPath)}, "factory\\n");\n` +
+      `  hunk.transformChangeset(async (changeset) => {\n` +
+      `    while (replacement && !existsSync(${JSON.stringify(releasePath)})) {\n` +
+      `      await new Promise((resolve) => setTimeout(resolve, 10));\n` +
+      `    }\n` +
+      `    return changeset;\n` +
+      `  });\n` +
+      `  hunk.on("startup", () => appendFileSync(${JSON.stringify(logPath)}, "startup\\n"));\n` +
+      `  hunk.on("session_reload", () => appendFileSync(${JSON.stringify(logPath)}, "session_reload\\n"));\n` +
+      `  hunk.on("shutdown", () => appendFileSync(${JSON.stringify(logPath)}, "shutdown\\n"));\n` +
+      `}\n`,
+  );
+}
+
+/** Write a probe whose replacement factory waits after registering its shutdown hook. */
+function writeDelayedFactoryExtension(path: string, logPath: string, releasePath: string) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(
+    path,
+    `import { appendFileSync, existsSync } from "node:fs";\n` +
+      `export default async function (hunk) {\n` +
+      `  const replacement = existsSync(${JSON.stringify(logPath)});\n` +
+      `  appendFileSync(${JSON.stringify(logPath)}, "factory\\n");\n` +
+      `  hunk.on("startup", () => appendFileSync(${JSON.stringify(logPath)}, "startup\\n"));\n` +
+      `  hunk.on("shutdown", () => appendFileSync(${JSON.stringify(logPath)}, "shutdown\\n"));\n` +
+      `  while (replacement && !existsSync(${JSON.stringify(releasePath)})) {\n` +
+      `    await new Promise((resolve) => setTimeout(resolve, 10));\n` +
+      `  }\n` +
+      `}\n`,
+  );
+}
+
+/** Write a probe whose original instance holds shutdown until the test releases it. */
+function writeDelayedOriginalShutdownExtension(path: string, logPath: string, releasePath: string) {
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(
+    path,
+    `import { appendFileSync, existsSync } from "node:fs";\n` +
+      `export default function (hunk) {\n` +
+      `  const replacement = existsSync(${JSON.stringify(logPath)});\n` +
+      `  const instance = replacement ? "replacement" : "original";\n` +
+      `  appendFileSync(${JSON.stringify(logPath)}, "factory:" + instance + "\\n");\n` +
+      `  hunk.on("startup", () => appendFileSync(${JSON.stringify(logPath)}, "startup:" + instance + "\\n"));\n` +
+      `  hunk.on("shutdown", async () => {\n` +
+      `    appendFileSync(${JSON.stringify(logPath)}, "shutdown:start:" + instance + "\\n");\n` +
+      `    while (!replacement && !existsSync(${JSON.stringify(releasePath)})) {\n` +
+      `      await new Promise((resolve) => setTimeout(resolve, 5));\n` +
+      `    }\n` +
+      `    appendFileSync(${JSON.stringify(logPath)}, "shutdown:end:" + instance + "\\n");\n` +
+      `  });\n` +
+      `}\n`,
+  );
+}
+
 function readProbeLog(logPath: string) {
   try {
     return readFileSync(logPath, "utf8").trim().split("\n").filter(Boolean);
@@ -204,17 +274,23 @@ async function flushUntil(
  * the session was launched with. The interactive refresh key cannot stand in for
  * it — that path reuses the live bootstrap input and so never loses anything.
  */
-function createTestBrokerClient() {
+function createTestBrokerClient(options: { replaceSessionError?: Error } = {}) {
   let bridge: { dispatchCommand: (message: unknown) => Promise<unknown> } | null = null;
+  let registration = { sessionId: "test-session" };
+  let replacementCount = 0;
 
   const client = {
     setBridge(next: typeof bridge) {
       bridge = next;
     },
     getRegistration() {
-      return { sessionId: "test-session" };
+      return registration;
     },
-    replaceSession() {},
+    replaceSession(nextRegistration: typeof registration) {
+      replacementCount += 1;
+      if (options.replaceSessionError) throw options.replaceSessionError;
+      registration = nextRegistration;
+    },
     updateSnapshot() {},
     updateRegistration() {},
     close() {},
@@ -222,6 +298,8 @@ function createTestBrokerClient() {
 
   return {
     client,
+    registrationId: () => registration.sessionId,
+    replacementCount: () => replacementCount,
     /** Reload the way the daemon does, with a freshly parsed input. */
     reload: async (nextInput: CliInput, sourcePath?: string) => {
       if (!bridge) {
@@ -243,11 +321,25 @@ async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>) => Promise<void>,
   hostClient?: HunkSessionBrokerClient,
+  options: {
+    externalQuitSignal?: AbortSignal;
+    onQuit?: () => void;
+    reviewProducer?: ReviewProducer;
+  } = {},
 ) {
-  const setup = await testRender(<AppHost bootstrap={bootstrap} hostClient={hostClient} />, {
-    width: 120,
-    height: 24,
-  });
+  const setup = await testRender(
+    <AppHost
+      bootstrap={bootstrap}
+      externalQuitSignal={options.externalQuitSignal}
+      hostClient={hostClient}
+      onQuit={options.onQuit}
+      reviewProducer={options.reviewProducer}
+    />,
+    {
+      width: 120,
+      height: 24,
+    },
+  );
 
   try {
     await flush(setup);
@@ -340,6 +432,272 @@ describe("reload keeps launch extension authority", () => {
         expect(events.filter((line) => line === "startup")).toHaveLength(1);
       },
       broker.client,
+    );
+  });
+
+  test("retires a prepared replacement when broker commit preparation throws", async () => {
+    const repo = createTestRepo("hunk-apphost-broker-replacement-failure-");
+    const logPath = join(repo, "probe.log");
+    const extPath = join(repo, "ext.ts");
+    writeProbeExtension(extPath, logPath);
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+    const broker = createTestBrokerClient({ replaceSessionError: new Error("broker exploded") });
+    const producer = new ReviewProducer(
+      {
+        files: bootstrap.changeset.files,
+        sourceLabel: bootstrap.changeset.sourceLabel,
+      },
+      { producerId: "broker-failure" },
+    );
+    const initialGeneration = producer.getPublication().generation;
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("startup"),
+          "the original extension instance to start",
+        );
+
+        await expect(
+          broker.reload({ kind: "vcs", staged: false, options: {} }, repo),
+        ).rejects.toThrow("broker exploded");
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).filter((line) => line === "shutdown").length === 1,
+          "the prepared replacement to retire after broker failure",
+        );
+
+        const events = readProbeLog(logPath);
+        expect(producer.getPublication().generation).toBe(initialGeneration);
+        expect(broker.registrationId()).toBe("test-session");
+        expect(broker.replacementCount()).toBe(1);
+        expect(events.filter((line) => line === "factory")).toHaveLength(2);
+        expect(events.filter((line) => line === "startup")).toHaveLength(1);
+        expect(events.filter((line) => line === "shutdown")).toHaveLength(1);
+      },
+      broker.client,
+      { reviewProducer: producer },
+    );
+  });
+
+  test("refuses a queued replacement reload after quit becomes terminal", async () => {
+    const repo = createTestRepo("hunk-apphost-queued-reload-quit-");
+    const logPath = join(repo, "probe.log");
+    const extPath = join(repo, "ext.ts");
+    writeProbeExtension(extPath, logPath);
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+    const broker = createTestBrokerClient();
+    const quitController = new AbortController();
+    let quits = 0;
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("startup"),
+          "the original extension instance to start",
+        );
+
+        const reload = broker.reload({ kind: "vcs", staged: false, options: {} }, repo);
+        quitController.abort();
+
+        await expect(reload).rejects.toThrow("shutting down");
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).filter((line) => line === "shutdown").length === 1,
+          "quit to retire the original extension",
+        );
+        expect(quits).toBe(1);
+        expect(broker.replacementCount()).toBe(0);
+        expect(readProbeLog(logPath).filter((line) => line === "factory")).toHaveLength(1);
+      },
+      broker.client,
+      { externalQuitSignal: quitController.signal, onQuit: () => (quits += 1) },
+    );
+  });
+
+  test("owns and retires a replacement still inside its asynchronous factory", async () => {
+    const repo = createTestRepo("hunk-apphost-factory-reload-quit-");
+    const logPath = join(repo, "probe.log");
+    const releasePath = join(repo, "release-factory");
+    const extPath = join(repo, "ext.ts");
+    writeDelayedFactoryExtension(extPath, logPath, releasePath);
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+    const broker = createTestBrokerClient();
+    const quitController = new AbortController();
+    let quits = 0;
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("startup"),
+          "the original extension instance to start",
+        );
+
+        const reload = broker.reload({ kind: "vcs", staged: false, options: {} }, repo);
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).filter((line) => line === "factory").length === 2,
+          "the replacement factory to suspend",
+        );
+
+        quitController.abort();
+        await flushUntil(
+          setup,
+          () =>
+            readProbeLog(logPath).filter((line) => line === "shutdown").length === 2 && quits === 1,
+          "quit to retire provisional factory authority before process teardown",
+        );
+        expect(existsSync(releasePath)).toBe(false);
+
+        writeFileSync(releasePath, "continue\n");
+        await expect(reload).rejects.toThrow("shutting down");
+        expect(broker.replacementCount()).toBe(0);
+        expect(readProbeLog(logPath).filter((line) => line === "startup")).toHaveLength(1);
+      },
+      broker.client,
+      { externalQuitSignal: quitController.signal, onQuit: () => (quits += 1) },
+    );
+  });
+
+  test("retires an in-flight replacement instead of adopting it after quit", async () => {
+    const repo = createTestRepo("hunk-apphost-inflight-reload-quit-");
+    const logPath = join(repo, "probe.log");
+    const releasePath = join(repo, "release-replacement");
+    const extPath = join(repo, "ext.ts");
+    writeDelayedReplacementExtension(extPath, logPath, releasePath);
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+    const broker = createTestBrokerClient();
+    const quitController = new AbortController();
+    let quits = 0;
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("startup"),
+          "the original extension instance to start",
+        );
+
+        const reload = broker.reload({ kind: "vcs", staged: false, options: {} }, repo);
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).filter((line) => line === "factory").length === 2,
+          "the replacement to wait inside session loading",
+        );
+        expect(existsSync(releasePath)).toBe(false);
+
+        quitController.abort();
+        await flushUntil(
+          setup,
+          () =>
+            readProbeLog(logPath).filter((line) => line === "shutdown").length === 2 && quits === 1,
+          "quit to retire both runtimes before process teardown",
+        );
+        // The host can now exit even though session loading has not returned;
+        // release it only so this test process can observe the rejected reload.
+        expect(existsSync(releasePath)).toBe(false);
+        writeFileSync(releasePath, "continue\n");
+        await expect(reload).rejects.toThrow("shutting down");
+
+        const events = readProbeLog(logPath);
+        expect(quits).toBe(1);
+        expect(broker.replacementCount()).toBe(0);
+        expect(events.filter((line) => line === "startup")).toHaveLength(1);
+        expect(events.filter((line) => line === "session_reload")).toHaveLength(0);
+      },
+      broker.client,
+      { externalQuitSignal: quitController.signal, onQuit: () => (quits += 1) },
+    );
+  });
+
+  test("waits for an adopted runtime's in-flight retirement before quit", async () => {
+    const repo = createTestRepo("hunk-apphost-retirement-reload-quit-");
+    const logPath = join(repo, "probe.log");
+    const releasePath = join(repo, "release-shutdown");
+    const extPath = join(repo, "ext.ts");
+    writeDelayedOriginalShutdownExtension(extPath, logPath, releasePath);
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+    const broker = createTestBrokerClient();
+    const quitController = new AbortController();
+    let quits = 0;
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("startup:original"),
+          "the original extension instance to start",
+        );
+
+        const reload = broker.reload({ kind: "vcs", staged: false, options: {} }, repo);
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("shutdown:start:original"),
+          "the original runtime retirement to suspend",
+        );
+
+        quitController.abort();
+        await pumpFrames(setup, 1);
+        expect(quits).toBe(0);
+        expect(readProbeLog(logPath)).not.toContain("shutdown:end:original");
+
+        writeFileSync(releasePath, "continue\n");
+        await reload;
+        await flushUntil(
+          setup,
+          () => quits === 1,
+          "quit to wait for the adopted runtime's prior retirement",
+        );
+
+        const events = readProbeLog(logPath);
+        expect(events).toContain("shutdown:end:original");
+        expect(events).toContain("shutdown:end:replacement");
+      },
+      broker.client,
+      { externalQuitSignal: quitController.signal, onQuit: () => (quits += 1) },
     );
   });
 

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -16,6 +16,7 @@ import type { AppBootstrap, LayoutMode } from "../core/types";
 import { createTestVcsAppBootstrap } from "../../test/helpers/app-bootstrap";
 import { capturedTestColorToHex } from "../../test/helpers/test-color-helpers";
 import { createTestDiffFile as buildTestDiffFile, lines } from "../../test/helpers/diff-helpers";
+import { createEmptyExtensionLoadResult } from "../extensions/types";
 import { AGENT_SKILL_COMMAND, AGENT_SKILL_PROMPT } from "./components/chrome/AgentSkillDialog";
 import { resolveTheme } from "./themes";
 
@@ -1186,9 +1187,6 @@ describe("App interactions", () => {
         });
         await flush(setup);
         frame = setup.captureCharFrame();
-        if (frame.includes("interaction coverage")) {
-          break;
-        }
       }
 
       expect(frame).toContain("interaction coverage");
@@ -1200,9 +1198,6 @@ describe("App interactions", () => {
         });
         await flush(setup);
         frame = setup.captureCharFrame();
-        if (frame.includes("this is a very")) {
-          break;
-        }
       }
 
       expect(frame).toContain("this is a very");
@@ -3780,6 +3775,37 @@ describe("App interactions", () => {
 
       expect(quit).toHaveBeenCalledTimes(1);
       expect(setup.captureCharFrame()).not.toContain("Save view preferences?");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("transient extension sessions never offer to save practice view preferences", async () => {
+    const quit = mock(() => undefined);
+    const bootstrap = createSingleFileBootstrap();
+    const extensions = createEmptyExtensionLoadResult(process.cwd());
+    extensions.registry.sessionOptions.push({
+      extensionId: "trainer",
+      options: { viewPreferences: "transient" },
+    });
+    bootstrap.extensions = extensions;
+    const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={quit} />, {
+      width: 180,
+      height: 24,
+    });
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await setup.mockInput.typeText("w");
+        await setup.mockInput.typeText("q");
+      });
+      await flush(setup);
+
+      expect(setup.captureCharFrame()).not.toContain("Save view preferences?");
+      expect(quit).toHaveBeenCalledTimes(1);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/AppHost.keybindings.test.tsx
+++ b/src/ui/AppHost.keybindings.test.tsx
@@ -10,6 +10,7 @@ import { resolveConfiguredCliInput } from "../core/config";
 import { getBundledVcsCatalog } from "../app/vcsCatalog";
 import { loadAppBootstrap } from "../core/changesetLoaders";
 import type { AppBootstrap } from "../core/types";
+import { createEmptyExtensionLoadResult } from "../extensions/types";
 import { AppHost } from "./AppHost";
 
 /**
@@ -174,6 +175,56 @@ describe("user keybindings", () => {
       });
       await flush(setup);
       expect(quits()).toBe(1);
+    });
+  });
+
+  test("emits command_executed after keyboard dispatch", async () => {
+    const repo = createTestRepo("hunk-keybindings-command-event-");
+    const bootstrap = await launchWithConfig(repo, "");
+    const extensions = createEmptyExtensionLoadResult(repo);
+    const seen: string[] = [];
+    extensions.registry.eventHandlers.command_executed.push({
+      extensionId: "coach",
+      handler: ({ commandId }) => {
+        seen.push(commandId);
+      },
+    });
+    bootstrap.extensions = extensions;
+
+    await withAppHost(bootstrap, async (setup) => {
+      await act(async () => {
+        await setup.mockInput.typeText("j");
+      });
+      await flush(setup);
+      expect(seen).toContain("hunk.review.stepDown");
+    });
+  });
+
+  test("emits command_executed when Tab leaves the focused file filter", async () => {
+    const repo = createTestRepo("hunk-keybindings-focused-command-event-");
+    const bootstrap = await launchWithConfig(repo, "");
+    const extensions = createEmptyExtensionLoadResult(repo);
+    const seen: string[] = [];
+    extensions.registry.eventHandlers.command_executed.push({
+      extensionId: "coach",
+      handler: ({ commandId }) => {
+        seen.push(commandId);
+      },
+    });
+    bootstrap.extensions = extensions;
+
+    await withAppHost(bootstrap, async (setup) => {
+      await act(async () => {
+        await setup.mockInput.pressTab();
+      });
+      await flush(setup);
+      seen.length = 0;
+
+      await act(async () => {
+        await setup.mockInput.pressTab();
+      });
+      await flush(setup);
+      expect(seen).toEqual(["hunk.app.toggleFocusArea"]);
     });
   });
 });

--- a/src/ui/AppHost.keybindings.test.tsx
+++ b/src/ui/AppHost.keybindings.test.tsx
@@ -96,10 +96,15 @@ async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
 async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>, quits: () => number) => Promise<void>,
+  externalQuitSignal?: AbortSignal,
 ) {
   let quitCount = 0;
   const setup = await testRender(
-    <AppHost bootstrap={bootstrap} onQuit={() => (quitCount += 1)} />,
+    <AppHost
+      bootstrap={bootstrap}
+      externalQuitSignal={externalQuitSignal}
+      onQuit={() => (quitCount += 1)}
+    />,
     { width: 120, height: 24 },
   );
 
@@ -256,6 +261,32 @@ describe("user keybindings", () => {
       expect(seen).toEqual(["command:hunk.app.quit", "shutdown"]);
       expect(quits()).toBe(1);
     });
+  });
+
+  test("retires extensions before an external terminal interrupt quits", async () => {
+    const repo = createTestRepo("hunk-keybindings-interrupt-shutdown-");
+    const bootstrap = await launchWithConfig(repo, "");
+    const extensions = createEmptyExtensionLoadResult(repo);
+    const quitController = new AbortController();
+    const seen: string[] = [];
+    extensions.registry.eventHandlers.shutdown.push({
+      extensionId: "coach",
+      handler: () => {
+        seen.push("shutdown");
+      },
+    });
+    bootstrap.extensions = extensions;
+
+    await withAppHost(
+      bootstrap,
+      async (setup, quits) => {
+        await act(async () => quitController.abort());
+        await flush(setup);
+        expect(seen).toEqual(["shutdown"]);
+        expect(quits()).toBe(1);
+      },
+      quitController.signal,
+    );
   });
 
   test("emits command_executed when Tab leaves the focused file filter", async () => {

--- a/src/ui/AppHost.keybindings.test.tsx
+++ b/src/ui/AppHost.keybindings.test.tsx
@@ -200,6 +200,64 @@ describe("user keybindings", () => {
     });
   });
 
+  test("observes commands invoked through extension command controls exactly once", async () => {
+    const repo = createTestRepo("hunk-keybindings-programmatic-command-event-");
+    const bootstrap = await launchWithConfig(repo, "");
+    const extensions = createEmptyExtensionLoadResult(repo);
+    const seen: string[] = [];
+    extensions.registry.commands.push({
+      extensionId: "coach",
+      command: { id: "toggle-lines", title: "Toggle lines", key: "y" },
+      handler: (ctx) => {
+        ctx.commands.execute("hunk.view.toggleLineNumbers");
+      },
+    });
+    extensions.registry.eventHandlers.command_executed.push({
+      extensionId: "coach",
+      handler: ({ commandId }) => {
+        seen.push(commandId);
+      },
+    });
+    bootstrap.extensions = extensions;
+
+    await withAppHost(bootstrap, async (setup) => {
+      await act(async () => {
+        await setup.mockInput.typeText("y");
+      });
+      await flush(setup);
+      expect(seen).toEqual(["hunk.view.toggleLineNumbers", "coach.toggle-lines"]);
+    });
+  });
+
+  test("observes quit before shutdown remains the terminal lifecycle event", async () => {
+    const repo = createTestRepo("hunk-keybindings-quit-event-order-");
+    const bootstrap = await launchWithConfig(repo, "");
+    const extensions = createEmptyExtensionLoadResult(repo);
+    const seen: string[] = [];
+    extensions.registry.eventHandlers.command_executed.push({
+      extensionId: "coach",
+      handler: ({ commandId }) => {
+        seen.push(`command:${commandId}`);
+      },
+    });
+    extensions.registry.eventHandlers.shutdown.push({
+      extensionId: "coach",
+      handler: () => {
+        seen.push("shutdown");
+      },
+    });
+    bootstrap.extensions = extensions;
+
+    await withAppHost(bootstrap, async (setup, quits) => {
+      await act(async () => {
+        await setup.mockInput.typeText("q");
+      });
+      await flush(setup);
+      expect(seen).toEqual(["command:hunk.app.quit", "shutdown"]);
+      expect(quits()).toBe(1);
+    });
+  });
+
   test("emits command_executed when Tab leaves the focused file filter", async () => {
     const repo = createTestRepo("hunk-keybindings-focused-command-event-");
     const bootstrap = await launchWithConfig(repo, "");

--- a/src/ui/AppHost.tsx
+++ b/src/ui/AppHost.tsx
@@ -24,9 +24,24 @@ import {
   validateSessionReloadWithinBounds,
 } from "../session/app/reloadBounds";
 import type { HunkSessionBrokerClient, ReloadSessionOptions } from "../session/types";
-import { App } from "./App";
+import {
+  App,
+  type WorkspaceFileWriter,
+  type WorkspaceRefreshRequest,
+  type WorkspaceWriteRunner,
+} from "./App";
 import { useStartupNotices } from "./hooks/useStartupNotices";
 import type { WatchedInputRuntime } from "./hooks/useWatchedInput";
+
+/** A replacement registry prepared for adoption and optionally already retiring. */
+interface PendingExtensionReplacement {
+  result: ExtensionLoadResult;
+}
+
+/** Build the stable refusal returned once quit becomes terminal for reload coordination. */
+function reloadRefusedDuringShutdown() {
+  return new Error("The review session is shutting down and cannot reload.");
+}
 
 /** Keep one live Hunk app mounted while allowing daemon-driven session reloads. */
 export function AppHost({
@@ -37,6 +52,7 @@ export function AppHost({
   reviewProducer,
   startupNoticeResolver,
   watchRuntime,
+  workspaceFileWriter,
 }: {
   bootstrap: AppBootstrap;
   /** Process and terminal interrupts routed through host-owned extension retirement. */
@@ -51,6 +67,7 @@ export function AppHost({
   reviewProducer?: ReviewProducer;
   startupNoticeResolver?: () => Promise<StartupNotice | null>;
   watchRuntime?: WatchedInputRuntime;
+  workspaceFileWriter?: WorkspaceFileWriter;
 }) {
   const initialBootstrap = bootstrap.reloadContext.vcsCatalog
     ? bootstrap
@@ -100,6 +117,10 @@ export function AppHost({
   const initialExtensionStartupPendingRef = useRef(true);
   const reloadTailRef = useRef<Promise<void>>(Promise.resolve());
   const quitRequestedRef = useRef(false);
+  const pendingExtensionReplacementRef = useRef<PendingExtensionReplacement | undefined>(undefined);
+  const pendingExtensionRetirementsRef = useRef<Set<Promise<void>>>(new Set());
+  const pendingWorkspaceWritesRef = useRef<Set<Promise<void>>>(new Set());
+  const workspaceRefreshRequestRef = useRef<WorkspaceRefreshRequest | undefined>(undefined);
   const pendingReloadLifecycleRef = useRef<{
     extensions: ExtensionLoadResult;
     cwd: string;
@@ -146,8 +167,72 @@ export function AppHost({
     pending.resolveMounted();
   }, [activeBootstrap, initialBootstrap.reloadContext.cwd]);
 
+  /** Track one prepared registry until it is either adopted or fully retired. */
+  const trackPreparedExtensionReplacement = useCallback((result: ExtensionLoadResult) => {
+    pendingExtensionReplacementRef.current = { result };
+  }, []);
+
+  /** Track every registry retirement until its shared shutdown completion settles. */
+  const retireOwnedExtensionLoadResult = useCallback((result: ExtensionLoadResult | undefined) => {
+    const retirement = retireExtensionLoadResult(result);
+    pendingExtensionRetirementsRef.current.add(retirement);
+    void retirement.then(
+      () => pendingExtensionRetirementsRef.current.delete(retirement),
+      () => pendingExtensionRetirementsRef.current.delete(retirement),
+    );
+    return retirement;
+  }, []);
+
+  /** Retire one prepared registry through a shared promise so quit and reload cleanup agree. */
+  const retirePreparedExtensionReplacement = useCallback(
+    (result: ExtensionLoadResult | undefined): Promise<void> => {
+      if (!result) return Promise.resolve();
+      const pending = pendingExtensionReplacementRef.current;
+      if (!pending || pending.result !== result) return retireOwnedExtensionLoadResult(result);
+      return retireOwnedExtensionLoadResult(result).finally(() => {
+        if (pendingExtensionReplacementRef.current === pending) {
+          pendingExtensionReplacementRef.current = undefined;
+        }
+      });
+    },
+    [retireOwnedExtensionLoadResult],
+  );
+
+  /** Own provisional loader authority immediately, including work exposed after quit. */
+  const ownProvisionalExtensionReplacement = useCallback(
+    (result: ExtensionLoadResult) => {
+      trackPreparedExtensionReplacement(result);
+      if (quitRequestedRef.current) {
+        void retirePreparedExtensionReplacement(result);
+      }
+    },
+    [retirePreparedExtensionReplacement, trackPreparedExtensionReplacement],
+  );
+
+  /** Clear prepared ownership only when this exact registry becomes the mounted authority. */
+  const adoptPreparedExtensionReplacement = useCallback((result: ExtensionLoadResult) => {
+    if (pendingExtensionReplacementRef.current?.result === result) {
+      pendingExtensionReplacementRef.current = undefined;
+    }
+  }, []);
+
+  /** Start one irreversible write atomically with host tracking, unless quit already won. */
+  const runWorkspaceWrite = useCallback<WorkspaceWriteRunner>(async (write) => {
+    if (quitRequestedRef.current) return false;
+    const pending = write();
+    pendingWorkspaceWritesRef.current.add(pending);
+    try {
+      await pending;
+      return true;
+    } finally {
+      pendingWorkspaceWritesRef.current.delete(pending);
+    }
+  }, []);
+
   const performReloadSession = useCallback(
     async (nextInput: CliInput, options?: ReloadSessionOptions) => {
+      if (quitRequestedRef.current) throw reloadRefusedDuringShutdown();
+
       // Re-run the same startup normalization pipeline used on first launch so reloads honor
       // runtime defaults and config layering instead of assuming `nextInput` is already final.
       // `sourcePath` matters for daemon-driven reloads that ask Hunk to reopen content from a
@@ -177,71 +262,105 @@ export function AppHost({
       let replacementExtensions: ExtensionLoadResult | undefined;
 
       if (options?.reloadExtensions || cwd !== extensionsCwdRef.current) {
-        const resolvedExtensions = await resolveConfiguredExtensions({
-          runtimeInput,
-          configured,
-          cwd,
-          baseVcsCatalog,
-          discoveryCatalog,
-          // Reuse the session hub so the mounted toast surface keeps receiving notifications.
-          notifications: currentExtensions?.notifications,
-        });
-        configured = resolvedExtensions.configured;
-        replacementExtensions = resolvedExtensions.extensions;
+        try {
+          const resolvedExtensions = await resolveConfiguredExtensions({
+            runtimeInput,
+            configured,
+            cwd,
+            baseVcsCatalog,
+            discoveryCatalog,
+            // Reuse the session hub so the mounted toast surface keeps receiving notifications.
+            notifications: currentExtensions?.notifications,
+            onProvisionalLoad: ownProvisionalExtensionReplacement,
+            assertActive: () => {
+              if (quitRequestedRef.current) throw reloadRefusedDuringShutdown();
+            },
+          });
+          configured = resolvedExtensions.configured;
+          replacementExtensions = resolvedExtensions.extensions;
+          trackPreparedExtensionReplacement(replacementExtensions);
+        } catch (error) {
+          // The resolver may fail after publishing a provisional registry but
+          // before returning it. Clear host ownership through the same shared
+          // retirement used by quit and the ordinary reload failure paths.
+          await retirePreparedExtensionReplacement(pendingExtensionReplacementRef.current?.result);
+          throw error;
+        }
+        if (quitRequestedRef.current) {
+          await retirePreparedExtensionReplacement(replacementExtensions);
+          throw reloadRefusedDuringShutdown();
+        }
       }
 
       const extensions = replacementExtensions ?? currentExtensions;
-      const preparedReload = await (async () => {
-        try {
-          const {
-            applied,
-            bootstrap: nextBootstrap,
-            input: reloadInput,
-            sessionVcs,
-          } = await loadConfiguredSessionBootstrap({
-            configured,
-            cwd,
-            extensions,
-            loadAtCwd: true,
-            baseVcsCatalog,
-          });
-          if (extensions) {
-            reportExtensionApplyIssues(applied.issues, extensions.context);
-          }
-          nextBootstrap.startupNotices =
-            sessionVcs.unknownVcsId !== undefined
-              ? [
-                  ...(configured.startupNotices ?? []),
-                  // Names the backend the reload really used, detection override included.
-                  createUnknownVcsNotice(sessionVcs.unknownVcsId, String(reloadInput.options.vcs)),
-                ]
-              : configured.startupNotices;
-          // The reload succeeded, so this content becomes the next generation; the
-          // registration and snapshot below are projections of it.
-          const publication = producer.publish({
-            files: nextBootstrap.changeset.files,
-            sourceLabel: nextBootstrap.changeset.sourceLabel,
-          });
-          const nextSnapshot = createInitialSessionSnapshot(nextBootstrap, publication);
+      let loaded: Awaited<ReturnType<typeof loadConfiguredSessionBootstrap>>;
+      try {
+        loaded = await loadConfiguredSessionBootstrap({
+          configured,
+          cwd,
+          extensions,
+          loadAtCwd: true,
+          baseVcsCatalog,
+        });
+      } catch (error) {
+        await retirePreparedExtensionReplacement(replacementExtensions);
+        throw error;
+      }
 
-          let sessionId = "local-session";
+      // This is the reload's commit gate. Nothing below awaits until the new
+      // registry, broker snapshot, pending lifecycle, and React state all agree.
+      // Quit therefore linearizes either wholly before or wholly after adoption.
+      if (quitRequestedRef.current) {
+        await retirePreparedExtensionReplacement(replacementExtensions);
+        throw reloadRefusedDuringShutdown();
+      }
+
+      let nextBootstrap!: AppBootstrap;
+      let nextSnapshot!: ReturnType<typeof createInitialSessionSnapshot>;
+      let sessionId = "local-session";
+      try {
+        const { applied, bootstrap, input: reloadInput, sessionVcs } = loaded;
+        nextBootstrap = bootstrap;
+        if (extensions) {
+          reportExtensionApplyIssues(applied.issues, extensions.context);
+        }
+        nextBootstrap.startupNotices =
+          sessionVcs.unknownVcsId !== undefined
+            ? [
+                ...(configured.startupNotices ?? []),
+                // Names the backend the reload really used, detection override included.
+                createUnknownVcsNotice(sessionVcs.unknownVcsId, String(reloadInput.options.vcs)),
+              ]
+            : configured.startupNotices;
+        const preparedPublication = producer.preparePublication({
+          files: nextBootstrap.changeset.files,
+          sourceLabel: nextBootstrap.changeset.sourceLabel,
+        });
+        nextSnapshot = createInitialSessionSnapshot(nextBootstrap, preparedPublication.publication);
+        const publicationReservation = producer.reservePublication(preparedPublication);
+        try {
           if (hostClient) {
             // Keep the daemon-facing registration aligned with the review about to mount.
             const nextRegistration = updateSessionRegistration(
               hostClient.getRegistration(),
               nextBootstrap,
-              publication,
+              preparedPublication.publication,
             );
             sessionId = nextRegistration.sessionId;
             hostClient.replaceSession(nextRegistration, nextSnapshot);
           }
-          return { nextBootstrap, nextSnapshot, sessionId };
+          // The matching React store does not exist yet. Detach the previous
+          // generation so broker commands refuse rather than mutate stale state
+          // until the child layout effect attaches the committed review.
+          publicationReservation.commit({ detachStore: true });
         } catch (error) {
-          await retireExtensionLoadResult(replacementExtensions);
+          publicationReservation.cancel();
           throw error;
         }
-      })();
-      const { nextBootstrap, nextSnapshot, sessionId } = preparedReload;
+      } catch (error) {
+        await retirePreparedExtensionReplacement(replacementExtensions);
+        throw error;
+      }
 
       let currentExtensionsRetired: Promise<void> | undefined;
       if (replacementExtensions) {
@@ -249,9 +368,10 @@ export function AppHost({
         // Revocation is synchronous so mounted controls and modes become inert
         // before shutdown starts; React then tears them down on this state update.
         // `retireExtensionLoadResult` revokes synchronously before its first await.
-        currentExtensionsRetired = retireExtensionLoadResult(currentExtensions);
+        currentExtensionsRetired = retireOwnedExtensionLoadResult(currentExtensions);
         extensionsRef.current = replacementExtensions;
         extensionsCwdRef.current = cwd;
+        adoptPreparedExtensionReplacement(replacementExtensions);
       }
       const reloadMounted = extensions
         ? new Promise<void>((resolveMounted) => {
@@ -288,36 +408,88 @@ export function AppHost({
       };
     },
     [
+      adoptPreparedExtensionReplacement,
       hostClient,
       launchExperimental,
       launchExtensionsEnabled,
       launchExtensionPaths,
+      ownProvisionalExtensionReplacement,
       producer,
+      retireOwnedExtensionLoadResult,
+      retirePreparedExtensionReplacement,
       sessionFileBounds,
+      trackPreparedExtensionReplacement,
     ],
   );
 
+  /** Append one operation to the session's reload coordinator. */
+  const enqueueReload = useCallback(<Result,>(run: () => Promise<Result>): Promise<Result> => {
+    const pending = reloadTailRef.current.then(run);
+    reloadTailRef.current = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
+  }, []);
+
   /** Serialize broker, watch, workspace, and manual reloads around extension replacement. */
   const reloadSession = useCallback(
-    (nextInput: CliInput, options?: ReloadSessionOptions) => {
-      const pending = reloadTailRef.current.then(() => performReloadSession(nextInput, options));
-      reloadTailRef.current = pending.then(
-        () => undefined,
-        () => undefined,
-      );
-      return pending;
-    },
-    [performReloadSession],
+    (nextInput: CliInput, options?: ReloadSessionOptions) =>
+      enqueueReload(() => {
+        if (quitRequestedRef.current) throw reloadRefusedDuringShutdown();
+        return performReloadSession(nextInput, options);
+      }),
+    [enqueueReload, performReloadSession],
   );
 
-  /** Revoke extension authority and leave after bounded shutdown. */
+  /** Keep the latest mounted refresh descriptor without letting stale cleanup clear its successor. */
+  const registerWorkspaceRefreshRequest = useCallback((request: WorkspaceRefreshRequest) => {
+    workspaceRefreshRequestRef.current = request;
+    return () => {
+      if (workspaceRefreshRequestRef.current === request) {
+        workspaceRefreshRequestRef.current = undefined;
+      }
+    };
+  }, []);
+
+  /** Reconcile a completed write against whichever review owns the queue when it reaches the front. */
+  const reloadAfterWorkspaceWrite = useCallback(() => {
+    void enqueueReload(async () => {
+      if (quitRequestedRef.current) return;
+      const request = workspaceRefreshRequestRef.current;
+      if (!request) return;
+      await performReloadSession(request.nextInput, {
+        reason: "manual",
+        resetApp: false,
+        sourcePath: request.sourcePath,
+      });
+    }).catch((error) => {
+      console.error("Failed to reload after an extension workspace write.", error);
+    });
+  }, [enqueueReload, performReloadSession]);
+
+  /** Revoke all extension authority, finish started writes, then leave. */
   const quitAfterShutdownEvent = useCallback(() => {
     if (quitRequestedRef.current) return;
     quitRequestedRef.current = true;
     queueMicrotask(() => {
-      void retireExtensionLoadResult(extensionsRef.current).finally(onQuit);
+      const preparedReplacement = pendingExtensionReplacementRef.current?.result;
+      const startedWrites = [...pendingWorkspaceWritesRef.current];
+      void retireOwnedExtensionLoadResult(extensionsRef.current);
+      void retirePreparedExtensionReplacement(preparedReplacement);
+
+      /** Drain known retirement work; cancelled loaders cannot create a later staged registry. */
+      const settleExtensionRetirements = async () => {
+        while (pendingExtensionRetirementsRef.current.size > 0) {
+          await Promise.allSettled(pendingExtensionRetirementsRef.current);
+        }
+      };
+
+      void Promise.all([settleExtensionRetirements(), Promise.allSettled(startedWrites)]).finally(
+        onQuit,
+      );
     });
-  }, [onQuit]);
+  }, [onQuit, retireOwnedExtensionLoadResult, retirePreparedExtensionReplacement]);
 
   useEffect(() => {
     if (!externalQuitSignal) return;
@@ -339,9 +511,13 @@ export function AppHost({
       hostClient={hostClient}
       noticeText={startupNoticeText}
       onQuit={quitAfterShutdownEvent}
+      onRegisterWorkspaceRefreshRequest={registerWorkspaceRefreshRequest}
       onReloadSession={reloadSession}
+      onWorkspaceWriteCompleted={reloadAfterWorkspaceWrite}
       reviewProducer={producer}
+      runWorkspaceWrite={runWorkspaceWrite}
       watchRuntime={watchRuntime}
+      workspaceFileWriter={workspaceFileWriter}
     />
   );
 }

--- a/src/ui/AppHost.tsx
+++ b/src/ui/AppHost.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { resolveConfiguredExtensions } from "../app/extensionBootstrap";
 import { ReviewProducer } from "../app/review/producer";
 import { loadConfiguredSessionBootstrap } from "../app/sessionBootstrap";
@@ -13,11 +13,7 @@ import {
   reportExtensionApplyIssues,
   resolveExtensionVcsAdapters,
 } from "../extensions/apply";
-import {
-  emitExtensionEvent,
-  emitExtensionEventBounded,
-  retireExtensionLoadResult,
-} from "../extensions/events";
+import { emitExtensionEvent, retireExtensionLoadResult } from "../extensions/events";
 import { extendVcsCatalog } from "../core/vcs";
 import {
   createInitialSessionSnapshot,
@@ -100,11 +96,13 @@ export function AppHost({
   const extensionsCwdRef = useRef(sessionFileBounds.defaultCwd);
   const initialExtensionStartupPendingRef = useRef(true);
   const reloadTailRef = useRef<Promise<void>>(Promise.resolve());
-  const pendingReplacementLifecycleRef = useRef<{
+  const quitRequestedRef = useRef(false);
+  const pendingReloadLifecycleRef = useRef<{
     extensions: ExtensionLoadResult;
     cwd: string;
     changeset: AppBootstrap["changeset"];
     reason: NonNullable<ReloadSessionOptions["reason"]>;
+    emitStartup: boolean;
     resolveMounted: () => void;
   } | null>(null);
   const startupNoticeText = useStartupNotices({
@@ -113,23 +111,31 @@ export function AppHost({
     resolver: startupNoticeResolver,
   });
 
-  useEffect(() => {
-    // Child effects run before the parent's, so by the time this fires the review
-    // UI has rendered the matching bootstrap and installed live extension controls.
+  useLayoutEffect(() => {
+    // Child layout effects run before the parent's, so controls and generation
+    // leases are live here; passive UI events still wait until this order lands.
     if (initialExtensionStartupPendingRef.current) {
       initialExtensionStartupPendingRef.current = false;
       emitExtensionEvent(extensionsRef.current, "startup", {
         cwd: initialBootstrap.reloadContext.cwd,
       });
+      emitExtensionEvent(extensionsRef.current, "changeset_loaded", {
+        changeset: initialBootstrap.changeset,
+      });
       return;
     }
 
-    const pending = pendingReplacementLifecycleRef.current;
+    const pending = pendingReloadLifecycleRef.current;
     if (!pending) {
       return;
     }
-    pendingReplacementLifecycleRef.current = null;
-    emitExtensionEvent(pending.extensions, "startup", { cwd: pending.cwd });
+    pendingReloadLifecycleRef.current = null;
+    if (pending.emitStartup) {
+      emitExtensionEvent(pending.extensions, "startup", { cwd: pending.cwd });
+    }
+    emitExtensionEvent(pending.extensions, "changeset_loaded", {
+      changeset: pending.changeset,
+    });
     emitExtensionEvent(pending.extensions, "session_reload", {
       changeset: pending.changeset,
       reason: pending.reason,
@@ -234,7 +240,6 @@ export function AppHost({
       })();
       const { nextBootstrap, nextSnapshot, sessionId } = preparedReload;
 
-      let replacementMounted: Promise<void> | undefined;
       let currentExtensionsRetired: Promise<void> | undefined;
       if (replacementExtensions) {
         // Only retire the visible runtime after its replacement review is known-good.
@@ -244,16 +249,19 @@ export function AppHost({
         currentExtensionsRetired = retireExtensionLoadResult(currentExtensions);
         extensionsRef.current = replacementExtensions;
         extensionsCwdRef.current = cwd;
-        replacementMounted = new Promise<void>((resolveMounted) => {
-          pendingReplacementLifecycleRef.current = {
-            extensions: replacementExtensions,
-            cwd,
-            changeset: nextBootstrap.changeset,
-            reason: options?.reason ?? "daemon",
-            resolveMounted,
-          };
-        });
       }
+      const reloadMounted = extensions
+        ? new Promise<void>((resolveMounted) => {
+            pendingReloadLifecycleRef.current = {
+              extensions,
+              cwd,
+              changeset: nextBootstrap.changeset,
+              reason: options?.reason ?? "daemon",
+              emitStartup: replacementExtensions !== undefined,
+              resolveMounted,
+            };
+          })
+        : undefined;
 
       setActiveBootstrap(nextBootstrap);
       if (options?.resetApp !== false) {
@@ -262,16 +270,9 @@ export function AppHost({
         setAppVersion((current) => current + 1);
       }
 
-      if (!replacementExtensions) {
-        emitExtensionEvent(extensions, "session_reload", {
-          changeset: nextBootstrap.changeset,
-          reason: options?.reason ?? "daemon",
-        });
-      } else {
-        // Keep the reload queue held until React commits the matching App and
-        // the replacement receives startup/session_reload through live controls.
-        await Promise.all([replacementMounted, currentExtensionsRetired]);
-      }
+      // Keep the reload queue held until React commits the matching App and
+      // lifecycle handlers receive controls leased to that review generation.
+      await Promise.all([reloadMounted, currentExtensionsRetired]);
 
       return {
         sessionId,
@@ -306,9 +307,13 @@ export function AppHost({
     [performReloadSession],
   );
 
-  /** Give `shutdown` handlers a bounded window, then leave regardless. */
+  /** Observe the triggering command, then revoke authority and leave after bounded shutdown. */
   const quitAfterShutdownEvent = useCallback(() => {
-    void emitExtensionEventBounded(extensionsRef.current, "shutdown", {}).finally(onQuit);
+    if (quitRequestedRef.current) return;
+    quitRequestedRef.current = true;
+    queueMicrotask(() => {
+      void retireExtensionLoadResult(extensionsRef.current).finally(onQuit);
+    });
   }, [onQuit]);
 
   return (

--- a/src/ui/AppHost.tsx
+++ b/src/ui/AppHost.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { resolveConfiguredExtensions } from "../app/extensionBootstrap";
 import { ReviewProducer } from "../app/review/producer";
 import { loadConfiguredSessionBootstrap } from "../app/sessionBootstrap";
@@ -31,6 +31,7 @@ import type { WatchedInputRuntime } from "./hooks/useWatchedInput";
 /** Keep one live Hunk app mounted while allowing daemon-driven session reloads. */
 export function AppHost({
   bootstrap,
+  externalQuitSignal,
   hostClient,
   onQuit = () => process.exit(0),
   reviewProducer,
@@ -38,6 +39,8 @@ export function AppHost({
   watchRuntime,
 }: {
   bootstrap: AppBootstrap;
+  /** Process and terminal interrupts routed through host-owned extension retirement. */
+  externalQuitSignal?: AbortSignal;
   hostClient?: HunkSessionBrokerClient;
   onQuit?: () => void;
   /**
@@ -307,7 +310,7 @@ export function AppHost({
     [performReloadSession],
   );
 
-  /** Observe the triggering command, then revoke authority and leave after bounded shutdown. */
+  /** Revoke extension authority and leave after bounded shutdown. */
   const quitAfterShutdownEvent = useCallback(() => {
     if (quitRequestedRef.current) return;
     quitRequestedRef.current = true;
@@ -315,6 +318,19 @@ export function AppHost({
       void retireExtensionLoadResult(extensionsRef.current).finally(onQuit);
     });
   }, [onQuit]);
+
+  useEffect(() => {
+    if (!externalQuitSignal) return;
+
+    const requestQuit = () => quitAfterShutdownEvent();
+    if (externalQuitSignal.aborted) {
+      requestQuit();
+      return;
+    }
+
+    externalQuitSignal.addEventListener("abort", requestQuit, { once: true });
+    return () => externalQuitSignal.removeEventListener("abort", requestQuit);
+  }, [externalQuitSignal, quitAfterShutdownEvent]);
 
   return (
     <App

--- a/src/ui/AppHost.workspace.test.tsx
+++ b/src/ui/AppHost.workspace.test.tsx
@@ -20,6 +20,7 @@ import { getBundledVcsCatalog } from "../app/vcsCatalog";
 import type { CliInput } from "../core/types";
 import { loadStartupExtensions } from "../extensions/startup";
 import type { HunkSessionBrokerClient } from "../session/types";
+import type { WorkspaceFileWriter } from "./App";
 import { AppHost } from "./AppHost";
 
 /** Specialize the core loader result with extension state assigned by these tests. */
@@ -200,6 +201,24 @@ function writeReadWriteFixture(extPath: string, logPath: string) {
   );
 }
 
+/** Create a filesystem writer the test can hold after authority's final start boundary. */
+function createDeferredWorkspaceWriter() {
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  let release!: () => void;
+  const barrier = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const writer: WorkspaceFileWriter = async (absolutePath, text) => {
+    markStarted();
+    await barrier;
+    writeFileSync(absolutePath, text);
+  };
+  return { release, started, writer };
+}
+
 /** Launch a bootstrap for one review input whose extensions come from one fixture path. */
 async function launchWithExtension(
   repo: string,
@@ -219,6 +238,7 @@ async function launchWithExtension(
 /** Capture the daemon bridge App registers so tests can replace a review generation. */
 function createTestBrokerClient() {
   let bridge: { dispatchCommand: (message: unknown) => Promise<unknown> } | null = null;
+  let replacementCount = 0;
   const client = {
     setBridge(next: typeof bridge) {
       bridge = next;
@@ -226,7 +246,9 @@ function createTestBrokerClient() {
     getRegistration() {
       return { sessionId: "test-session" };
     },
-    replaceSession() {},
+    replaceSession() {
+      replacementCount += 1;
+    },
     updateSnapshot() {},
     updateRegistration() {},
     close() {},
@@ -234,6 +256,7 @@ function createTestBrokerClient() {
 
   return {
     client,
+    replacementCount: () => replacementCount,
     reload: async (nextInput: CliInput) => {
       if (!bridge) throw new Error("App never registered a session bridge.");
       return await bridge.dispatchCommand({
@@ -250,10 +273,21 @@ function createTestBrokerClient() {
 async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>) => Promise<void>,
-  hostClient?: HunkSessionBrokerClient,
+  options: {
+    externalQuitSignal?: AbortSignal;
+    hostClient?: HunkSessionBrokerClient;
+    onQuit?: () => void;
+    workspaceFileWriter?: WorkspaceFileWriter;
+  } = {},
 ) {
   const setup = await testRender(
-    <AppHost bootstrap={bootstrap} hostClient={hostClient} onQuit={() => {}} />,
+    <AppHost
+      bootstrap={bootstrap}
+      externalQuitSignal={options.externalQuitSignal}
+      hostClient={options.hostClient}
+      onQuit={options.onQuit ?? (() => {})}
+      workspaceFileWriter={options.workspaceFileWriter}
+    />,
     {
       width: 140,
       height: 30,
@@ -331,7 +365,7 @@ describe("extension workspace reads", () => {
         );
         await reload;
       },
-      broker.client,
+      { hostClient: broker.client },
     );
   });
 
@@ -544,6 +578,111 @@ describe("extension workspace writes", () => {
         "the reloaded review to show the written content",
       );
     });
+  });
+
+  test("reports a deferred write truthfully and reconciles after a competing reload", async () => {
+    const repo = createTestRepo("hunk-ext-write-reload-race-");
+    const extDir = createTempDir("hunk-ext-write-reload-race-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeWorkspaceFixture(extPath, logPath);
+
+    const bootstrap = await launchWithExtension(repo, extPath, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "stack", extensionPaths: [extPath] },
+    });
+    const deferredWriter = createDeferredWorkspaceWriter();
+    const broker = createTestBrokerClient();
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await act(async () => setup.mockInput.typeText("y"));
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("Write alpha.txt?"),
+          "the deferred write confirm to open",
+        );
+        await act(async () => setup.mockInput.pressEnter());
+        await deferredWriter.started;
+
+        const competingReload = broker.reload({ kind: "vcs", staged: false, options: {} });
+        await flushUntil(
+          setup,
+          () => broker.replacementCount() === 1,
+          "the competing reload to replace the originating review",
+        );
+        await competingReload;
+
+        deferredWriter.release();
+        await flushUntil(
+          setup,
+          () =>
+            readProbeLog(logPath).includes('result {"ok":true}') && broker.replacementCount() === 2,
+          "the successful write to reconcile the active review",
+        );
+
+        expect(readProbeLog(logPath).some((line) => line.includes("unavailable"))).toBe(false);
+        expect(readFileSync(join(repo, "alpha.txt"), "utf8")).toBe("rewritten\n");
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("rewritten"),
+          "the active review to show the deferred write",
+        );
+      },
+      { hostClient: broker.client, workspaceFileWriter: deferredWriter.writer },
+    );
+  });
+
+  test("graceful quit waits for a write that already crossed the start boundary", async () => {
+    const repo = createTestRepo("hunk-ext-write-quit-race-");
+    const extDir = createTempDir("hunk-ext-write-quit-race-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeWorkspaceFixture(extPath, logPath);
+
+    const bootstrap = await launchWithExtension(repo, extPath, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "stack", extensionPaths: [extPath] },
+    });
+    const deferredWriter = createDeferredWorkspaceWriter();
+    const quitController = new AbortController();
+    let quits = 0;
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await act(async () => setup.mockInput.typeText("y"));
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("Write alpha.txt?"),
+          "the pre-quit write confirm to open",
+        );
+        await act(async () => setup.mockInput.pressEnter());
+        await deferredWriter.started;
+
+        quitController.abort();
+        await flush(setup);
+        expect(quits).toBe(0);
+
+        deferredWriter.release();
+        await flushUntil(
+          setup,
+          () => quits === 1 && readProbeLog(logPath).includes('result {"ok":true}'),
+          "the started write to finish before graceful quit",
+        );
+        expect(readFileSync(join(repo, "alpha.txt"), "utf8")).toBe("rewritten\n");
+      },
+      {
+        externalQuitSignal: quitController.signal,
+        onQuit: () => {
+          quits += 1;
+        },
+        workspaceFileWriter: deferredWriter.writer,
+      },
+    );
   });
 
   test("refuses when the reviewed file disappears while consent is pending", async () => {

--- a/src/ui/AppHost.workspace.test.tsx
+++ b/src/ui/AppHost.workspace.test.tsx
@@ -19,6 +19,7 @@ import type { AppBootstrap } from "../app/types";
 import { getBundledVcsCatalog } from "../app/vcsCatalog";
 import type { CliInput } from "../core/types";
 import { loadStartupExtensions } from "../extensions/startup";
+import type { HunkSessionBrokerClient } from "../session/types";
 import { AppHost } from "./AppHost";
 
 /** Specialize the core loader result with extension state assigned by these tests. */
@@ -215,15 +216,49 @@ async function launchWithExtension(
   return bootstrap;
 }
 
+/** Capture the daemon bridge App registers so tests can replace a review generation. */
+function createTestBrokerClient() {
+  let bridge: { dispatchCommand: (message: unknown) => Promise<unknown> } | null = null;
+  const client = {
+    setBridge(next: typeof bridge) {
+      bridge = next;
+    },
+    getRegistration() {
+      return { sessionId: "test-session" };
+    },
+    replaceSession() {},
+    updateSnapshot() {},
+    updateRegistration() {},
+    close() {},
+  } as unknown as HunkSessionBrokerClient;
+
+  return {
+    client,
+    reload: async (nextInput: CliInput) => {
+      if (!bridge) throw new Error("App never registered a session bridge.");
+      return await bridge.dispatchCommand({
+        type: "command",
+        requestId: "test-request",
+        command: "reload_session",
+        input: { sessionId: "test-session", nextInput },
+      });
+    },
+  };
+}
+
 /** Mount one AppHost, run the body, and tear down. */
 async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>) => Promise<void>,
+  hostClient?: HunkSessionBrokerClient,
 ) {
-  const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={() => {}} />, {
-    width: 140,
-    height: 30,
-  });
+  const setup = await testRender(
+    <AppHost bootstrap={bootstrap} hostClient={hostClient} onQuit={() => {}} />,
+    {
+      width: 140,
+      height: 30,
+    },
+  );
 
   try {
     await flush(setup);
@@ -236,6 +271,70 @@ async function withAppHost(
 }
 
 describe("extension workspace reads", () => {
+  test("returns null when a deferred read finishes after the review reloads", async () => {
+    const repo = createTestRepo("hunk-ext-read-reload-race-");
+    const extDir = createTempDir("hunk-ext-read-reload-race-ext-");
+    const logPath = join(extDir, "probe.log");
+    const extPath = join(extDir, "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerCommand({ id: "read", title: "Read", key: "y" }, async (ctx) => {\n` +
+        `    const file = ctx.selection.file;\n` +
+        `    if (!file) return;\n` +
+        `    const text = await ctx.workspace.readDocument(file.id, "new");\n` +
+        `    appendFileSync(${JSON.stringify(logPath)}, "read " + JSON.stringify(text) + "\\n");\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "stack", extensionPaths: [extPath] },
+    });
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    let finishRead!: (text: string) => void;
+    const deferredRead = new Promise<string>((resolve) => {
+      finishRead = resolve;
+    });
+    bootstrap.changeset.files[0]!.sourceFetcher = {
+      cacheKey: "deferred-read",
+      async getFullText() {
+        markReadStarted();
+        return await deferredRead;
+      },
+    };
+    const broker = createTestBrokerClient();
+
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await act(async () => setup.mockInput.typeText("y"));
+        await readStarted;
+
+        let reloadFinished = false;
+        const reload = broker
+          .reload({ kind: "vcs", staged: false, options: {} })
+          .then(() => (reloadFinished = true));
+        await flushUntil(setup, () => reloadFinished, "the replacement review to commit");
+
+        finishRead("stale review text");
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).includes("read null"),
+          "the retired read to resolve as unavailable",
+        );
+        await reload;
+      },
+      broker.client,
+    );
+  });
+
   test("reads the working tree's current document for a working-tree review", async () => {
     const repo = createTestRepo("hunk-ext-read-worktree-");
     const extDir = createTempDir("hunk-ext-read-worktree-ext-");

--- a/src/ui/components/chrome/ConfirmDialog.tsx
+++ b/src/ui/components/chrome/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
 import type { ReactNode } from "react";
 import { useState } from "react";
+import { MODAL_FRAME_CHROME_ROWS, resolveModalGeometry } from "../../lib/modalGeometry";
 import type { AppTheme } from "../../themes";
 import { ModalFrame } from "./ModalFrame";
 
@@ -15,11 +16,54 @@ export interface ConfirmDialogAction {
 }
 
 /** Rows ConfirmDialog adds around the body: ModalFrame chrome plus spacer and action row. */
-const CONFIRM_DIALOG_CHROME_ROWS = 7;
+const CONFIRM_DIALOG_CHROME_ROWS = MODAL_FRAME_CHROME_ROWS + 2;
 
 /** Modal height for a ConfirmDialog whose body renders the given number of rows. */
 export function confirmDialogHeight(bodyRows: number) {
   return bodyRows + CONFIRM_DIALOG_CHROME_ROWS;
+}
+
+/** Render the shared mouse-clickable key legend used by modal action footers. */
+export function DialogActionRow({
+  actions,
+  theme,
+}: {
+  actions: ConfirmDialogAction[];
+  theme: AppTheme;
+}) {
+  const [hoveredActionKey, setHoveredActionKey] = useState<string | null>(null);
+
+  return (
+    <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
+      {actions.map((action, index) => {
+        const hovered = hoveredActionKey === action.keyLabel;
+        return (
+          <box key={action.keyLabel} style={{ flexDirection: "row" }}>
+            {index > 0 ? <text fg={theme.badgeNeutral}> · </text> : null}
+            <box
+              style={{
+                flexDirection: "row",
+                paddingLeft: 1,
+                paddingRight: 1,
+                backgroundColor: hovered ? theme.accentMuted : undefined,
+              }}
+              onMouseOver={() => setHoveredActionKey(action.keyLabel)}
+              onMouseOut={() =>
+                setHoveredActionKey((current) => (current === action.keyLabel ? null : current))
+              }
+              onMouseUp={(event: TuiMouseEvent) => {
+                event.stopPropagation();
+                action.run();
+              }}
+            >
+              <text fg={theme.accent}>{action.keyLabel}</text>
+              <text fg={hovered ? theme.text : theme.muted}> {action.label}</text>
+            </box>
+          </box>
+        );
+      })}
+    </box>
+  );
 }
 
 /**
@@ -58,7 +102,9 @@ export function ConfirmDialog({
   title: string;
   width: number;
 }) {
-  const [hoveredActionKey, setHoveredActionKey] = useState<string | null>(null);
+  const frame = resolveModalGeometry({ width, height, terminalWidth, terminalHeight });
+  const showActions = frame.height > MODAL_FRAME_CHROME_ROWS;
+  const showActionGap = frame.height >= confirmDialogHeight(0);
 
   return (
     <ModalFrame
@@ -71,36 +117,8 @@ export function ConfirmDialog({
       onClose={onClose}
     >
       {children}
-      <box style={{ width: "100%", height: 1 }} />
-      <box style={{ width: "100%", height: 1, flexDirection: "row" }}>
-        {actions.map((action, index) => {
-          const hovered = hoveredActionKey === action.keyLabel;
-          return (
-            <box key={action.keyLabel} style={{ flexDirection: "row" }}>
-              {index > 0 ? <text fg={theme.badgeNeutral}> · </text> : null}
-              <box
-                style={{
-                  flexDirection: "row",
-                  paddingLeft: 1,
-                  paddingRight: 1,
-                  backgroundColor: hovered ? theme.accentMuted : undefined,
-                }}
-                onMouseOver={() => setHoveredActionKey(action.keyLabel)}
-                onMouseOut={() =>
-                  setHoveredActionKey((current) => (current === action.keyLabel ? null : current))
-                }
-                onMouseUp={(event: TuiMouseEvent) => {
-                  event.stopPropagation();
-                  action.run();
-                }}
-              >
-                <text fg={theme.accent}>{action.keyLabel}</text>
-                <text fg={hovered ? theme.text : theme.muted}> {action.label}</text>
-              </box>
-            </box>
-          );
-        })}
-      </box>
+      {showActionGap ? <box style={{ width: "100%", height: 1 }} /> : null}
+      {showActions ? <DialogActionRow actions={actions} theme={theme} /> : null}
     </ModalFrame>
   );
 }

--- a/src/ui/components/chrome/ExtensionDialog.tsx
+++ b/src/ui/components/chrome/ExtensionDialog.tsx
@@ -6,7 +6,7 @@ import type {
 } from "../../lib/extensionDialogs";
 import { extensionToastPrefix } from "../../lib/extensionNotifications";
 import { listWindowStart } from "../../lib/listWindow";
-import { fitText, padText } from "../../lib/text";
+import { fitText, padText, wrapText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
 import { ConfirmDialog, confirmDialogHeight } from "./ConfirmDialog";
 import { ModalFrame } from "./ModalFrame";
@@ -15,10 +15,10 @@ import { ModalFrame } from "./ModalFrame";
  * The modal surface behind `ctx.dialogs`.
  *
  * Every dialog is drawn by Hunk from host-controlled chrome, with the
- * extension's own text confined to the title, body, and choices — a prompt an
- * extension raises can never look like Hunk asking. The attribution row reuses
- * the same `ext` marker `notify` toasts carry, so "this came from an extension"
- * reads the same wherever extension output appears.
+ * extension's own text confined to the title, body, and choices. User-installed
+ * extensions receive an attribution row using the same `ext` marker `notify`
+ * toasts carry, so their prompts cannot look like Hunk asking. Bundled
+ * extensions are Hunk-owned UI and omit that redundant row.
  *
  * Keyboard handling deliberately lives in `useAppKeyboardShortcuts` beside
  * every other modal surface; this component owns mouse parity only.
@@ -89,6 +89,9 @@ export function ExtensionDialog({
 
   const width = dialogWidth(terminalWidth);
   const bodyWidth = Math.max(1, width - 4);
+  const wrappedBodyLines = request.bodyLines.flatMap((line) => wrapText(line, bodyWidth));
+  const attributionRows = request.showAttribution ? 1 : 0;
+  const attributionGapRows = request.showAttribution && wrappedBodyLines.length > 0 ? 1 : 0;
 
   return (
     <ConfirmDialog
@@ -96,7 +99,7 @@ export function ExtensionDialog({
         { keyLabel: "enter/y", label: request.confirmLabel, run: onAccept },
         { keyLabel: "esc/n", label: request.cancelLabel, run: onCancel },
       ]}
-      height={confirmDialogHeight(request.bodyLines.length > 0 ? request.bodyLines.length + 2 : 1)}
+      height={confirmDialogHeight(wrappedBodyLines.length + attributionRows + attributionGapRows)}
       terminalHeight={terminalHeight}
       terminalWidth={terminalWidth}
       theme={theme}
@@ -104,11 +107,13 @@ export function ExtensionDialog({
       width={width}
       onClose={onCancel}
     >
-      <box style={{ width: "100%", height: 1 }}>
-        <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
-      </box>
-      {request.bodyLines.length > 0 ? <box style={{ width: "100%", height: 1 }} /> : null}
-      {request.bodyLines.map((line, index) => (
+      {request.showAttribution ? (
+        <box style={{ width: "100%", height: 1 }}>
+          <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
+        </box>
+      ) : null}
+      {attributionGapRows > 0 ? <box style={{ width: "100%", height: 1 }} /> : null}
+      {wrappedBodyLines.map((line, index) => (
         // Body lines are positional prose, so their index is their identity.
         <box key={`${index}-${line}`} style={{ width: "100%", height: 1 }}>
           <text fg={theme.muted}>{fitText(line, bodyWidth)}</text>
@@ -139,9 +144,9 @@ function ExtensionSelectDialog({
   const width = dialogWidth(terminalWidth);
   const bodyWidth = Math.max(1, width - 4);
   const modalHeight = Math.min(Math.max(11, terminalHeight - 6), 24);
-  // ModalFrame chrome, plus this dialog's attribution, legend, spacer, and the
+  // ModalFrame chrome, plus the legend, spacer, optional attribution, and the
   // row that reports how many options fell outside the window.
-  const visibleRows = Math.max(3, modalHeight - 9);
+  const visibleRows = Math.max(3, modalHeight - (request.showAttribution ? 9 : 8));
   const start = listWindowStart(selectedIndex, request.options.length, visibleRows);
   const visibleOptions = request.options.slice(start, start + visibleRows);
   const markerWidth = 2;
@@ -157,9 +162,11 @@ function ExtensionSelectDialog({
       width={width}
       onClose={onCancel}
     >
-      <box style={{ width: "100%", height: 1 }}>
-        <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
-      </box>
+      {request.showAttribution ? (
+        <box style={{ width: "100%", height: 1 }}>
+          <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
+        </box>
+      ) : null}
       <box style={{ width: "100%", height: 1 }}>
         <text fg={theme.muted}>{fitText("↑/↓ move  Enter choose  Esc cancel", bodyWidth)}</text>
       </box>
@@ -220,8 +227,8 @@ function ExtensionInputDialog({
 }) {
   const width = dialogWidth(terminalWidth);
   const bodyWidth = Math.max(1, width - 4);
-  // ModalFrame chrome plus attribution, spacer, field, spacer, legend.
-  const modalHeight = 10;
+  // ModalFrame chrome plus field, spacer, legend, and optional attribution + spacer.
+  const modalHeight = request.showAttribution ? 10 : 8;
 
   return (
     <ModalFrame
@@ -233,10 +240,14 @@ function ExtensionInputDialog({
       width={width}
       onClose={onCancel}
     >
-      <box style={{ width: "100%", height: 1 }}>
-        <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
-      </box>
-      <box style={{ width: "100%", height: 1 }} />
+      {request.showAttribution ? (
+        <>
+          <box style={{ width: "100%", height: 1 }}>
+            <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
+          </box>
+          <box style={{ width: "100%", height: 1 }} />
+        </>
+      ) : null}
       <box style={{ width: "100%", height: 1, backgroundColor: theme.panelAlt }}>
         {/* The field only edits text: Enter and Escape are answered by
             useAppKeyboardShortcuts, where every dialog's action keys live —

--- a/src/ui/components/chrome/ExtensionDialog.tsx
+++ b/src/ui/components/chrome/ExtensionDialog.tsx
@@ -5,10 +5,12 @@ import type {
   ExtensionSelectDialogRequest,
 } from "../../lib/extensionDialogs";
 import { extensionToastPrefix } from "../../lib/extensionNotifications";
+import { windowDialogText } from "../../lib/extensionDialogGeometry";
 import { listWindowStart } from "../../lib/listWindow";
-import { fitText, padText, wrapText } from "../../lib/text";
+import { MODAL_FRAME_CHROME_ROWS, resolveModalGeometry } from "../../lib/modalGeometry";
+import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
-import { ConfirmDialog, confirmDialogHeight } from "./ConfirmDialog";
+import { ConfirmDialog, confirmDialogHeight, DialogActionRow } from "./ConfirmDialog";
 import { ModalFrame } from "./ModalFrame";
 
 /**
@@ -48,7 +50,7 @@ export function ExtensionDialog({
 }: {
   /** Live text of an input dialog's field; ignored by the other kinds. */
   inputValue: string;
-  onAccept: () => void;
+  onAccept: (selectedIndexOverride?: number) => void;
   onCancel: () => void;
   onChangeInput: (value: string) => void;
   /** Highlight one option row without accepting it, mirroring the theme selector. */
@@ -62,6 +64,7 @@ export function ExtensionDialog({
   if (request.kind === "select") {
     return (
       <ExtensionSelectDialog
+        onAccept={onAccept}
         onCancel={onCancel}
         onPickOption={onPickOption}
         request={request}
@@ -77,6 +80,7 @@ export function ExtensionDialog({
     return (
       <ExtensionInputDialog
         inputValue={inputValue}
+        onAccept={onAccept}
         onCancel={onCancel}
         onChangeInput={onChangeInput}
         request={request}
@@ -87,11 +91,20 @@ export function ExtensionDialog({
     );
   }
 
-  const width = dialogWidth(terminalWidth);
-  const bodyWidth = Math.max(1, width - 4);
-  const wrappedBodyLines = request.bodyLines.flatMap((line) => wrapText(line, bodyWidth));
-  const attributionRows = request.showAttribution ? 1 : 0;
-  const attributionGapRows = request.showAttribution && wrappedBodyLines.length > 0 ? 1 : 0;
+  const frame = resolveModalGeometry({
+    width: dialogWidth(terminalWidth),
+    height: Number.MAX_SAFE_INTEGER,
+    terminalWidth,
+    terminalHeight,
+  });
+  const bodyWidth = Math.max(1, frame.width - 4);
+  const availableBodyRows = Math.max(0, frame.height - confirmDialogHeight(0));
+  const attributionRows = request.showAttribution && availableBodyRows > 0 ? 1 : 0;
+  const rowsAfterAttribution = Math.max(0, availableBodyRows - attributionRows);
+  const attributionGapRows =
+    attributionRows > 0 && request.bodyLines.length > 0 && rowsAfterAttribution > 1 ? 1 : 0;
+  const bodyRows = Math.max(0, rowsAfterAttribution - attributionGapRows);
+  const visibleBody = windowDialogText(request.bodyLines, bodyWidth, bodyRows);
 
   return (
     <ConfirmDialog
@@ -99,21 +112,21 @@ export function ExtensionDialog({
         { keyLabel: "enter/y", label: request.confirmLabel, run: onAccept },
         { keyLabel: "esc/n", label: request.cancelLabel, run: onCancel },
       ]}
-      height={confirmDialogHeight(wrappedBodyLines.length + attributionRows + attributionGapRows)}
+      height={confirmDialogHeight(visibleBody.lines.length + attributionRows + attributionGapRows)}
       terminalHeight={terminalHeight}
       terminalWidth={terminalWidth}
       theme={theme}
       title={request.title}
-      width={width}
+      width={frame.width}
       onClose={onCancel}
     >
-      {request.showAttribution ? (
+      {attributionRows > 0 ? (
         <box style={{ width: "100%", height: 1 }}>
           <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
         </box>
       ) : null}
       {attributionGapRows > 0 ? <box style={{ width: "100%", height: 1 }} /> : null}
-      {wrappedBodyLines.map((line, index) => (
+      {visibleBody.lines.map((line, index) => (
         // Body lines are positional prose, so their index is their identity.
         <box key={`${index}-${line}`} style={{ width: "100%", height: 1 }}>
           <text fg={theme.muted}>{fitText(line, bodyWidth)}</text>
@@ -125,6 +138,7 @@ export function ExtensionDialog({
 
 /** Render a select dialog as a keyboard- and mouse-driven option list. */
 function ExtensionSelectDialog({
+  onAccept,
   onCancel,
   onPickOption,
   request,
@@ -133,6 +147,7 @@ function ExtensionSelectDialog({
   terminalWidth,
   theme,
 }: {
+  onAccept: (selectedIndexOverride?: number) => void;
   onCancel: () => void;
   onPickOption: (index: number) => void;
   request: ExtensionSelectDialogRequest;
@@ -141,36 +156,42 @@ function ExtensionSelectDialog({
   terminalWidth: number;
   theme: AppTheme;
 }) {
-  const width = dialogWidth(terminalWidth);
-  const bodyWidth = Math.max(1, width - 4);
-  const modalHeight = Math.min(Math.max(11, terminalHeight - 6), 24);
-  // ModalFrame chrome, plus the legend, spacer, optional attribution, and the
-  // row that reports how many options fell outside the window.
-  const visibleRows = Math.max(3, modalHeight - (request.showAttribution ? 9 : 8));
-  const start = listWindowStart(selectedIndex, request.options.length, visibleRows);
+  const frame = resolveModalGeometry({
+    width: dialogWidth(terminalWidth),
+    height: Math.min(Math.max(11, terminalHeight - 6), 24),
+    terminalWidth,
+    terminalHeight,
+  });
+  const bodyWidth = Math.max(1, frame.width - 4);
+  const contentRows = Math.max(0, frame.height - MODAL_FRAME_CHROME_ROWS);
+  const attributionRows = request.showAttribution && contentRows >= 2 ? 1 : 0;
+  const actionRows = contentRows - attributionRows >= 2 ? 1 : 0;
+  const statusRows = contentRows - attributionRows - actionRows >= 2 ? 1 : 0;
+  const actionGapRows = contentRows - attributionRows - actionRows - statusRows >= 2 ? 1 : 0;
+  const visibleRows = Math.max(
+    0,
+    contentRows - attributionRows - actionRows - statusRows - actionGapRows,
+  );
+  const start = listWindowStart(selectedIndex, request.options.length, Math.max(1, visibleRows));
   const visibleOptions = request.options.slice(start, start + visibleRows);
   const markerWidth = 2;
   const labelWidth = Math.max(4, bodyWidth - markerWidth);
 
   return (
     <ModalFrame
-      height={modalHeight}
+      height={frame.height}
       terminalHeight={terminalHeight}
       terminalWidth={terminalWidth}
       theme={theme}
       title={request.title}
-      width={width}
+      width={frame.width}
       onClose={onCancel}
     >
-      {request.showAttribution ? (
+      {attributionRows > 0 ? (
         <box style={{ width: "100%", height: 1 }}>
           <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
         </box>
       ) : null}
-      <box style={{ width: "100%", height: 1 }}>
-        <text fg={theme.muted}>{fitText("↑/↓ move  Enter choose  Esc cancel", bodyWidth)}</text>
-      </box>
-      <box style={{ width: "100%", height: 1 }} />
       {visibleOptions.map((option, offset) => {
         const index = start + offset;
         const selected = index === selectedIndex;
@@ -187,6 +208,7 @@ function ExtensionSelectDialog({
             onMouseUp={(event: TuiMouseEvent) => {
               event.stopPropagation();
               onPickOption(index);
+              onAccept(index);
             }}
           >
             <text fg={selected ? theme.text : theme.muted}>
@@ -196,12 +218,25 @@ function ExtensionSelectDialog({
           </box>
         );
       })}
-      {start + visibleRows < request.options.length ? (
+      {statusRows > 0 ? (
         <box style={{ width: "100%", height: 1 }}>
           <text fg={theme.muted}>
-            {fitText(`… ${request.options.length - start - visibleRows} more`, bodyWidth)}
+            {fitText(
+              `${start + 1}-${Math.min(start + visibleRows, request.options.length)} of ${request.options.length}`,
+              bodyWidth,
+            )}
           </text>
         </box>
+      ) : null}
+      {actionGapRows > 0 ? <box style={{ width: "100%", height: 1 }} /> : null}
+      {actionRows > 0 ? (
+        <DialogActionRow
+          actions={[
+            { keyLabel: "enter", label: "choose", run: () => onAccept(selectedIndex) },
+            { keyLabel: "esc", label: "cancel", run: onCancel },
+          ]}
+          theme={theme}
+        />
       ) : null}
     </ModalFrame>
   );
@@ -210,6 +245,7 @@ function ExtensionSelectDialog({
 /** Render an input dialog as a focused single-line field. */
 function ExtensionInputDialog({
   inputValue,
+  onAccept,
   onCancel,
   onChangeInput,
   request,
@@ -218,6 +254,7 @@ function ExtensionInputDialog({
   theme,
 }: {
   inputValue: string;
+  onAccept: () => void;
   onCancel: () => void;
   onChangeInput: (value: string) => void;
   request: ExtensionInputDialogRequest;
@@ -225,46 +262,65 @@ function ExtensionInputDialog({
   terminalWidth: number;
   theme: AppTheme;
 }) {
-  const width = dialogWidth(terminalWidth);
-  const bodyWidth = Math.max(1, width - 4);
-  // ModalFrame chrome plus field, spacer, legend, and optional attribution + spacer.
-  const modalHeight = request.showAttribution ? 10 : 8;
+  // ModalFrame chrome plus field, spacer, actions, and optional attribution + spacer.
+  const frame = resolveModalGeometry({
+    width: dialogWidth(terminalWidth),
+    height: request.showAttribution ? 10 : 8,
+    terminalWidth,
+    terminalHeight,
+  });
+  const bodyWidth = Math.max(1, frame.width - 4);
+  const contentRows = Math.max(0, frame.height - MODAL_FRAME_CHROME_ROWS);
+  const attributionRows = request.showAttribution && contentRows >= 2 ? 1 : 0;
+  const actionRows = contentRows - attributionRows >= 2 ? 1 : 0;
+  const attributionGapRows = contentRows - attributionRows - actionRows >= 2 ? 1 : 0;
+  const fieldGapRows = contentRows - attributionRows - actionRows - attributionGapRows >= 2 ? 1 : 0;
+  const fieldRows = Math.max(
+    0,
+    contentRows - attributionRows - actionRows - attributionGapRows - fieldGapRows,
+  );
 
   return (
     <ModalFrame
-      height={modalHeight}
+      height={frame.height}
       terminalHeight={terminalHeight}
       terminalWidth={terminalWidth}
       theme={theme}
       title={request.title}
-      width={width}
+      width={frame.width}
       onClose={onCancel}
     >
-      {request.showAttribution ? (
-        <>
-          <box style={{ width: "100%", height: 1 }}>
-            <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
-          </box>
-          <box style={{ width: "100%", height: 1 }} />
-        </>
+      {attributionRows > 0 ? (
+        <box style={{ width: "100%", height: 1 }}>
+          <text fg={theme.badgeNeutral}>{attributionText(request.extensionId, bodyWidth)}</text>
+        </box>
       ) : null}
-      <box style={{ width: "100%", height: 1, backgroundColor: theme.panelAlt }}>
-        {/* The field only edits text: Enter and Escape are answered by
-            useAppKeyboardShortcuts, where every dialog's action keys live —
-            the app's global key handler consumes them before a focused
-            renderable's own submit machinery could see them. */}
-        <input
-          width={bodyWidth}
-          value={inputValue}
-          placeholder={request.placeholder}
-          focused={true}
-          onInput={onChangeInput}
+      {attributionGapRows > 0 ? <box style={{ width: "100%", height: 1 }} /> : null}
+      {fieldRows > 0 ? (
+        <box style={{ width: "100%", height: 1, backgroundColor: theme.panelAlt }}>
+          {/* The field only edits text: Enter and Escape are answered by
+              useAppKeyboardShortcuts, where every dialog's action keys live —
+              the app's global key handler consumes them before a focused
+              renderable's own submit machinery could see them. */}
+          <input
+            width={bodyWidth}
+            value={inputValue}
+            placeholder={request.placeholder}
+            focused={true}
+            onInput={onChangeInput}
+          />
+        </box>
+      ) : null}
+      {fieldGapRows > 0 ? <box style={{ width: "100%", height: 1 }} /> : null}
+      {actionRows > 0 ? (
+        <DialogActionRow
+          actions={[
+            { keyLabel: "enter", label: "submit", run: onAccept },
+            { keyLabel: "esc", label: "cancel", run: onCancel },
+          ]}
+          theme={theme}
         />
-      </box>
-      <box style={{ width: "100%", height: 1 }} />
-      <box style={{ width: "100%", height: 1 }}>
-        <text fg={theme.muted}>{fitText("Enter submit  Esc cancel", bodyWidth)}</text>
-      </box>
+      ) : null}
     </ModalFrame>
   );
 }

--- a/src/ui/components/chrome/ModalFrame.tsx
+++ b/src/ui/components/chrome/ModalFrame.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
 import type { ReactNode } from "react";
+import { resolveModalGeometry } from "../../lib/modalGeometry";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
 
@@ -25,10 +26,17 @@ export function ModalFrame({
   title: string;
   width: number;
 }) {
-  const clampedWidth = Math.min(width, Math.max(24, terminalWidth - 2));
-  const clampedHeight = Math.min(height, Math.max(5, terminalHeight - 2));
-  const left = Math.max(1, Math.floor((terminalWidth - clampedWidth) / 2));
-  const top = Math.max(1, Math.floor((terminalHeight - clampedHeight) / 2));
+  const {
+    height: clampedHeight,
+    left,
+    top,
+    width: clampedWidth,
+  } = resolveModalGeometry({
+    width,
+    height,
+    terminalWidth,
+    terminalHeight,
+  });
   const closeText = onClose ? "[Esc]" : "";
   const titleWidth = Math.max(1, clampedWidth - 2 - (closeText ? closeText.length + 1 : 0));
 

--- a/src/ui/components/panes/AgentInlineNote.tsx
+++ b/src/ui/components/panes/AgentInlineNote.tsx
@@ -8,7 +8,7 @@ import { useLayoutEffect, useRef, type ReactNode } from "react";
 import type { AgentAnnotation, DiffFile, LayoutMode } from "../../../core/types";
 import { agentNoteBoxLayout } from "../../lib/agentNoteGeometry";
 import { annotationRangeLabel, reviewNoteSource } from "../../lib/agentAnnotations";
-import { wrapText } from "../../lib/agentPopover";
+import { wrapText } from "../../lib/text";
 
 import { sanitizeTerminalLine } from "../../../lib/terminalText";
 import { fitText, measureTextWidth, padText } from "../../lib/text";

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -32,7 +32,7 @@ import {
 } from "./rowStyle";
 import { type PlannedReviewRow } from "./reviewRenderPlan";
 import { inlineNoteTitle } from "../components/panes/AgentInlineNote";
-import { wrapText } from "../lib/agentPopover";
+import { wrapText } from "../lib/text";
 import { sanitizeTerminalLine, sanitizeTerminalSpans } from "../../lib/terminalText";
 import {
   isPrintableAsciiText,

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -7,7 +7,7 @@ import type {
   ExtensionKeyEvent,
 } from "../../extensions/types";
 import type { MenuId } from "../components/chrome/menu";
-import { dispatchAppCommand, type AppCommand } from "../lib/appCommands";
+import { dispatchAppCommand, executeAppCommand, type AppCommand } from "../lib/appCommands";
 import type { ExtensionDialogRequest } from "../lib/extensionDialogs";
 import { toExtensionKeyEvent } from "../lib/extensionKeyEvent";
 import { isEscapeKey, isSaveDraftNoteKey } from "../lib/keyboard";
@@ -444,7 +444,11 @@ export function useAppKeyboardShortcuts({
       // Deliberately no modifier check: Shift+Tab toggles focus exactly like
       // Tab, in both its CSI-u and legacy backtab encodings.
       if (key.name === "tab") {
-        toggleFocusArea();
+        // Keep this text-input escape hatch on the named command path so
+        // extensions observe the same semantic action as a Tab from the file list.
+        if (!executeAppCommand(commandsRef.current, "hunk.app.toggleFocusArea")) {
+          toggleFocusArea();
+        }
         return "mine";
       }
 

--- a/src/ui/hooks/useExtensionDialogController.ts
+++ b/src/ui/hooks/useExtensionDialogController.ts
@@ -12,7 +12,7 @@ export interface ExtensionDialogController {
   request: ExtensionDialogRequest | null;
   selectedIndex: number;
   inputValue: string;
-  accept: () => void;
+  accept: (selectedIndexOverride?: number) => void;
   cancel: () => void;
   moveSelection: (delta: number) => void;
   pickOption: (index: number) => void;
@@ -53,11 +53,11 @@ export function useExtensionDialogController({
   }, [queue]);
 
   /** Answer the visible request with the state appropriate to its dialog kind. */
-  const accept = () => {
+  const accept = (selectedIndexOverride?: number) => {
     if (!request) return;
 
     if (request.kind === "select") {
-      queue.accept(request.id, request.options[selectedIndex]);
+      queue.accept(request.id, request.options[selectedIndexOverride ?? selectedIndex]);
       return;
     }
 

--- a/src/ui/hooks/useExtensionDialogController.ts
+++ b/src/ui/hooks/useExtensionDialogController.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import {
   createExtensionDialogQueue,
   type ExtensionDialogQueue,
@@ -40,9 +40,12 @@ export function useExtensionDialogController({
   }, [initialInput, requestId]);
 
   const previousReviewGenerationRef = useRef(reviewGeneration);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (previousReviewGenerationRef.current !== reviewGeneration) {
       previousReviewGenerationRef.current = reviewGeneration;
+      // Child layout effects run before AppHost publishes lifecycle events for
+      // the committed generation. Drain only the retired review's requests so
+      // a session_reload handler can safely open the replacement's first dialog.
       queue.cancelAll();
     }
   }, [queue, reviewGeneration]);

--- a/src/ui/lib/agentPopover.ts
+++ b/src/ui/lib/agentPopover.ts
@@ -1,71 +1,8 @@
 import { sanitizeTerminalLine } from "../../lib/terminalText";
-import { fitText, measureTextWidth, sliceTextByWidth } from "./text";
+import { fitText, wrapText } from "./text";
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
-}
-
-/** Wrap plain text to a fixed terminal-cell width, breaking long tokens when needed. */
-export function wrapText(text: string, width: number) {
-  if (width <= 0) {
-    return [""];
-  }
-
-  const normalized = sanitizeTerminalLine(text).trim().replace(/\s+/g, " ");
-  if (normalized.length === 0) {
-    return [""];
-  }
-
-  const words = normalized.split(" ");
-  const lines: string[] = [];
-  let current = "";
-  let currentWidth = 0;
-
-  const pushCurrent = () => {
-    if (current.length > 0) {
-      lines.push(current);
-      current = "";
-      currentWidth = 0;
-    }
-  };
-
-  for (const word of words) {
-    const wordWidth = measureTextWidth(word);
-
-    if (wordWidth > width) {
-      pushCurrent();
-      let offset = 0;
-      while (offset < wordWidth) {
-        const chunk = sliceTextByWidth(word, offset, width);
-        if (chunk.width <= 0) {
-          // Width is narrower than one cluster; keep the remainder on one
-          // line (fitText clamps at render time) instead of dropping it.
-          const rest = sliceTextByWidth(word, offset, Number.MAX_SAFE_INTEGER);
-          if (rest.text.length > 0) {
-            lines.push(rest.text);
-          }
-          break;
-        }
-        lines.push(chunk.text);
-        offset += chunk.width;
-      }
-      continue;
-    }
-
-    const nextWidth = current.length === 0 ? wordWidth : currentWidth + 1 + wordWidth;
-    if (nextWidth <= width) {
-      current = current.length === 0 ? word : `${current} ${word}`;
-      currentWidth = nextWidth;
-      continue;
-    }
-
-    pushCurrent();
-    current = word;
-    currentWidth = wordWidth;
-  }
-
-  pushCurrent();
-  return lines.length > 0 ? lines : [""];
 }
 
 /** Title shown above an agent note — author name if present, otherwise "AI note", with optional "i/n" suffix. */

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -7,6 +7,7 @@ import {
   builtinCommandKeyDefaults,
   dispatchAppCommand,
   executeAppCommand,
+  observeAppCommandDispatch,
   type BuildAppCommandsOptions,
   type ResolvedCommandKeys,
 } from "./appCommands";
@@ -328,6 +329,42 @@ describe("executeAppCommand", () => {
     expect(executeAppCommand(disabled, "hunk.app.refresh")).toBe(false);
     expect(executeAppCommand(commands, "nobody.registered.this")).toBe(false);
     expect(ran).toEqual([]);
+  });
+});
+
+describe("observeAppCommandDispatch", () => {
+  test("observes successful terminal dispatch exactly once with the command id", () => {
+    const { commands, ran } = createTestCommands();
+    const observed: string[] = [];
+    const wrapped = observeAppCommandDispatch(commands, (id) => observed.push(id));
+
+    expect(dispatchAppCommand(wrapped, keyEvent({ name: "q" }))?.id).toBe("hunk.app.quit");
+    expect(ran).toEqual(["requestQuit"]);
+    expect(observed).toEqual(["hunk.app.quit"]);
+  });
+
+  test("does not observe disabled or throwing commands", () => {
+    const { commands } = createTestCommands();
+    const quit = commands.find((command) => command.id === "hunk.app.quit")!;
+    const observed: string[] = [];
+    const disabled = observeAppCommandDispatch([{ ...quit, isEnabled: () => false }], (id) =>
+      observed.push(id),
+    );
+    expect(dispatchAppCommand(disabled, keyEvent({ name: "q" }))).toBeUndefined();
+
+    const throwing = observeAppCommandDispatch(
+      [
+        {
+          ...quit,
+          run: () => {
+            throw new Error("boom");
+          },
+        },
+      ],
+      (id) => observed.push(id),
+    );
+    expect(() => throwing[0]!.run(keyEvent({ name: "q" }), 1)).toThrow("boom");
+    expect(observed).toEqual([]);
   });
 });
 

--- a/src/ui/lib/appCommands.ts
+++ b/src/ui/lib/appCommands.ts
@@ -75,6 +75,27 @@ export interface AppCommand {
   closesMenu?: boolean;
 }
 
+/**
+ * Observe successful terminal dispatch without moving command identity into review state.
+ *
+ * Keyboard dispatch, menus, and extension command controls all invoke these
+ * entries, while browser/session actions correctly continue through ReviewIntent.
+ */
+export function observeAppCommandDispatch(
+  commands: readonly AppCommand[],
+  onDispatched: (commandId: string) => void,
+): AppCommand[] {
+  return commands.map((command) => ({
+    ...command,
+    run(key, count) {
+      command.run(key, count);
+      // AppCommand is deliberately synchronous. Extension handlers may have
+      // detached async work still running after terminal dispatch returns.
+      onDispatched(command.id);
+    },
+  }));
+}
+
 /** What the terminal does for one catalogued command. */
 interface BuiltinCommandHandler {
   /** Report whether the command may run right now; skipped when false. */

--- a/src/ui/lib/extensionCapabilityLease.test.ts
+++ b/src/ui/lib/extensionCapabilityLease.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createEmptyExtensionRegistry } from "../../extensions/types";
-import {
-  createExtensionCapabilityLease,
-  runWithExtensionCapabilityLease,
-} from "./extensionCapabilityLease";
+import { createExtensionCapabilityLease } from "./extensionCapabilityLease";
 
 describe("createExtensionCapabilityLease", () => {
   test("follows App, runtime, and review-generation ownership", () => {
@@ -43,40 +40,5 @@ describe("createExtensionCapabilityLease", () => {
     });
 
     expect(lease.isLive()).toBe(true);
-  });
-});
-
-describe("runWithExtensionCapabilityLease", () => {
-  test("returns the expired answer when authority changes during an async operation", async () => {
-    let live = true;
-    let finish!: (value: string) => void;
-    const operation = new Promise<string>((resolve) => {
-      finish = resolve;
-    });
-    const result = runWithExtensionCapabilityLease(
-      { isLive: () => live },
-      () => operation,
-      () => "expired",
-    );
-
-    live = false;
-    finish("stale result");
-
-    expect(await result).toBe("expired");
-  });
-
-  test("does not start an async operation after authority expires", async () => {
-    let started = false;
-    const result = await runWithExtensionCapabilityLease(
-      { isLive: () => false },
-      async () => {
-        started = true;
-        return "stale result";
-      },
-      () => "expired",
-    );
-
-    expect(started).toBe(false);
-    expect(result).toBe("expired");
   });
 });

--- a/src/ui/lib/extensionCapabilityLease.test.ts
+++ b/src/ui/lib/extensionCapabilityLease.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { createEmptyExtensionRegistry } from "../../extensions/types";
-import { createExtensionCapabilityLease } from "./extensionCapabilityLease";
+import {
+  createExtensionCapabilityLease,
+  runWithExtensionCapabilityLease,
+} from "./extensionCapabilityLease";
 
 describe("createExtensionCapabilityLease", () => {
   test("follows App, runtime, and review-generation ownership", () => {
@@ -40,5 +43,40 @@ describe("createExtensionCapabilityLease", () => {
     });
 
     expect(lease.isLive()).toBe(true);
+  });
+});
+
+describe("runWithExtensionCapabilityLease", () => {
+  test("returns the expired answer when authority changes during an async operation", async () => {
+    let live = true;
+    let finish!: (value: string) => void;
+    const operation = new Promise<string>((resolve) => {
+      finish = resolve;
+    });
+    const result = runWithExtensionCapabilityLease(
+      { isLive: () => live },
+      () => operation,
+      () => "expired",
+    );
+
+    live = false;
+    finish("stale result");
+
+    expect(await result).toBe("expired");
+  });
+
+  test("does not start an async operation after authority expires", async () => {
+    let started = false;
+    const result = await runWithExtensionCapabilityLease(
+      { isLive: () => false },
+      async () => {
+        started = true;
+        return "stale result";
+      },
+      () => "expired",
+    );
+
+    expect(started).toBe(false);
+    expect(result).toBe("expired");
   });
 });

--- a/src/ui/lib/extensionCapabilityLease.test.ts
+++ b/src/ui/lib/extensionCapabilityLease.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { createEmptyExtensionRegistry } from "../../extensions/types";
+import { createExtensionCapabilityLease } from "./extensionCapabilityLease";
+
+describe("createExtensionCapabilityLease", () => {
+  test("follows App, runtime, and review-generation ownership", () => {
+    const owningRegistry = createEmptyExtensionRegistry();
+    owningRegistry.eventBusPhase = "ready";
+    let activeRegistry = owningRegistry;
+    let appAlive = true;
+    let reviewCurrent = true;
+    const lease = createExtensionCapabilityLease({
+      owningRegistry,
+      getActiveRegistry: () => activeRegistry,
+      isAppAlive: () => appAlive,
+      isReviewCurrent: () => reviewCurrent,
+    });
+
+    expect(lease.isLive()).toBe(true);
+    reviewCurrent = false;
+    expect(lease.isLive()).toBe(false);
+    reviewCurrent = true;
+    activeRegistry = createEmptyExtensionRegistry();
+    expect(lease.isLive()).toBe(false);
+    activeRegistry = owningRegistry;
+    owningRegistry.eventBusPhase = "closed";
+    expect(lease.isLive()).toBe(false);
+    owningRegistry.eventBusPhase = "ready";
+    appAlive = false;
+    expect(lease.isLive()).toBe(false);
+  });
+
+  test("can represent runtime authority without binding one review generation", () => {
+    const registry = createEmptyExtensionRegistry();
+    registry.eventBusPhase = "ready";
+    const lease = createExtensionCapabilityLease({
+      owningRegistry: registry,
+      getActiveRegistry: () => registry,
+      isAppAlive: () => true,
+    });
+
+    expect(lease.isLive()).toBe(true);
+  });
+});

--- a/src/ui/lib/extensionCapabilityLease.ts
+++ b/src/ui/lib/extensionCapabilityLease.ts
@@ -33,3 +33,14 @@ export function createExtensionCapabilityLease({
       (isReviewCurrent?.() ?? true),
   });
 }
+
+/** Run one async host operation only while its capability remains live at both boundaries. */
+export async function runWithExtensionCapabilityLease<Result>(
+  lease: ExtensionCapabilityLease,
+  operation: () => Promise<Result>,
+  expired: () => Result,
+): Promise<Result> {
+  if (!lease.isLive()) return expired();
+  const result = await operation();
+  return lease.isLive() ? result : expired();
+}

--- a/src/ui/lib/extensionCapabilityLease.ts
+++ b/src/ui/lib/extensionCapabilityLease.ts
@@ -1,0 +1,35 @@
+import type { ExtensionRegistry } from "../../extensions/types";
+
+/** Host-owned lifetime check shared by controls retained from extension handlers. */
+export interface ExtensionCapabilityLease {
+  /** Whether the App, extension runtime, and optional review generation still own the control. */
+  isLive(): boolean;
+}
+
+/**
+ * Mint one lease for host-mediated extension capabilities.
+ *
+ * Runtime identity prevents a retired handler from controlling its replacement;
+ * the optional review predicate additionally retires controls when a soft reload
+ * changes the review beneath an in-flight handler.
+ */
+export function createExtensionCapabilityLease({
+  getActiveRegistry,
+  isAppAlive,
+  isReviewCurrent,
+  owningRegistry,
+}: {
+  owningRegistry: ExtensionRegistry | undefined;
+  getActiveRegistry: () => ExtensionRegistry | undefined;
+  isAppAlive: () => boolean;
+  isReviewCurrent?: () => boolean;
+}): ExtensionCapabilityLease {
+  return Object.freeze({
+    isLive: () =>
+      isAppAlive() &&
+      owningRegistry !== undefined &&
+      owningRegistry.eventBusPhase !== "closed" &&
+      getActiveRegistry() === owningRegistry &&
+      (isReviewCurrent?.() ?? true),
+  });
+}

--- a/src/ui/lib/extensionCapabilityLease.ts
+++ b/src/ui/lib/extensionCapabilityLease.ts
@@ -33,14 +33,3 @@ export function createExtensionCapabilityLease({
       (isReviewCurrent?.() ?? true),
   });
 }
-
-/** Run one async host operation only while its capability remains live at both boundaries. */
-export async function runWithExtensionCapabilityLease<Result>(
-  lease: ExtensionCapabilityLease,
-  operation: () => Promise<Result>,
-  expired: () => Result,
-): Promise<Result> {
-  if (!lease.isLive()) return expired();
-  const result = await operation();
-  return lease.isLive() ? result : expired();
-}

--- a/src/ui/lib/extensionDialogGeometry.test.ts
+++ b/src/ui/lib/extensionDialogGeometry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { windowDialogText } from "./extensionDialogGeometry";
+
+describe("windowDialogText", () => {
+  test("wraps prose within the available terminal-cell rows", () => {
+    expect(windowDialogText(["one two three"], 7, 3)).toEqual({
+      lines: ["one two", "three"],
+      truncated: false,
+    });
+  });
+
+  test("pins an overflow marker to the final allocated row", () => {
+    expect(windowDialogText(["one two three four"], 7, 2)).toEqual({
+      lines: ["one two", "…"],
+      truncated: true,
+    });
+    expect(windowDialogText(["overflow"], 3, 0)).toEqual({ lines: [], truncated: true });
+  });
+});

--- a/src/ui/lib/extensionDialogGeometry.ts
+++ b/src/ui/lib/extensionDialogGeometry.ts
@@ -1,0 +1,27 @@
+import { wrapText } from "./text";
+
+/** Wrapped body rows that fit one modal body allocation. */
+export interface WindowedDialogText {
+  lines: string[];
+  truncated: boolean;
+}
+
+/** Wrap prose to terminal cells, then reserve the final row as an overflow marker. */
+export function windowDialogText(
+  sourceLines: readonly string[],
+  width: number,
+  maxRows: number,
+): WindowedDialogText {
+  const wrapped = sourceLines.flatMap((line) => wrapText(line, width));
+  if (wrapped.length <= maxRows) {
+    return { lines: wrapped, truncated: false };
+  }
+  if (maxRows <= 0) {
+    return { lines: [], truncated: wrapped.length > 0 };
+  }
+
+  return {
+    lines: [...wrapped.slice(0, Math.max(0, maxRows - 1)), "…"],
+    truncated: true,
+  };
+}

--- a/src/ui/lib/extensionDialogs.test.ts
+++ b/src/ui/lib/extensionDialogs.test.ts
@@ -145,6 +145,24 @@ describe("createExtensionDialogQueue", () => {
     expect(await again).toBe(true);
   });
 
+  test("refuses retained controls and cancels acceptance after their lease expires", async () => {
+    const queue = createExtensionDialogQueue();
+    let live = true;
+    const retired = queue.createDialogs("retired", { isLive: () => live });
+
+    const open = retired.confirm({ title: "Still current?" });
+    live = false;
+    queue.accept(queue.current()!.id);
+    expect(await open).toBe(false);
+    expect(await retired.input({ title: "Too late" })).toBeNull();
+    expect(queue.current()).toBeNull();
+
+    const replacement = queue.createDialogs("replacement", { isLive: () => true });
+    const next = replacement.confirm({ title: "Current" });
+    queue.accept(queue.current()!.id);
+    expect(await next).toBe(true);
+  });
+
   test("cancels the pending and queued dialogs on shutdown, and refuses later ones", async () => {
     const queue = createExtensionDialogQueue();
     const dialogs = queue.createDialogs("probe");

--- a/src/ui/lib/extensionDialogs.test.ts
+++ b/src/ui/lib/extensionDialogs.test.ts
@@ -80,6 +80,7 @@ describe("createExtensionDialogQueue", () => {
     expect(queue.current()).toMatchObject({
       kind: "confirm",
       extensionId: "carrier",
+      showAttribution: true,
       bodyLines: ["one", "two"],
       confirmLabel: "ok",
       cancelLabel: "cancel",
@@ -88,6 +89,19 @@ describe("createExtensionDialogQueue", () => {
     queue.cancel(queue.current()!.id);
     void dialogs.confirm({ title: "Delete?", confirmLabel: "delete", cancelLabel: "keep" });
     expect(queue.current()).toMatchObject({ confirmLabel: "delete", cancelLabel: "keep" });
+  });
+
+  test("can omit attribution only when the host marks the dialog as native UI", () => {
+    const queue = createExtensionDialogQueue();
+    const dialogs = queue.createDialogs("bundled-guide", { showAttribution: false });
+
+    void dialogs.confirm({ title: "Welcome" });
+
+    expect(queue.current()).toMatchObject({
+      extensionId: "bundled-guide",
+      showAttribution: false,
+      title: "Welcome",
+    });
   });
 
   test("strips terminal escapes out of extension-authored text", () => {

--- a/src/ui/lib/extensionDialogs.ts
+++ b/src/ui/lib/extensionDialogs.ts
@@ -73,7 +73,10 @@ type ExtensionDialogResult = boolean | string | null;
 /** The host-side controller for every extension dialog in one session. */
 export interface ExtensionDialogQueue {
   /** Build the `dialogs` object one extension's command handlers receive. */
-  createDialogs(extensionId: string, options?: { showAttribution?: boolean }): ExtensionDialogs;
+  createDialogs(
+    extensionId: string,
+    options?: { isLive?: () => boolean; showAttribution?: boolean },
+  ): ExtensionDialogs;
   /** The dialog that should be on screen, or `null` when none is. */
   current(): ExtensionDialogRequest | null;
   /**
@@ -177,6 +180,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
   const pending: {
     request: ExtensionDialogRequest;
     settle: (value: ExtensionDialogResult) => void;
+    isLive: () => boolean;
   }[] = [];
   const listeners = new Set<() => void>();
   let closed = false;
@@ -203,9 +207,10 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
   function enqueue<Result extends ExtensionDialogResult>(
     build: (id: number) => ExtensionDialogRequest,
     cancelValue: Result,
+    isLive: () => boolean,
   ): Promise<Result> {
     return new Promise<Result>((resolve) => {
-      if (closed) {
+      if (closed || !isLive()) {
         resolve(cancelValue);
         return;
       }
@@ -215,7 +220,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
       const wasIdle = pending.length === 0;
       // The result type is decided by the request kind the caller built, which
       // is the one place both halves are known.
-      pending.push({ request, settle: (value) => resolve(value as Result) });
+      pending.push({ request, settle: (value) => resolve(value as Result), isLive });
       if (wasIdle) {
         notify();
       }
@@ -247,6 +252,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
 
   return {
     createDialogs(extensionId: string, options = {}): ExtensionDialogs {
+      const isLive = options.isLive ?? (() => true);
       const showAttribution = options.showAttribution !== false;
       return {
         // Async so a validation failure rejects the returned promise instead of
@@ -265,6 +271,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
               cancelLabel: normalizeLabel(options.cancelLabel, DEFAULT_CANCEL_LABEL),
             }),
             false,
+            isLive,
           );
         },
         async select(options: ExtensionSelectOptions) {
@@ -280,6 +287,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
               options: choices,
             }),
             null,
+            isLive,
           );
         },
         async input(options: ExtensionInputOptions) {
@@ -299,6 +307,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
                 typeof options.initial === "string" ? sanitizeTerminalLine(options.initial) : "",
             }),
             null,
+            isLive,
           );
         },
       };
@@ -311,6 +320,11 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
     accept(id: number, value?: string) {
       const active = pending[0];
       if (!active || active.request.id !== id) {
+        return;
+      }
+
+      if (!active.isLive()) {
+        settleCurrent(cancelValueFor(active.request));
         return;
       }
 

--- a/src/ui/lib/extensionDialogs.ts
+++ b/src/ui/lib/extensionDialogs.ts
@@ -38,6 +38,8 @@ interface ExtensionDialogRequestBase {
   id: number;
   /** The extension that raised the dialog, rendered as its attribution. */
   extensionId: string;
+  /** Whether host chrome should identify the extension that raised the dialog. */
+  showAttribution: boolean;
   title: string;
 }
 
@@ -71,7 +73,7 @@ type ExtensionDialogResult = boolean | string | null;
 /** The host-side controller for every extension dialog in one session. */
 export interface ExtensionDialogQueue {
   /** Build the `dialogs` object one extension's command handlers receive. */
-  createDialogs(extensionId: string): ExtensionDialogs;
+  createDialogs(extensionId: string, options?: { showAttribution?: boolean }): ExtensionDialogs;
   /** The dialog that should be on screen, or `null` when none is. */
   current(): ExtensionDialogRequest | null;
   /**
@@ -244,7 +246,8 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
   };
 
   return {
-    createDialogs(extensionId: string): ExtensionDialogs {
+    createDialogs(extensionId: string, options = {}): ExtensionDialogs {
+      const showAttribution = options.showAttribution !== false;
       return {
         // Async so a validation failure rejects the returned promise instead of
         // throwing synchronously out of the extension's `await`.
@@ -255,6 +258,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
               kind: "confirm",
               id,
               extensionId,
+              showAttribution,
               title,
               bodyLines: normalizeBodyLines(options.body),
               confirmLabel: normalizeLabel(options.confirmLabel, DEFAULT_CONFIRM_LABEL),
@@ -267,7 +271,14 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
           const title = normalizeTitle("select", options?.title);
           const choices = normalizeOptions(options.options);
           return await enqueue<string | null>(
-            (id) => ({ kind: "select", id, extensionId, title, options: choices }),
+            (id) => ({
+              kind: "select",
+              id,
+              extensionId,
+              showAttribution,
+              title,
+              options: choices,
+            }),
             null,
           );
         },
@@ -278,6 +289,7 @@ export function createExtensionDialogQueue(): ExtensionDialogQueue {
               kind: "input",
               id,
               extensionId,
+              showAttribution,
               title,
               placeholder: normalizeLabel(options.placeholder, ""),
               // Sanitized like every other extension-authored string, but not

--- a/src/ui/lib/modalGeometry.test.ts
+++ b/src/ui/lib/modalGeometry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { resolveModalGeometry } from "./modalGeometry";
+
+describe("resolveModalGeometry", () => {
+  test("centers requested dimensions inside the terminal", () => {
+    expect(
+      resolveModalGeometry({ width: 40, height: 10, terminalWidth: 80, terminalHeight: 24 }),
+    ).toEqual({ width: 40, height: 10, left: 20, top: 7 });
+  });
+
+  test("uses the real narrow and short viewport instead of an artificial minimum", () => {
+    expect(
+      resolveModalGeometry({ width: 72, height: 20, terminalWidth: 30, terminalHeight: 8 }),
+    ).toEqual({ width: 28, height: 6, left: 1, top: 1 });
+  });
+});

--- a/src/ui/lib/modalGeometry.ts
+++ b/src/ui/lib/modalGeometry.ts
@@ -1,0 +1,40 @@
+/** Border, title, and padding rows ModalFrame reserves around its children. */
+export const MODAL_FRAME_CHROME_ROWS = 5;
+
+/** Concrete dimensions and placement of a modal inside one terminal viewport. */
+export interface ModalGeometry {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+}
+
+/**
+ * Clamp requested modal dimensions before either measurement or rendering.
+ *
+ * Callers use the returned width to wrap content, so their row plans always
+ * match the frame ModalFrame eventually draws, including narrow terminals.
+ */
+export function resolveModalGeometry({
+  height,
+  terminalHeight,
+  terminalWidth,
+  width,
+}: {
+  width: number;
+  height: number;
+  terminalWidth: number;
+  terminalHeight: number;
+}): ModalGeometry {
+  const availableWidth = Math.max(1, terminalWidth - 2);
+  const availableHeight = Math.max(1, terminalHeight - 2);
+  const resolvedWidth = Math.max(1, Math.min(width, availableWidth));
+  const resolvedHeight = Math.max(1, Math.min(height, availableHeight));
+
+  return {
+    width: resolvedWidth,
+    height: resolvedHeight,
+    left: Math.max(0, Math.floor((terminalWidth - resolvedWidth) / 2)),
+    top: Math.max(0, Math.floor((terminalHeight - resolvedHeight) / 2)),
+  };
+}

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -176,6 +176,70 @@ export function measureTextWidth(text: string) {
   return measureSanitizedTextWidth(sanitizeTerminalLine(text));
 }
 
+/** Wrap plain prose to terminal-cell width, preferring word boundaries. */
+export function wrapText(text: string, width: number) {
+  if (width <= 0) {
+    return [""];
+  }
+
+  const normalized = sanitizeTerminalLine(text).trim().replace(/\s+/g, " ");
+  if (normalized.length === 0) {
+    return [""];
+  }
+
+  const words = normalized.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  let currentWidth = 0;
+
+  /** Commit the current prose row before starting another one. */
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      lines.push(current);
+      current = "";
+      currentWidth = 0;
+    }
+  };
+
+  for (const word of words) {
+    const wordWidth = measureTextWidth(word);
+
+    if (wordWidth > width) {
+      pushCurrent();
+      let offset = 0;
+      while (offset < wordWidth) {
+        const chunk = sliceTextByWidth(word, offset, width);
+        if (chunk.width <= 0) {
+          // Width is narrower than one cluster; keep the remainder on one
+          // line (fitText clamps at render time) instead of dropping it.
+          const rest = sliceTextByWidth(word, offset, Number.MAX_SAFE_INTEGER);
+          if (rest.text.length > 0) {
+            lines.push(rest.text);
+          }
+          break;
+        }
+        lines.push(chunk.text);
+        offset += chunk.width;
+      }
+      continue;
+    }
+
+    const nextWidth = current.length === 0 ? wordWidth : currentWidth + 1 + wordWidth;
+    if (nextWidth <= width) {
+      current = current.length === 0 ? word : `${current} ${word}`;
+      currentWidth = nextWidth;
+      continue;
+    }
+
+    pushCurrent();
+    current = word;
+    currentWidth = wordWidth;
+  }
+
+  pushCurrent();
+  return lines.length > 0 ? lines : [""];
+}
+
 export interface WrappedTextChunk {
   text: string;
   width: number;

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -12,7 +12,7 @@ import {
   type MenuEntry,
 } from "../components/chrome/menu";
 import { createVisibleAgentNote } from "./agentAnnotations";
-import { buildAgentPopoverContent, resolveAgentPopoverPlacement, wrapText } from "./agentPopover";
+import { buildAgentPopoverContent, resolveAgentPopoverPlacement } from "./agentPopover";
 import { isEscapeKey, isSaveDraftNoteKey } from "./keyboard";
 import {
   cellRangeToCharRange,
@@ -21,6 +21,7 @@ import {
   measureTextWidth,
   padText,
   sliceTextByWidth,
+  wrapText,
   wrapTextByWidth,
 } from "./text";
 import { computeHunkRevealScrollTop } from "./hunkScroll";

--- a/src/ui/runInteractiveApp.tsx
+++ b/src/ui/runInteractiveApp.tsx
@@ -69,9 +69,15 @@ export async function runInteractiveApp({
   const appRenderer = renderer;
   const root = createRoot(appRenderer);
   const shutdownSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  const externalQuitController = new AbortController();
   let shuttingDown = false;
   let jobControlSuspendSupport: JobControlSuspendSupport = { dispose: () => undefined };
   let jobControlInterruptSupport: JobControlInterruptSupport = { dispose: () => undefined };
+
+  /** Ask AppHost to retire extension authority before tearing down the terminal. */
+  function requestQuit() {
+    externalQuitController.abort();
+  }
 
   /** Tear down the renderer before exit so the primary terminal screen comes back cleanly. */
   function shutdown() {
@@ -81,7 +87,7 @@ export async function runInteractiveApp({
 
     shuttingDown = true;
     for (const signal of shutdownSignals) {
-      process.off(signal, shutdown);
+      process.off(signal, requestQuit);
     }
     jobControlInterruptSupport.dispose();
     jobControlSuspendSupport.dispose();
@@ -90,15 +96,16 @@ export async function runInteractiveApp({
   }
 
   for (const signal of shutdownSignals) {
-    process.once(signal, shutdown);
+    process.once(signal, requestQuit);
   }
-  jobControlInterruptSupport = installJobControlInterruptSupport(appRenderer, shutdown);
+  jobControlInterruptSupport = installJobControlInterruptSupport(appRenderer, requestQuit);
   jobControlSuspendSupport = installJobControlSuspendSupport(appRenderer);
 
   // The app owns the full alternate screen session from this point on.
   root.render(
     <AppHost
       bootstrap={bootstrap}
+      externalQuitSignal={externalQuitController.signal}
       hostClient={hostClient}
       onQuit={shutdown}
       reviewProducer={reviewProducer}

--- a/test/pty/extensions-integration.test.ts
+++ b/test/pty/extensions-integration.test.ts
@@ -216,7 +216,7 @@ const DIALOG_EXTENSION_SOURCE = `export default function (hunk) {
   hunk.registerCommand({ id: "ask", title: "Ask", key: "y" }, async (ctx) => {
     const proceed = await ctx.dialogs.confirm({
       title: "Reformat the changeset?",
-      body: "Nothing is written to disk.",
+      body: "Nothing is written to disk. This deliberately long explanation wraps across many terminal rows while the actions remain pinned below it.",
       confirmLabel: "reformat",
     });
     ctx.notify(proceed ? "DIALOG ANSWERED YES" : "DIALOG ANSWERED NO");
@@ -471,7 +471,7 @@ describe("PTY extensions", () => {
     }
   });
 
-  test("a command key opens an extension confirm dialog that enter resolves", async () => {
+  test("a short terminal pins extension confirm actions for mouse acceptance", async () => {
     const configHome = harness.createIsolatedConfigHome();
     const fixture = harness.createRepoExtensionFixture(DIALOG_EXTENSION_SOURCE);
     const session = await harness.launchHunk({
@@ -484,8 +484,8 @@ describe("PTY extensions", () => {
         join(fixture.dir, ".hunk", "extensions", "fixture.ts"),
       ],
       cwd: fixture.dir,
-      cols: 140,
-      rows: 24,
+      cols: 50,
+      rows: 12,
       env: { XDG_CONFIG_HOME: configHome },
     });
 
@@ -504,15 +504,14 @@ describe("PTY extensions", () => {
         (text) => text.includes("Reformat the changeset?"),
         20_000,
       );
-      expect(prompt).toContain("Nothing is written to disk.");
+      expect(prompt).toContain("…");
       // The frame names the extension that raised the dialog, so a prompt
       // cannot present itself as Hunk asking.
       expect(prompt).toContain("ext fixture");
       expect(prompt).toContain("enter/y reformat");
 
-      // Enter resolves the promise the handler is awaiting, and its answer
-      // comes back as an ordinary extension toast.
-      await session.press("enter");
+      // The pinned action remains mouse-accessible even after body windowing.
+      await session.click(/enter\/y reformat/);
       const answered = await harness.waitForSnapshot(
         session,
         (text) => text.includes("DIALOG ANSWERED YES"),

--- a/test/pty/extensions-integration.test.ts
+++ b/test/pty/extensions-integration.test.ts
@@ -53,6 +53,14 @@ const NOTIFY_EXTENSION_SOURCE = `export default function (hunk) {
 }
 `;
 
+/** An extension that records whether terminal interrupts deliver graceful shutdown. */
+const INTERRUPT_SHUTDOWN_EXTENSION_SOURCE = `import { appendFileSync } from "node:fs";
+export default function (hunk) {
+  hunk.on("startup", (_payload, ctx) => ctx.notify("INTERRUPT FIXTURE READY"));
+  hunk.on("shutdown", () => appendFileSync(".hunk-shutdown.log", "shutdown\\n"));
+}
+`;
+
 /**
  * An extension contributing an extra sidebar opened by a registered command.
  *
@@ -258,6 +266,34 @@ describe("PTY extensions", () => {
       expect(reloaded).toContain("alpha.ts");
 
       expect(readTrustState(configHome)[fixture.dir]).toBe("trusted");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("Ctrl-C delivers extension shutdown before the terminal exits", async () => {
+    const configHome = harness.createIsolatedConfigHome();
+    const fixture = harness.createRepoExtensionFixture(INTERRUPT_SHUTDOWN_EXTENSION_SOURCE);
+    const shutdownLog = join(fixture.dir, ".hunk-shutdown.log");
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 120,
+      rows: 24,
+      env: { XDG_CONFIG_HOME: configHome },
+    });
+
+    try {
+      await session.waitForText(/Run this repository's extensions\?/, { timeout: 20_000 });
+      await session.press("t");
+      await session.waitForText(/INTERRUPT FIXTURE READY/, { timeout: 20_000 });
+
+      session.sendKey(["ctrl", "c"]);
+      const deadline = Date.now() + 5_000;
+      while (!existsSync(shutdownLog) && Date.now() < deadline) {
+        await Bun.sleep(20);
+      }
+      expect(readFileSync(shutdownLog, "utf8")).toBe("shutdown\n");
     } finally {
       session.close();
     }

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -270,7 +270,7 @@ Writes require a reloadable, unstaged working-tree review and a writable reviewe
 
 ## `hunk.on(event, handler)`
 
-Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks the UI waiting for one. Every handler receives `ctx.panes`, live `ctx.navigation`, and attributed `ctx.dialogs` alongside `cwd` and `notify`, so a `startup` handler can present one focused welcome dialog and navigate to its first example without a keypress. `ctx.sidebars` is deprecated. Controls retained across a review or extension-registry replacement expire instead of controlling the replacement UI; workspace reads/writes return `null`/`unavailable`.
+Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks the UI waiting for one. Every handler receives `ctx.panes`, live `ctx.navigation`, and attributed `ctx.dialogs` alongside `cwd` and `notify`, so a `startup` handler can present one focused welcome dialog and navigate to its first example without a keypress. `ctx.sidebars` is deprecated. Controls retained across a review or extension-registry replacement expire instead of controlling the replacement UI; workspace reads and writes that have not started return `null`/`unavailable`. Once a consented filesystem write starts, it reports its actual outcome, graceful shutdown waits for it, and success reconciles the review then active.
 
 | Event                  | Payload                 | When                                                     |
 | ---------------------- | ----------------------- | -------------------------------------------------------- |

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -7,7 +7,20 @@ The extension factory receives one API object. Registration calls are only valid
 
 ## `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `5`). Version 5 adds line highlighters and line-granular navigation (`revealLine`); version 4 added keyboard modes and docked panes, with API-v3 sidebar names remaining as deprecated aliases.
+The API generation this Hunk speaks (currently `6`). Branch on it if you want one file to support several Hunk versions. Version 6 adds session behavior, terminal-command observation, and live navigation/dialogs in lifecycle and bus handlers; version 5 added line highlighters and line-granular navigation (`revealLine`); version 4 added keyboard modes and docked panes, with API-v3 sidebar names remaining as deprecated aliases.
+
+## `hunk.configureSession(options)`
+
+Request host behavior for the review session loading the extension. Training,
+demo, and presentation extensions can make their view-setting changes temporary:
+
+```ts
+hunk.configureSession({ viewPreferences: "transient" });
+```
+
+If any loaded extension requests this, Hunk skips the save-view-preferences
+prompt on quit instead of offering to write practice state into user config.
+The default is `"default"`.
 
 ## `hunk.registerTheme(theme)`
 
@@ -225,7 +238,7 @@ hunk.registerCommand({ id: "pick-hunk", title: "Pick a hunk", key: "ctrl+k" }, a
 });
 ```
 
-Hunk draws the dialog; your text fills the title, body, and choices, and the frame carries an `ext <your-id>` attribution line — the same marker `notify` toasts use — so a prompt cannot present itself as Hunk asking.
+Hunk draws the dialog; your text fills the title, body, and choices. Dialogs from installed extensions carry an `ext <your-id>` attribution line — the same marker `notify` toasts use — so a third-party prompt cannot present itself as Hunk asking. Hunk's own bundled extensions omit that redundant marker.
 
 One dialog shows at a time; concurrent requests queue in call order, across extensions. Escape cancels (`false` or `null`), Enter accepts; confirm dialogs also answer to `y`/`n`, select dialogs to `↑`/`↓`, and everything is clickable. A session reload cancels open and queued dialogs, and a dialog pending at shutdown resolves its cancel value.
 
@@ -257,12 +270,13 @@ Writes require a reloadable, unstaged working-tree review and a writable reviewe
 
 ## `hunk.on(event, handler)`
 
-Subscribe to a lifecycle or UI event. Handlers may be async and receive `ctx.panes`, `cwd`, and `notify`. `ctx.sidebars` is deprecated.
+Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks the UI waiting for one. Every handler receives `ctx.panes`, live `ctx.navigation`, and attributed `ctx.dialogs` alongside `cwd` and `notify`, so a `startup` handler can present one focused welcome dialog and navigate to its first example without a keypress. `ctx.sidebars` is deprecated.
 
 | Event                  | Payload                 | When                                                     |
 | ---------------------- | ----------------------- | -------------------------------------------------------- |
 | `startup`              | `{ cwd }`               | once, after the app mounts with its first changeset      |
 | `changeset_loaded`     | `{ changeset }`         | first load and every reload                              |
+| `command_executed`     | `{ commandId }`         | whenever a named built-in or extension command runs      |
 | `selection_changed`    | `{ fileId, hunkIndex }` | when the review selection settles (debounced ~150ms)     |
 | `file_viewed`          | `{ file, hunkIndex }`   | when selection settles on a file or a reload replaces it |
 | `filter_changed`       | `{ filter }`            | whenever the file-filter query changes                   |
@@ -275,6 +289,7 @@ Subscribe to a lifecycle or UI event. Handlers may be async and receive `ctx.pan
 | `shutdown`             | `{}`                    | on exit, best-effort within a short timeout              |
 
 - `selection_changed` is trailing-debounced: holding `[`/`]` retargets many times a second, and handlers only care where the user landed. `fileId` and `hunkIndex` are `null` when nothing is selected.
+- `command_executed` reports stable command ids after invocation from a key, menu, or another host command surface. It follows remapped keys; widget-owned Escape, Enter, note-editor Ctrl-S, and F10 menu navigation are not commands.
 - `session_reload`'s `reason` is `"watch"`, `"daemon"` (an agent command through the session broker), or `"manual"`.
 - `note_created` and `note_edited` cover notes authored in Hunk's own UI this session. Agent session comments do not emit them, and a reload may remap or drop notes — an accumulated list is not a complete review record.
 - `shutdown` handlers get 250ms before Hunk exits anyway; treat it as best-effort flushing.

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -270,13 +270,13 @@ Writes require a reloadable, unstaged working-tree review and a writable reviewe
 
 ## `hunk.on(event, handler)`
 
-Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks the UI waiting for one. Every handler receives `ctx.panes`, live `ctx.navigation`, and attributed `ctx.dialogs` alongside `cwd` and `notify`, so a `startup` handler can present one focused welcome dialog and navigate to its first example without a keypress. `ctx.sidebars` is deprecated.
+Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks the UI waiting for one. Every handler receives `ctx.panes`, live `ctx.navigation`, and attributed `ctx.dialogs` alongside `cwd` and `notify`, so a `startup` handler can present one focused welcome dialog and navigate to its first example without a keypress. `ctx.sidebars` is deprecated. Controls retained across a review or extension-registry replacement expire instead of controlling the replacement UI; workspace reads/writes return `null`/`unavailable`.
 
 | Event                  | Payload                 | When                                                     |
 | ---------------------- | ----------------------- | -------------------------------------------------------- |
 | `startup`              | `{ cwd }`               | once, after the app mounts with its first changeset      |
 | `changeset_loaded`     | `{ changeset }`         | first load and every reload                              |
-| `command_executed`     | `{ commandId }`         | whenever a named built-in or extension command runs      |
+| `command_executed`     | `{ commandId }`         | after a named command dispatches in this terminal host   |
 | `selection_changed`    | `{ fileId, hunkIndex }` | when the review selection settles (debounced ~150ms)     |
 | `file_viewed`          | `{ file, hunkIndex }`   | when selection settles on a file or a reload replaces it |
 | `filter_changed`       | `{ filter }`            | whenever the file-filter query changes                   |
@@ -288,11 +288,12 @@ Subscribe to a lifecycle or UI event. Handlers may be async; Hunk never blocks t
 | `session_reload`       | `{ changeset, reason }` | on every session reload                                  |
 | `shutdown`             | `{}`                    | on exit, best-effort within a short timeout              |
 
+- A newly mounted instance receives `startup` before its first `changeset_loaded`; reloads deliver `changeset_loaded` before `session_reload` after the matching review commits.
 - `selection_changed` is trailing-debounced: holding `[`/`]` retargets many times a second, and handlers only care where the user landed. `fileId` and `hunkIndex` are `null` when nothing is selected.
-- `command_executed` reports stable command ids after invocation from a key, menu, or another host command surface. It follows remapped keys; widget-owned Escape, Enter, note-editor Ctrl-S, and F10 menu navigation are not commands.
+- `command_executed` reports stable command ids after terminal dispatch from a key, menu, or `ctx.commands.execute`. Detached async extension work may still be running; the event observes the accepted action rather than promise settlement. It follows remapped keys; browser/session review intents and widget-owned Escape, Enter, note-editor Ctrl-S, and F10 menu navigation are not terminal commands.
 - `session_reload`'s `reason` is `"watch"`, `"daemon"` (an agent command through the session broker), or `"manual"`.
 - `note_created` and `note_edited` cover notes authored in Hunk's own UI this session. Agent session comments do not emit them, and a reload may remap or drop notes — an accumulated list is not a complete review record.
-- `shutdown` handlers get 250ms before Hunk exits anyway; treat it as best-effort flushing.
+- `shutdown` handlers get 250ms before Hunk exits anyway; treat it as best-effort flushing. UI authority has already been revoked, so shutdown is for releasing extension-owned resources rather than navigation or dialogs.
 
 ## `hunk.events`
 


### PR DESCRIPTION
## Summary

- add transient session preferences for guided and demo extensions
- expose named command execution, navigation, and native dialogs to lifecycle handlers
- retain extension attribution while presenting bundled dialogs with native styling
- document and test the guided-workflow extension surface

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run check:docs`
- `bun test`
