### PR TITLE
feat: agent attention marks and line-exact navigation for live sessions

### DIFF
--- a/.changeset/agent-attention-marks.md
+++ b/.changeset/agent-attention-marks.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Agents can now light up exact character ranges in a live review with `hunk session highlight add` / `clear` (five contrast-guaranteed tones, painted through the same pipeline as extension line highlights), and `hunk session navigate` line targets now land the viewport on the exact line instead of just its hunk.

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -133,8 +133,10 @@ each daemon-pushed mark with the same `validate.ts` contract and caps, holds
 them per file, and `src/ui/highlights/merge.ts` appends them after extension
 marks in the one map `DiffPane` paints from — so agent marks share paint,
 contrast, and geometry guarantees, and win where ranges overlap. Unlike
-extension marks, nothing re-derives agent marks after a reload, so a document
-replacement clears them. Line-target `session navigate` reuses the same
+extension marks, nothing re-derives agent marks after a reload, so
+`src/ui/highlights/reconcile.ts` carries them across a document replacement only
+for files whose `contentIdentity` is unchanged — those still show the same
+characters — and drops the rest. Line-target `session navigate` reuses the same
 `revealLine` landing policy `ctx.navigation.revealLine` gets.
 
 `src/ui/fileViews/mode.ts` owns file-view mode activation, validity, and callback

--- a/docs/extension-architecture.md
+++ b/docs/extension-architecture.md
@@ -127,6 +127,16 @@ keeps highlights out of `buildDiffSectionRowPlan`, its caches, and every
 geometry measurement: a highlight change is a repaint, never a re-plan. The
 static pager never runs extension code, so highlights are interactive-only.
 
+Agent attention marks (`hunk session highlight add` / `clear`) join this same
+pipeline rather than growing a second one: `useReviewController.ts` validates
+each daemon-pushed mark with the same `validate.ts` contract and caps, holds
+them per file, and `src/ui/highlights/merge.ts` appends them after extension
+marks in the one map `DiffPane` paints from — so agent marks share paint,
+contrast, and geometry guarantees, and win where ranges overlap. Unlike
+extension marks, nothing re-derives agent marks after a reload, so a document
+replacement clears them. Line-target `session navigate` reuses the same
+`revealLine` landing policy `ctx.navigation.revealLine` gets.
+
 `src/ui/fileViews/mode.ts` owns file-view mode activation, validity, and callback
 containment. The presentation controller stores the active mode and funnels all
 exit paths through one teardown, including re-entrant handoffs.

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -155,7 +155,7 @@ hunk session highlight clear --repo .
 - `--start` is a 0-based inclusive offset into the line's text and `--end` is exclusive, counted in UTF-16 code units — the same `[start, end)` range extensions use
 - Tones: `match` (default), `info`, `warning`, `error`; `current` renders as reverse video and is best reserved for the one range under discussion
 - Pass `--focus` to also land the viewport on the marked line
-- Marks survive scrolling and navigation but clear when the session reloads; `highlight clear` removes them explicitly (optionally per `--file`)
+- Marks survive scrolling, navigation, and reloads that leave the marked file's content unchanged; a reload that changes that file drops its marks, and `highlight clear` removes them explicitly (optionally per `--file`)
 - Marks are visual only — pair them with a `comment add` when the explanation should persist as a note
 
 ### Experimental rich markup notes (STML)

--- a/skills/hunk-review/SKILL.md
+++ b/skills/hunk-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hunk-review
-description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files and hunks, reloads session contents, and adds inline review comments. Use when the user has a Hunk session running or wants to review diffs interactively.
+description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files, hunks, and exact lines, reloads session contents, adds inline review comments, and paints attention marks on character ranges. Use when the user has a Hunk session running or wants to review diffs interactively.
 ---
 
 # Hunk Review
@@ -21,6 +21,7 @@ If no session exists, ask the user to launch Hunk in their terminal first.
 7. hunk session reload -- <command>                     # swap contents if needed
 8. hunk session comment add ...                         # leave one review note
 9. hunk session comment apply ...                       # apply many agent notes in one stdin batch
+10. hunk session highlight add ...                      # light up the exact range you are explaining
 ```
 
 ## Session selection
@@ -78,6 +79,7 @@ hunk session navigate --repo . --prev-comment
 
 - `--hunk <n>` is 1-based
 - `--new-line` / `--old-line` are 1-based line numbers on that diff side
+- A line target lands the user's viewport on that exact line (falling back to its hunk when the line is inside a collapsed region); `--hunk` lands on the hunk
 - Use either `--next-comment` or `--prev-comment`, not both
 
 ### Reload
@@ -132,6 +134,30 @@ printf '%s\n' '{"comments":[{"filePath":"README.md","newLine":103,"summary":"Tig
 - `comment list` and `comment clear` accept optional `--file`
 - Quote `--summary` and `--rationale` defensively in the shell
 
+### Attention marks
+
+Highlights paint character ranges inside the diff lines the user is looking at — use them to light up the exact expression you are explaining while you narrate.
+
+```bash
+hunk session highlight add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --start <n> --end <n> [--tone <tone>] [--focus] [--json]
+hunk session highlight clear (<session-id> | --repo <path>) [--file <path>] [--json]
+```
+
+Examples:
+
+```bash
+hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19
+hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19 --tone warning --focus
+hunk session highlight clear --repo .
+```
+
+- `highlight add` requires `--file`, exactly one of `--old-line` or `--new-line`, and the `--start` / `--end` offsets
+- `--start` is a 0-based inclusive offset into the line's text and `--end` is exclusive, counted in UTF-16 code units — the same `[start, end)` range extensions use
+- Tones: `match` (default), `info`, `warning`, `error`; `current` renders as reverse video and is best reserved for the one range under discussion
+- Pass `--focus` to also land the viewport on the marked line
+- Marks survive scrolling and navigation but clear when the session reloads; `highlight clear` removes them explicitly (optionally per `--file`)
+- Marks are visual only — pair them with a `comment add` when the explanation should persist as a note
+
 ### Experimental rich markup notes (STML)
 
 Only use STML when `hunk session context --json` lists `stml` in `experimentalFeatures`. The user opts into that experience by launching the review with `--experimental`; do not ask a normal session to render markup.
@@ -166,6 +192,7 @@ Guidelines:
 
 - Work in the order that tells the clearest story, not necessarily file order
 - Navigate before commenting so the user sees the code you're discussing
+- Use `highlight add --focus` to steer the user's eyes to the exact expression while you explain it, and `highlight clear` before moving to the next topic
 - Use `comment apply` for agent-generated batches and `comment add` for one-off notes
 - Use `--focus` sparingly when the note itself should actively steer the review
 - Keep comments focused: intent, structure, risks, or follow-ups
@@ -181,5 +208,7 @@ Guidelines:
 - **"Pass --stdin to read batch comments from stdin JSON."** -- `comment apply` only reads its batch payload from stdin.
 - **"Specify exactly one navigation target"** -- pick one of `--hunk`, `--old-line`, or `--new-line`.
 - **"Specify exactly one comment target"** -- pass `comment add` one of `--old-line` or `--new-line`.
+- **"Specify exactly one highlight target"** -- pass `highlight add` one of `--old-line` or `--new-line`.
+- **"Highlight --end must be greater than --start"** -- offsets are `[start, end)` UTF-16 code units into the line text; end is exclusive.
 - **"Specify either --next-comment or --prev-comment, not both."** -- choose one comment-navigation direction.
 - **"Could not read the raw diff for ..."** -- the session reloaded or closed while `--include-patch` was reading it. Re-run `review`; drop `--include-patch` if you only need file and hunk structure.

--- a/src/core/cli.test.ts
+++ b/src/core/cli.test.ts
@@ -948,6 +948,138 @@ describe("parseCli", () => {
     });
   });
 
+  test("parses session highlight add with defaults", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "highlight",
+      "add",
+      "session-1",
+      "--file",
+      "src/App.tsx",
+      "--new-line",
+      "42",
+      "--start",
+      "0",
+      "--end",
+      "13",
+    ]);
+
+    expect(parsed).toEqual({
+      kind: "session",
+      action: "highlight-add",
+      selector: { sessionId: "session-1" },
+      filePath: "src/App.tsx",
+      side: "new",
+      line: 42,
+      start: 0,
+      end: 13,
+      reveal: false,
+      output: "text",
+    });
+  });
+
+  test("parses session highlight add with tone, old side, and focus", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "highlight",
+      "add",
+      "--repo",
+      "/tmp/repo",
+      "--file",
+      "src/App.tsx",
+      "--old-line",
+      "7",
+      "--start",
+      "6",
+      "--end",
+      "19",
+      "--tone",
+      "warning",
+      "--focus",
+      "--json",
+    ]);
+
+    expect(parsed).toEqual({
+      kind: "session",
+      action: "highlight-add",
+      selector: { repoRoot: resolve("/tmp/repo") },
+      filePath: "src/App.tsx",
+      side: "old",
+      line: 7,
+      start: 6,
+      end: 19,
+      tone: "warning",
+      reveal: true,
+      output: "json",
+    });
+  });
+
+  test("rejects session highlight add with an empty range, bad tone, or missing target", async () => {
+    const base = [
+      "bun",
+      "hunk",
+      "session",
+      "highlight",
+      "add",
+      "session-1",
+      "--file",
+      "src/App.tsx",
+    ];
+
+    await expect(
+      parseCli([...base, "--new-line", "42", "--start", "5", "--end", "5"]),
+    ).rejects.toThrow("Highlight --end must be greater than --start");
+    await expect(
+      parseCli([...base, "--new-line", "42", "--start", "0", "--end", "4", "--tone", "loud"]),
+    ).rejects.toThrow("Highlight tone must be one of match, current, info, warning, error.");
+    await expect(parseCli([...base, "--start", "0", "--end", "4"])).rejects.toThrow(
+      "Specify exactly one highlight target: --old-line <n> or --new-line <n>.",
+    );
+    await expect(
+      parseCli([...base, "--new-line", "42", "--start", "-1", "--end", "4"]),
+    ).rejects.toThrow();
+  });
+
+  test("parses session highlight clear globally and per file", async () => {
+    expect(await parseCli(["bun", "hunk", "session", "highlight", "clear", "session-1"])).toEqual({
+      kind: "session",
+      action: "highlight-clear",
+      selector: { sessionId: "session-1" },
+      output: "text",
+    });
+
+    expect(
+      await parseCli([
+        "bun",
+        "hunk",
+        "session",
+        "highlight",
+        "clear",
+        "--repo",
+        "/tmp/repo",
+        "--file",
+        "src/App.tsx",
+        "--json",
+      ]),
+    ).toEqual({
+      kind: "session",
+      action: "highlight-clear",
+      selector: { repoRoot: resolve("/tmp/repo") },
+      filePath: "src/App.tsx",
+      output: "json",
+    });
+  });
+
+  test("rejects unknown session highlight subcommands", async () => {
+    await expect(parseCli(["bun", "hunk", "session", "highlight", "paint"])).rejects.toThrow(
+      "Supported highlight subcommands are add and clear.",
+    );
+  });
+
   test("rejects session commands without an explicit target", async () => {
     await expect(parseCli(["bun", "hunk", "session", "get"])).rejects.toThrow(
       "Specify one live Hunk session with <session-id> or --repo <path>.",

--- a/src/core/cli.ts
+++ b/src/core/cli.ts
@@ -26,15 +26,20 @@ import {
   type SessionCommandOptions,
   COMMENT_DIRECTION_CONSTRAINT,
   COMMENT_TARGET_CONSTRAINT,
+  HIGHLIGHT_TARGET_CONSTRAINT,
+  HIGHLIGHT_TONES,
+  isHighlightTone,
   NAVIGATE_TARGET_CONSTRAINT,
   optionKeyFromFlag,
   SESSION_AGENT_COMMANDS,
   SESSION_AGENT_COMMAND_LIST,
   SESSION_COMMENT_COMMAND_LIST,
+  SESSION_HIGHLIGHT_COMMAND_LIST,
 } from "../session/agent/surface";
 import {
   COMMENT_APPLY_STDIN_MESSAGE,
   constraintViolationMessage,
+  HIGHLIGHT_RANGE_MESSAGE,
   RELOAD_SEPARATOR_MESSAGE,
 } from "../session/agent/errors";
 import { DEFAULT_TAB_WIDTH, parseTabWidth } from "./tabWidth";
@@ -258,6 +263,20 @@ function parsePositiveInt(value: string) {
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed)) {
     throw new Error(`Invalid positive integer: ${value}`);
+  }
+
+  return parsed;
+}
+
+/** Parse one required non-negative integer CLI value, accepting 0. */
+function parseNonNegativeInt(value: string) {
+  if (!/^(0|[1-9]\d*)$/.test(value)) {
+    throw new Error(`Invalid non-negative integer: ${value}`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`Invalid non-negative integer: ${value}`);
   }
 
   return parsed;
@@ -880,6 +899,8 @@ function buildSessionCommand(spec: AgentCommandSpec) {
       : command.option.bind(command);
     if (option.parse === "positiveInt") {
       register(option.flag, option.description, parsePositiveInt);
+    } else if (option.parse === "nonNegativeInt") {
+      register(option.flag, option.description, parseNonNegativeInt);
     } else {
       register(option.flag, option.description);
     }
@@ -1292,6 +1313,93 @@ async function parseSessionCommand(tokens: string[]): Promise<ParsedCliInput> {
     }
 
     throw new Error("Supported comment subcommands are add, apply, list, rm, and clear.");
+  }
+
+  if (subcommand === "highlight") {
+    const [highlightSubcommand, ...highlightRest] = rest;
+    if (!highlightSubcommand || highlightSubcommand === "--help" || highlightSubcommand === "-h") {
+      return {
+        kind: "help",
+        text: ["Usage:", ...sessionUsageLines(SESSION_HIGHLIGHT_COMMAND_LIST)].join("\n") + "\n",
+      };
+    }
+
+    if (highlightSubcommand === "add") {
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["highlight-add"]);
+
+      let parsedSessionId: string | undefined;
+      let parsedOptions: SessionCommandOptions<"highlight-add"> = {
+        file: "",
+        start: 0,
+        end: 0,
+      };
+
+      command.action(
+        (sessionId: string | undefined, options: SessionCommandOptions<"highlight-add">) => {
+          parsedSessionId = sessionId;
+          parsedOptions = options;
+        },
+      );
+
+      if (highlightRest.includes("--help") || highlightRest.includes("-h")) {
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["highlight-add"]);
+      }
+
+      await parseStandaloneCommand(command, highlightRest);
+
+      enforceConstraint(HIGHLIGHT_TARGET_CONSTRAINT, parsedOptions);
+      if (parsedOptions.end <= parsedOptions.start) {
+        throw new Error(HIGHLIGHT_RANGE_MESSAGE);
+      }
+      const tone = parsedOptions.tone;
+      if (tone !== undefined && !isHighlightTone(tone)) {
+        throw new Error(`Highlight tone must be one of ${HIGHLIGHT_TONES.join(", ")}.`);
+      }
+
+      return {
+        kind: "session",
+        action: "highlight-add",
+        output: resolveJsonOutput(parsedOptions),
+        selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
+        filePath: parsedOptions.file,
+        side: parsedOptions.oldLine !== undefined ? "old" : "new",
+        line: parsedOptions.oldLine ?? parsedOptions.newLine ?? 0,
+        start: parsedOptions.start,
+        end: parsedOptions.end,
+        ...(tone !== undefined && isHighlightTone(tone) ? { tone } : {}),
+        reveal: parsedOptions.focus ?? false,
+      };
+    }
+
+    if (highlightSubcommand === "clear") {
+      const command = buildSessionCommand(SESSION_AGENT_COMMANDS["highlight-clear"]);
+
+      let parsedSessionId: string | undefined;
+      let parsedOptions: SessionCommandOptions<"highlight-clear"> = {};
+
+      command.action(
+        (sessionId: string | undefined, options: SessionCommandOptions<"highlight-clear">) => {
+          parsedSessionId = sessionId;
+          parsedOptions = options;
+        },
+      );
+
+      if (highlightRest.includes("--help") || highlightRest.includes("-h")) {
+        return sessionCommandHelpText(command, SESSION_AGENT_COMMANDS["highlight-clear"]);
+      }
+
+      await parseStandaloneCommand(command, highlightRest);
+
+      return {
+        kind: "session",
+        action: "highlight-clear",
+        output: resolveJsonOutput(parsedOptions),
+        selector: resolveExplicitSessionSelector(parsedSessionId, parsedOptions.repo),
+        filePath: parsedOptions.file,
+      };
+    }
+
+    throw new Error("Supported highlight subcommands are add and clear.");
   }
 
   throw new Error(`Unknown session command: ${subcommand}`);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -278,6 +278,30 @@ export interface SessionCommentClearCommandInput {
   confirmed: boolean;
 }
 
+export interface SessionHighlightAddCommandInput {
+  kind: "session";
+  action: "highlight-add";
+  output: SessionCommandOutput;
+  selector: SessionSelectorInput;
+  filePath: string;
+  side: "old" | "new";
+  line: number;
+  /** 0-based inclusive UTF-16 code-unit offset into the line's raw text. */
+  start: number;
+  /** Exclusive end offset; must exceed `start`. */
+  end: number;
+  tone?: "match" | "current" | "info" | "warning" | "error";
+  reveal: boolean;
+}
+
+export interface SessionHighlightClearCommandInput {
+  kind: "session";
+  action: "highlight-clear";
+  output: SessionCommandOutput;
+  selector: SessionSelectorInput;
+  filePath?: string;
+}
+
 export type SessionCommandInput =
   | SessionListCommandInput
   | SessionGetCommandInput
@@ -288,7 +312,9 @@ export type SessionCommandInput =
   | SessionCommentApplyCommandInput
   | SessionCommentListCommandInput
   | SessionCommentRemoveCommandInput
-  | SessionCommentClearCommandInput;
+  | SessionCommentClearCommandInput
+  | SessionHighlightAddCommandInput
+  | SessionHighlightClearCommandInput;
 
 /**
  * Review requests extend the published input views rather than restating them,

--- a/src/hunk-review/skillDocument.ts
+++ b/src/hunk-review/skillDocument.ts
@@ -32,7 +32,7 @@ function navigateExamples(kind: "absolute" | "relative") {
 const FRONTMATTER = [
   "---",
   "name: hunk-review",
-  "description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files and hunks, reloads session contents, and adds inline review comments. Use when the user has a Hunk session running or wants to review diffs interactively.",
+  "description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files, hunks, and exact lines, reloads session contents, adds inline review comments, and paints attention marks on character ranges. Use when the user has a Hunk session running or wants to review diffs interactively.",
   "---",
 ];
 
@@ -57,6 +57,7 @@ const WORKFLOW = [
   "7. hunk session reload -- <command>                     # swap contents if needed",
   "8. hunk session comment add ...                         # leave one review note",
   "9. hunk session comment apply ...                       # apply many agent notes in one stdin batch",
+  "10. hunk session highlight add ...                      # light up the exact range you are explaining",
   "```",
 ];
 
