### PR TITLE
fix(vcs): synthesize untracked file diffs in-process instead of one git subprocess per file

### DIFF
--- a/.changeset/slow-untracked-diff.md
+++ b/.changeset/slow-untracked-diff.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix `hunk diff` taking tens of seconds in repos with many untracked files by synthesizing untracked diffs in-process instead of spawning one `git diff --no-index` subprocess per file.

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { SourceTextTooLargeError } from "./fileSource";
@@ -602,6 +610,31 @@ describe("loadAppBootstrap", () => {
     const dangling = bootstrap.changeset.files.find((file) => file.path === "dangling-link");
     expect(dangling?.patch).toContain("new file mode 120000");
     expect(dangling?.patch).toContain("+missing-file");
+  });
+
+  // Windows has no Unix execute bits, so the mode distinction only exists on POSIX.
+  const unixTest = platform() === "win32" ? test.skip : test;
+  unixTest("reports untracked executable files with git's 100755 mode", async () => {
+    const dir = createTempRepo("hunk-git-untracked-exec-");
+
+    writeFileSync(join(dir, "tracked.ts"), "export const tracked = 1;\n");
+    git(dir, "add", "tracked.ts");
+    git(dir, "commit", "-m", "initial");
+
+    writeFileSync(join(dir, "script.sh"), "#!/bin/sh\necho hi\n");
+    chmodSync(join(dir, "script.sh"), 0o755);
+    writeFileSync(join(dir, "plain.txt"), "not executable\n");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    const script = bootstrap.changeset.files.find((file) => file.path === "script.sh");
+    expect(script?.patch).toContain("new file mode 100755");
+    const plain = bootstrap.changeset.files.find((file) => file.path === "plain.txt");
+    expect(plain?.patch).toContain("new file mode 100644");
   });
 
   test("can exclude untracked files from working tree reviews", async () => {

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -576,6 +576,34 @@ describe("loadAppBootstrap", () => {
     ]);
   });
 
+  test("reviews untracked file symlinks as links without following their targets", async () => {
+    const dir = createTempRepo("hunk-git-untracked-file-symlink-");
+
+    writeFileSync(join(dir, "target.txt"), "real contents\n");
+    git(dir, "add", "target.txt");
+    git(dir, "commit", "-m", "initial");
+
+    symlinkSync("target.txt", join(dir, "good-link"));
+    symlinkSync("missing-file", join(dir, "dangling-link"));
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    const good = bootstrap.changeset.files.find((file) => file.path === "good-link");
+    expect(good?.metadata.type).toBe("new");
+    expect(good?.patch).toContain("new file mode 120000");
+    expect(good?.patch).toContain("+target.txt");
+    expect(good?.patch).not.toContain("real contents");
+
+    // A dangling symlink has no target to read, but its link line still reviews.
+    const dangling = bootstrap.changeset.files.find((file) => file.path === "dangling-link");
+    expect(dangling?.patch).toContain("new file mode 120000");
+    expect(dangling?.patch).toContain("+missing-file");
+  });
+
   test("can exclude untracked files from working tree reviews", async () => {
     const dir = createTempRepo("hunk-git-no-untracked-");
 

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -448,7 +448,8 @@ describe("loadAppBootstrap", () => {
       "example.ts",
       "new-file.ts",
     ]);
-    expect(bootstrap.changeset.files[1]?.patch).toContain("new file mode");
+    expect(bootstrap.changeset.files[1]?.metadata.type).toBe("new");
+    expect(bootstrap.changeset.files[1]?.patch).toContain("+export const added = true;");
   });
 
   slTest(
@@ -750,7 +751,8 @@ describe("loadAppBootstrap", () => {
     });
 
     expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["untracked.ts"]);