@@ -103,6 +104,7 @@ const NAVIGATE_SECTION = [
   "",
   "- `--hunk <n>` is 1-based",
   "- `--new-line` / `--old-line` are 1-based line numbers on that diff side",
+  "- A line target lands the user's viewport on that exact line (falling back to its hunk when the line is inside a collapsed region); `--hunk` lands on the hunk",
   "- Use either `--next-comment` or `--prev-comment`, not both",
 ];
 
@@ -154,6 +156,28 @@ const COMMENTS_SECTION = [
   "- Quote `--summary` and `--rationale` defensively in the shell",
 ];
 
+const HIGHLIGHTS_SECTION = [
+  "### Attention marks",
+  "",
+  "Highlights paint character ranges inside the diff lines the user is looking at — use them to light up the exact expression you are explaining while you narrate.",
+  "",
+  ...bashFence(synopsisLines(commands["highlight-add"], commands["highlight-clear"])),
+  "",
+  "Examples:",
+  "",
+  ...bashFence([
+    ...(commands["highlight-add"].examples ?? []),
+    ...(commands["highlight-clear"].examples ?? []),
+  ]),
+  "",
+  "- `highlight add` requires `--file`, exactly one of `--old-line` or `--new-line`, and the `--start` / `--end` offsets",
+  "- `--start` is a 0-based inclusive offset into the line's text and `--end` is exclusive, counted in UTF-16 code units — the same `[start, end)` range extensions use",
+  "- Tones: `match` (default), `info`, `warning`, `error`; `current` renders as reverse video and is best reserved for the one range under discussion",
+  "- Pass `--focus` to also land the viewport on the marked line",
+  "- Marks survive scrolling and navigation but clear when the session reloads; `highlight clear` removes them explicitly (optionally per `--file`)",
+  "- Marks are visual only — pair them with a `comment add` when the explanation should persist as a note",
+];
+
 const STML_SECTION = [
   "### Experimental rich markup notes (STML)",
   "",
@@ -191,6 +215,7 @@ const GUIDING_SECTION = [
   "",
   "- Work in the order that tells the clearest story, not necessarily file order",
   "- Navigate before commenting so the user sees the code you're discussing",
+  "- Use `highlight add --focus` to steer the user's eyes to the exact expression while you explain it, and `highlight clear` before moving to the next topic",
   "- Use `comment apply` for agent-generated batches and `comment add` for one-off notes",
   "- Use `--focus` sparingly when the note itself should actively steer the review",
   "- Keep comments focused: intent, structure, risks, or follow-ups",
@@ -217,6 +242,7 @@ export function renderHunkReviewSkill() {
     NAVIGATE_SECTION,
     RELOAD_SECTION,
     COMMENTS_SECTION,
+    HIGHLIGHTS_SECTION,
     STML_SECTION,
     NEW_FILES_SECTION,
     GUIDING_SECTION,

--- a/src/hunk-review/skillDocument.ts
+++ b/src/hunk-review/skillDocument.ts
@@ -174,7 +174,7 @@ const HIGHLIGHTS_SECTION = [
   "- `--start` is a 0-based inclusive offset into the line's text and `--end` is exclusive, counted in UTF-16 code units — the same `[start, end)` range extensions use",
   "- Tones: `match` (default), `info`, `warning`, `error`; `current` renders as reverse video and is best reserved for the one range under discussion",
   "- Pass `--focus` to also land the viewport on the marked line",
-  "- Marks survive scrolling and navigation but clear when the session reloads; `highlight clear` removes them explicitly (optionally per `--file`)",
+  "- Marks survive scrolling, navigation, and reloads that leave the marked file's content unchanged; a reload that changes that file drops its marks, and `highlight clear` removes them explicitly (optionally per `--file`)",
   "- Marks are visual only — pair them with a `comment add` when the explanation should persist as a note",
 ];
 

--- a/src/session/agent/cliClient.test.ts
+++ b/src/session/agent/cliClient.test.ts
@@ -18,10 +18,12 @@ import {
 import {
   createHttpHunkSessionCliClient,
   formatClearCommentsOutput,
+  formatClearHighlightsOutput,
   formatCommentApplyOutput,
   formatCommentListOutput,
   formatCommentOutput,
   formatContextOutput,
+  formatHighlightOutput,
   formatListOutput,
   formatNavigationOutput,
   formatReloadOutput,
@@ -88,6 +90,27 @@ describe("HTTP Hunk session CLI client", () => {
         result: {
           removedCount: 1,
           remainingCommentCount: 0,
+          filePath: "src/app.ts",
+        },
+      },
+      "highlight-add": {
+        result: {
+          fileId: "file-1",
+          filePath: "src/app.ts",
+          hunkIndex: 0,
+          side: "new" as const,
+          line: 12,
+          start: 2,
+          end: 9,
+          tone: "warning" as const,
+          fileMarkCount: 1,
+          revealed: "line" as const,
+        },
+      },
+      "highlight-clear": {
+        result: {
+          removedCount: 2,
+          remainingCount: 0,
           filePath: "src/app.ts",
         },
       },
@@ -202,6 +225,30 @@ describe("HTTP Hunk session CLI client", () => {
         output: "json",
       }),
     ).toMatchObject({ removedCount: 1 });
+    expect(
+      await client.addHighlight({
+        kind: "session",
+        action: "highlight-add",
+        selector,
+        filePath: "src/app.ts",
+        side: "new",
+        line: 12,
+        start: 2,
+        end: 9,
+        tone: "warning",
+        reveal: true,
+        output: "json",
+      }),
+    ).toMatchObject({ fileMarkCount: 1, revealed: "line" });
+    expect(
+      await client.clearHighlights({
+        kind: "session",
+        action: "highlight-clear",
+        selector,
+        filePath: "src/app.ts",
+        output: "json",
+      }),
+    ).toMatchObject({ removedCount: 2 });
 
     expect(requests).toEqual([
       { action: "list" },
@@ -243,6 +290,18 @@ describe("HTTP Hunk session CLI client", () => {
       { action: "comment-list", selector, filePath: "src/app.ts" },
       { action: "comment-rm", selector, commentId: "comment-1" },
       { action: "comment-clear", selector, filePath: "src/app.ts" },
+      {
+        action: "highlight-add",
+        selector,
+        filePath: "src/app.ts",
+        side: "new",
+        line: 12,
+        start: 2,
+        end: 9,
+        tone: "warning",
+        reveal: true,
+      },
+      { action: "highlight-clear", selector, filePath: "src/app.ts" },
     ]);
   });
 
@@ -575,5 +634,73 @@ describe("Hunk session CLI formatters", () => {
         remainingCommentCount: 0,
       }),
     ).toBe("Cleared 5 live comments from session session-1. Remaining comments: 0.\n");
+  });
+
+  test("highlight formatters describe marks, reveals, and line-exact navigation", () => {
+    expect(
+      formatNavigationOutput(selector, {
+        fileId: "file-1",
+        filePath: "src/app.ts",
+        hunkIndex: 1,
+        revealed: "line",
+        side: "new",
+        line: 42,
+      }),
+    ).toBe("Revealed src/app.ts:42 (new) in hunk 2 of session session-1.\n");
+    // A hunk fallback reads as the classic focus message, not a false line claim.
+    expect(
+      formatNavigationOutput(selector, {
+        fileId: "file-1",
+        filePath: "src/app.ts",
+        hunkIndex: 1,
+        revealed: "hunk",
+        side: "new",
+        line: 42,
+      }),
+    ).toBe("Focused src/app.ts hunk 2 in session session-1.\n");
+
+    expect(
+      formatHighlightOutput(selector, {
+        fileId: "file-1",
+        filePath: "src/app.ts",
+        hunkIndex: 0,
+        side: "new",
+        line: 12,
+        start: 2,
+        end: 9,
+        tone: "warning",
+        fileMarkCount: 3,
+        revealed: "line",
+      }),
+    ).toBe(
+      "Marked src/app.ts:12 (new) [2, 9) as warning in session session-1 and revealed its line. File marks: 3.\n",
+    );
+    expect(
+      formatHighlightOutput(selector, {
+        fileId: "file-1",
+        filePath: "src/app.ts",
+        hunkIndex: 0,
+        side: "old",
+        line: 7,
+        start: 0,
+        end: 4,
+        tone: "match",
+        fileMarkCount: 1,
+      }),
+    ).toBe("Marked src/app.ts:7 (old) [0, 4) as match in session session-1. File marks: 1.\n");
+
+    expect(
+      formatClearHighlightsOutput(selector, {
+        removedCount: 2,
+        remainingCount: 1,
+        filePath: "src/app.ts",
+      }),
+    ).toBe("Cleared 2 attention marks from src/app.ts in session session-1. Remaining marks: 1.\n");
+    expect(
+      formatClearHighlightsOutput(selector, {
+        removedCount: 4,
+        remainingCount: 0,
+      }),
+    ).toBe("Cleared 4 attention marks from session session-1. Remaining marks: 0.\n");
   });
 });

--- a/src/session/agent/cliClient.ts
+++ b/src/session/agent/cliClient.ts
@@ -554,6 +554,12 @@ export function formatNoteListOutput(
     .join("\n\n")}\n`;
 }
 
+/**
+ * Report one applied attention mark, including whether the review moved to it.
+ *
+ * The running mark count is part of the answer because marks accumulate per
+ * file: an agent that keeps marking needs to see its own total without asking.
+ */
 export function formatHighlightOutput(
   selector: SessionSelectorInput,
   result: AppliedHighlightResult,
@@ -571,6 +577,12 @@ export function formatHighlightOutput(
   );
 }
 
+/**
+ * Report how many attention marks were cleared, and from what scope.
+ *
+ * Clearing is addressed either to one file or to the whole session, so the
+ * scope is named back to the caller rather than assumed.
+ */
 export function formatClearHighlightsOutput(
   selector: SessionSelectorInput,
   result: ClearedHighlightsResult,

--- a/src/session/agent/cliClient.ts
+++ b/src/session/agent/cliClient.ts
@@ -14,7 +14,9 @@ import {
 import type {
   AppliedCommentBatchResult,
   AppliedCommentResult,
+  AppliedHighlightResult,
   ClearedCommentsResult,
+  ClearedHighlightsResult,
   ListedSession,
   NavigatedSelectionResult,
   ReloadedSessionResult,
@@ -30,6 +32,8 @@ import type {
   SessionCommentClearCommandInput,
   SessionCommentListCommandInput,
   SessionCommentRemoveCommandInput,
+  SessionHighlightAddCommandInput,
+  SessionHighlightClearCommandInput,
   SessionNavigateCommandInput,
   SessionReloadCommandInput,
   SessionReviewCommandInput,
@@ -52,6 +56,8 @@ export interface HunkSessionCliClient {
   ): Promise<Array<SessionLiveCommentSummary | SessionReviewNoteSummary>>;
   removeComment(input: SessionCommentRemoveCommandInput): Promise<RemovedCommentResult>;
   clearComments(input: SessionCommentClearCommandInput): Promise<ClearedCommentsResult>;
+  addHighlight(input: SessionHighlightAddCommandInput): Promise<AppliedHighlightResult>;
+  clearHighlights(input: SessionHighlightClearCommandInput): Promise<ClearedHighlightsResult>;
 }
 
 async function extractResponseError(response: Response) {
@@ -207,6 +213,32 @@ class HttpHunkSessionCliClient implements HunkSessionCliClient {
         selector: input.selector,
         filePath: input.filePath,
         includeUser: input.includeUser,
+      })
+    ).result;
+  }
+
+  async addHighlight(input: SessionHighlightAddCommandInput) {
+    return (
+      await this.request<{ result: AppliedHighlightResult }>({
+        action: "highlight-add",
+        selector: input.selector,
+        filePath: input.filePath,
+        side: input.side,
+        line: input.line,
+        start: input.start,
+        end: input.end,
+        tone: input.tone,
+        reveal: input.reveal,
+      })
+    ).result;
+  }
+
+  async clearHighlights(input: SessionHighlightClearCommandInput) {
+    return (
+      await this.request<{ result: ClearedHighlightsResult }>({
+        action: "highlight-clear",
+        selector: input.selector,
+        filePath: input.filePath,
       })
     ).result;
   }
@@ -426,6 +458,10 @@ export function formatNavigationOutput(
   selector: SessionSelectorInput,
   result: NavigatedSelectionResult,
 ) {
+  if (result.revealed === "line" && result.line !== undefined) {
+    return `Revealed ${formatSessionPath(result.filePath)}:${result.line} (${result.side}) in hunk ${result.hunkIndex + 1} of ${formatSessionSelector(selector)}.\n`;
+  }
+
   return `Focused ${formatSessionPath(result.filePath)} hunk ${result.hunkIndex + 1} in ${formatSessionSelector(selector)}.\n`;
 }
 
@@ -516,6 +552,33 @@ export function formatNoteListOutput(
       ].join("\n"),
     )
     .join("\n\n")}\n`;
+}
+
+export function formatHighlightOutput(
+  selector: SessionSelectorInput,
+  result: AppliedHighlightResult,
+) {
+  const reveal =
+    result.revealed === "line"
+      ? " and revealed its line"
+      : result.revealed === "hunk"
+        ? " and revealed its hunk"
+        : "";
+  return (
+    `Marked ${formatSessionPath(result.filePath)}:${result.line} (${result.side}) ` +
+    `[${result.start}, ${result.end}) as ${result.tone} in ${formatSessionSelector(selector)}${reveal}. ` +
+    `File marks: ${result.fileMarkCount}.\n`
+  );
+}
+
+export function formatClearHighlightsOutput(
+  selector: SessionSelectorInput,
+  result: ClearedHighlightsResult,
+) {
+  const scope = result.filePath
+    ? `${formatSessionPath(result.filePath)} in ${formatSessionSelector(selector)}`
+    : formatSessionSelector(selector);
+  return `Cleared ${result.removedCount} attention marks from ${scope}. Remaining marks: ${result.remainingCount}.\n`;
 }
 
 export function formatClearCommentsOutput(

--- a/src/session/agent/commands.test.ts
+++ b/src/session/agent/commands.test.ts
@@ -121,6 +121,21 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
       removedCount: 0,
       remainingCommentCount: 0,
     }),
+    addHighlight: async () => ({
+      fileId: "file-1",
+      filePath: "README.md",
+      hunkIndex: 0,
+      side: "new",
+      line: 1,
+      start: 0,
+      end: 4,
+      tone: "match",
+      fileMarkCount: 1,
+    }),
+    clearHighlights: async () => ({
+      removedCount: 0,
+      remainingCount: 0,
+    }),
     ...overrides,
   };
 }

--- a/src/session/agent/commands.test.ts
+++ b/src/session/agent/commands.test.ts
@@ -71,6 +71,8 @@ function createClient(overrides: Partial<HunkDaemonCliClient>): HunkDaemonCliCli
         "comment-list",
         "comment-rm",
         "comment-clear",
+        "highlight-add",
+        "highlight-clear",
       ],
     }),
     listSessions: async () => [],
@@ -1063,6 +1065,76 @@ describe("session command compatibility checks", () => {
     ).toBe("Cleared 2 live comments from README.md in session session-1. Remaining comments: 0.\n");
 
     expect(calls).toEqual(["navigate", "comment-list", "comment-rm", "comment-clear"]);
+  });
+
+  test("routes highlight actions through the daemon and formats text output", async () => {
+    const selector: SessionSelectorInput = { sessionId: "session-1" };
+    const calls: string[] = [];
+
+    setSessionCommandTestHooks({
+      createClient: () =>
+        createClient({
+          addHighlight: async (input) => {
+            calls.push("highlight-add");
+            expect(input.selector).toEqual(selector);
+            expect(input.filePath).toBe("README.md");
+            expect(input.side).toBe("new");
+            expect(input.line).toBe(2);
+            expect(input.start).toBe(4);
+            expect(input.end).toBe(11);
+            expect(input.tone).toBe("info");
+            expect(input.reveal).toBe(true);
+            return {
+              fileId: "file-1",
+              filePath: "README.md",
+              hunkIndex: 0,
+              side: "new",
+              line: 2,
+              start: 4,
+              end: 11,
+              tone: "info",
+              fileMarkCount: 1,
+              revealed: "line",
+            };
+          },
+          clearHighlights: async (input) => {
+            calls.push("highlight-clear");
+            expect(input.selector).toEqual(selector);
+            expect(input.filePath).toBeUndefined();
+            return { removedCount: 1, remainingCount: 0 };
+          },
+        }),
+      resolveDaemonAvailability: async () => true,
+    });
+
+    expect(
+      await runSessionCommand({
+        kind: "session",
+        action: "highlight-add",
+        selector,
+        filePath: "README.md",
+        side: "new",
+        line: 2,
+        start: 4,
+        end: 11,
+        tone: "info",
+        reveal: true,
+        output: "text",
+      } satisfies SessionCommandInput),
+    ).toBe(
+      "Marked README.md:2 (new) [4, 11) as info in session session-1 and revealed its line. File marks: 1.\n",
+    );
+
+    expect(
+      await runSessionCommand({
+        kind: "session",
+        action: "highlight-clear",
+        selector,
+        output: "text",
+      } satisfies SessionCommandInput),
+    ).toBe("Cleared 1 attention marks from session session-1. Remaining marks: 0.\n");
+
+    expect(calls).toEqual(["highlight-add", "highlight-clear"]);
   });
 });
 

--- a/src/session/agent/commands.ts
+++ b/src/session/agent/commands.ts
@@ -17,10 +17,12 @@ import { matchesSessionSelector, normalizeSessionSelector } from "@hunk/session-
 import {
   createHttpHunkSessionCliClient,
   formatClearCommentsOutput,
+  formatClearHighlightsOutput,
   formatCommentApplyOutput,
   formatCommentListOutput,
   formatCommentOutput,
   formatContextOutput,
+  formatHighlightOutput,
   formatListOutput,
   formatNavigationOutput,
   formatNoteListOutput,
@@ -46,6 +48,8 @@ const REQUIRED_ACTION_BY_COMMAND: Record<SessionCommandInput["action"], SessionD
   "comment-list": "comment-list",
   "comment-rm": "comment-rm",
   "comment-clear": "comment-clear",
+  "highlight-add": "highlight-add",
+  "highlight-clear": "highlight-clear",
 };
 
 export type HunkDaemonCliClient = HunkSessionCliClient;
@@ -274,6 +278,24 @@ export async function runSessionCommand(input: SessionCommandInput) {
       });
       return renderOutput(input.output, { result }, () =>
         formatClearCommentsOutput(input.selector, result),
+      );
+    }
+    case "highlight-add": {
+      const result = await client.addHighlight({
+        ...input,
+        selector: normalizedSelector!,
+      });
+      return renderOutput(input.output, { result }, () =>
+        formatHighlightOutput(input.selector, result),
+      );
+    }
+    case "highlight-clear": {
+      const result = await client.clearHighlights({
+        ...input,
+        selector: normalizedSelector!,
+      });
+      return renderOutput(input.output, { result }, () =>
+        formatClearHighlightsOutput(input.selector, result),
       );
     }
   }

--- a/src/session/agent/errors.test.ts
+++ b/src/session/agent/errors.test.ts
@@ -5,6 +5,7 @@ import {
   agentErrorQuotePrefix,
   COMMENT_APPLY_STDIN_MESSAGE,
   constraintViolationMessage,
+  HIGHLIGHT_RANGE_MESSAGE,
   NO_ACTIVE_SESSIONS_MESSAGE,
   noDiffFileMatchesMessage,
   RELOAD_SEPARATOR_MESSAGE,
@@ -13,6 +14,7 @@ import {
 import {
   COMMENT_DIRECTION_CONSTRAINT,
   COMMENT_TARGET_CONSTRAINT,
+  HIGHLIGHT_TARGET_CONSTRAINT,
   NAVIGATE_TARGET_CONSTRAINT,
 } from "./surface";
 
@@ -66,6 +68,8 @@ describe("agent error messages", () => {
       COMMENT_APPLY_STDIN_MESSAGE,
       constraintViolationMessage(NAVIGATE_TARGET_CONSTRAINT),
       constraintViolationMessage(COMMENT_TARGET_CONSTRAINT),
+      constraintViolationMessage(HIGHLIGHT_TARGET_CONSTRAINT),
+      HIGHLIGHT_RANGE_MESSAGE,
       constraintViolationMessage(COMMENT_DIRECTION_CONSTRAINT),
       reviewResourceUnavailableMessage("src/App.tsx"),
     ];

--- a/src/session/agent/errors.ts
+++ b/src/session/agent/errors.ts
@@ -33,6 +33,10 @@ export const RELOAD_SEPARATOR_MESSAGE =
 /** `comment apply` invoked without opting into the stdin JSON batch. */
 export const COMMENT_APPLY_STDIN_MESSAGE = "Pass --stdin to read batch comments from stdin JSON.";
 
+/** `highlight add` invoked with an empty or inverted character range. */
+export const HIGHLIGHT_RANGE_MESSAGE =
+  "Highlight --end must be greater than --start; the range is [start, end) with an exclusive end.";
+
 /** The daemon is reachable but no live Hunk session has registered with it. */
 export const NO_ACTIVE_SESSIONS_MESSAGE =
   "No active Hunk sessions are registered with the daemon. Open Hunk and wait for it to connect.";
@@ -103,6 +107,14 @@ export const AGENT_ERROR_DOCS: AgentErrorDoc[] = [
   {
     quote: "Specify exactly one comment target",
     remedy: "pass `comment add` one of `--old-line` or `--new-line`.",
+  },
+  {
+    quote: "Specify exactly one highlight target",
+    remedy: "pass `highlight add` one of `--old-line` or `--new-line`.",
+  },
+  {
+    quote: "Highlight --end must be greater than --start",
+    remedy: "offsets are `[start, end)` UTF-16 code units into the line text; end is exclusive.",
   },
   {
     quote: "Specify either --next-comment or --prev-comment, not both.",

--- a/src/session/agent/surface.test.ts
+++ b/src/session/agent/surface.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
   agentOptionFlagName,
+  isHighlightTone,
   optionKeyFromFlag,
   type AgentCommandOption,
   SESSION_AGENT_COMMAND_LIST,
   SESSION_AGENT_COMMANDS,
   SESSION_COMMENT_COMMAND_LIST,
+  SESSION_HIGHLIGHT_COMMAND_LIST,
   type SessionCommandOptions,
 } from "./surface";
 
@@ -21,6 +23,10 @@ describe("session agent command surface", () => {
       "session comment list",
       "session comment rm",
       "session comment clear",
+    ]);
+    expect(SESSION_HIGHLIGHT_COMMAND_LIST.map((spec) => spec.name)).toEqual([
+      "session highlight add",
+      "session highlight clear",
     ]);
   });
 
@@ -103,5 +109,22 @@ describe("session agent command surface", () => {
         expect(option.parse).toBe("positiveInt");
       }
     }
+  });
+
+  test("parses highlight offsets as 0-based start and positive exclusive end", () => {
+    const options: readonly AgentCommandOption[] = SESSION_AGENT_COMMANDS["highlight-add"].options;
+    const parseByFlag = new Map(
+      options.map((option) => [agentOptionFlagName(option), option.parse]),
+    );
+    // `--start` accepts 0 because offsets are 0-based; `--end` is exclusive so it starts at 1.
+    expect(parseByFlag.get("--start")).toBe("nonNegativeInt");
+    expect(parseByFlag.get("--end")).toBe("positiveInt");
+  });
+
+  test("recognizes exactly the five shared highlight tones", () => {
+    for (const tone of ["match", "current", "info", "warning", "error"]) {
+      expect(isHighlightTone(tone)).toBe(true);
+    }
+    expect(isHighlightTone("loud")).toBe(false);
   });
 });

--- a/src/session/agent/surface.ts
+++ b/src/session/agent/surface.ts
@@ -15,8 +15,8 @@ export interface AgentCommandOption {
   readonly flag: string;
   /** Description shared by `--help` output and generated docs. */
   readonly description: string;
-  /** Parse the option value as a 1-based positive integer. */
-  readonly parse?: "positiveInt";
+  /** Parse the option value as a 1-based positive or 0-based non-negative integer. */
+  readonly parse?: "positiveInt" | "nonNegativeInt";
   /** Register with Commander as a required option. */
   readonly required?: boolean;
 }
@@ -60,7 +60,7 @@ type FlagBody<Flag extends string> = Flag extends `--${infer Name} ${string}`
 
 /** The parsed value Commander produces for one option: boolean flag, string value, or number. */
 type OptionValue<Option extends AgentCommandOption> = Option["flag"] extends `${string} <${string}>`
-  ? Option extends { readonly parse: "positiveInt" }
+  ? Option extends { readonly parse: "positiveInt" | "nonNegativeInt" }
     ? number
     : string
   : boolean;
@@ -156,6 +156,23 @@ export const COMMENT_TARGET_CONSTRAINT = {
   label: "comment target",
   flags: ["--old-line <n>", "--new-line <n>"],
 } as const satisfies AgentCommandConstraint;
+
+/** Highlight anchoring targets: callers must pass exactly one. */
+export const HIGHLIGHT_TARGET_CONSTRAINT = {
+  kind: "exactly-one",
+  label: "highlight target",
+  flags: ["--old-line <n>", "--new-line <n>"],
+} as const satisfies AgentCommandConstraint;
+
+/** The five-tone vocabulary highlight marks share with extension line highlighters. */
+export const HIGHLIGHT_TONES = ["match", "current", "info", "warning", "error"] as const;
+
+export type HighlightTone = (typeof HIGHLIGHT_TONES)[number];
+
+/** Check one CLI-provided tone value against the shared five-tone vocabulary. */
+export function isHighlightTone(value: string): value is HighlightTone {
+  return (HIGHLIGHT_TONES as readonly string[]).includes(value);
+}
 
 /** Relative comment navigation directions: callers may pass at most one. */
 export const COMMENT_DIRECTION_CONSTRAINT = {
@@ -400,6 +417,57 @@ export const SESSION_AGENT_COMMANDS = {
       `hunk session comment clear ${SESSION_SELECTOR_SYNOPSIS} [--file <path>] [--include-user|--all] --yes [--json]`,
     ],
   },
+  "highlight-add": {
+    name: "session highlight add",
+    summary: "paint one attention mark inside a diff line",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      { ...diffFileOption, required: true },
+      {
+        flag: "--start <n>",
+        description: "0-based inclusive start offset into the line's text (UTF-16 code units)",
+        parse: "nonNegativeInt",
+        required: true,
+      },
+      {
+        flag: "--end <n>",
+        description: "exclusive end offset; must be greater than --start",
+        parse: "positiveInt",
+        required: true,
+      },
+      repoOption,
+      oldLineOption,
+      newLineOption,
+      {
+        flag: "--tone <tone>",
+        description: `mark tone: ${HIGHLIGHT_TONES.join(", ")} (default match)`,
+      },
+      { flag: "--focus", description: "add the mark and land the viewport on its line" },
+      jsonOption,
+    ],
+    constraints: [HIGHLIGHT_TARGET_CONSTRAINT],
+    synopsis: [
+      `hunk session highlight add ${SESSION_SELECTOR_SYNOPSIS} --file <path> ${constraintSynopsis(HIGHLIGHT_TARGET_CONSTRAINT)} --start <n> --end <n> [--tone <tone>] [--focus] [--json]`,
+    ],
+    examples: [
+      "hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19",
+      "hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19 --tone warning --focus",
+    ],
+  },
+  "highlight-clear": {
+    name: "session highlight clear",
+    summary: "clear agent attention marks",
+    positionals: [{ token: "[sessionId]" }],
+    options: [
+      repoOption,
+      { flag: "--file <path>", description: "clear only one diff file's marks" },
+      jsonOption,
+    ],
+    synopsis: [
+      `hunk session highlight clear ${SESSION_SELECTOR_SYNOPSIS} [--file <path>] [--json]`,
+    ],
+    examples: ["hunk session highlight clear --repo ."],
+  },
 } as const satisfies Record<SessionDaemonAction, AgentCommandSpec>;
 
 /** Specs in display order for help text and generated docs. */