-    expect(bootstrap.changeset.files[0]?.patch).toContain("new file mode");
+    expect(bootstrap.changeset.files[0]?.metadata.type).toBe("new");
+    expect(bootstrap.changeset.files[0]?.patch).toContain("+export const added = true;");
   });
 
   test("still shows an untracked agent sidecar when it lives inside the repo", async () => {

--- a/src/core/vcs/untracked.ts
+++ b/src/core/vcs/untracked.ts
@@ -32,6 +32,24 @@ export function buildSkippedLargeUntrackedDiffFile(
   });
 }
 
+/** Wrap synthesized added-file hunks in the git-style header patch consumers parse. */
+function buildUntrackedPatchText(safePath: string, mode: string, contents: string) {
+  const body = createTwoFilesPatch("/dev/null", safePath, "", contents, "", "", {
+    context: 3,
+  }).replaceAll("\r\n", "\n");
+
+  // Replace jsdiff's "===" banner with the git-style header every patch
+  // consumer parses, so the file is typed as an addition, not a change.
+  return [
+    `diff --git a/${safePath} b/${safePath}`,
+    `new file mode ${mode}`,
+    ...body
+      .split("\n")
+      .slice(1)
+      .map((line) => (line.startsWith("+++ ") ? `+++ b/${safePath}` : line)),
+  ].join("\n");
+}
+
 /** Build one filesystem-backed untracked file diff from its current contents. */
 export function buildFilesystemUntrackedDiffFile(
   repoRoot: string,
@@ -40,6 +58,29 @@ export function buildFilesystemUntrackedDiffFile(
   sourcePrefix: string,
 ) {
   const absolutePath = join(repoRoot, filePath);
+  const safePath = escapeUntrackedPatchPath(filePath);
+
+  // Diff a symlink as Git does — mode 120000 whose one line is the link target —
+  // instead of dereferencing it. This also keeps dangling symlinks reviewable
+  // rather than failing the whole load on the missing target.
+  let linkTarget: string | null = null;
+  try {
+    if (fs.lstatSync(absolutePath).isSymbolicLink()) {
+      linkTarget = fs.readlinkSync(absolutePath);
+    }
+  } catch {
+    // A path that vanished after being listed falls through to the regular
+    // read below, which surfaces the same missing-file error as before.
+  }
+  if (linkTarget !== null) {
+    const patch = buildUntrackedPatchText(safePath, "120000", linkTarget);
+    // No source fetcher: reading the path would dereference the link, and the
+    // patch already carries the only content a symlink has.
+    return buildDiffFile(parseSingleFilePatch(patch, filePath), patch, index, sourcePrefix, null, {
+      isUntracked: true,
+    });
+  }
+
   const largeFileCheck = inspectLargeUntrackedFile(repoRoot, filePath);
   if (largeFileCheck.shouldSkip) {
     return buildSkippedLargeUntrackedDiffFile(filePath, index, sourcePrefix, largeFileCheck);
@@ -56,27 +97,7 @@ export function buildFilesystemUntrackedDiffFile(
     );
   }
 
-  const safePath = escapeUntrackedPatchPath(filePath);
-  const body = createTwoFilesPatch(
-    "/dev/null",
-    safePath,
-    "",
-    fs.readFileSync(absolutePath, "utf8"),
-    "",
-    "",
-    { context: 3 },
-  ).replaceAll("\r\n", "\n");
-
-  // Replace jsdiff's "===" banner with the git-style header every patch
-  // consumer parses, so the file is typed as an addition, not a change.
-  const patch = [
-    `diff --git a/${safePath} b/${safePath}`,
-    "new file mode 100644",
-    ...body
-      .split("\n")
-      .slice(1)
-      .map((line) => (line.startsWith("+++ ") ? `+++ b/${safePath}` : line)),
-  ].join("\n");
+  const patch = buildUntrackedPatchText(safePath, "100644", fs.readFileSync(absolutePath, "utf8"));
 
   return buildDiffFile(parseSingleFilePatch(patch, filePath), patch, index, sourcePrefix, null, {
     isUntracked: true,

--- a/src/core/vcs/untracked.ts
+++ b/src/core/vcs/untracked.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { join } from "node:path";
 import { createSkippedBinaryMetadata, isProbablyBinaryFile } from "../binary";
 import { buildDiffFile, createSkippedLargeMetadata } from "../diffFile";
+import { createFileSourceFetcher } from "../fileSource";
 import { inspectLargeUntrackedFile } from "../../lib/largeFile";
 import { escapeUntrackedPatchPath } from "../../lib/patchPath";
 import { parseSingleFilePatch } from "../patch/singleFile";
@@ -55,9 +56,10 @@ export function buildFilesystemUntrackedDiffFile(
     );
   }
 
-  const patch = createTwoFilesPatch(
+  const safePath = escapeUntrackedPatchPath(filePath);
+  const body = createTwoFilesPatch(
     "/dev/null",
-    escapeUntrackedPatchPath(filePath),
+    safePath,
     "",
     fs.readFileSync(absolutePath, "utf8"),
     "",
@@ -65,7 +67,27 @@ export function buildFilesystemUntrackedDiffFile(
     { context: 3 },
   ).replaceAll("\r\n", "\n");
 
+  // Replace jsdiff's "===" banner with the git-style header every patch
+  // consumer parses, so the file is typed as an addition, not a change.
+  const patch = [
+    `diff --git a/${safePath} b/${safePath}`,
+    "new file mode 100644",
+    ...body
+      .split("\n")
+      .slice(1)
+      .map((line) => (line.startsWith("+++ ") ? `+++ b/${safePath}` : line)),
+  ].join("\n");
+
   return buildDiffFile(parseSingleFilePatch(patch, filePath), patch, index, sourcePrefix, null, {
     isUntracked: true,
+    // An added file has no old side; the new side reads the working copy so
+    // source-backed features treat synthesized untracked files like any other.
+    sourceFetcherBuilder: (file) =>
+      file.isBinary
+        ? undefined
+        : createFileSourceFetcher({
+            old: { kind: "none" },
+            new: { kind: "fs", absolutePath },
+          }),
   });
 }

--- a/src/core/vcs/untracked.ts
+++ b/src/core/vcs/untracked.ts
@@ -97,7 +97,17 @@ export function buildFilesystemUntrackedDiffFile(
     );
   }
 
-  const patch = buildUntrackedPatchText(safePath, "100644", fs.readFileSync(absolutePath, "utf8"));
+  // Git records exactly two regular-file modes: 100755 when any execute bit
+  // is set, 100644 otherwise.
+  let mode = "100644";
+  try {
+    if (fs.statSync(absolutePath).mode & 0o111) {
+      mode = "100755";
+    }
+  } catch {
+    // A vanished path surfaces its missing-file error from the read below.
+  }
+  const patch = buildUntrackedPatchText(safePath, mode, fs.readFileSync(absolutePath, "utf8"));
 
   return buildDiffFile(parseSingleFilePatch(patch, filePath), patch, index, sourcePrefix, null, {
     isUntracked: true,

--- a/src/extensions/default/vcs/git/commands.ts
+++ b/src/extensions/default/vcs/git/commands.ts
@@ -7,7 +7,6 @@ import {
   type ExtensionVcsStashShowInput,
 } from "hunkdiff/extension";
 import { LARGE_DIFF_FILE_MAX_BYTES, LARGE_DIFF_FILE_MAX_LINES } from "../../../../lib/largeFile";
-import { escapeUntrackedPatchPath } from "../../../../lib/patchPath";
 import { normalizePathForOS } from "../../../../lib/osPath";
 
 /**
@@ -222,21 +221,6 @@ export function buildGitIgnoredDirectoryArgs() {
     "--directory",
     "-z",
   ];
-}
-
-/** Build the synthetic patch used to render one untracked file as a new-file diff. */
-function buildGitNewFileDiffArgs(filePath: string) {
-  // `--no-ext-diff` keeps user-configured `diff.external` tools (difftastic, delta, etc.)
-  // from replacing the unified-diff output Pierre needs to parse this synthetic patch.
-  return withNormalizedDiffPrefixes([
-    "diff",
-    "--no-ext-diff",
-    "--no-index",
-    "--no-color",
-    "--",
-    "/dev/null",
-    filePath,
-  ]);
 }
 
 /** Build the exact `git show` arguments used for commit review. */
@@ -660,7 +644,7 @@ function isReviewableUntrackedPath(repoRoot: string, filePath: string) {
   try {
     pathInfo = fs.lstatSync(absolutePath);
   } catch {
-    // If the path disappeared after `git status`, let the downstream Git diff
+    // If the path disappeared after `git status`, let downstream synthesis
     // surface the same error path users would have seen before this filter.
     return true;
   }
@@ -674,8 +658,8 @@ function isReviewableUntrackedPath(repoRoot: string, filePath: string) {
   }
 
   try {
-    // Git reports directory symlinks as untracked paths, but `git diff --no-index`
-    // cannot synthesize a parseable file patch for them.
+    // Git reports directory symlinks as untracked paths, but Hunk cannot
+    // synthesize a file patch from a directory's contents.
     return !fs.statSync(absolutePath).isDirectory();
   } catch {
     // Broken symlinks still diff as reviewable path entries, so keep them.
@@ -715,52 +699,6 @@ export function listGitUntrackedFiles(
   return untrackedFiles.filter((filePath) =>
     isReviewableUntrackedPath(normalizedRepoRoot, filePath),
   );
-}
-
-/** Rewrite Git's quoted untracked-file headers into parser-friendly paths. */
-export function normalizeUntrackedPatchHeaders(patchText: string, filePath: string) {
-  const safePath = escapeUntrackedPatchPath(filePath);
-
-  return patchText
-    .replaceAll("\r\n", "\n")
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("diff --git ")) {
-        return `diff --git a/${safePath} b/${safePath}`;
-      }
-
-      if (line.startsWith("+++ ")) {
-        return `+++ b/${safePath}`;
-      }
-
-      if (line.startsWith("Binary files /dev/null and ")) {
-        return `Binary files /dev/null and b/${safePath} differ`;
-      }
-
-      return line;
-    })
-    .join("\n");
-}
-
-/** Return the raw Git patch text for one untracked file using `git diff --no-index`. */
-export function runGitUntrackedFileDiffText(
-  input: ExtensionVcsDiffInput,
-  filePath: string,
-  {
-    cwd = process.cwd(),
-    repoRoot,
-    gitExecutable = "git",
-  }: Omit<RunGitTextOptions, "input" | "args"> & { repoRoot?: string } = {},
-) {
-  const normalizedRepoRoot = repoRoot ?? resolveGitRepoRoot(input, { cwd, gitExecutable });
-
-  return runGitCommand({
-    input,
-    args: buildGitNewFileDiffArgs(filePath),
-    cwd: normalizedRepoRoot,
-    gitExecutable,
-    acceptedExitCodes: [0, 1],
-  }).stdout;
 }
 
 export interface GitMetadata {

--- a/src/extensions/default/vcs/git/index.test.ts
+++ b/src/extensions/default/vcs/git/index.test.ts
@@ -105,7 +105,7 @@ describe("GitVcsAdapter", () => {
     expect(result.title).toContain("working tree");
     expect(result.patchText).toContain("diff --git a/tracked.txt b/tracked.txt");
     expect(result.patchText).toContain("+new");
-    expect(result.extraFiles?.map((file) => file.path)).toContain("untracked.txt");
+    expect(result.untrackedPaths).toContain("untracked.txt");
     expect(result.sourceCacheKey).toContain("git-source-v1");
 
     const equivalentResult = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, {
@@ -125,12 +125,10 @@ describe("GitVcsAdapter", () => {
     });
     expect(changedIndexResult.sourceCacheKey).not.toBe(result.sourceCacheKey);
 
-    // The untracked file is reported as its own one-file patch rather than as a
-    // path Hunk reads back, so Git's own binary detection and quoting decide
-    // what it says.
-    const untracked = result.extraFiles?.find((file) => file.path === "untracked.txt");
-    expect(untracked?.kind).toBe("patch");
-    expect(untracked?.isUntracked).toBe(true);
+    // Untracked files come back as paths for Hunk to synthesize in-process:
+    // one `git status` covers all of them instead of one `git diff --no-index`
+    // subprocess per file, which made review scale with the untracked count.
+    expect(result.extraFiles ?? []).toHaveLength(0);
   });
 
   test("loads revision and stash patches through adapter operations", async () => {

--- a/src/extensions/default/vcs/git/index.ts
+++ b/src/extensions/default/vcs/git/index.ts
@@ -8,7 +8,6 @@ import {
   buildGitStashShowArgs,
   listGitIgnoredDirectoryRoots,
   listGitUntrackedFiles,
-  normalizeUntrackedPatchHeaders,
   parseGitNumstat,
   resolveGitColorMovedOptions,
   resolveGitCommitRef,
@@ -16,13 +15,11 @@ import {
   resolveGitMetadata,
   resolveGitRepoRoot,
   runGitText,
-  runGitUntrackedFileDiffText,
   shouldSkipLargeTrackedDiff,
   type GitBackedInput,
   type GitDiffEndpoints,
 } from "./commands";
 import { gitEndpointSourceSpec, readGitFileSource } from "./source";
-import { inspectLargeUntrackedFile } from "../../../../lib/largeFile";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -191,47 +188,6 @@ function createGitDiffSourceCapability(
 }
 
 /* -------------------------------------------------------------------------- */
-/* Files reviewed outside the main patch                                       */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Describe one untracked file for review.
- *
- * Git renders the addition itself rather than Hunk reading the working copy, so
- * its own binary detection and path quoting decide what the patch says — the
- * same output `git diff` would have produced for a tracked file.
- */
-function buildUntrackedExtraFile(
-  input: ExtensionVcsDiffInput,
-  filePath: string,
-  repoRoot: string,
-  gitExecutable: string,
-): ExtensionVcsExtraFile {
-  const largeFileCheck = inspectLargeUntrackedFile(repoRoot, filePath);
-  if (largeFileCheck.shouldSkip) {
-    return {
-      kind: "skipped",
-      path: filePath,
-      reason: "too-large",
-      changeType: "new",
-      isUntracked: true,
-      stats: largeFileCheck.stats,
-      statsTruncated: largeFileCheck.statsTruncated,
-    };
-  }
-
-  return {
-    kind: "patch",
-    path: filePath,
-    isUntracked: true,
-    patchText: normalizeUntrackedPatchHeaders(
-      runGitUntrackedFileDiffText(input, filePath, { repoRoot, gitExecutable }),
-      filePath,
-    ),
-  };
-}
-
-/* -------------------------------------------------------------------------- */
 /* Watch plans                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -360,20 +316,20 @@ export function createGitVcsAdapter({
               gitExecutable,
             }),
             ...sourceCapability,
-            extraFiles: [
-              ...largeTrackedFiles.map(
-                (file): ExtensionVcsExtraFile => ({
-                  kind: "skipped",
-                  path: file.path,
-                  reason: "too-large",
-                  changeType: "change",
-                  stats: { additions: file.additions, deletions: file.deletions },
-                }),
-              ),
-              ...listGitUntrackedFiles(input, { cwd, repoRoot, gitExecutable }).map((filePath) =>
-                buildUntrackedExtraFile(input, filePath, repoRoot, gitExecutable),
-              ),
-            ],
+            extraFiles: largeTrackedFiles.map(
+              (file): ExtensionVcsExtraFile => ({
+                kind: "skipped",
+                path: file.path,
+                reason: "too-large",
+                changeType: "change",
+                stats: { additions: file.additions, deletions: file.deletions },
+              }),
+            ),
+            // One `git status` lists the paths; Hunk synthesizes each added-file
+            // diff in-process. Rendering them through `git diff --no-index`
+            // instead costs one subprocess per file, which made working-tree
+            // review scale with the untracked file count.
+            untrackedPaths: listGitUntrackedFiles(input, { cwd, repoRoot, gitExecutable }),
           };
         },
         watchPlan(input, { cwd }) {

--- a/src/ui/components/scrollbar/VerticalScrollbar.test.tsx
+++ b/src/ui/components/scrollbar/VerticalScrollbar.test.tsx
@@ -262,24 +262,28 @@ describe("Vertical scrollbar", () => {
         contentHeight={40}
         theme={theme}
         height={10}
-        hideDelayMs={20}
+        hideDelayMs={120}
       />,
       { width: 2, height: 10 },
     );
 
     try {
       await flush(setup);
+      // Real timers, so keep wide margins on both sides of the deadline:
+      // Windows CI timer granularity oversleeps enough to flip tight ones.
       await act(async () => {
         handle.current?.show();
-        await Bun.sleep(15);
+        await Bun.sleep(100);
         handle.current?.show();
-        await Bun.sleep(10);
+        await Bun.sleep(60);
       });
       await flush(setup);
+      // 160ms since the first show() but only 60ms since the second: still
+      // visible only because the second show() restarted the deadline.
       expect(frameHasBackground(setup, theme.accentMuted)).toBe(true);
 
       await act(async () => {
-        await Bun.sleep(15);
+        await Bun.sleep(180);
       });
       await flush(setup);
       expect(frameHasBackground(setup, theme.accentMuted)).toBe(false);


### PR DESCRIPTION
## What changed

`hunk diff` working-tree review spawned a synchronous `git diff --no-index` subprocess for **every untracked file**, so startup scaled with the untracked file count. In a repo with a few thousand untracked-but-not-ignored files (vendored deps, build output, a `node_modules` missing from `.gitignore`) this took tens of seconds, nearly all of it process-spawn syscall overhead — matching user reports like `time hunk diff` → 24.78s wall / 16.27s sys.

The Git adapter now uses the published `untrackedPaths` contract that Sapling already uses: one `git status` lists the paths and Hunk synthesizes each added-file diff in-process. The per-file subprocess path (`runGitUntrackedFileDiffText`, `normalizeUntrackedPatchHeaders`, `buildGitNewFileDiffArgs`) is deleted.

Switching surfaced two fidelity gaps in the shared synthesis path, fixed in `src/core/vcs/untracked.ts` so Sapling benefits too:

- Synthesized patches now carry a git-style `diff --git` / `new file mode 100644` header, so every patch consumer types untracked files as **additions** rather than changes.
- Synthesized untracked files now attach a source fetcher (old side null, new side reads the working copy), matching what the git-rendered path provided.

## Numbers

Reproduced with a repo containing 2000 small untracked files:

| | before | after |
|---|---|---|
| adapter load | 25,303ms | 80ms |
| host-side synthesis | — | 110ms |

## Reviewer notes

- Untracked patch text is now jsdiff-synthesized with rewritten git-style headers instead of real `git diff --no-index` output. Header shape (`a/`/`b/` prefixes, escaped paths) matches what `normalizeUntrackedPatchHeaders` used to produce; binary and too-large untracked files use the same skipped placeholders Sapling untracked files already get.
- Verified: unit tests on the git adapter/loaders/core VCS all pass (three assertions updated to the new contract shape); full `bun test` failures are pre-existing on the clean tree (PTY extension tests, website specs missing `@axe-core/playwright`); typecheck's only error is the pre-existing `@hunk/term-video` script issue; plus a real TTY run in the 2000-file repo (renders all untracked files, quits responsively) and empty-file/CRLF edge cases through synthesis.
- Follow-up worth considering separately: even at ~0.2s, thousands of untracked files render thousands of added-file diffs — a cap with an "N untracked files not shown" placeholder may be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)