@@ -409,6 +477,11 @@ export const SESSION_AGENT_COMMAND_LIST: readonly AgentCommandSpec[] =
 /** Specs for the `hunk session comment` subcommand family, in display order. */
 export const SESSION_COMMENT_COMMAND_LIST = SESSION_AGENT_COMMAND_LIST.filter((spec) =>
   spec.name.startsWith("session comment "),
+);
+
+/** Specs for the `hunk session highlight` subcommand family, in display order. */
+export const SESSION_HIGHLIGHT_COMMAND_LIST = SESSION_AGENT_COMMAND_LIST.filter((spec) =>
+  spec.name.startsWith("session highlight "),
 );
 
 /** Extract the flag name (e.g. `--old-line`) from a Commander flag definition. */

--- a/src/session/app/bridge.test.ts
+++ b/src/session/app/bridge.test.ts
@@ -45,6 +45,22 @@ function createHandlers() {
       removed: true,
       remainingCommentCount: 0,
     })),
+    addAgentLineHighlight: mock((input) => ({
+      fileId: "file-1",
+      filePath: input.filePath,
+      hunkIndex: 0,
+      side: input.side,
+      line: input.line,
+      start: input.start,
+      end: input.end,
+      tone: input.tone ?? ("match" as const),
+      fileMarkCount: 1,
+    })),
+    clearAgentLineHighlights: mock((filePath?: string) => ({
+      removedCount: filePath ? 1 : 2,
+      remainingCount: 0,
+      filePath,
+    })),
   };
 }
 

--- a/src/session/app/bridge.ts
+++ b/src/session/app/bridge.ts
@@ -3,7 +3,9 @@ import type { HunkReviewFailureV1, HunkReviewResourceReadResultV1 } from "../rev
 import type {
   AppliedCommentBatchResult,
   AppliedCommentResult,
+  AppliedHighlightResult,
   ClearedCommentsResult,
+  ClearedHighlightsResult,
   HunkSessionCommandResult,
   HunkSessionServerMessage,
   NavigatedSelectionResult,
@@ -30,6 +32,10 @@ export interface HunkSessionBridgeHandlers {
   navigateToLocation: (
     input: Extract<HunkSessionServerMessage, { command: "navigate_to_hunk" }>["input"],
   ) => NavigatedSelectionResult;
+  addAgentLineHighlight: (
+    input: Extract<HunkSessionServerMessage, { command: "highlight" }>["input"],
+  ) => AppliedHighlightResult;
+  clearAgentLineHighlights: (filePath?: string) => ClearedHighlightsResult;
   openAgentNotes: () => void;
   reloadSession: (
     nextInput: Extract<
@@ -90,6 +96,10 @@ export function createHunkSessionBridge(handlers: HunkSessionBridgeHandlers) {
         }
         case "navigate_to_hunk":
           return handlers.navigateToLocation(message.input);
+        case "highlight":
+          return handlers.addAgentLineHighlight(message.input);
+        case "clear_highlights":
+          return handlers.clearAgentLineHighlights(message.input.filePath);
         case "reload_session":
           return handlers.reloadSession(message.input.nextInput, {
             resetApp: false,

--- a/src/session/broker/brokerServer.test.ts
+++ b/src/session/broker/brokerServer.test.ts
@@ -305,6 +305,8 @@ describe("Hunk session daemon server", () => {
           "comment-list",
           "comment-rm",
           "comment-clear",
+          "highlight-add",
+          "highlight-clear",
         ],
       });
 

--- a/src/session/broker/brokerServer.ts
+++ b/src/session/broker/brokerServer.ts
@@ -14,7 +14,9 @@ import { createHunkSessionBrokerState, type HunkSessionBrokerState } from "./sta
 import type {
   AppliedCommentBatchResult,
   AppliedCommentResult,
+  AppliedHighlightResult,
   ClearedCommentsResult,
+  ClearedHighlightsResult,
   HunkSessionCommandResult,
   HunkSessionServerMessage,
   NavigatedSelectionResult,
@@ -54,6 +56,8 @@ const SUPPORTED_SESSION_ACTIONS: SessionDaemonAction[] = [
   "comment-list",
   "comment-rm",
   "comment-clear",
+  "highlight-add",
+  "highlight-clear",
 ];
 
 export interface ServeSessionBrokerDaemonOptions {
@@ -371,6 +375,38 @@ export async function handleSessionApiRequest(state: HunkSessionBrokerState, req
               includeUser: input.includeUser,
             },
             timeoutMessage: "Timed out waiting for the session to clear the requested comments.",
+          }),
+        };
+        break;
+      case "highlight-add":
+        response = {
+          result: await state.dispatchCommand<AppliedHighlightResult, "highlight">({
+            selector: input.selector,
+            command: "highlight",
+            input: {
+              ...input.selector,
+              filePath: input.filePath,
+              side: input.side,
+              line: input.line,
+              start: input.start,
+              end: input.end,
+              tone: input.tone,
+              reveal: input.reveal,
+            },
+            timeoutMessage: "Timed out waiting for the session to apply the highlight.",
+          }),
+        };
+        break;
+      case "highlight-clear":
+        response = {
+          result: await state.dispatchCommand<ClearedHighlightsResult, "clear_highlights">({
+            selector: input.selector,
+            command: "clear_highlights",
+            input: {
+              ...input.selector,
+              filePath: input.filePath,
+            },
+            timeoutMessage: "Timed out waiting for the session to clear the requested highlights.",
           }),
         };
         break;

--- a/src/session/broker/reviewResources.integration.test.ts
+++ b/src/session/broker/reviewResources.integration.test.ts
@@ -86,6 +86,12 @@ function connect(files: DiffFile[], cache = new ReviewResourceCache()) {
     navigateToLocation: () => {
       throw new Error("unused");
     },
+    addAgentLineHighlight: () => {
+      throw new Error("unused");
+    },
+    clearAgentLineHighlights: () => {
+      throw new Error("unused");
+    },
     openAgentNotes: () => undefined,
     reloadSession: () => {
       throw new Error("unused");

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -4,6 +4,8 @@ import type {
   SessionCommentClearCommandInput,
   SessionCommentListCommandInput,
   SessionCommentRemoveCommandInput,
+  SessionHighlightAddCommandInput,
+  SessionHighlightClearCommandInput,
   SessionNavigateCommandInput,
   SessionReloadCommandInput,
   SessionReviewCommandInput,
@@ -12,7 +14,9 @@ import type {
 import type {
   AppliedCommentBatchResult,
   AppliedCommentResult,
+  AppliedHighlightResult,
   ClearedCommentsResult,
+  ClearedHighlightsResult,
   ListedSession,
   NavigatedSelectionResult,
   ReloadedSessionResult,
@@ -32,7 +36,7 @@ export const HUNK_SESSION_API_VERSION = 1;
  * builds can refresh an older daemon even when it still exposes the same API endpoints. Bump this
  * when daemon-forwarded payloads change, even if the supported action names stay stable.
  */
-export const HUNK_SESSION_DAEMON_VERSION = 8;
+export const HUNK_SESSION_DAEMON_VERSION = 9;
 
 export type SessionDaemonAction =
   | "list"
@@ -45,7 +49,9 @@ export type SessionDaemonAction =
   | "comment-apply"
   | "comment-list"
   | "comment-rm"
-  | "comment-clear";
+  | "comment-clear"
+  | "highlight-add"
+  | "highlight-clear";
 
 export interface SessionDaemonCapabilities {
   version: number;
@@ -120,6 +126,22 @@ export type SessionDaemonRequest =
       selector: SessionCommentClearCommandInput["selector"];
       filePath?: string;
       includeUser?: boolean;
+    }
+  | {
+      action: "highlight-add";
+      selector: SessionHighlightAddCommandInput["selector"];
+      filePath: string;
+      side: "old" | "new";
+      line: number;
+      start: number;
+      end: number;
+      tone?: "match" | "current" | "info" | "warning" | "error";
+      reveal: boolean;
+    }
+  | {
+      action: "highlight-clear";
+      selector: SessionHighlightClearCommandInput["selector"];
+      filePath?: string;
     };
 
 export type SessionDaemonResponse =
@@ -133,4 +155,6 @@ export type SessionDaemonResponse =
   | { result: AppliedCommentBatchResult }
   | { comments: Array<SessionLiveCommentSummary | SessionReviewNoteSummary> }
   | { result: RemovedCommentResult }
-  | { result: ClearedCommentsResult };
+  | { result: ClearedCommentsResult }
+  | { result: AppliedHighlightResult }
+  | { result: ClearedHighlightsResult };

--- a/src/session/protocolSchemas.test.ts
+++ b/src/session/protocolSchemas.test.ts
@@ -58,11 +58,62 @@ describe("session daemon request validation", () => {
       { action: "comment-list", selector: { sessionId: "s-1" }, type: "user" },
       { action: "comment-rm", selector: { sessionId: "s-1" }, commentId: "c-1" },
       { action: "comment-clear", selector: { sessionId: "s-1" }, includeUser: true },
+      {
+        action: "highlight-add",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        side: "new",
+        line: 12,
+        start: 0,
+        end: 8,
+        tone: "warning",
+        reveal: true,
+      },
+      {
+        action: "highlight-add",
+        selector: { repoRoot: "/repo" },
+        filePath: "a.ts",
+        side: "old",
+        line: 3,
+        start: 4,
+        end: 9,
+        reveal: false,
+      },
+      { action: "highlight-clear", selector: { sessionId: "s-1" }, filePath: "a.ts" },
+      { action: "highlight-clear", selector: { sessionId: "s-1" } },
     ];
 
     for (const request of requests) {
       expect(() => parseSessionDaemonRequest(request)).not.toThrow();
     }
+  });
+
+  test("rejects malformed highlight payloads", () => {
+    expect(() =>
+      parseSessionDaemonRequest({
+        action: "highlight-add",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        side: "new",
+        line: 12,
+        start: -1,
+        end: 8,
+        reveal: false,
+      }),
+    ).toThrow(/start/);
+    expect(() =>
+      parseSessionDaemonRequest({
+        action: "highlight-add",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        side: "new",
+        line: 12,
+        start: 0,
+        end: 8,
+        tone: "loud",
+        reveal: false,
+      }),
+    ).toThrow(/tone/);
   });
 
   test("rejects unknown actions with a readable error", () => {

--- a/src/session/protocolSchemas.ts
+++ b/src/session/protocolSchemas.ts
@@ -106,6 +106,22 @@ export const sessionDaemonRequestSchema = z.discriminatedUnion("action", [
     filePath: z.string().optional(),
     includeUser: z.boolean().optional(),
   }),
+  z.strictObject({
+    action: z.literal("highlight-add"),
+    selector: selectorSchema,
+    filePath: z.string(),
+    side: sideSchema,
+    line: z.int().positive(),
+    start: z.int().nonnegative(),
+    end: z.int().positive(),
+    tone: z.enum(["match", "current", "info", "warning", "error"]).optional(),
+    reveal: z.boolean(),
+  }),
+  z.strictObject({
+    action: z.literal("highlight-clear"),
+    selector: selectorSchema,
+    filePath: z.string().optional(),
+  }),
 ]);
 
 /** Compose one readable rejection reason from the first schema issue. */

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,4 +1,5 @@
 import type { ExperimentalFeature } from "../core/experimental";
+import type { ExtensionLineHighlightTone } from "../extension-api/types";
 import type { CommentTargetInput, DiffSide } from "../core/liveComments";
 import type { ReviewPublicationAddress } from "../core/review/generationOrder";
 import type { CliInput, ReviewNoteSource } from "../core/types";
@@ -146,6 +147,23 @@ export interface ReadReviewResourceToolInput
 export interface ApplyReviewActionToolInput
   extends SessionTargetInput, HunkReviewActionEnvelopeV1 {}
 
+/** One agent-set attention mark: a character range inside one diff line. */
+export interface HighlightToolInput extends SessionTargetInput {
+  filePath: string;
+  side: DiffSide;
+  line: number;
+  /** `[start, end)` UTF-16 code-unit offsets into the line's raw source text. */
+  start: number;
+  end: number;
+  tone?: ExtensionLineHighlightTone;
+  /** Also land the viewport on the marked line. */
+  reveal?: boolean;
+}
+
+export interface ClearHighlightsToolInput extends SessionTargetInput {
+  filePath?: string;
+}
+
 export interface SessionLiveCommentSummary {
   commentId: string;
   filePath: string;
@@ -195,6 +213,31 @@ export interface NavigatedSelectionResult {
   filePath: string;
   hunkIndex: number;
   selectedHunk?: SelectedHunkSummary;
+  /** For line targets: whether the viewport landed on the exact line or fell back to its hunk. */
+  revealed?: "line" | "hunk";
+  side?: DiffSide;
+  line?: number;
+}
+
+export interface AppliedHighlightResult {
+  fileId: string;
+  filePath: string;
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+  start: number;
+  end: number;
+  tone: ExtensionLineHighlightTone;
+  /** Agent marks now active on this file, including this one. */
+  fileMarkCount: number;
+  /** Where the optional `reveal` landed. */
+  revealed?: "line" | "hunk";
+}
+
+export interface ClearedHighlightsResult {
+  removedCount: number;
+  remainingCount: number;
+  filePath?: string;
 }
 
 export interface RemovedCommentResult {
@@ -295,7 +338,9 @@ export type HunkSessionCommandResult =
   | RemovedCommentResult
   | ClearedCommentsResult
   | ReloadedSessionResult
-  | HunkReviewResultV1;
+  | HunkReviewResultV1
+  | AppliedHighlightResult
+  | ClearedHighlightsResult;
 
 export type HunkSessionClientMessage = SessionClientMessage<
   HunkSessionInfo,
@@ -318,4 +363,6 @@ export type HunkSessionServerMessage =
   | SessionServerMessage<"remove_comment", RemoveCommentToolInput>
   | SessionServerMessage<"clear_comments", ClearCommentsToolInput>
   | SessionServerMessage<"read_review_resource", ReadReviewResourceToolInput>
-  | SessionServerMessage<"apply_review_action", ApplyReviewActionToolInput>;
+  | SessionServerMessage<"apply_review_action", ApplyReviewActionToolInput>
+  | SessionServerMessage<"highlight", HighlightToolInput>
+  | SessionServerMessage<"clear_highlights", ClearHighlightsToolInput>;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -112,6 +112,7 @@ import type { LineCursor } from "./lib/lineCursors";
 import { buildExtensionReviewSelection } from "./lib/extensionSelection";
 import { useFilePresentationController } from "./fileViews/useFilePresentationController";
 import { useFilePresentationRendering } from "./fileViews/useFilePresentationRendering";
+import { mergeLineHighlightMaps } from "./highlights/merge";
 import { useLineHighlights } from "./highlights/useLineHighlights";
 import { useLineHighlightsController } from "./highlights/useLineHighlightsController";
 import { useKeyboardModeController } from "./keyboardModes/useKeyboardModeController";
@@ -1170,9 +1171,18 @@ export function App({
     onIssue: showFileViewWarning,
   });
 
+  // Extension marks and agent attention marks paint through one pipeline: the
+  // merged map is the only mark source the diff pane sees.
+  const paintedLineHighlights = useMemo(
+    () => mergeLineHighlightMaps(extensionLineHighlights, review.agentLineHighlightsByFileId),
+    [extensionLineHighlights, review.agentLineHighlightsByFileId],
+  );
+
   useHunkSessionBridge({
+    addAgentLineHighlight: review.addAgentLineHighlight,
     addLiveComment: review.addLiveComment,
     addLiveCommentBatch: review.addLiveCommentBatch,
+    clearAgentLineHighlights: review.clearAgentLineHighlights,
     clearLiveComments: review.clearLiveComments,
     hostClient,
     liveCommentCount: review.liveCommentCount,
@@ -2203,7 +2213,7 @@ export function App({
             expandedGapsByFileId={review.expandedGapsByFileId}
             fileViews={fileViewLayouts}
             files={filteredFiles}
-            lineHighlights={extensionLineHighlights}
+            lineHighlights={paintedLineHighlights}
             pagerMode={pagerMode}
             screenLeft={diffPaneScreenLeft}
             screenTop={diffPaneScreenTop}

--- a/src/ui/AppHost.reload.test.tsx
+++ b/src/ui/AppHost.reload.test.tsx
@@ -5,11 +5,89 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
+import { SESSION_BROKER_REGISTRATION_VERSION } from "@hunk/session-broker-core";
 import { removeTestDirectory } from "../../test/helpers/filesystem";
+import type {
+  HunkSessionBrokerClient,
+  HunkSessionRegistration,
+  HunkSessionServerMessage,
+  HunkSessionSnapshot,
+} from "../session/types";
 
 const { getBundledVcsCatalog } = await import("../app/vcsCatalog");
 const { loadAppBootstrap } = await import("../core/loaders");
 const { AppHost } = await import("./AppHost");
+
+/** Stand in for the session daemon so a test can send the commands agents send. */
+function createTestHostClient() {
+  type Bridge = Parameters<HunkSessionBrokerClient["setBridge"]>[0];
+
+  let bridge: Bridge = null;
+  let registration: HunkSessionRegistration = {
+    registrationVersion: SESSION_BROKER_REGISTRATION_VERSION,
+    sessionId: "session-1",
+    pid: process.pid,
+    cwd: process.cwd(),
+    repoRoot: process.cwd(),
+    launchedAt: "2026-03-24T00:00:00.000Z",
+    info: { inputKind: "diff", title: "before.ts → after.ts", sourceLabel: "after.ts", files: [] },
+  };
+
+  return {
+    hostClient: {
+      getRegistration: () => registration,
+      replaceSession: (nextRegistration: HunkSessionRegistration) => {
+        registration = nextRegistration;
+      },
+      setBridge: (nextBridge: Bridge) => {
+        bridge = nextBridge;
+      },
+      updateSnapshot: (_snapshot: HunkSessionSnapshot) => {},
+    } as unknown as HunkSessionBrokerClient,
+    dispatchCommand: async (message: HunkSessionServerMessage) => {
+      if (!bridge) {
+        throw new Error("Expected App to register a bridge before running the test command.");
+      }
+
+      return bridge.dispatchCommand(message);
+    },
+  };
+}
+
+/**
+ * Return the backgrounds painted behind `marked` and behind the rest of its rendered line.
+ *
+ * An attention mark is only visible as a background the surrounding code does not share, so
+ * comparing the two is how a test sees the mark that character frames cannot show.
+ */
+function markedLineBackgrounds(
+  frame: ReturnType<Awaited<ReturnType<typeof testRender>>["captureSpans"]>,
+  lineText: string,
+  marked: string,
+) {
+  const line = frame.lines.find((candidate) =>
+    candidate.spans
+      .map((span) => span.text)
+      .join("")
+      .includes(lineText),
+  );
+  const spans = line?.spans ?? [];
+  const renderedText = spans.map((span) => span.text).join("");
+  const markStart = renderedText.indexOf(marked, renderedText.indexOf(lineText));
+  const markEnd = markStart + marked.length;
+
+  const markedBackgrounds = new Set<string>();
+  const unmarkedBackgrounds = new Set<string>();
+  let offset = 0;
+  for (const span of spans) {
+    const spanEnd = offset + span.text.length;
+    const overlapsMark = markStart >= 0 && offset < markEnd && spanEnd > markStart;
+    (overlapsMark ? markedBackgrounds : unmarkedBackgrounds).add(JSON.stringify(span.bg ?? null));
+    offset = spanEnd;
+  }
+
+  return { markedBackgrounds, unmarkedBackgrounds };
+}
 
 async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
   await act(async () => {
@@ -129,6 +207,192 @@ describe("reload stale highlight cache", () => {
       }
 
       expect(refreshed).toBe(true);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      await removeTestDirectory(dir);
+    }
+  });
+});
+
+describe("reload agent attention marks", () => {
+  test("r key keeps agent attention marks when nothing changed on disk", async () => {
+    const dir = mkdtempSync(join(process.cwd(), ".hunk-reload-marks-"));
+    const left = join(dir, "before.ts");
+    const right = join(dir, "after.ts");
+
+    writeFileSync(left, "export const answer = 41;\n");
+    writeFileSync(right, "export const answer = 42;\n");
+
+    const bootstrap = await loadAppBootstrap({
+      kind: "diff",
+      left,
+      right,
+      options: { mode: "stack" },
+    });
+    const { dispatchCommand, hostClient } = createTestHostClient();
+    const setup = await testRender(<AppHost bootstrap={bootstrap} hostClient={hostClient} />, {
+      width: 120,
+      height: 20,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await dispatchCommand({
+          type: "command",
+          requestId: "highlight-1",
+          command: "highlight",
+          input: {
+            sessionId: "session-1",
+            filePath: "after.ts",
+            side: "new",
+            line: 1,
+            start: 13,
+            end: 19,
+            tone: "current",
+            reveal: true,
+          },
+        });
+      });
+      await flush(setup);
+      const painted = markedLineBackgrounds(
+        setup.captureSpans(),
+        "export const answer = 42",
+        "answer",
+      );
+      expect(painted.markedBackgrounds.size).toBe(1);
+      expect(painted.unmarkedBackgrounds).not.toContain([...painted.markedBackgrounds][0]!);
+
+      // Refresh with nothing changed on disk: the review is rebuilt, the marked line is not.
+      await act(async () => {
+        await setup.mockInput.typeText("r");
+        await Bun.sleep(120);
+        await setup.renderOnce();
+      });
+      await flush(setup);
+
+      const repainted = markedLineBackgrounds(
+        setup.captureSpans(),
+        "export const answer = 42",
+        "answer",
+      );
+      expect([...repainted.markedBackgrounds]).toEqual([...painted.markedBackgrounds]);
+      expect(repainted.unmarkedBackgrounds).not.toContain([...repainted.markedBackgrounds][0]!);
+
+      const cleared = await act(async () =>
+        dispatchCommand({
+          type: "command",
+          requestId: "clear-1",
+          command: "clear_highlights",
+          input: { sessionId: "session-1" },
+        }),
+      );
+      expect(cleared).toMatchObject({ removedCount: 1, remainingCount: 0 });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      await removeTestDirectory(dir);
+    }
+  });
+
+  test("r key keeps marks painted on an unchanged file whose runtime id shifts", async () => {
+    // VCS file ids embed the file's index in the changeset, so an unrelated file joining
+    // the review gives an untouched file a brand-new runtime id. The carried mark is
+    // re-keyed onto that id and must still reach paint: a paint path that trusted the
+    // previous file identity instead of the re-keyed id would silently drop it here.
+    const dir = mkdtempSync(join(tmpdir(), "hunk-reload-marks-shift-"));
+    const alpha = join(dir, "alpha.ts");
+    const bravo = join(dir, "bravo.ts");
+
+    execSync("git init && git config user.email test@test && git config user.name test", {
+      cwd: dir,
+      stdio: "ignore",
+    });
+    writeFileSync(alpha, "export const alpha = 1;\n");
+    writeFileSync(bravo, "export const bravo = 1;\n");
+    execSync("git add . && git commit -m init", { cwd: dir, stdio: "ignore" });
+
+    // Only bravo starts out changed, so it is the changeset's first (index 0) file.
+    writeFileSync(bravo, "export const bravo = 2;\n");
+
+    const bootstrap = await loadAppBootstrap(
+      { kind: "vcs", staged: false, options: { mode: "stack", excludeUntracked: true } },
+      { cwd: dir, vcsCatalog: getBundledVcsCatalog() },
+    );
+    const { dispatchCommand, hostClient } = createTestHostClient();
+    const setup = await testRender(<AppHost bootstrap={bootstrap} hostClient={hostClient} />, {
+      width: 120,
+      height: 40,
+    });
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        await dispatchCommand({
+          type: "command",
+          requestId: "highlight-1",
+          command: "highlight",
+          input: {
+            sessionId: "session-1",
+            filePath: "bravo.ts",
+            side: "new",
+            line: 1,
+            start: 13,
+            end: 18,
+            tone: "current",
+          },
+        });
+      });
+      await flush(setup);
+      const painted = markedLineBackgrounds(
+        setup.captureSpans(),
+        "export const bravo = 2",
+        "bravo",
+      );
+      expect(painted.markedBackgrounds.size).toBe(1);
+      expect(painted.unmarkedBackgrounds).not.toContain([...painted.markedBackgrounds][0]!);
+
+      // Change alpha only: after reload the changeset is [alpha, bravo], so bravo keeps
+      // its content but not its runtime id.
+      writeFileSync(alpha, "export const alpha = 100;\n");
+      await act(async () => {
+        await setup.mockInput.typeText("r");
+      });
+
+      let reloaded = false;
+      for (let attempt = 0; attempt < 30; attempt++) {
+        await flush(setup);
+        if (setup.captureCharFrame().includes("export const alpha = 100")) {
+          reloaded = true;
+          break;
+        }
+        await Bun.sleep(50);
+      }
+      expect(reloaded).toBe(true);
+
+      const repainted = markedLineBackgrounds(
+        setup.captureSpans(),
+        "export const bravo = 2",
+        "bravo",
+      );
+      expect([...repainted.markedBackgrounds]).toEqual([...painted.markedBackgrounds]);
+      expect(repainted.unmarkedBackgrounds).not.toContain([...repainted.markedBackgrounds][0]!);
+
+      // The carried mark still answers to clear, so it is live state, not a paint ghost.
+      const cleared = await act(async () =>
+        dispatchCommand({
+          type: "command",
+          requestId: "clear-2",
+          command: "clear_highlights",
+          input: { sessionId: "session-1" },
+        }),
+      );
+      expect(cleared).toMatchObject({ removedCount: 1, remainingCount: 0 });
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/highlights/merge.test.ts
+++ b/src/ui/highlights/merge.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { mergeLineHighlightMaps } from "./merge";
+import type { ValidatedLineHighlight } from "./validate";
+
+function mark(line: number, start: number, end: number): ValidatedLineHighlight {
+  return { side: "new", line, start, end, tone: "match" };
+}
+
+describe("mergeLineHighlightMaps", () => {
+  test("returns either side unchanged when the other is empty, preserving identity", () => {
+    const base = new Map([["file-1", [mark(1, 0, 4)]]]);
+    const empty = new Map<string, readonly ValidatedLineHighlight[]>();
+
+    expect(mergeLineHighlightMaps(base, empty)).toBe(base);
+    expect(mergeLineHighlightMaps(empty, base)).toBe(base);
+  });
+
+  test("appends overlay marks after base marks so the overlay paints last", () => {
+    const base = new Map([["file-1", [mark(1, 0, 4)]]]);
+    const overlay = new Map([
+      ["file-1", [mark(1, 2, 6)]],
+      ["file-2", [mark(3, 0, 2)]],
+    ]);
+
+    const merged = mergeLineHighlightMaps(base, overlay);
+    expect(merged.get("file-1")).toEqual([mark(1, 0, 4), mark(1, 2, 6)]);
+    expect(merged.get("file-2")).toEqual([mark(3, 0, 2)]);
+    // Neither input map is mutated by the merge.
+    expect(base.get("file-1")).toHaveLength(1);
+    expect(overlay.get("file-1")).toHaveLength(1);
+  });
+});

--- a/src/ui/highlights/merge.ts
+++ b/src/ui/highlights/merge.ts
@@ -1,0 +1,28 @@
+import type { ValidatedLineHighlight } from "./validate";
+
+/**
+ * Merge two per-file mark maps into the one map the diff pane paints from.
+ *
+ * Overlay marks append after base marks, so where ranges overlap the overlay
+ * paints last and wins — agent attention marks land on top of extension marks.
+ * Either side empty returns the other unchanged, preserving map identity so
+ * row memoization downstream keeps holding.
+ */
+export function mergeLineHighlightMaps(
+  base: ReadonlyMap<string, readonly ValidatedLineHighlight[]>,
+  overlay: ReadonlyMap<string, readonly ValidatedLineHighlight[]>,
+): ReadonlyMap<string, readonly ValidatedLineHighlight[]> {
+  if (overlay.size === 0) {
+    return base;
+  }
+  if (base.size === 0) {
+    return overlay;
+  }
+
+  const merged = new Map(base);
+  for (const [fileId, marks] of overlay) {
+    const existing = merged.get(fileId);
+    merged.set(fileId, existing ? [...existing, ...marks] : marks);
+  }
+  return merged;
+}

--- a/src/ui/highlights/reconcile.test.ts
+++ b/src/ui/highlights/reconcile.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { ReviewDocumentV1 } from "../../core/review/types";
+import { createTestReviewDocument } from "../../../test/helpers/review-store-helpers";
+import type { ValidatedLineHighlight } from "./validate";
+import { carryOverLineHighlights } from "./reconcile";
+
+const mark: ValidatedLineHighlight = { side: "new", line: 1, start: 0, end: 4, tone: "current" };
+
+/** Build one document whose runtime ids differ from its keys, as a reload's would. */
+function createReloadedDocument(
+  files: Array<{ key: string; contentIdentity?: string }>,
+  generation: string,
+): ReviewDocumentV1 {
+  const document = createTestReviewDocument(files);
+  return {
+    files: document.files.map((file) => ({ ...file, runtimeId: `${file.key}:${generation}` })),
+  };
+}
+
+describe("carryOverLineHighlights", () => {
+  test("re-keys marks onto the replacement runtime id when content is unchanged", () => {
+    const previous = createReloadedDocument([{ key: "alpha" }, { key: "beta" }], "1");
+    const next = createReloadedDocument([{ key: "alpha" }, { key: "beta" }], "2");
+
+    const carried = carryOverLineHighlights(new Map([["alpha:1", [mark]]]), previous, next);
+
+    expect([...carried.keys()]).toEqual(["alpha:2"]);
+    expect(carried.get("alpha:2")).toEqual([mark]);
+  });
+
+  test("drops marks for a file that came back with different content", () => {
+    const previous = createReloadedDocument([{ key: "alpha" }], "1");
+    const next = createReloadedDocument(
+      [{ key: "alpha", contentIdentity: "content:changed" }],
+      "2",
+    );
+
+    const carried = carryOverLineHighlights(new Map([["alpha:1", [mark]]]), previous, next);
+
+    expect(carried.size).toBe(0);
+  });
+
+  test("drops marks for a file that left the review", () => {
+    const previous = createReloadedDocument([{ key: "alpha" }, { key: "beta" }], "1");
+    const next = createReloadedDocument([{ key: "beta" }], "2");
+
+    const carried = carryOverLineHighlights(
+      new Map([
+        ["alpha:1", [mark]],
+        ["beta:1", [mark]],
+      ]),
+      previous,
+      next,
+    );
+
+    expect([...carried.keys()]).toEqual(["beta:2"]);
+  });
+
+  test("returns an empty map when there is nothing to carry", () => {
+    const previous = createReloadedDocument([{ key: "alpha" }], "1");
+    const next = createReloadedDocument([{ key: "alpha" }], "2");
+
+    expect(carryOverLineHighlights(new Map(), previous, next).size).toBe(0);
+  });
+});

--- a/src/ui/highlights/reconcile.ts
+++ b/src/ui/highlights/reconcile.ts
@@ -1,0 +1,40 @@
+import type { ReviewDocumentV1 } from "../../core/review/types";
+import type { ValidatedLineHighlight } from "./validate";
+
+/**
+ * Carries agent attention marks across one review document reconcile.
+ *
+ * Marks name exact character offsets in one line of one file, and nothing re-derives them
+ * after a reload the way extension highlighters re-run. A file that comes back with an
+ * unchanged `contentIdentity` still shows the same characters on the same lines, so its
+ * marks stay valid and are re-keyed onto the replacement's runtime id. Marks belonging to
+ * a file that left the review, or came back with different content, are dropped rather
+ * than left lighting up text nobody marked.
+ */
+export function carryOverLineHighlights(
+  marksByFileId: ReadonlyMap<string, readonly ValidatedLineHighlight[]>,
+  previous: ReviewDocumentV1,
+  next: ReviewDocumentV1,
+): ReadonlyMap<string, readonly ValidatedLineHighlight[]> {
+  const carried = new Map<string, readonly ValidatedLineHighlight[]>();
+  if (marksByFileId.size === 0) {
+    return carried;
+  }
+
+  const nextByKey = new Map(next.files.map((file) => [file.key, file] as const));
+  for (const file of previous.files) {
+    const marks = marksByFileId.get(file.runtimeId);
+    if (!marks || marks.length === 0) {
+      continue;
+    }
+
+    const replacement = nextByKey.get(file.key);
+    if (!replacement || replacement.contentIdentity !== file.contentIdentity) {
+      continue;
+    }
+
+    carried.set(replacement.runtimeId, marks);
+  }
+
+  return carried;
+}

--- a/src/ui/hooks/useHunkSessionBridge.ts
+++ b/src/ui/hooks/useHunkSessionBridge.ts
@@ -14,8 +14,10 @@ import type { ReviewController } from "./useReviewController";
 
 /** Bridge one live Hunk review session to the local session daemon. */
 export function useHunkSessionBridge({
+  addAgentLineHighlight,
   addLiveComment,
   addLiveCommentBatch,
+  clearAgentLineHighlights,
   clearLiveComments,
   hostClient,
   liveCommentCount,
@@ -34,8 +36,10 @@ export function useHunkSessionBridge({
   selectedHunkIndex,
   showAgentNotes,
 }: {
+  addAgentLineHighlight: ReviewController["addAgentLineHighlight"];
   addLiveComment: ReviewController["addLiveComment"];
   addLiveCommentBatch: ReviewController["addLiveCommentBatch"];
+  clearAgentLineHighlights: ReviewController["clearAgentLineHighlights"];
   clearLiveComments: ReviewController["clearLiveComments"];
   hostClient?: HunkSessionBrokerClient;
   liveCommentCount: number;
@@ -63,8 +67,10 @@ export function useHunkSessionBridge({
   const bridge = useMemo(
     () =>
       createHunkSessionBridge({
+        addAgentLineHighlight,
         addLiveComment,
         addLiveCommentBatch,
+        clearAgentLineHighlights,
         clearLiveComments,
         navigateToLocation,
         openAgentNotes,
@@ -73,8 +79,10 @@ export function useHunkSessionBridge({
         reviewProducer,
       }),
     [
+      addAgentLineHighlight,
       addLiveComment,
       addLiveCommentBatch,
+      clearAgentLineHighlights,
       clearLiveComments,
       navigateToLocation,
       openAgentNotes,

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -1951,4 +1951,289 @@ describe("useReviewController", () => {
       });
     }
   });
+
+  test("paints one validated agent attention mark and reveals its line on focus", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const before = expectValue(controllerRef.current).lineCursorRevealRequest;
+
+      let result: ReturnType<ReviewController["addAgentLineHighlight"]> | undefined;
+      await act(async () => {
+        result = expectValue(controllerRef.current).addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 12,
+          start: 0,
+          end: 6,
+          tone: "warning",
+          reveal: true,
+        });
+      });
+      await flush(setup);
+
+      expect(result).toMatchObject({
+        fileId: "alpha",
+        filePath: "alpha.ts",
+        hunkIndex: 1,
+        side: "new",
+        line: 12,
+        start: 0,
+        end: 6,
+        tone: "warning",
+        fileMarkCount: 1,
+        revealed: "line",
+      });
+      // The mark is retained in the same validated shape the paint pipeline consumes.
+      expect(expectValue(controllerRef.current).agentLineHighlightsByFileId.get("alpha")).toEqual([
+        { side: "new", line: 12, start: 0, end: 6, tone: "warning" },
+      ]);
+      // Focus rode the shared reveal path: line cursor on the marked row, reveal placement.
+      expect(expectValue(controllerRef.current).lineCursor).toMatchObject({
+        fileId: "alpha",
+        target: { side: "new", line: 12 },
+      });
+      expect(expectValue(controllerRef.current).lineCursorRevealRequest).toEqual({
+        id: before.id + 1,
+        placement: "reveal",
+      });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("defaults agent marks to the match tone without moving the viewport", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const before = expectValue(controllerRef.current).lineCursorRevealRequest;
+
+      let result: ReturnType<ReviewController["addAgentLineHighlight"]> | undefined;
+      await act(async () => {
+        result = expectValue(controllerRef.current).addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 1,
+          start: 13,
+          end: 18,
+        });
+      });
+      await flush(setup);
+
+      expect(result).toMatchObject({ tone: "match", hunkIndex: 0, fileMarkCount: 1 });
+      expect(result?.revealed).toBeUndefined();
+      expect(expectValue(controllerRef.current).lineCursorRevealRequest.id).toBe(before.id);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("rejects agent marks on unknown files, uncovered lines, and empty ranges", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const controller = expectValue(controllerRef.current);
+
+      expect(() =>
+        controller.addAgentLineHighlight({
+          filePath: "missing.ts",
+          side: "new",
+          line: 1,
+          start: 0,
+          end: 4,
+        }),
+      ).toThrow("No diff file matches missing.ts.");
+      expect(() =>
+        controller.addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 9001,
+          start: 0,
+          end: 4,
+        }),
+      ).toThrow("No new diff hunk in alpha.ts covers line 9001.");
+      // Empty and inverted ranges fail the same structural validation extension marks pass through.
+      expect(() =>
+        controller.addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 1,
+          start: 4,
+          end: 4,
+        }),
+      ).toThrow("Highlight range [4, 4) is not a valid [start, end) character range.");
+
+      await flush(setup);
+      expect(expectValue(controllerRef.current).agentLineHighlightsByFileId.size).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("clears agent marks per file and globally with honest counts", async () => {
+    const { controllerRef, setup } = await renderReviewController([
+      createTwoHunkFile(),
+      createThreeHunkFile("beta", "beta.ts"),
+    ]);
+
+    try {
+      await flush(setup);
+
+      await act(async () => {
+        const controller = expectValue(controllerRef.current);
+        controller.addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 1,
+          start: 0,
+          end: 4,
+        });
+        controller.addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 12,
+          start: 0,
+          end: 4,
+        });
+        controller.addAgentLineHighlight({
+          filePath: "beta.ts",
+          side: "new",
+          line: 1,
+          start: 0,
+          end: 4,
+        });
+      });
+      await flush(setup);
+
+      let cleared: ReturnType<ReviewController["clearAgentLineHighlights"]> | undefined;
+      await act(async () => {
+        cleared = expectValue(controllerRef.current).clearAgentLineHighlights("alpha.ts");
+      });
+      await flush(setup);
+      expect(cleared).toEqual({ removedCount: 2, remainingCount: 1, filePath: "alpha.ts" });
+      expect(expectValue(controllerRef.current).agentLineHighlightsByFileId.has("alpha")).toBe(
+        false,
+      );
+
+      await act(async () => {
+        cleared = expectValue(controllerRef.current).clearAgentLineHighlights();
+      });
+      await flush(setup);
+      expect(cleared).toEqual({ removedCount: 1, remainingCount: 0 });
+      expect(expectValue(controllerRef.current).agentLineHighlightsByFileId.size).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("a session reload clears agent attention marks", async () => {
+    // Marks address exact character offsets; after a reload nothing re-derives them the way
+    // extension highlighters re-run, so a stale mark would light up different text.
+    const { controllerRef, setFilesRef, setup } = await renderReviewController([createAlphaFile()]);
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        expectValue(controllerRef.current).addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 1,
+          start: 0,
+          end: 6,
+        });
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).agentLineHighlightsByFileId.size).toBe(1);
+
+      await act(async () => {
+        expectValue(setFilesRef.current)([createReloadedAlphaFile()]);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).agentLineHighlightsByFileId.size).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("navigate line targets land the viewport on the exact line", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()]);
+
+    try {
+      await flush(setup);
+      const before = expectValue(controllerRef.current).lineCursorRevealRequest;
+
+      let result: ReturnType<ReviewController["navigateToLocation"]> | undefined;
+      await act(async () => {
+        result = expectValue(controllerRef.current).navigateToLocation({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 12,
+        });
+      });
+      await flush(setup);
+
+      expect(result).toMatchObject({
+        fileId: "alpha",
+        filePath: "alpha.ts",
+        hunkIndex: 1,
+        revealed: "line",
+        side: "new",
+        line: 12,
+      });
+      expect(expectValue(controllerRef.current).lineCursor).toMatchObject({
+        fileId: "alpha",
+        target: { side: "new", line: 12 },
+      });
+      // The same reveal placement extensions get from ctx.navigation.revealLine.
+      expect(expectValue(controllerRef.current).lineCursorRevealRequest).toEqual({
+        id: before.id + 1,
+        placement: "reveal",
+      });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("navigate line targets fall back to the hunk when no row is measured", async () => {
+    const { controllerRef, setup } = await renderReviewController([createTwoHunkFile()], {
+      publishLineCursors: false,
+    });
+
+    try {
+      await flush(setup);
+
+      let result: ReturnType<ReviewController["navigateToLocation"]> | undefined;
+      await act(async () => {
+        result = expectValue(controllerRef.current).navigateToLocation({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 12,
+        });
+      });
+      await flush(setup);
+
+      expect(result).toMatchObject({ hunkIndex: 1, revealed: "hunk" });
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(1);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
 });

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -2137,7 +2137,52 @@ describe("useReviewController", () => {
     }
   });
 
-  test("a session reload clears agent attention marks", async () => {
+  test("a reload keeps agent attention marks on files whose content is unchanged", async () => {
+    // A refresh that finds nothing changed on disk still rebuilds the file list, and the marks
+    // it carries still name the same characters, so they survive and re-key onto the new ids.
+    const { controllerRef, setFilesRef, setup } = await renderReviewController([createAlphaFile()]);
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        expectValue(controllerRef.current).addAgentLineHighlight({
+          filePath: "alpha.ts",
+          side: "new",
+          line: 8,
+          start: 0,
+          end: 6,
+        });
+      });
+      await flush(setup);
+      expect([...expectValue(controllerRef.current).agentLineHighlightsByFileId.keys()]).toEqual([
+        "alpha",
+      ]);
+
+      await act(async () => {
+        // Same path and content, rebuilt under a new runtime id, as a reload produces.
+        expectValue(setFilesRef.current)([{ ...createAlphaFile(), id: "alpha-reloaded" }]);
+      });
+      await flush(setup);
+
+      const marks = expectValue(controllerRef.current).agentLineHighlightsByFileId;
+      expect([...marks.keys()]).toEqual(["alpha-reloaded"]);
+      expect(marks.get("alpha-reloaded")).toEqual([
+        { side: "new", line: 8, start: 0, end: 6, tone: "match" },
+      ]);
+
+      let cleared: ReturnType<ReviewController["clearAgentLineHighlights"]> | undefined;
+      await act(async () => {
+        cleared = expectValue(controllerRef.current).clearAgentLineHighlights();
+      });
+      expect(cleared).toEqual({ removedCount: 1, remainingCount: 0 });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("a session reload clears agent attention marks on files whose content changed", async () => {
     // Marks address exact character offsets; after a reload nothing re-derives them the way
     // extension highlighters re-run, so a stale mark would light up different text.
     const { controllerRef, setFilesRef, setup } = await renderReviewController([createAlphaFile()]);
@@ -2148,7 +2193,7 @@ describe("useReviewController", () => {
         expectValue(controllerRef.current).addAgentLineHighlight({
           filePath: "alpha.ts",
           side: "new",
-          line: 1,
+          line: 8,
           start: 0,
           end: 6,
         });

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -48,9 +48,12 @@ import type { AgentAnnotation, DiffFile, LayoutMode, UserNoteLineTarget } from "
 import type {
   AppliedCommentBatchResult,
   AppliedCommentResult,
+  AppliedHighlightResult,
   ClearedCommentsResult,
+  ClearedHighlightsResult,
   CommentBatchItemInput,
   CommentToolInput,
+  HighlightToolInput,
   LiveComment,
   NavigateToHunkToolInput,
   NavigatedSelectionResult,
@@ -59,6 +62,12 @@ import type {
   SessionReviewNoteSummary,
 } from "../../session/types";
 import type { FileSourceStatus } from "../diff/expandCollapsedRows";
+import {
+  MAX_LINE_HIGHLIGHTS_PER_FILE,
+  MAX_LINE_HIGHLIGHTS_PER_LINE,
+  validateLineHighlights,
+  type ValidatedLineHighlight,
+} from "../highlights/validate";
 
 import type { LineRevealPlacement } from "../lib/hunkScroll";
 import {
@@ -90,6 +99,9 @@ import {
   planTerminalSelectionReconciliation,
   resolveReviewNavigationTarget,
 } from "../lib/reviewState";
+
+const EMPTY_AGENT_LINE_HIGHLIGHTS: ReadonlyMap<string, readonly ValidatedLineHighlight[]> =
+  new Map();
 
 /** Merge file-id keyed annotation maps without losing their concrete item types. */
 function mergeAnnotationMaps<T extends AgentAnnotation, U extends AgentAnnotation>(
@@ -237,6 +249,10 @@ export interface ReviewController {
   ) => ClearedCommentsResult;
   navigateToLocation: (input: NavigateToHunkToolInput) => NavigatedSelectionResult;
   removeLiveComment: (commentId: string) => RemovedCommentResult;
+  /** Agent attention marks per file id, painted through the extension line-highlight pipeline. */
+  agentLineHighlightsByFileId: ReadonlyMap<string, readonly ValidatedLineHighlight[]>;
+  addAgentLineHighlight: (input: HighlightToolInput) => AppliedHighlightResult;
+  clearAgentLineHighlights: (filePath?: string) => ClearedHighlightsResult;
   cancelDraftNote: () => void;
   removeUserNote: (noteId: string) => void;
   saveDraftNote: () => UserReviewNote | null;
@@ -309,6 +325,20 @@ export function useReviewController({
 
   const reconciledDocumentRef = useRef(document);
 
+  // Agent attention marks, keyed by runtime file id. A ref backs the state so daemon
+  // handlers can compute counts synchronously; both always move together.
+  const agentLineHighlightsRef = useRef(EMPTY_AGENT_LINE_HIGHLIGHTS);
+  const [agentLineHighlightsByFileId, setAgentLineHighlightsByFileId] = useState(
+    EMPTY_AGENT_LINE_HIGHLIGHTS,
+  );
+  const commitAgentLineHighlights = useCallback(
+    (next: ReadonlyMap<string, readonly ValidatedLineHighlight[]>) => {
+      agentLineHighlightsRef.current = next;
+      setAgentLineHighlightsByFileId(next);
+    },
+    [],
+  );
+
   // Adopt a replacement file list in the same commit that renders it, so a soft reload
   // never paints new files against state the previous patch produced. The store retires
   // content-derived state itself; the work here is the cursor and in-flight source
@@ -328,8 +358,14 @@ export function useReviewController({
         }
       }
     }
+    // Marks address exact character offsets in specific line content, and nothing re-derives
+    // them after a reload the way extension highlighters re-run — a stale mark would silently
+    // light up different text. Reloading the review clears them wholesale.
+    if (agentLineHighlightsRef.current.size > 0) {
+      commitAgentLineHighlights(EMPTY_AGENT_LINE_HIGHLIGHTS);
+    }
     store.dispatch({ type: "document/reconcile", document });
-  }, [document, store]);
+  }, [commitAgentLineHighlights, document, store]);
 
   const state = useReviewStoreSnapshot(store);
   const filter = state.filter;
@@ -833,6 +869,26 @@ export function useReviewController({
       }
 
       const target = resolveReviewNavigationTarget({ allFiles, input });
+
+      // A line target lands the viewport on the exact line through the same reveal path
+      // `ctx.navigation.revealLine` uses, degrading to the hunk when the stream renders no
+      // row for the line. `"none"` means the file is not currently visible, where only the
+      // plain hunk selection below has defined behavior.
+      if (input.hunkIndex === undefined && input.side && input.line !== undefined) {
+        const reached = revealLine(target.file.id, input.side, input.line);
+        if (reached !== "none") {
+          return {
+            fileId: target.file.id,
+            filePath: target.file.path,
+            hunkIndex: target.hunkIndex,
+            selectedHunk: buildSelectedHunkSummary(target.file, target.hunkIndex),
+            revealed: reached,
+            side: input.side,
+            line: input.line,
+          };
+        }
+      }
+
       selectHunk(target.file.id, target.hunkIndex);
       return {
         fileId: target.file.id,
@@ -841,7 +897,113 @@ export function useReviewController({
         selectedHunk: buildSelectedHunkSummary(target.file, target.hunkIndex),
       };
     },
-    [allFiles, fileByKey, moveSelection, selectHunk],
+    [allFiles, fileByKey, moveSelection, revealLine, selectHunk],
+  );
+
+  /**
+   * Paint one agent attention mark, validated by the same contract extension line
+   * highlighters answer to, so both sources feed one painted-mark pipeline.
+   */
+  const addAgentLineHighlight = useCallback(
+    (input: HighlightToolInput): AppliedHighlightResult => {
+      const file = findDiffFileByPath(allFiles, input.filePath);
+      if (!file) {
+        throw new Error(noDiffFileMatchesMessage(input.filePath));
+      }
+
+      // Requiring hunk coverage catches line-number typos the way comment targets do; the
+      // agent-visible review model only exposes hunk-covered lines anyway.
+      const hunkIndex = reviewHunkIndexForLine(file.metadata.hunks, input.side, input.line);
+      if (hunkIndex < 0) {
+        throw new Error(
+          `No ${input.side} diff hunk in ${input.filePath} covers line ${input.line}.`,
+        );
+      }
+
+      const validation = validateLineHighlights([
+        { side: input.side, line: input.line, range: [input.start, input.end], tone: input.tone },
+      ]);
+      const mark = validation.ok ? validation.marks[0] : undefined;
+      if (!mark) {
+        throw new Error(
+          `Highlight range [${input.start}, ${input.end}) is not a valid [start, end) character range.`,
+        );
+      }
+
+      const existing = agentLineHighlightsRef.current.get(file.id) ?? [];
+      if (existing.length >= MAX_LINE_HIGHLIGHTS_PER_FILE) {
+        throw new Error(
+          `${input.filePath} already carries ${MAX_LINE_HIGHLIGHTS_PER_FILE} attention marks. Clear some first.`,
+        );
+      }
+      const marksOnLine = existing.filter(
+        (candidate) => candidate.side === mark.side && candidate.line === mark.line,
+      ).length;
+      if (marksOnLine >= MAX_LINE_HIGHLIGHTS_PER_LINE) {
+        throw new Error(
+          `${input.filePath}:${input.line} already carries ${MAX_LINE_HIGHLIGHTS_PER_LINE} attention marks. Clear some first.`,
+        );
+      }
+
+      const next = new Map(agentLineHighlightsRef.current);
+      next.set(file.id, [...existing, mark]);
+      commitAgentLineHighlights(next);
+
+      let revealed: "line" | "hunk" | undefined;
+      if (input.reveal ?? false) {
+        const reached = revealLine(file.id, mark.side, mark.line);
+        if (reached === "none") {
+          selectHunk(file.id, hunkIndex);
+          revealed = "hunk";
+        } else {
+          revealed = reached;
+        }
+      }
+
+      return {
+        fileId: file.id,
+        filePath: file.path,
+        hunkIndex,
+        side: mark.side,
+        line: mark.line,
+        start: mark.start,
+        end: mark.end,
+        tone: mark.tone,
+        fileMarkCount: existing.length + 1,
+        ...(revealed ? { revealed } : {}),
+      };
+    },
+    [allFiles, commitAgentLineHighlights, revealLine, selectHunk],
+  );
+
+  /** Clear agent attention marks, globally or for one file. */
+  const clearAgentLineHighlights = useCallback(
+    (filePath?: string): ClearedHighlightsResult => {
+      const current = agentLineHighlightsRef.current;
+      const total = [...current.values()].reduce((sum, marks) => sum + marks.length, 0);
+
+      if (!filePath) {
+        if (total > 0) {
+          commitAgentLineHighlights(EMPTY_AGENT_LINE_HIGHLIGHTS);
+        }
+        return { removedCount: total, remainingCount: 0 };
+      }
+
+      const file = findDiffFileByPath(allFiles, filePath);
+      if (!file) {
+        throw new Error(noDiffFileMatchesMessage(filePath));
+      }
+
+      const removed = current.get(file.id)?.length ?? 0;
+      if (removed > 0) {
+        const next = new Map(current);
+        next.delete(file.id);
+        commitAgentLineHighlights(next);
+      }
+
+      return { removedCount: removed, remainingCount: total - removed, filePath };
+    },
+    [allFiles, commitAgentLineHighlights],
   );
 
   /**
@@ -1230,10 +1392,13 @@ export function useReviewController({
     toggleGap,
     toggleSelectedHunkGap,
     visibleFiles,
+    addAgentLineHighlight,
     addLiveComment,
     addLiveCommentBatch,
+    agentLineHighlightsByFileId,
     anchorLineCursor,
     anchorSelection,
+    clearAgentLineHighlights,
     clearFilter,
     cancelDraftNote,
     clearLiveComments,

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -62,6 +62,7 @@ import type {
   SessionReviewNoteSummary,
 } from "../../session/types";
 import type { FileSourceStatus } from "../diff/expandCollapsedRows";
+import { carryOverLineHighlights } from "../highlights/reconcile";
 import {
   MAX_LINE_HIGHLIGHTS_PER_FILE,
   MAX_LINE_HIGHLIGHTS_PER_LINE,
@@ -360,9 +361,11 @@ export function useReviewController({
     }
     // Marks address exact character offsets in specific line content, and nothing re-derives
     // them after a reload the way extension highlighters re-run — a stale mark would silently
-    // light up different text. Reloading the review clears them wholesale.
+    // light up different text. Files that came back with identical content keep their marks,
+    // re-keyed onto the replacement runtime ids; every other mark is dropped.
     if (agentLineHighlightsRef.current.size > 0) {
-      commitAgentLineHighlights(EMPTY_AGENT_LINE_HIGHLIGHTS);
+      const carried = carryOverLineHighlights(agentLineHighlightsRef.current, previous, document);
+      commitAgentLineHighlights(carried.size > 0 ? carried : EMPTY_AGENT_LINE_HIGHLIGHTS);
     }
     store.dispatch({ type: "document/reconcile", document });
   }, [commitAgentLineHighlights, document, store]);

--- a/test/pty/session-attention-integration.test.ts
+++ b/test/pty/session-attention-integration.test.ts
@@ -1,0 +1,269 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createPtyHarness, lineIndexOf, rowCellBackgrounds } from "./harness";
+
+const harness = createPtyHarness();
+const repoRoot = process.cwd();
+
+/** Give PTY-backed startup, daemon registration, and redraws headroom on slower CI machines. */
+setDefaultTimeout(45_000);
+
+/**
+ * One tall hunk with a needle deep inside it: every line differs, so git emits
+ * a single hunk whose marked line cannot share a 24-row viewport with its
+ * anchor — the shape only a line-exact reveal can land.
+ */
+const NEEDLE_LINE = 111;
+const NEEDLE_TOKEN = "ATTENTIONNEEDLE";
+// `export const ` is 13 code units, so "needle" occupies offsets [13, 19).
+const NEEDLE_START = 13;
+const NEEDLE_END = 19;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  harness.cleanup();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+/** Write the tall before/after fixture pair into one tracked temp directory. */
+function createTallFilePair() {
+  const dir = mkdtempSync(join(tmpdir(), "hunk-session-attention-"));
+  tempDirs.push(dir);
+
+  const before = join(dir, "before.ts");
+  const after = join(dir, "after.ts");
+  writeFileSync(
+    before,
+    `${Array.from(
+      { length: 130 },
+      (_, index) => `export const line${String(index + 1).padStart(3, "0")} = ${index + 1};`,
+    ).join("\n")}\n`,
+  );
+  writeFileSync(
+    after,
+    `${Array.from({ length: 130 }, (_, index) =>
+      index + 1 === NEEDLE_LINE
+        ? `export const needle = "${NEEDLE_TOKEN}";`
+        : `export const line${String(index + 1).padStart(3, "0")} = ${index + 1001};`,
+    ).join("\n")}\n`,
+  );
+
+  return { dir, before, after };
+}
+
+/** Reserve one free loopback port so parallel test files cannot collide on the daemon. */
+async function reserveLoopbackPort() {
+  const listener = createServer();
+  await new Promise<void>((resolve, reject) => {
+    listener.once("error", reject);
+    listener.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = listener.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve) => listener.close(() => resolve()));
+
+  if (!port) {
+    throw new Error("Failed to reserve a loopback port for the session daemon test.");
+  }
+
+  return port;
+}
+
+/** Run one `hunk session ...` CLI invocation against the test daemon port. */
+function runSessionCli(args: string[], port: number, configHome: string) {
+  const proc = Bun.spawnSync(["bun", "run", "src/main.tsx", "session", ...args], {
+    cwd: repoRoot,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      XDG_CONFIG_HOME: configHome,
+      HUNK_MCP_PORT: String(port),
+    },
+  });
+
+  return {
+    exitCode: proc.exitCode,
+    stdout: Buffer.from(proc.stdout).toString("utf8"),
+    stderr: Buffer.from(proc.stderr).toString("utf8"),
+  };
+}
+
+/** Poll one condition until it returns a value or the timeout passes. */
+async function waitUntil<T>(
+  label: string,
+  fn: () => Promise<T | null> | T | null,
+  timeoutMs = 20_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const value = await fn();
+    if (value !== null) {
+      return value;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${label}.`);
+    }
+
+    await Bun.sleep(150);
+  }
+}
+
+describe("PTY session attention marks", () => {
+  test("a session CLI highlight paints the range and reveals the deep line", async () => {
+    const configHome = harness.createIsolatedConfigHome();
+    const fixture = createTallFilePair();
+    const port = await reserveLoopbackPort();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      cwd: fixture.dir,
+      cols: 140,
+      rows: 24,
+      env: {
+        XDG_CONFIG_HOME: configHome,
+        // The harness disables session brokering by default; this test is about it.
+        HUNK_MCP_DISABLE: "0",
+        HUNK_MCP_PORT: String(port),
+      },
+    });
+
+    let daemonPid: number | null = null;
+
+    try {
+      const review = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("line001"),
+        30_000,
+      );
+      // The review opens at the hunk anchor, pages above the marked line.
+      expect(review).not.toContain(NEEDLE_TOKEN);
+
+      const health = await waitUntil("session daemon health", async () => {
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}/health`);
+          return response.ok ? ((await response.json()) as { pid: number }) : null;
+        } catch {
+          return null;
+        }
+      });
+      daemonPid = health.pid;
+
+      const sessionId = await waitUntil("registered Hunk session", () => {
+        const listed = runSessionCli(["list", "--json"], port, configHome);
+        if (listed.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(listed.stdout) as { sessions: Array<{ sessionId: string }> };
+        return parsed.sessions[0]?.sessionId ?? null;
+      });
+
+      // Mark "needle" on the deep line and focus it in one call.
+      const highlight = runSessionCli(
+        [
+          "highlight",
+          "add",
+          sessionId,
+          "--file",
+          "after.ts",
+          "--new-line",
+          String(NEEDLE_LINE),
+          "--start",
+          String(NEEDLE_START),
+          "--end",
+          String(NEEDLE_END),
+          "--tone",
+          "warning",
+          "--focus",
+          "--json",
+        ],
+        port,
+        configHome,
+      );
+      expect(highlight.stderr).toBe("");
+      expect(highlight.exitCode).toBe(0);
+      expect(JSON.parse(highlight.stdout)).toMatchObject({
+        result: {
+          filePath: "after.ts",
+          side: "new",
+          line: NEEDLE_LINE,
+          start: NEEDLE_START,
+          end: NEEDLE_END,
+          tone: "warning",
+          fileMarkCount: 1,
+          revealed: "line",
+        },
+      });
+
+      // The focus reveal landed the marked line near the viewport top, where
+      // every other Hunk reveal lands.
+      const revealed = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes(NEEDLE_TOKEN),
+        20_000,
+      );
+      const row = lineIndexOf(revealed, NEEDLE_TOKEN);
+      expect(row).toBeGreaterThan(0);
+      expect(row).toBeLessThan(12);
+
+      // The mark paints: cells under "needle" carry a background the same
+      // row's unmarked cells do not. Text snapshots cannot show this; the
+      // per-cell backgrounds can.
+      const rowText = revealed.split("\n")[row]!;
+      const markedColumn = rowText.indexOf("needle");
+      const unmarkedColumn = rowText.indexOf(NEEDLE_TOKEN);
+      expect(markedColumn).toBeGreaterThanOrEqual(0);
+      const backgrounds = rowCellBackgrounds(session, row);
+      expect(backgrounds[markedColumn]).toBeDefined();
+      expect(backgrounds[markedColumn]).not.toBe(backgrounds[unmarkedColumn]);
+
+      // Clearing removes the only mark and reports honest counts.
+      const cleared = runSessionCli(["highlight", "clear", sessionId, "--json"], port, configHome);
+      expect(cleared.exitCode).toBe(0);
+      expect(JSON.parse(cleared.stdout)).toMatchObject({
+        result: { removedCount: 1, remainingCount: 0 },
+      });
+
+      // Line-target navigation reports the same line-exact landing.
+      const navigate = runSessionCli(
+        ["navigate", sessionId, "--file", "after.ts", "--new-line", "25", "--json"],
+        port,
+        configHome,
+      );
+      expect(navigate.exitCode).toBe(0);
+      expect(JSON.parse(navigate.stdout)).toMatchObject({
+        result: { filePath: "after.ts", revealed: "line", side: "new", line: 25 },
+      });
+      const navigated = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("line025") && !text.includes(NEEDLE_TOKEN),
+        20_000,
+      );
+      const navigatedRow = lineIndexOf(navigated, "line025");
+      expect(navigatedRow).toBeGreaterThan(0);
+      expect(navigatedRow).toBeLessThan(12);
+    } finally {
+      session.close();
+      if (daemonPid) {
+        try {
+          process.kill(daemonPid, "SIGTERM");
+        } catch {
+          // Ignore daemons that already exited during cleanup.
+        }
+      }
+    }
+  });
+});

--- a/test/session/broker-e2e.test.ts
+++ b/test/session/broker-e2e.test.ts
@@ -461,6 +461,143 @@ describe("session broker end-to-end", () => {
     }
   }, 20_000);
 
+  test("session CLI marks a character range and reveals its exact line in a live session", async () => {
+    if (!ttyToolsAvailable) {
+      return;
+    }
+
+    // One tall hunk: every line differs, so git emits a single hunk whose deep lines cannot
+    // share a 24-row viewport with its anchor — the shape hunk navigation cannot land.
+    const needleLine = 111;
+    const needleToken = "ATTENTIONNEEDLE";
+    const fixture = createFixtureFiles(
+      "attention",
+      Array.from(
+        { length: 130 },
+        (_, index) => `export const line${String(index + 1).padStart(3, "0")} = ${index + 1};`,
+      ),
+      Array.from({ length: 130 }, (_, index) =>
+        index + 1 === needleLine
+          ? `export const needle = "${needleToken}";`
+          : `export const line${String(index + 1).padStart(3, "0")} = ${index + 1001};`,
+      ),
+    );
+    const port = await reserveLoopbackPort();
+    const hunkProc = spawnHunkSession(fixture, port);
+
+    let daemonPid: number | null = null;
+
+    try {
+      const health = await waitForHealth(port);
+      daemonPid = health.pid;
+      expect(health.ok).toBe(true);
+
+      const listed = await waitUntil("registered Hunk session", async () => {
+        const { proc, stdout } = runSessionCli(["list", "--json"], port);
+        if (proc.exitCode !== 0) {
+          return null;
+        }
+
+        const parsed = JSON.parse(stdout) as SessionListJson;
+        return parsed.sessions.length > 0 ? parsed.sessions : null;
+      });
+      const targetSession =
+        listed.find((session) => session.files.some((file) => file.path === fixture.afterName)) ??
+        listed[0]!;
+
+      // The review opens at the hunk anchor, pages above the marked line.
+      const initial = await waitForTranscript(fixture, "rendered review", (current) =>
+        current.includes("line001"),
+      );
+      expect(initial).not.toContain(needleToken);
+
+      // Mark "needle" on the deep line and focus it in one call.
+      const highlight = runSessionCli(
+        [
+          "highlight",
+          "add",
+          targetSession.sessionId,
+          "--file",
+          fixture.afterName,
+          "--new-line",
+          String(needleLine),
+          "--start",
+          "13",
+          "--end",
+          "19",
+          "--tone",
+          "warning",
+          "--focus",
+          "--json",
+        ],
+        port,
+      );
+      expect(highlight.proc.exitCode).toBe(0);
+      expect(highlight.stderr).toBe("");
+      expect(JSON.parse(highlight.stdout)).toMatchObject({
+        result: {
+          filePath: fixture.afterName,
+          side: "new",
+          line: needleLine,
+          start: 13,
+          end: 19,
+          tone: "warning",
+          fileMarkCount: 1,
+          revealed: "line",
+        },
+      });
+
+      // The focus reveal scrolled the marked line into the live terminal.
+      await waitForTranscript(fixture, "revealed marked line", (current) =>
+        current.includes(needleToken),
+      );
+
+      // Line-target navigation reports the same line-exact landing.
+      const navigate = runSessionCli(
+        [
+          "navigate",
+          targetSession.sessionId,
+          "--file",
+          fixture.afterName,
+          "--new-line",
+          "25",
+          "--json",
+        ],
+        port,
+      );
+      expect(navigate.proc.exitCode).toBe(0);
+      expect(JSON.parse(navigate.stdout)).toMatchObject({
+        result: {
+          filePath: fixture.afterName,
+          revealed: "line",
+          side: "new",
+          line: 25,
+        },
+      });
+
+      const cleared = runSessionCli(
+        ["highlight", "clear", targetSession.sessionId, "--json"],
+        port,
+      );
+      expect(cleared.proc.exitCode).toBe(0);
+      expect(JSON.parse(cleared.stdout)).toMatchObject({
+        result: { removedCount: 1, remainingCount: 0 },
+      });
+
+      expect(await quitHunkSession(hunkProc, fixture)).toBe(0);
+    } finally {
+      await cleanupHunkSession(hunkProc);
+
+      if (daemonPid) {
+        try {
+          process.kill(daemonPid, "SIGTERM");
+        } catch {
+          // Ignore daemons that already exited during cleanup.
+        }
+      }
+    }
+  }, 30_000);
+
   test("one daemon routes CLI comments to the correct Hunk session when multiple local sessions are open", async () => {
     if (!ttyToolsAvailable) {
       return;

--- a/website/public/docs/hunk-review-skill.md
+++ b/website/public/docs/hunk-review-skill.md
@@ -1,6 +1,6 @@
 ---
 name: hunk-review
-description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files and hunks, reloads session contents, and adds inline review comments. Use when the user has a Hunk session running or wants to review diffs interactively.
+description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files, hunks, and exact lines, reloads session contents, adds inline review comments, and paints attention marks on character ranges. Use when the user has a Hunk session running or wants to review diffs interactively.
 ---
 
 # Hunk Review
@@ -21,6 +21,7 @@ If no session exists, ask the user to launch Hunk in their terminal first.
 7. hunk session reload -- <command>                     # swap contents if needed
 8. hunk session comment add ...                         # leave one review note
 9. hunk session comment apply ...                       # apply many agent notes in one stdin batch
+10. hunk session highlight add ...                      # light up the exact range you are explaining
 ```
 
 ## Session selection
@@ -78,6 +79,7 @@ hunk session navigate --repo . --prev-comment
 
 - `--hunk <n>` is 1-based
 - `--new-line` / `--old-line` are 1-based line numbers on that diff side
+- A line target lands the user's viewport on that exact line (falling back to its hunk when the line is inside a collapsed region); `--hunk` lands on the hunk
 - Use either `--next-comment` or `--prev-comment`, not both
 
 ### Reload
@@ -132,6 +134,30 @@ printf '%s\n' '{"comments":[{"filePath":"README.md","newLine":103,"summary":"Tig
 - `comment list` and `comment clear` accept optional `--file`
 - Quote `--summary` and `--rationale` defensively in the shell
 
+### Attention marks
+
+Highlights paint character ranges inside the diff lines the user is looking at — use them to light up the exact expression you are explaining while you narrate.
+
+```bash
+hunk session highlight add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --start <n> --end <n> [--tone <tone>] [--focus] [--json]
+hunk session highlight clear (<session-id> | --repo <path>) [--file <path>] [--json]
+```
+
+Examples:
+
+```bash
+hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19
+hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19 --tone warning --focus
+hunk session highlight clear --repo .
+```
+
+- `highlight add` requires `--file`, exactly one of `--old-line` or `--new-line`, and the `--start` / `--end` offsets
+- `--start` is a 0-based inclusive offset into the line's text and `--end` is exclusive, counted in UTF-16 code units — the same `[start, end)` range extensions use
+- Tones: `match` (default), `info`, `warning`, `error`; `current` renders as reverse video and is best reserved for the one range under discussion
+- Pass `--focus` to also land the viewport on the marked line
+- Marks survive scrolling, navigation, and reloads that leave the marked file's content unchanged; a reload that changes that file drops its marks, and `highlight clear` removes them explicitly (optionally per `--file`)
+- Marks are visual only — pair them with a `comment add` when the explanation should persist as a note
+
 ### Experimental rich markup notes (STML)
 
 Only use STML when `hunk session context --json` lists `stml` in `experimentalFeatures`. The user opts into that experience by launching the review with `--experimental`; do not ask a normal session to render markup.
@@ -166,6 +192,7 @@ Guidelines:
 
 - Work in the order that tells the clearest story, not necessarily file order
 - Navigate before commenting so the user sees the code you're discussing
+- Use `highlight add --focus` to steer the user's eyes to the exact expression while you explain it, and `highlight clear` before moving to the next topic
 - Use `comment apply` for agent-generated batches and `comment add` for one-off notes
 - Use `--focus` sparingly when the note itself should actively steer the review
 - Keep comments focused: intent, structure, risks, or follow-ups
@@ -181,5 +208,7 @@ Guidelines:
 - **"Pass --stdin to read batch comments from stdin JSON."** -- `comment apply` only reads its batch payload from stdin.
 - **"Specify exactly one navigation target"** -- pick one of `--hunk`, `--old-line`, or `--new-line`.
 - **"Specify exactly one comment target"** -- pass `comment add` one of `--old-line` or `--new-line`.
+- **"Specify exactly one highlight target"** -- pass `highlight add` one of `--old-line` or `--new-line`.
+- **"Highlight --end must be greater than --start"** -- offsets are `[start, end)` UTF-16 code units into the line text; end is exclusive.
 - **"Specify either --next-comment or --prev-comment, not both."** -- choose one comment-navigation direction.
 - **"Could not read the raw diff for ..."** -- the session reloaded or closed while `--include-patch` was reading it. Re-run `review`; drop `--include-patch` if you only need file and hunk structure.

--- a/website/src/content/docs/docs/reference/cli.md
+++ b/website/src/content/docs/docs/reference/cli.md
@@ -495,3 +495,56 @@ hunk session comment clear (<session-id> | --repo <path>) [--file <path>] [--inc
 | `--json`         | emit structured JSON                                      |
 
 **Positionals:** `[sessionId]`.
+
+### `hunk session highlight add`
+
+paint one attention mark inside a diff line
+
+```bash
+hunk session highlight add (<session-id> | --repo <path>) --file <path> (--old-line <n> | --new-line <n>) --start <n> --end <n> [--tone <tone>] [--focus] [--json]
+```
+
+| Option           | Description                                                                       |
+| ---------------- | --------------------------------------------------------------------------------- |
+| `--file <path>`  | diff file path as shown by Hunk Required.                                         |
+| `--start <n>`    | 0-based inclusive start offset into the line's text (UTF-16 code units) Required. |
+| `--end <n>`      | exclusive end offset; must be greater than --start Required.                      |
+| `--repo <path>`  | target the live session whose repo root matches this path                         |
+| `--old-line <n>` | 1-based line number on the old side                                               |
+| `--new-line <n>` | 1-based line number on the new side                                               |
+| `--tone <tone>`  | mark tone: match, current, info, warning, error (default match)                   |
+| `--focus`        | add the mark and land the viewport on its line                                    |
+| `--json`         | emit structured JSON                                                              |
+
+**Positionals:** `[sessionId]`.
+
+**Constraints:** exactly one of `--old-line <n>`, `--new-line <n>`.
+
+**Examples:**
+
+```bash
+hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19
+hunk session highlight add --repo . --file src/App.tsx --new-line 42 --start 6 --end 19 --tone warning --focus
+```
+
+### `hunk session highlight clear`
+
+clear agent attention marks
+
+```bash
+hunk session highlight clear (<session-id> | --repo <path>) [--file <path>] [--json]
+```
+
+| Option          | Description                                               |
+| --------------- | --------------------------------------------------------- |
+| `--repo <path>` | target the live session whose repo root matches this path |
+| `--file <path>` | clear only one diff file's marks                          |
+| `--json`        | emit structured JSON                                      |
+
+**Positionals:** `[sessionId]`.
+
+**Examples:**
+
+```bash
+hunk session highlight clear --repo .
+```


### PR DESCRIPTION
## What


https://github.com/user-attachments/assets/55b6c7d1-88ac-4aac-89cd-38d310101baa



Stacked on #727 (which stacks on #726). This PR makes the agent story in both of those descriptions **true**: the capabilities extensions gained there are now reachable by coding agents driving a live review session through the daemon.

```sh
hunk session highlight add <session> --file src/config.ts --new-line 214 \
  --start 13 --end 23 --tone warning --focus
hunk session highlight clear <session>
hunk session navigate <session> --file src/config.ts --new-line 214
```

Until now an agent explaining a changeset in someone's terminal could scroll hunk-to-hunk and leave comments — and hope the reader's eye found the right spot. Now it can mark the exact characters it is talking about and land the viewport on the exact line, in one call.

## The guided-walkthrough primitive

`highlight add --focus` is the composed gesture: mark the range, reveal its line at the app's standard landing position, narrate, `highlight clear`, move on. An agent answering "where does this change behavior?" lights up the expression as it explains it. Nothing else in the ecosystem can do this in the reviewer's own terminal.

## Design

- **One paint pipeline, one addressing vocabulary.** Agent marks validate through the same module, tones, offset semantics (`[start, end)` UTF-16 code units of the raw line text), and per-file/per-line caps as extension line highlighters (#726), and merge into the single map `DiffPane` already paints from — agent marks paint last where ranges overlap. No second paint path; the same contrast guarantee and geometry-neutrality hold.
- **Same reveal, same landing spot.** `session navigate --old-line/--new-line` (previously hunk-granular) now rides the exact `revealLine` path from #727 — `max(2, 25% of viewport)` context above, guarded hunk fallback for unrenderable lines — and reports `revealed: "line" | "hunk"` so the agent knows what actually happened.
- **Sibling of the comment family.** Selectors, `--file` addressing, and the exactly-one line-target constraint are the ones `session comment add` already established; the command surface, validation, `--help`, and the generated review skill all derive from the one declarative spec in `surface.ts`.
- **Lifetime tied to the content they address.** Marks survive scrolling, navigation, and reloads that leave the marked file's content unchanged — they are re-keyed onto the rebuilt review. A reload that changes that file, or drops it, takes its marks with it: unlike comments, nothing can re-derive offset-addressed marks against changed text, and a stale mark would silently light up the wrong characters. Documented in the skill and architecture doc.
- **Versioned rollout.** Daemon protocol version bumped; older daemons auto-refresh through the existing capability check.

## Evidence

PTY end-to-end against a real daemon-registered session: `highlight add … --focus --json` returns `revealed: "line"`, a needle 111 lines into a large hunk lands in the top half of a 24-row terminal, cell-background inspection proves the marked characters carry a background their neighbors don't, and `highlight clear` reports exact removal counts. A `script`-based mirror covers CI Linux in `test/session/broker-e2e.test.ts`.

## Notes

- The generated `hunk-review` skill teaches agents the mark → focus → narrate → clear flow (regenerated via `bun run generate:skill`, never hand-edited).
- Same sequencing note as #727: all three PRs ship inside one unreleased API/protocol generation; merging out of order across a release requires re-versioning.



## Why `reconcile.ts` and `merge.ts` survive #733's rework

#733's staleness machinery (per-file publish, paint-time file-identity filtering, generation-scoped retention, the merged-total cap) lives inside `useLineHighlights` and governs extension-derived marks only: it makes sure stale marks are *dropped*, and relies on highlighters *re-running* to restore fresh ones. Agent attention marks have no re-derivation source — nothing re-runs them after a reload — so `reconcile.ts` is the only mechanism that *keeps* still-valid marks, enforcing the same staleness discipline from the other direction: carried only when `contentIdentity` is unchanged, re-keyed onto the replacement's runtime id, dropped for changed or departed files. The two are complementary, not duplicative. #733's identity guard cannot reject carried marks because agent marks never pass through it: they merge in after it via `merge.ts`, keyed by the current runtime id. `AppHost.reload.test.tsx` proves both reload shapes at the painted-cell level — same-id reload, and the VCS case where an unrelated file joining the changeset shifts an untouched file's index-embedding runtime id (sabotaging the re-key makes that test fail). The merged paint total stays bounded: ≤ 4000 from the extension merged cap plus ≤ 2000 from the agent per-file cap, with agent marks accumulating only one validated CLI call at a time.
