### PR TITLE
fix(review): terminal consumes core's note-anchor, reveal, and command-lowering policies

### DIFF
--- a/.changeset/gap-anchored-notes-stay-with-their-hunk.md
+++ b/.changeset/gap-anchored-notes-stay-with-their-hunk.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Agent notes anchored to collapsed or expanded-away lines now render beside their owning hunk instead of the top of the file.

--- a/scripts/inline-edit-extension.test.ts
+++ b/scripts/inline-edit-extension.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../src/extension-api/types";
 import { validateFileViewLayout } from "../src/ui/fileViews/layout";
 import { buildFileViewRenderPlan } from "../src/ui/fileViews/renderPlan";
+import { createVisibleAgentNote } from "../src/ui/lib/agentAnnotations";
 import inlineEditExtension from "../examples/extensions/inline-edit";
 
 const TEST_FILE = {
@@ -717,7 +718,10 @@ describe("inline edit example extension", () => {
     });
     expect(
       buildFileViewRenderPlan(layout!, [
-        { id: "line-two", annotation: { id: "line-two", summary: "Line two", newRange: [2, 2] } },
+        createVisibleAgentNote([], {
+          id: "line-two",
+          annotation: { id: "line-two", summary: "Line two", newRange: [2, 2] },
+        }),
       ]).unresolvedNoteIds,
     ).toEqual([]);
 

--- a/src/core/commandCatalog.test.ts
+++ b/src/core/commandCatalog.test.ts
@@ -118,6 +118,24 @@ describe("app command catalog", () => {
     });
   });
 
+  // Intent: an add-note affordance can address a row the reviewer is only pointing at, so
+  // the client says where the note goes and the lowering falls back to the selection.
+  test("lowers a new note at the location the client addressed", () => {
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.startNote"), {
+        count: 1,
+        state: createTestReviewState(["alpha", "beta"]),
+        noteLocation: { fileKey: "beta", hunkIndex: 1 },
+        noteTarget: { side: "new", line: 21 },
+      }),
+    ).toEqual({
+      type: "notes/start-draft",
+      fileKey: "beta",
+      hunkIndex: 1,
+      target: { side: "new", line: 21 },
+    });
+  });
+
   test("lowers the gap toggle to the gap the shared policy reaches", () => {
     expect(
       lowerAppCommandToReviewIntent(entry("hunk.review.toggleHunkGap"), {

--- a/src/core/commandCatalog.ts
+++ b/src/core/commandCatalog.ts
@@ -498,6 +498,17 @@ export function appCommandCatalogEntry(id: string): AppCommandCatalogEntry | und
   return APP_COMMAND_CATALOG.find((entry) => entry.id === id);
 }
 
+/**
+ * Look one built-in command up by its catalogued id.
+ *
+ * Total where `appCommandCatalogEntry` is partial, because `AppCommandId` is derived from
+ * the catalog itself: a client naming a built-in it lowers does not have to handle the
+ * possibility that the command does not exist.
+ */
+export function builtinAppCommand(id: AppCommandId): AppCommandCatalogEntry {
+  return APP_COMMAND_CATALOG.find((entry) => entry.id === id) as AppCommandCatalogEntry;
+}
+
 /** The facts a command needs to become one concrete review intent. */
 export interface AppCommandLoweringContext {
   /** Host-normalized positive repeat count. */
@@ -516,6 +527,14 @@ export interface AppCommandLoweringContext {
    * default for the whole hunk.
    */
   noteTarget?: ReviewLineAddressV1;
+  /**
+   * The file and hunk the invoking client's note affordance addressed.
+   *
+   * The other renderer-owned fact: a client may offer "add a note here" on a row the
+   * reviewer is merely pointing at or has scrolled to, which is not always what the review
+   * has selected. Omitted, the note lands on the current selection.
+   */
+  noteLocation?: { fileKey: string; hunkIndex: number };
 }
 
 /**
@@ -530,7 +549,7 @@ export interface AppCommandLoweringContext {
  */
 export function lowerAppCommandToReviewIntent(
   entry: AppCommandCatalogEntry,
-  { count, state, noteTarget }: AppCommandLoweringContext,
+  { count, state, noteTarget, noteLocation }: AppCommandLoweringContext,
 ): ReviewIntent | undefined {
   switch (entry.review?.kind) {
     case "selection/move":
@@ -542,7 +561,7 @@ export function lowerAppCommandToReviewIntent(
     case "notes/toggle-visibility":
       return { type: "notes/set-visibility", visible: !state.showAgentNotes };
     case "notes/start-draft": {
-      const { fileKey, hunkIndex } = selectNormalizedSelection(state);
+      const { fileKey, hunkIndex } = noteLocation ?? selectNormalizedSelection(state);
       return fileKey === null
         ? undefined
         : {

--- a/src/core/review/anchors.test.ts
+++ b/src/core/review/anchors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveReviewNoteAnchor, reviewLineAnchor } from "./anchors";
+import { resolveReviewNoteAnchor, reviewGapOwnerHunkIndex, reviewLineAnchor } from "./anchors";
 import type { ReviewHunkSpan } from "./geometry";
 
 /** Three well-separated hunks, each spanning three rows on both sides. */
@@ -66,6 +66,42 @@ describe("resolveReviewNoteAnchor", () => {
     const anchor = resolveReviewNoteAnchor(hunks, { oldRange: [21, 21] });
 
     expect(anchor.intersectingHunkIndices).toEqual([1]);
+  });
+});
+
+describe("reviewGapOwnerHunkIndex", () => {
+  test("hands a gap line to the hunk it leads into", () => {
+    expect(reviewGapOwnerHunkIndex(hunks, "new", 10)).toBe(1);
+    expect(reviewGapOwnerHunkIndex(hunks, "new", 30)).toBe(2);
+  });
+
+  test("hands a line after the last hunk to that hunk's trailing gap", () => {
+    expect(reviewGapOwnerHunkIndex(hunks, "new", 500)).toBe(2);
+  });
+
+  test("hands a line before the first hunk to that hunk's leading gap", () => {
+    expect(
+      reviewGapOwnerHunkIndex(
+        [{ additionStart: 5, additionCount: 2, deletionStart: 5, deletionCount: 2 }],
+        "new",
+        1,
+      ),
+    ).toBe(0);
+  });
+
+  test("owns nothing in a file with no hunks", () => {
+    expect(reviewGapOwnerHunkIndex([], "new", 1)).toBeUndefined();
+  });
+
+  test("reads the side it was asked about", () => {
+    const shifted: ReviewHunkSpan[] = [
+      { additionStart: 1, additionCount: 1, deletionStart: 1, deletionCount: 1 },
+      { additionStart: 30, additionCount: 1, deletionStart: 10, deletionCount: 1 },
+    ];
+
+    expect(reviewGapOwnerHunkIndex(shifted, "new", 20)).toBe(1);
+    expect(reviewGapOwnerHunkIndex(shifted, "old", 20)).toBe(1);
+    expect(reviewGapOwnerHunkIndex(shifted, "old", 5)).toBe(1);
   });
 });
 

--- a/src/core/review/anchors.ts
+++ b/src/core/review/anchors.ts
@@ -14,6 +14,29 @@
 import { reviewHunkRange, reviewRangesOverlap, type ReviewHunkSpan } from "./geometry";
 import type { ReviewLineRange, ReviewRangeAnchorV1, ReviewSide } from "./types";
 
+/**
+ * Names the hunk a line outside every hunk hangs from.
+ *
+ * A line the patch omitted sits in a collapsed gap, and a gap is addressed by the hunk it
+ * leads into (`before:<hunkIndex>`) or the one it trails (`trailing:<hunkIndex>`). Picking
+ * the first hunk that starts after the line — the last hunk when none does — resolves that
+ * same ownership from geometry alone, which is what a caller anchoring an imported note
+ * needs when nothing declares where the note was written. Undefined when the file has no
+ * hunk to hang anything from.
+ */
+export function reviewGapOwnerHunkIndex(
+  hunks: readonly ReviewHunkSpan[],
+  side: ReviewSide,
+  line: number,
+): number | undefined {
+  if (hunks.length === 0) {
+    return undefined;
+  }
+
+  const following = hunks.findIndex((hunk) => reviewHunkRange(hunk, side)[0] > line);
+  return following >= 0 ? following : hunks.length - 1;
+}
+
 export interface ReviewNoteAnchorInput {
   oldRange?: ReviewLineRange;
   newRange?: ReviewLineRange;

--- a/src/core/review/selectors.test.ts
+++ b/src/core/review/selectors.test.ts
@@ -17,6 +17,7 @@ import {
   selectReviewFileByKey,
   selectReviewGapForSelection,
   selectReviewNavigationFiles,
+  resolveReviewRevealNoteId,
   selectRevealTarget,
   selectVisibleReviewFiles,
 } from "./selectors";
@@ -214,6 +215,32 @@ describe("note selectors", () => {
 
     expect(selectActiveRevealNoteId(state)).toBe("live-early");
     expect(selectActiveRevealNoteId({ ...state, liveNotes: [], userNotes: [] })).toBeUndefined();
+  });
+
+  // Intent: a surface that draws notes the store never held — the terminal's sidecar
+  // annotations — asks the same policy which of them a reveal targets.
+  test("answer the same way for candidates a surface supplies itself", () => {
+    expect(
+      resolveReviewRevealNoteId([
+        { id: "late", line: 9 },
+        { id: "draft", line: 40, draft: true },
+        { id: "early", line: 1 },
+      ]),
+    ).toBe("draft");
+    expect(
+      resolveReviewRevealNoteId([
+        { id: "late", line: 9 },
+        { id: "early", line: 1 },
+      ]),
+    ).toBe("early");
+    // Same anchor line: the note that arrived first keeps the reveal.
+    expect(
+      resolveReviewRevealNoteId([
+        { id: "first", line: 4 },
+        { id: "second", line: 4 },
+      ]),
+    ).toBe("first");
+    expect(resolveReviewRevealNoteId([])).toBeUndefined();
   });
 });
 

--- a/src/core/review/selectors.ts
+++ b/src/core/review/selectors.ts
@@ -204,14 +204,41 @@ export function selectNotesByHunk(
   return byHunk;
 }
 
+/** One note a reveal could land on, described the way any surface can describe what it draws. */
+export interface ReviewRevealNoteCandidate {
+  id: string;
+  /** The line the note hangs beside; "earliest in the hunk" compares these. */
+  line: number;
+  /** The reviewer's open draft, which outranks every settled note. */
+  draft?: boolean;
+}
+
 /**
- * Which note a "jump to the note" reveal targets.
+ * Picks the note a "jump to the note" reveal targets, among one hunk's notes.
  *
- * Named policy: an active draft in the selected hunk wins, because the reviewer is
- * writing it right now; otherwise the note whose anchor sits earliest in the hunk, with
- * arrival order breaking ties. Undefined means the selected hunk has nothing to reveal
- * and the caller should fall back to revealing the hunk itself.
+ * Named policy: an open draft wins, because the reviewer is writing it right now;
+ * otherwise the note whose anchor sits earliest, with arrival order breaking ties.
+ * Candidates arrive already scoped to the hunk being revealed, because *which* notes a
+ * surface shows is that surface's own fact — the terminal draws sidecar annotations that
+ * never entered the note store — while which of them wins is this one rule. Undefined
+ * means the hunk has nothing to reveal and the caller should reveal the hunk itself.
  */
+export function resolveReviewRevealNoteId(
+  candidates: readonly ReviewRevealNoteCandidate[],
+): string | undefined {
+  const draft = candidates.find((candidate) => candidate.draft);
+  if (draft) {
+    return draft.id;
+  }
+
+  return candidates
+    .map((candidate, arrival) => ({ candidate, arrival }))
+    .sort(
+      (left, right) => left.candidate.line - right.candidate.line || left.arrival - right.arrival,
+    )[0]?.candidate.id;
+}
+
+/** Which note a "jump to the note" reveal targets among the notes the store holds. */
 export function selectActiveRevealNoteId(
   state: Pick<ReviewState, "draftNote" | "liveNotes" | "selection" | "userNotes">,
 ): string | undefined {
@@ -221,14 +248,14 @@ export function selectActiveRevealNoteId(
   }
 
   const draft = state.draftNote;
-  if (draft && draft.fileKey === fileKey && draft.hunkIndex === hunkIndex) {
-    return draft.id;
-  }
-
-  return renderableNotes(state)
-    .filter((note) => note.fileKey === fileKey && reviewNoteOwnerHunkIndex(note) === hunkIndex)
-    .map((note, arrival) => ({ note, arrival, line: reviewNoteAnchorLine(note).line }))
-    .sort((left, right) => left.line - right.line || left.arrival - right.arrival)[0]?.note.id;
+  return resolveReviewRevealNoteId([
+    ...(draft && draft.fileKey === fileKey && draft.hunkIndex === hunkIndex
+      ? [{ id: draft.id, line: draft.line, draft: true }]
+      : []),
+    ...renderableNotes(state)
+      .filter((note) => note.fileKey === fileKey && reviewNoteOwnerHunkIndex(note) === hunkIndex)
+      .map((note) => ({ id: note.id, line: reviewNoteAnchorLine(note).line })),
+  ]);
 }
 
 /** Return whether one collapsed gap is currently expanded. */

--- a/src/core/review/state.ts
+++ b/src/core/review/state.ts
@@ -45,18 +45,28 @@ export function reviewNoteVisibleByPolicy(
 }
 
 /**
+ * Anything carrying a resolved note anchor, whether or not it is a stored note.
+ *
+ * A surface may hold a note in its own shape — the terminal draws sidecar annotations and
+ * open drafts that never became `ReviewNoteV1`s — and still has to ask where that note
+ * hangs. Both placement policies read the anchor and nothing else, so they answer for any
+ * of them.
+ */
+export type ReviewAnchoredNote = Pick<ReviewNoteV1, "anchor">;
+
+/**
  * Which hunk renders one note.
  *
  * Ownership is an explicit anchor field rather than a range-containment guess, so a note
  * that core placed through a fallback path is not silently dropped by a consumer that
  * re-derives placement.
  */
-export function reviewNoteOwnerHunkIndex(note: ReviewNoteV1) {
+export function reviewNoteOwnerHunkIndex(note: ReviewAnchoredNote) {
   return note.anchor.ownerHunkIndex ?? note.anchor.intersectingHunkIndices[0] ?? 0;
 }
 
 /** Which line one note hangs beside, falling back to the new side's first line. */
-export function reviewNoteAnchorLine(note: ReviewNoteV1): ReviewLineAddressV1 {
+export function reviewNoteAnchorLine(note: ReviewAnchoredNote): ReviewLineAddressV1 {
   return note.anchor.preferred ?? { side: "new", line: 1 };
 }
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1323,7 +1323,7 @@ export function App({
 
   /** Toggle the global agent note layer on or off. */
   const toggleAgentNotes = () => {
-    review.setShowAgentNotes(!showAgentNotes);
+    review.toggleAgentNotes();
   };
 
   /** Toggle line-number gutters without changing the diff content itself. */

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -494,15 +494,18 @@ export function DiffPane({
       const hunks = file.metadata.hunks;
       const notes: VisibleAgentNote[] = annotations.map((annotation, index) => {
         const source = reviewNoteSource(annotation);
+        // Explicit ids and synthesized index ids live in disjoint namespaces so an
+        // annotation named "3" can never collide with an id-less annotation at index 3 —
+        // reveal resolves rows by this id, and a collision would aim it at the wrong note.
+        const id = annotation.id
+          ? `annotation:${file.id}:id:${annotation.id}`
+          : `annotation:${file.id}:at:${index}`;
         if (source !== "user") {
-          return createVisibleAgentNote(hunks, {
-            id: `annotation:${file.id}:${annotation.id ?? index}`,
-            annotation,
-          });
+          return createVisibleAgentNote(hunks, { id, annotation });
         }
 
         return createVisibleAgentNote(hunks, {
-          id: `annotation:${file.id}:${annotation.id ?? index}`,
+          id,
           annotation,
           source,
           editable: true,

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -21,7 +21,12 @@ import type {
   LayoutMode,
   UserNoteLineTarget,
 } from "../../../core/types";
-import { reviewNoteVisibleByPolicy } from "../../../core/review/state";
+import { resolveReviewRevealNoteId } from "../../../core/review/selectors";
+import {
+  reviewNoteAnchorLine,
+  reviewNoteOwnerHunkIndex,
+  reviewNoteVisibleByPolicy,
+} from "../../../core/review/state";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
 import type { CursorHighlight } from "../../diff/renderRows";
@@ -1635,31 +1640,45 @@ export function DiffPane({
     };
   }, [fileSectionLayouts, sectionGeometry, selectedFile, selectedFileIndex, selectedHunkIndex]);
 
-  /** Absolute scroll offset and height of the first inline note in the selected hunk, if any. */
+  /**
+   * The note a note-preferring reveal aims at, named by the shared policy.
+   *
+   * The candidates are this pane's own — sidecar annotations, agent comments, the
+   * reviewer's notes, and the open draft, each hanging from the hunk its resolved anchor
+   * names — while which of them wins is the one rule every review surface answers with.
+   */
+  const revealNoteId = useMemo(() => {
+    if (!scrollToNote || !selectedFileId) {
+      return null;
+    }
+
+    const notes = allAgentNotesByFile.get(selectedFileId);
+    return notes
+      ? (resolveReviewRevealNoteId(
+          notes.flatMap((note) =>
+            reviewNoteOwnerHunkIndex(note) === selectedHunkIndex
+              ? [
+                  {
+                    id: note.id,
+                    line: reviewNoteAnchorLine(note).line,
+                    draft: note.source === "draft",
+                  },
+                ]
+              : [],
+          ),
+        ) ?? null)
+      : null;
+  }, [allAgentNotesByFile, scrollToNote, selectedFileId, selectedHunkIndex]);
+
+  /** Absolute scroll offset and height of the note that reveal aims at, once it is measured. */
   const selectedNoteBounds = useMemo(() => {
-    if (!scrollToNote || !selectedEstimatedHunkBounds || selectedFileIndex < 0) {
+    if (!revealNoteId || !selectedEstimatedHunkBounds || selectedFileIndex < 0) {
       return null;
     }
 
-    const geometry = sectionGeometry[selectedFileIndex];
-    if (!geometry) {
-      return null;
-    }
-
-    const sectionRelativeHunkTop =
-      selectedEstimatedHunkBounds.top - selectedEstimatedHunkBounds.sectionTop;
-    const sectionRelativeHunkBottom = sectionRelativeHunkTop + selectedEstimatedHunkBounds.height;
-    const noteRow =
-      (draftNoteId
-        ? geometry.rowBoundsByStableKey.get(inlineNoteStableKey(draftNoteId))
-        : undefined) ??
-      geometry.rowBounds.find(
-        (row) =>
-          row.key.startsWith("inline-note:") &&
-          row.top >= sectionRelativeHunkTop &&
-          row.top < sectionRelativeHunkBottom,
-      );
-
+    const noteRow = sectionGeometry[selectedFileIndex]?.rowBoundsByStableKey.get(
+      inlineNoteStableKey(revealNoteId),
+    );
     if (!noteRow) {
       return null;
     }
@@ -1668,7 +1687,7 @@ export function DiffPane({
       top: selectedEstimatedHunkBounds.sectionTop + noteRow.top,
       height: noteRow.height,
     };
-  }, [draftNoteId, scrollToNote, sectionGeometry, selectedEstimatedHunkBounds, selectedFileIndex]);
+  }, [revealNoteId, sectionGeometry, selectedEstimatedHunkBounds, selectedFileIndex]);
   const selectedEstimatedHunkTop = selectedEstimatedHunkBounds?.top ?? null;
   const selectedEstimatedHunkHeight = selectedEstimatedHunkBounds?.height ?? null;
   const selectedEstimatedHunkStartRowId = selectedEstimatedHunkBounds?.startRowId ?? null;

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -26,7 +26,11 @@ import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/PierreDiffView";
 import type { CursorHighlight } from "../../diff/renderRows";
 import type { DraftReviewNote } from "../../lib/reviewProjection";
-import { reviewNoteSource, type VisibleAgentNote } from "../../lib/agentAnnotations";
+import {
+  createVisibleAgentNote,
+  reviewNoteSource,
+  type VisibleAgentNote,
+} from "../../lib/agentAnnotations";
 import {
   computeRapidScrollOverscanRows,
   RAPID_SCROLL_OVERSCAN_IDLE_MS,
@@ -479,22 +483,26 @@ export function DiffPane({
         (annotation) =>
           reviewNoteVisibleByPolicy({ source: reviewNoteSource(annotation) }, showAgentNotes),
       );
+      // Every note kind resolves its anchor through the shared resolver here, once, so the
+      // render plan places sidecar annotations, agent comments, reviewer notes, and the open
+      // draft from one decision about where each of them hangs.
+      const hunks = file.metadata.hunks;
       const notes: VisibleAgentNote[] = annotations.map((annotation, index) => {
         const source = reviewNoteSource(annotation);
         if (source !== "user") {
-          return {
+          return createVisibleAgentNote(hunks, {
             id: `annotation:${file.id}:${annotation.id ?? index}`,
             annotation,
-          };
+          });
         }
 
-        return {
+        return createVisibleAgentNote(hunks, {
           id: `annotation:${file.id}:${annotation.id ?? index}`,
           annotation,
           source,
           editable: true,
           onRemove: annotation.id ? () => onRemoveUserNote?.(annotation.id!) : undefined,
-        };
+        });
       });
 
       if (draftNote?.fileId === file.id) {
@@ -506,21 +514,26 @@ export function DiffPane({
           newRange: draftNote.newRange,
           editable: true,
         };
-        notes.push({
-          id: draftNote.id,
-          annotation: draftAnnotation,
-          source: "draft",
-          editable: true,
-          draft: {
-            body: draftNote.body,
-            focused: draftNoteFocused,
-            onBlur: onBlurDraftNote,
-            onCancel: onCancelDraftNote ?? (() => {}),
-            onFocus: onFocusDraftNote,
-            onInput: onUpdateDraftNote ?? (() => {}),
-            onSave: onSaveDraftNote ?? (() => {}),
-          },
-        });
+        notes.push(
+          createVisibleAgentNote(hunks, {
+            id: draftNote.id,
+            annotation: draftAnnotation,
+            // The draft knows exactly where the reviewer opened it, including on an expanded
+            // gap line no hunk contains.
+            target: { hunkIndex: draftNote.hunkIndex, side: draftNote.side, line: draftNote.line },
+            source: "draft",
+            editable: true,
+            draft: {
+              body: draftNote.body,
+              focused: draftNoteFocused,
+              onBlur: onBlurDraftNote,
+              onCancel: onCancelDraftNote ?? (() => {}),
+              onFocus: onFocusDraftNote,
+              onInput: onUpdateDraftNote ?? (() => {}),
+              onSave: onSaveDraftNote ?? (() => {}),
+            },
+          }),
+        );
       }
 
       if (notes.length > 0) {

--- a/src/ui/components/panes/FileView.test.tsx
+++ b/src/ui/components/panes/FileView.test.tsx
@@ -10,6 +10,7 @@ import { measureFileViewGeometry } from "../../fileViews/geometry";
 import { validateFileViewLayout } from "../../fileViews/layout";
 import { buildFileViewRenderPlan } from "../../fileViews/renderPlan";
 import type { ResolvedFileViewLayout } from "../../fileViews/useFileViews";
+import { createVisibleAgentNote } from "../../lib/agentAnnotations";
 import { reviewRowId } from "../../lib/ids";
 import { resolveTheme } from "../../themes";
 import { FileView, isFileViewRowSelected } from "./FileView";
@@ -113,10 +114,10 @@ describe("FileView custom rows", () => {
       60,
     );
     const plan = buildFileViewRenderPlan(fileView.layout, [
-      {
+      createVisibleAgentNote([], {
         id: "note",
         annotation: { id: "note", summary: "Review bound output", newRange: [1, 1] },
-      },
+      }),
     ]);
     const geometry = measureFileViewGeometry({
       resolved: fileView,
@@ -386,10 +387,10 @@ describe("FileView custom rows", () => {
     });
     const fileView = resolveTestLayout(largeLayout, 20);
     const plan = buildFileViewRenderPlan(fileView.layout, [
-      {
+      createVisibleAgentNote([], {
         id: "windowed-note",
         annotation: { summary: "WINDOWED NOTE", newRange: [500, 500] },
-      },
+      }),
     ]);
     const geometry = measureFileViewGeometry({
       resolved: fileView,

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -10,6 +10,7 @@ import {
   createTestSourceFetcher,
   lines,
 } from "../../../test/helpers/diff-helpers";
+import { createVisibleAgentNote } from "../lib/agentAnnotations";
 import { hexColorDistance } from "../lib/color";
 import { RAPID_SCROLL_OVERSCAN_IDLE_MS } from "../lib/adaptiveScrollOverscan";
 import { resolveTheme } from "../themes";
@@ -3350,13 +3351,13 @@ describe("UI components", () => {
         width={88}
         selectedHunkIndex={0}
         visibleAgentNotes={[
-          {
+          createVisibleAgentNote(file.metadata.hunks, {
             id: "note:ungrounded",
             annotation: {
               summary: "Ungrounded note",
               rationale: "Falls back to the first visible row.",
             },
-          },
+          }),
         ]}
         showHunkHeaders={false}
         scrollable={false}

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2364,6 +2364,73 @@ describe("UI components", () => {
     }
   });
 
+  test("DiffPane reveal is not confused by an explicit note id that spells an index", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+
+    // Same geometry as the policy test above, but the notes' identities collide under an
+    // index-based id scheme: the policy's winner has no id and sits at index 0, while the
+    // decoy's explicit id is the string "0". If synthesized and explicit ids share a
+    // namespace, the reveal resolves the winner's id to the decoy's row.
+    const beforeLines = Array.from(
+      { length: 80 },
+      (_, index) => `export const line${index + 1} = ${index + 1};`,
+    );
+    const afterLines = [...beforeLines];
+    afterLines[0] = "export const line1 = 100;";
+    afterLines[59] = "export const line60 = 6000;";
+
+    const file = createTestDiffFile(
+      "collide-note",
+      "collide-note.ts",
+      lines(...beforeLines),
+      lines(...afterLines),
+    );
+    const hunkFirstLine = file.metadata.hunks[1]!.additionStart;
+    file.agent = {
+      path: file.path,
+      summary: "file note",
+      annotations: [
+        // The reveal's rightful target: the only note in the selected hunk, with the
+        // explicit id "1" — the string the decoy's index synthesizes.
+        {
+          id: "1",
+          newRange: [hunkFirstLine, hunkFirstLine],
+          summary: "COLLIDE TARGET",
+        },
+        // An id-less note at index 1, two viewports away in the first hunk. Under a shared
+        // namespace its row registers last under the target's id, so the reveal scrolls here.
+        { newRange: [1, 1], summary: "COLLIDE DECOY" },
+      ],
+    };
+
+    const props = createDiffPaneProps([file], theme, {
+      diffContentWidth: 40,
+      headerLabelWidth: 20,
+      selectedFileId: file.id,
+      selectedHunkIndex: 1,
+      scrollToNote: true,
+      separatorWidth: 44,
+      showAgentNotes: true,
+      showHunkHeaders: true,
+      width: 48,
+    });
+    const setup = await testRender(<DiffPane {...props} />, { width: 52, height: 12 });
+
+    try {
+      await settleDiffPane(setup);
+      const frame = setup.captureCharFrame();
+
+      // The shared policy names the earliest-anchored note; its id must resolve to its own
+      // row even though another note's explicit id spells the winner's index.
+      expect(frame).toContain("COLLIDE TARGET");
+      expect(frame).not.toContain("COLLIDE DECOY");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("AgentCard removes top and bottom padding while keeping the footer inside the frame", async () => {
     const theme = resolveTheme("github-dark-default", null);
     const frame = await captureFrame(

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -2302,6 +2302,68 @@ describe("UI components", () => {
     }
   });
 
+  test("DiffPane reveals the note the shared policy names, not the first one drawn in the hunk", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+
+    // Two hunks far apart. Both notes hang from the second hunk and land on its first row:
+    // one is anchored there, the other to a line the collapsed gap swallowed.
+    const beforeLines = Array.from(
+      { length: 80 },
+      (_, index) => `export const line${index + 1} = ${index + 1};`,
+    );
+    const afterLines = [...beforeLines];
+    afterLines[0] = "export const line1 = 100;";
+    afterLines[59] = "export const line60 = 6000;";
+
+    const file = createTestDiffFile(
+      "policy-note",
+      "policy-note.ts",
+      lines(...beforeLines),
+      lines(...afterLines),
+    );
+    const hunkFirstLine = file.metadata.hunks[1]!.additionStart;
+    file.agent = {
+      path: file.path,
+      summary: "file note",
+      annotations: [
+        {
+          newRange: [hunkFirstLine, hunkFirstLine],
+          summary: "HUNK NOTE",
+          // Tall enough that revealing the note below it pushes this one off the top.
+          rationale: Array.from({ length: 6 }, (_, index) => `filler line ${index + 1}`).join(" "),
+        },
+        { newRange: [hunkFirstLine - 20, hunkFirstLine - 20], summary: "GAP NOTE" },
+      ],
+    };
+
+    const props = createDiffPaneProps([file], theme, {
+      diffContentWidth: 40,
+      headerLabelWidth: 20,
+      selectedFileId: file.id,
+      selectedHunkIndex: 1,
+      scrollToNote: true,
+      separatorWidth: 44,
+      showAgentNotes: true,
+      showHunkHeaders: true,
+      width: 48,
+    });
+    const setup = await testRender(<DiffPane {...props} />, { width: 52, height: 12 });
+
+    try {
+      await settleDiffPane(setup);
+      const frame = setup.captureCharFrame();
+
+      // Both notes sit on the same row, so the note drawn first is the one a scan of the
+      // hunk's rows finds. The shared policy takes the earliest anchor instead.
+      expect(frame).toContain("GAP NOTE");
+      expect(frame).not.toContain("HUNK NOTE");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("AgentCard removes top and bottom padding while keeping the footer inside the frame", async () => {
     const theme = resolveTheme("github-dark-default", null);
     const frame = await captureFrame(

--- a/src/ui/diff/diffSectionGeometry.test.ts
+++ b/src/ui/diff/diffSectionGeometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { VisibleAgentNote } from "../lib/agentAnnotations";
+import { createVisibleAgentNote, type VisibleAgentNote } from "../lib/agentAnnotations";
 import { measureDiffSectionGeometry } from "./diffSectionGeometry";
 import { resolveTheme } from "../themes";
 import {
@@ -96,10 +96,10 @@ describe("measureDiffSectionGeometry", () => {
     const file = createTestDiffFile({ after, before, id: "snapshot", path: "snapshot.txt" });
     const expandedKeys = new Set(["trailing:0"]);
     const visibleAgentNotes: VisibleAgentNote[] = [
-      {
+      createVisibleAgentNote(file.metadata.hunks, {
         id: "original-note",
         annotation: { newRange: [5, 5], summary: "Original note." },
-      },
+      }),
     ];
     const geometry = measureDiffSectionGeometry(
       file,
@@ -117,10 +117,12 @@ describe("measureDiffSectionGeometry", () => {
     expandedKeys.clear();
     visibleAgentNotes[0]!.annotation.newRange = [1, 1];
     visibleAgentNotes[0]!.annotation.summary = "Mutated after geometry measurement.";
-    visibleAgentNotes.push({
-      id: "late-note",
-      annotation: { newRange: [1, 1], summary: "Added after geometry measurement." },
-    });
+    visibleAgentNotes.push(
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "late-note",
+        annotation: { newRange: [1, 1], summary: "Added after geometry measurement." },
+      }),
+    );
 
     const plannedRows = geometry.plannedRows;
     expect(plannedRows.map((row) => row.key)).toEqual(
@@ -134,14 +136,14 @@ describe("measureDiffSectionGeometry", () => {
   test("replaces stale width variants while retaining separate base and note slots", () => {
     const file = createTestDiffFile();
     const visibleAgentNotes: VisibleAgentNote[] = [
-      {
+      createVisibleAgentNote(file.metadata.hunks, {
         id: "annotation:example:0",
         annotation: {
           newRange: [1, 1],
           rationale: "Keep a note-aware geometry slot.",
           summary: "Explain",
         },
-      },
+      }),
     ];
 
     const width100 = measureDiffSectionGeometry(file, "split", true, theme, [], 100, true, false);
@@ -169,14 +171,14 @@ describe("measureDiffSectionGeometry", () => {
   test("accounts for visible inline notes without moving the hunk anchor", () => {
     const file = createTestDiffFile();
     const visibleAgentNotes: VisibleAgentNote[] = [
-      {
+      createVisibleAgentNote(file.metadata.hunks, {
         id: "annotation:example:0",
         annotation: {
           newRange: [1, 1],
           rationale: "Keep note height in section geometry.",
           summary: "Explain the change",
         },
-      },
+      }),
     ];
 
     const baseGeometry = measureDiffSectionGeometry(file, "split", true, theme, [], 120);
@@ -197,14 +199,14 @@ describe("measureDiffSectionGeometry", () => {
   test("reuses note-aware geometry across equivalent note arrays", () => {
     const file = createTestDiffFile();
     const buildNotes = (summary: string): VisibleAgentNote[] => [
-      {
+      createVisibleAgentNote(file.metadata.hunks, {
         id: "annotation:example:0",
         annotation: {
           newRange: [1, 1],
           rationale: "Keep note height in section geometry.",
           summary,
         },
-      },
+      }),
     ];
 
     const first = measureDiffSectionGeometry(
@@ -455,14 +457,14 @@ describe("measureDiffSectionGeometry", () => {
       path: "same-length-source.txt",
     });
     const visibleAgentNotes: VisibleAgentNote[] = [
-      {
+      createVisibleAgentNote(file.metadata.hunks, {
         id: "annotation:same-length-source:0",
         annotation: {
           newRange: [5, 5],
           rationale: "Forces note-aware geometry caching.",
           summary: "Changed line",
         },
-      },
+      }),
     ];
     const expandedKeys = new Set(["trailing:0"]);
     const shortSourceLines = [...afterLines];

--- a/src/ui/diff/plannedReviewRows.test.ts
+++ b/src/ui/diff/plannedReviewRows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { VisibleAgentNote } from "../lib/agentAnnotations";
+import { createVisibleAgentNote, type VisibleAgentNote } from "../lib/agentAnnotations";
 import { reviewRowId } from "../lib/ids";
 import type { PlannedReviewRow } from "./reviewRenderPlan";
 import {
@@ -88,7 +88,7 @@ function inlineNote(key: string, hunkIndex: number): PlannedReviewRow {
     summary: "Explain why this branch changed.",
     rationale: "The note should reserve space in the hunk bounds.",
   };
-  const note: VisibleAgentNote = { id: "note-1", annotation };
+  const note: VisibleAgentNote = createVisibleAgentNote([], { id: "note-1", annotation });
 
   return {
     kind: "inline-note",

--- a/src/ui/diff/reviewRenderPlan.test.ts
+++ b/src/ui/diff/reviewRenderPlan.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { parseDiffFromFile } from "@pierre/diffs";
 import type { DiffFile } from "../../core/types";
+import { createVisibleAgentNote } from "../lib/agentAnnotations";
+import { expandCollapsedRows } from "./expandCollapsedRows";
 import {
   contextLineStableKeyTarget,
   lineStableKey,
@@ -15,6 +17,15 @@ const { buildReviewRenderPlan } = await import("./reviewRenderPlan");
 function lines(...values: string[]) {
   return `${values.join("\n")}\n`;
 }
+
+/** Twelve lines changed at line 2 and line 11: two hunks with a collapsed gap between them. */
+const TWELVE_LINES_BEFORE = lines(
+  ...Array.from({ length: 12 }, (_, index) => `export const line${index + 1} = ${index + 1};`),
+);
+const TWELVE_LINES_AFTER = TWELVE_LINES_BEFORE.replace(
+  "export const line2 = 2;",
+  "export const line2 = 200;",
+).replace("export const line11 = 11;", "export const line11 = 1100;");
 
 function createDiffFile(id: string, path: string, before: string, after: string): DiffFile {
   const metadata = parseDiffFromFile(
@@ -89,14 +100,14 @@ describe("review render plan", () => {
       selectedHunkIndex: 0,
       showHunkHeaders: true,
       visibleAgentNotes: [
-        {
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:alpha:0:0",
           annotation: {
             newRange: [2, 3],
             summary: "Explain the expanded new-side range",
             rationale: "The annotation should anchor to the first matching new-side row.",
           },
-        },
+        }),
       ],
     });
 
@@ -135,14 +146,14 @@ describe("review render plan", () => {
       selectedHunkIndex: 0,
       showHunkHeaders: true,
       visibleAgentNotes: [
-        {
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:deleted:0:0",
           annotation: {
             oldRange: [1, 1],
             summary: "Explain the removed line",
             rationale: "Deletion notes should visually anchor on the old side.",
           },
-        },
+        }),
       ],
     });
 
@@ -167,38 +178,7 @@ describe("review render plan", () => {
 
   test("assigns hunk anchor ids from the first visible row for every hunk when hunk headers are hidden", () => {
     const theme = resolveTheme("github-dark-default", null);
-    const file = createDiffFile(
-      "beta",
-      "beta.ts",
-      lines(
-        "export const line1 = 1;",
-        "export const line2 = 2;",
-        "export const line3 = 3;",
-        "export const line4 = 4;",
-        "export const line5 = 5;",
-        "export const line6 = 6;",
-        "export const line7 = 7;",
-        "export const line8 = 8;",
-        "export const line9 = 9;",
-        "export const line10 = 10;",
-        "export const line11 = 11;",
-        "export const line12 = 12;",
-      ),
-      lines(
-        "export const line1 = 1;",
-        "export const line2 = 200;",
-        "export const line3 = 3;",
-        "export const line4 = 4;",
-        "export const line5 = 5;",
-        "export const line6 = 6;",
-        "export const line7 = 7;",
-        "export const line8 = 8;",
-        "export const line9 = 9;",
-        "export const line10 = 10;",
-        "export const line11 = 1100;",
-        "export const line12 = 12;",
-      ),
-    );
+    const file = createDiffFile("beta", "beta.ts", TWELVE_LINES_BEFORE, TWELVE_LINES_AFTER);
     const rows = buildSplitRows(file, null, theme);
     const plannedRows = buildReviewRenderPlan({
       fileId: file.id,
@@ -221,7 +201,7 @@ describe("review render plan", () => {
     expect(anchorRows.every((row) => row.row.type === "split-line")).toBe(true);
   });
 
-  test("anchors range-less notes to the first visible line row without guide rows", () => {
+  test("anchors range-less notes to the shared default line without guide rows", () => {
     const theme = resolveTheme("github-dark-default", null);
     const file = createDiffFile(
       "stack",
@@ -236,13 +216,13 @@ describe("review render plan", () => {
       selectedHunkIndex: 0,
       showHunkHeaders: true,
       visibleAgentNotes: [
-        {
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:stack:0:0",
           annotation: {
             summary: "General hunk note",
             rationale: "No explicit line range is attached yet.",
           },
-        },
+        }),
       ],
     });
 
@@ -256,47 +236,20 @@ describe("review render plan", () => {
       plannedRows.some((row) => row.kind === "diff-row" && row.noteGuideSide !== undefined),
     ).toBe(false);
 
+    // A note with no range of its own hangs from the shared default: the new side's first line.
     const anchoredRow = inlineNoteAnchorRow(plannedRows);
     expect(anchoredRow?.kind).toBe("diff-row");
     if (anchoredRow?.kind === "diff-row") {
       expect(anchoredRow.row.type).toBe("stack-line");
+      if (anchoredRow.row.type === "stack-line") {
+        expect(anchoredRow.row.cell.newLineNumber).toBe(1);
+      }
     }
   });
 
   test("anchors notes on the matching hunk in multi-hunk diffs", () => {
     const theme = resolveTheme("github-dark-default", null);
-    const file = createDiffFile(
-      "multi",
-      "multi.ts",
-      lines(
-        "export const line1 = 1;",
-        "export const line2 = 2;",
-        "export const line3 = 3;",
-        "export const line4 = 4;",
-        "export const line5 = 5;",
-        "export const line6 = 6;",
-        "export const line7 = 7;",
-        "export const line8 = 8;",
-        "export const line9 = 9;",
-        "export const line10 = 10;",
-        "export const line11 = 11;",
-        "export const line12 = 12;",
-      ),
-      lines(
-        "export const line1 = 1;",
-        "export const line2 = 200;",
-        "export const line3 = 3;",
-        "export const line4 = 4;",
-        "export const line5 = 5;",
-        "export const line6 = 6;",
-        "export const line7 = 7;",
-        "export const line8 = 8;",
-        "export const line9 = 9;",
-        "export const line10 = 10;",
-        "export const line11 = 1100;",
-        "export const line12 = 12;",
-      ),
-    );
+    const file = createDiffFile("multi", "multi.ts", TWELVE_LINES_BEFORE, TWELVE_LINES_AFTER);
     const rows = buildSplitRows(file, null, theme);
     const plannedRows = buildReviewRenderPlan({
       fileId: file.id,
@@ -304,14 +257,14 @@ describe("review render plan", () => {
       selectedHunkIndex: 1,
       showHunkHeaders: true,
       visibleAgentNotes: [
-        {
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:multi:1:0",
           annotation: {
             newRange: [11, 11],
             summary: "Explain the later change",
             rationale: "The note should attach to the second hunk only.",
           },
-        },
+        }),
       ],
     });
 
@@ -322,6 +275,83 @@ describe("review render plan", () => {
       expect(anchoredRow.row.type).toBe("split-line");
       if (anchoredRow.row.type === "split-line") {
         expect(anchoredRow.row.right.lineNumber).toBe(11);
+      }
+    }
+  });
+
+  test("keeps a note on collapsed lines inside its owning hunk", () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const file = createDiffFile(
+      "collapsed",
+      "collapsed.ts",
+      TWELVE_LINES_BEFORE,
+      TWELVE_LINES_AFTER,
+    );
+    const rows = buildSplitRows(file, null, theme);
+    // Lines 6-7 sit in the gap between the two hunks, so no rendered row covers them.
+    const note = createVisibleAgentNote(file.metadata.hunks, {
+      id: "annotation:collapsed:0",
+      annotation: {
+        newRange: [6, 7],
+        summary: "Explain the collapsed region",
+        rationale: "The patch shows neither of these lines.",
+      },
+    });
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      selectedHunkIndex: 0,
+      showHunkHeaders: true,
+      visibleAgentNotes: [note],
+    });
+
+    expect(note.anchor.intersectingHunkIndices).toEqual([]);
+    expect(note.anchor.ownerHunkIndex).toBe(1);
+
+    const inlineNote = firstInlineNote(plannedRows);
+    expect(inlineNote?.kind).toBe("inline-note");
+    if (inlineNote?.kind === "inline-note") {
+      expect(inlineNote.hunkIndex).toBe(1);
+    }
+
+    const anchoredRow = inlineNoteAnchorRow(plannedRows);
+    expect(anchoredRow?.kind).toBe("diff-row");
+    if (anchoredRow?.kind === "diff-row") {
+      expect(anchoredRow.hunkIndex).toBe(1);
+      expect(anchoredRow.row.type).toBe("split-line");
+      if (anchoredRow.row.type === "split-line") {
+        expect(anchoredRow.row.right.lineNumber).toBe(8);
+      }
+    }
+  });
+
+  test("places a note on an expanded gap line beside that line", () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const file = createDiffFile("expanded", "expanded.ts", TWELVE_LINES_BEFORE, TWELVE_LINES_AFTER);
+    const rows = expandCollapsedRows(buildSplitRows(file, null, theme), {
+      layout: "split",
+      expandedKeys: new Set(["before:1"]),
+      sourceStatus: { kind: "loaded", text: TWELVE_LINES_AFTER },
+    });
+    const note = createVisibleAgentNote(file.metadata.hunks, {
+      id: "annotation:expanded:0",
+      annotation: { newRange: [7, 7], summary: "Explain the revealed line" },
+    });
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      selectedHunkIndex: 1,
+      showHunkHeaders: true,
+      visibleAgentNotes: [note],
+    });
+
+    const anchoredRow = inlineNoteAnchorRow(plannedRows);
+    expect(anchoredRow?.kind).toBe("diff-row");
+    if (anchoredRow?.kind === "diff-row") {
+      expect(anchoredRow.row.type).toBe("split-line");
+      if (anchoredRow.row.type === "split-line") {
+        expect(anchoredRow.row.isExpansionRow).toBe(true);
+        expect(anchoredRow.row.right.lineNumber).toBe(7);
       }
     }
   });
@@ -341,20 +371,20 @@ describe("review render plan", () => {
       selectedHunkIndex: 0,
       showHunkHeaders: true,
       visibleAgentNotes: [
-        {
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:counted:0:0",
           annotation: {
             newRange: [2, 2],
             summary: "First visible note",
           },
-        },
-        {
+        }),
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:counted:0:1",
           annotation: {
             newRange: [1, 1],
             summary: "Second visible note",
           },
-        },
+        }),
       ],
     });
 

--- a/src/ui/diff/reviewRenderPlan.ts
+++ b/src/ui/diff/reviewRenderPlan.ts
@@ -1,5 +1,7 @@
+import { reviewNoteAnchorLine, reviewNoteOwnerHunkIndex } from "../../core/review/state";
+import type { ReviewRangeAnchorV1 } from "../../core/review/types";
 import type { AgentAnnotation, UserNoteLineTarget } from "../../core/types";
-import { annotationAnchor, type VisibleAgentNote } from "../lib/agentAnnotations";
+import type { VisibleAgentNote } from "../lib/agentAnnotations";
 import { diffHunkId } from "../lib/ids";
 import type { DiffRow } from "./pierre";
 
@@ -200,63 +202,64 @@ function diffRowStableKeys(row: DiffRow) {
   ]);
 }
 
-/** Check whether a rendered diff row visually covers the note anchor line. */
-function rowMatchesNote(row: DiffLineRow, annotation: AgentAnnotation) {
-  const anchor = annotationAnchor(annotation);
-  if (!anchor) {
-    return false;
-  }
-
+/** The line one rendered row shows on one diff side, when it shows one at all. */
+function rowLineNumber(row: DiffLineRow, side: "old" | "new") {
   if (row.type === "split-line") {
-    return anchor.side === "new"
-      ? row.right.lineNumber === anchor.lineNumber
-      : row.left.lineNumber === anchor.lineNumber;
+    return side === "new" ? row.right.lineNumber : row.left.lineNumber;
   }
 
-  return anchor.side === "new"
-    ? row.cell.newLineNumber === anchor.lineNumber
-    : row.cell.oldLineNumber === anchor.lineNumber;
+  return side === "new" ? row.cell.newLineNumber : row.cell.oldLineNumber;
 }
 
-/** Check whether one rendered diff row falls inside the annotation range on either side. */
-function rowOverlapsAnnotation(row: DiffLineRow, annotation: AgentAnnotation) {
-  const matchesOld =
-    annotation.oldRange &&
-    (row.type === "split-line"
-      ? row.left.lineNumber !== undefined &&
-        row.left.lineNumber >= annotation.oldRange[0] &&
-        row.left.lineNumber <= annotation.oldRange[1]
-      : row.cell.oldLineNumber !== undefined &&
-        row.cell.oldLineNumber >= annotation.oldRange[0] &&
-        row.cell.oldLineNumber <= annotation.oldRange[1]);
-
-  if (matchesOld) {
-    return true;
+/** Check whether one rendered diff row falls inside the note's range on either side. */
+function rowOverlapsNoteRange(row: DiffLineRow, anchor: ReviewRangeAnchorV1) {
+  for (const side of ["old", "new"] as const) {
+    const range = side === "old" ? anchor.oldRange : anchor.newRange;
+    const lineNumber = rowLineNumber(row, side);
+    if (range && lineNumber !== undefined && lineNumber >= range[0] && lineNumber <= range[1]) {
+      return true;
+    }
   }
 
-  return Boolean(
-    annotation.newRange &&
-    (row.type === "split-line"
-      ? row.right.lineNumber !== undefined &&
-        row.right.lineNumber >= annotation.newRange[0] &&
-        row.right.lineNumber <= annotation.newRange[1]
-      : row.cell.newLineNumber !== undefined &&
-        row.cell.newLineNumber >= annotation.newRange[0] &&
-        row.cell.newLineNumber <= annotation.newRange[1]),
-  );
+  return false;
 }
 
 /**
- * Resolve the rendered diff row after which the inline note should appear.
- * Range-less notes intentionally anchor beside the first code row in the file,
- * not against hunk header metadata.
+ * Resolve the rendered diff row after which one inline note should appear.
+ *
+ * The owning hunk is the one the shared anchor resolver named, never the hunk of whatever
+ * row happens to contain the note's range: a note anchored to lines this patch collapsed,
+ * or to a gap line, has an owner but no matching row, and re-deriving placement by
+ * containment strands it at the top of the file. Inside that hunk the note sits beside the
+ * first row at or after its anchor line, falling back to the closest row before it and
+ * then to the hunk's first row — a note always lands next to the code it explains.
  */
-function findInlineNoteAnchorRow(rows: DiffRow[], annotation: AgentAnnotation) {
+function findInlineNoteAnchorRow(rows: DiffRow[], note: VisibleAgentNote) {
   const fileLineRows = lineRows(rows);
-  const headerRow = rows.find((row) => row.type === "hunk-header");
+  const ownerHunkIndex = reviewNoteOwnerHunkIndex(note);
+  const ownerRows = fileLineRows.filter((row) => row.hunkIndex === ownerHunkIndex);
+  const candidates = ownerRows.length > 0 ? ownerRows : fileLineRows;
+  const { side, line } = reviewNoteAnchorLine(note);
+
+  let precedingRow: DiffLineRow | undefined;
+  for (const row of candidates) {
+    const lineNumber = rowLineNumber(row, side);
+    if (lineNumber === undefined) {
+      continue;
+    }
+
+    if (lineNumber >= line) {
+      return row;
+    }
+
+    precedingRow = row;
+  }
 
   return (
-    fileLineRows.find((row) => rowMatchesNote(row, annotation)) ?? fileLineRows[0] ?? headerRow
+    precedingRow ??
+    candidates[0] ??
+    rows.find((row) => row.type === "hunk-header" && row.hunkIndex === ownerHunkIndex) ??
+    rows.find((row) => row.type === "hunk-header")
   );
 }
 
@@ -265,13 +268,13 @@ function buildInlineVisibleNotePlacements(rows: DiffRow[], visibleAgentNotes: Vi
   const placementsByAnchor = new Map<string, InlineVisibleNotePlacement[]>();
 
   for (const note of visibleAgentNotes) {
-    const anchorRow = findInlineNoteAnchorRow(rows, note.annotation);
+    const anchorRow = findInlineNoteAnchorRow(rows, note);
     if (!anchorRow) {
       continue;
     }
 
-    const anchorSide = annotationAnchor(note.annotation)?.side;
-    const coveredRows = fileLineRows.filter((row) => rowOverlapsAnnotation(row, note.annotation));
+    const anchorSide = note.anchor.preferred?.side;
+    const coveredRows = fileLineRows.filter((row) => rowOverlapsNoteRange(row, note.anchor));
     const guideRows = coveredRows.filter((row) => row.key !== anchorRow.key);
     const anchorPlacements = placementsByAnchor.get(anchorRow.key) ?? [];
 
@@ -280,6 +283,8 @@ function buildInlineVisibleNotePlacements(rows: DiffRow[], visibleAgentNotes: Vi
       anchorSide,
       guidedRowKeys:
         guideRows.length > 0 ? new Set(guideRows.map((row) => row.key)) : EMPTY_ROW_KEYS,
+      // The row's own hunk, which is the resolved owner whenever that hunk drew rows;
+      // reporting an owner with no rows here would give it measured bounds it has not got.
       hunkIndex: anchorRow.hunkIndex,
       note,
       noteCount: 1,

--- a/src/ui/fileViews/geometry.test.ts
+++ b/src/ui/fileViews/geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ExtensionFileViewLayout } from "../../extension-api/types";
 import { measureAgentInlineNoteHeight } from "../components/panes/AgentInlineNote";
+import { createVisibleAgentNote } from "../lib/agentAnnotations";
 import { measureFileViewGeometry } from "./geometry";
 import { validateFileViewLayout } from "./layout";
 import { buildFileViewRenderPlan } from "./renderPlan";
@@ -107,7 +108,9 @@ describe("file-view geometry", () => {
       summary: "Review this range",
       newRange: [1, 1] as [number, number],
     };
-    const plan = buildFileViewRenderPlan(checked.value.layout, [{ id: "note", annotation }]);
+    const plan = buildFileViewRenderPlan(checked.value.layout, [
+      createVisibleAgentNote([], { id: "note", annotation }),
+    ]);
     const noteHeight = measureAgentInlineNoteHeight({
       annotation,
       anchorSide: "new",

--- a/src/ui/fileViews/renderPlan.test.ts
+++ b/src/ui/fileViews/renderPlan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ExtensionFileViewLayout } from "../../extension-api/types";
-import type { VisibleAgentNote } from "../lib/agentAnnotations";
+import { createVisibleAgentNote, type VisibleAgentNote } from "../lib/agentAnnotations";
 import { buildFileViewRenderPlan } from "./renderPlan";
 
 const layout: ExtensionFileViewLayout = {
@@ -24,10 +24,10 @@ function note(
   id: string,
   ranges: { oldRange?: [number, number]; newRange?: [number, number] },
 ): VisibleAgentNote {
-  return {
+  return createVisibleAgentNote([], {
     id,
     annotation: { id, summary: id, ...ranges },
-  };
+  });
 }
 
 describe("file-view render plan", () => {

--- a/src/ui/hooks/useReviewController.test.tsx
+++ b/src/ui/hooks/useReviewController.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act, StrictMode, useEffect, useRef, useState } from "react";
+import { builtinAppCommand } from "../../core/commandCatalog";
 import { SourceTextTooLargeError } from "../../core/fileSource";
 import type { DiffFile } from "../../core/types";
 import {
@@ -1160,6 +1161,88 @@ describe("useReviewController", () => {
 
       expect(expectValue(controllerRef.current).expandedGapsByFileId["alpha"]).toBeUndefined();
       expect(expectValue(controllerRef.current).sourceStatusByFileId["alpha"]).toBeUndefined();
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  // Intent: these three handlers execute the effect their catalog entry declares, rather
+  // than a terminal restatement of it that could drift from what a browser palette or an
+  // agent command lowering the same id would do.
+  test("runs the review effect the catalog declares for the note layer, the nearest gap, and a new note", async () => {
+    expect(builtinAppCommand("hunk.view.toggleAgentNotes").review).toEqual({
+      kind: "notes/toggle-visibility",
+    });
+    expect(builtinAppCommand("hunk.review.toggleHunkGap").review).toEqual({
+      kind: "expansion/toggle-selected-gap",
+    });
+    expect(builtinAppCommand("hunk.review.startNote").review).toEqual({
+      kind: "notes/start-draft",
+    });
+
+    const beforeLines = Array.from(
+      { length: 12 },
+      (_, index) => `export const line${index + 1} = ${index + 1};`,
+    );
+    const afterLines = [...beforeLines];
+    afterLines[0] = "export const line1 = 100;";
+    afterLines[11] = "export const line12 = 1200;";
+    const after = lines(...afterLines);
+    const file = createDiffFile(
+      "alpha",
+      "alpha.ts",
+      lines(...beforeLines),
+      after,
+      null,
+      createTestSourceFetcher((side) => (side === "new" ? after : null)),
+    );
+
+    const { controllerRef, setup } = await renderReviewController([file]);
+
+    try {
+      await flush(setup);
+
+      // A declared toggle, not a set: two invocations return the layer to where it started.
+      await act(async () => {
+        expectValue(controllerRef.current).toggleAgentNotes();
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).showAgentNotes).toBe(true);
+      await act(async () => {
+        expectValue(controllerRef.current).toggleAgentNotes();
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).showAgentNotes).toBe(false);
+
+      // A note with no measured line lands on the shared whole-hunk default: the selected
+      // hunk's first added line.
+      expect(expectValue(controllerRef.current).selectedHunkIndex).toBe(0);
+      await act(async () => {
+        expectValue(controllerRef.current).startUserNote();
+      });
+      await flush(setup);
+      expect(expectValue(controllerRef.current).draftNote).toMatchObject({
+        fileId: "alpha",
+        hunkIndex: 0,
+        side: "new",
+        line: 1,
+      });
+      await act(async () => {
+        expectValue(controllerRef.current).cancelDraftNote();
+      });
+      await flush(setup);
+
+      // The selected hunk opens the file, so it has no leading gap of its own and the
+      // declared effect reaches forward to the next hunk's — the shared gap policy.
+      await act(async () => {
+        expectValue(controllerRef.current).toggleSelectedHunkGap();
+      });
+      await flush(setup);
+      expect([...(expectValue(controllerRef.current).expandedGapsByFileId["alpha"] ?? [])]).toEqual(
+        ["before:1"],
+      );
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/hooks/useReviewController.ts
+++ b/src/ui/hooks/useReviewController.ts
@@ -24,6 +24,12 @@ import {
   findDiffFileByPath,
   resolveCommentTarget,
 } from "../../core/liveComments";
+import {
+  builtinAppCommand,
+  lowerAppCommandToReviewIntent,
+  type AppCommandId,
+  type AppCommandLoweringContext,
+} from "../../core/commandCatalog";
 import { SourceTextTooLargeError } from "../../core/fileSource";
 import {
   applyReviewIntent,
@@ -39,7 +45,6 @@ import {
   reviewFileKeysWithRetiredContent,
   selectExpandedGapIdsByFileKey,
   selectNormalizedSelection,
-  selectReviewGapForSelection,
 } from "../../core/review/selectors";
 import { REVIEW_VIEWPORT_ANCHOR_REVEAL, type ReviewRevealRequest } from "../../core/review/state";
 import { createReviewStore, type ReviewStore } from "../../core/review/store";
@@ -261,6 +266,8 @@ export interface ReviewController {
   selectFile: (fileId: string, options?: ReviewSelectionOptions) => void;
   selectHunk: (fileId: string, hunkIndex: number, options?: ReviewSelectionOptions) => void;
   setShowAgentNotes: (visible: boolean) => void;
+  /** Flip the note layer the way the catalogued toggle command declares it. */
+  toggleAgentNotes: () => void;
   startUserNote: (
     fileId?: string,
     hunkIndex?: number,
@@ -474,6 +481,24 @@ export function useReviewController({
   const runIntent = useCallback(
     <T extends ReviewIntent>(intent: T, facts?: ReviewIntentFacts) =>
       applyReviewIntent(store, intent, facts),
+    [store],
+  );
+
+  /**
+   * Lower one built-in command to the intent its catalog entry declares.
+   *
+   * The terminal invokes these commands from keys, menus, and the mouse, and lowers each
+   * one here rather than restating its effect: what "toggle the note layer" or "toggle the
+   * nearest gap" means is the catalog's declaration, and this hook only supplies the facts
+   * a renderer owns and keeps the bookkeeping that follows.
+   */
+  const lowerCommand = useCallback(
+    (id: AppCommandId, facts?: Omit<AppCommandLoweringContext, "count" | "state">) =>
+      lowerAppCommandToReviewIntent(builtinAppCommand(id), {
+        count: 1,
+        state: store.getSnapshot(),
+        ...facts,
+      }),
     [store],
   );
 
@@ -709,6 +734,14 @@ export function useReviewController({
     [runIntent],
   );
 
+  /** Flip the shared agent note layer, as the catalogued command declares that flip. */
+  const toggleAgentNotes = useCallback(() => {
+    const intent = lowerCommand("hunk.view.toggleAgentNotes");
+    if (intent) {
+      runIntent(intent);
+    }
+  }, [lowerCommand, runIntent]);
+
   /** Start one full-source load and mirror its progress into review state as a status. */
   const startSourceLoad = useCallback(
     (file: DiffFile, fileKey: string, side: SourceLoadRequest["side"]) => {
@@ -799,7 +832,34 @@ export function useReviewController({
     }
   }, [fileByKey, startSourceLoad, store, state.document]);
 
-  /** Toggle expansion of one collapsed gap and lazily load source when needed. */
+  /** Run one expansion toggle plus the line-cursor bookkeeping that belongs to the terminal. */
+  const applyGapToggle = useCallback(
+    (file: DiffFile, intent: Extract<ReviewIntent, { type: "expansion/toggle" }>) => {
+      const restorePointKey = `${file.id}:${intent.gapId}`;
+      const restorePoint = lineCursorBeforeExpandRef.current.get(restorePointKey) ?? null;
+      const cursorBeforeToggle = lineCursorRef.current;
+      // The intent decides whether this is an expand or a collapse and reports the side
+      // whose source fills the gap; the line-cursor bookkeeping below is the terminal's
+      // own, and reads that decision rather than predicting it.
+      const toggled = runIntent(intent);
+      if (toggled.expanded) {
+        if (cursorBeforeToggle) {
+          lineCursorBeforeExpandRef.current.set(restorePointKey, cursorBeforeToggle);
+        }
+        pendingLineCursorRef.current = { kind: "reveal", fileId: file.id, gapKey: intent.gapId };
+      } else {
+        lineCursorBeforeExpandRef.current.delete(restorePointKey);
+        pendingLineCursorRef.current = restorePoint
+          ? { kind: "restore", cursor: restorePoint }
+          : null;
+      }
+
+      startSourceLoad(file, intent.fileKey, toggled.side);
+    },
+    [runIntent, startSourceLoad],
+  );
+
+  /** Toggle expansion of one collapsed gap the renderer addressed by file id. */
   const toggleGap = useCallback(
     (fileId: string, gapKey: string) => {
       const file = allFiles.find((entry) => entry.id === fileId);
@@ -808,40 +868,23 @@ export function useReviewController({
         return;
       }
 
-      const restorePointKey = `${fileId}:${gapKey}`;
-      const restorePoint = lineCursorBeforeExpandRef.current.get(restorePointKey) ?? null;
-      const cursorBeforeToggle = lineCursorRef.current;
-      // The intent decides whether this is an expand or a collapse and reports the side
-      // whose source fills the gap; the line-cursor bookkeeping below is the terminal's
-      // own, and reads that decision rather than predicting it.
-      const toggled = runIntent({ type: "expansion/toggle", fileKey, gapId: gapKey });
-      if (toggled.expanded) {
-        if (cursorBeforeToggle) {
-          lineCursorBeforeExpandRef.current.set(restorePointKey, cursorBeforeToggle);
-        }
-        pendingLineCursorRef.current = { kind: "reveal", fileId, gapKey };
-      } else {
-        lineCursorBeforeExpandRef.current.delete(restorePointKey);
-        pendingLineCursorRef.current = restorePoint
-          ? { kind: "restore", cursor: restorePoint }
-          : null;
-      }
-
-      startSourceLoad(file, fileKey, toggled.side);
+      applyGapToggle(file, { type: "expansion/toggle", fileKey, gapId: gapKey });
     },
-    [allFiles, keyByFileId, runIntent, startSourceLoad],
+    [allFiles, applyGapToggle, keyByFileId],
   );
 
-  /** Toggle the collapsed gap nearest to the current hunk selection. */
+  /** Toggle the collapsed gap the catalogued "toggle unchanged context" command reaches. */
   const toggleSelectedHunkGap = useCallback(() => {
-    // Which gap "toggle unchanged context" reaches is the shared policy, not a terminal
-    // rule: the same command fired from anywhere else must land on the same gap.
-    const target = selectReviewGapForSelection(store.getSnapshot());
-    const file = target ? fileByKey.get(target.fileKey) : undefined;
-    if (target && file) {
-      toggleGap(file.id, target.gapId);
+    const intent = lowerCommand("hunk.review.toggleHunkGap");
+    if (intent?.type !== "expansion/toggle") {
+      return;
     }
-  }, [fileByKey, store, toggleGap]);
+
+    const file = fileByKey.get(intent.fileKey);
+    if (file?.sourceFetcher) {
+      applyGapToggle(file, intent);
+    }
+  }, [applyGapToggle, fileByKey, lowerCommand]);
 
   /**
    * Resolve one session-daemon navigation request against the current review and select it.
@@ -1215,16 +1258,21 @@ export function useReviewController({
         return null;
       }
 
-      // The draft's identity is the caller's to own, and where a whole-hunk note lands is
-      // the shared default; a measured cursor target overrides it.
+      // Where the note lands is the catalogued command's effect: the row this renderer
+      // measured when it has one, the shared whole-hunk default when it does not.
+      const intent = lowerCommand("hunk.review.startNote", {
+        noteLocation: { fileKey, hunkIndex },
+        ...(requestedTarget ? { noteTarget: requestedTarget } : {}),
+      });
+      if (intent?.type !== "notes/start-draft") {
+        return null;
+      }
+
+      // The draft's identity is the caller's to own, and adopting a position the viewport
+      // already settled on is the shared anchor policy, so such a draft asks for no reveal.
       const { draft } = runIntent(
         {
-          type: "notes/start-draft",
-          fileKey,
-          hunkIndex,
-          ...(requestedTarget ? { target: requestedTarget } : {}),
-          // Adopting a position the viewport already settled on is the shared anchor
-          // policy, so the draft asks for no reveal at all in that case.
+          ...intent,
           ...(options?.preserveViewport ? { reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL } : {}),
         },
         { draftId: `draft:${file.id}:${hunkIndex}:${Date.now()}` },
@@ -1239,6 +1287,7 @@ export function useReviewController({
       applyLineCursor,
       keyByFileId,
       lineCursors,
+      lowerCommand,
       runIntent,
       selectedFile?.id,
       selectedHunkIndex,
@@ -1415,6 +1464,7 @@ export function useReviewController({
     selectFile,
     selectHunk,
     setShowAgentNotes,
+    toggleAgentNotes,
     startUserNote,
     setFilter,
     updateDraftNote,

--- a/src/ui/lib/agentAnnotations.ts
+++ b/src/ui/lib/agentAnnotations.ts
@@ -1,11 +1,20 @@
 import type { Hunk } from "@pierre/diffs";
 import type { AgentAnnotation, DiffFile, ReviewNoteSource } from "../../core/types";
 import { reviewAnnotationOverlapsHunk } from "../../core/review/annotations";
+import { resolveReviewNoteAnchor, reviewGapOwnerHunkIndex } from "../../core/review/anchors";
+import type { ReviewHunkSpan } from "../../core/review/geometry";
+import type { ReviewLineAddressV1, ReviewRangeAnchorV1 } from "../../core/review/types";
 import { fileLabel } from "./files";
 
 export interface VisibleAgentNote {
   id: string;
   annotation: AgentAnnotation;
+  /**
+   * Where this note hangs, as the shared resolver decided it: the owning hunk plus the
+   * line the card sits beside. Render planning places the card from this and never from
+   * range containment against the rows it happens to have drawn.
+   */
+  anchor: ReviewRangeAnchorV1;
   source?: ReviewNoteSource | "draft";
   editable?: boolean;
   draft?: {
@@ -71,6 +80,46 @@ export function annotationAnchor(annotation: AgentAnnotation): AnnotationAnchor 
   }
 
   return null;
+}
+
+/** One note's declared target, from the surface that knows where the note was written. */
+export interface VisibleNoteTarget extends ReviewLineAddressV1 {
+  hunkIndex: number;
+}
+
+/**
+ * Builds one note the review stream draws, resolving where it hangs through core.
+ *
+ * Every kind of note goes through here — sidecar annotations, agent live comments, the
+ * reviewer's own notes, and the open draft — so ownership is decided once by the shared
+ * resolver. A note that declares its target keeps it; one that only carries ranges hangs
+ * from the line those ranges start at, and from the hunk owning the gap that line falls
+ * in when no hunk contains it at all.
+ */
+export function createVisibleAgentNote(
+  hunks: readonly ReviewHunkSpan[],
+  note: Omit<VisibleAgentNote, "anchor"> & { target?: VisibleNoteTarget },
+): VisibleAgentNote {
+  const { target, ...visible } = note;
+  const rangeAnchor = annotationAnchor(note.annotation);
+  const preferred: ReviewLineAddressV1 | undefined = target
+    ? { side: target.side, line: target.line }
+    : rangeAnchor
+      ? { side: rangeAnchor.side, line: rangeAnchor.lineNumber }
+      : undefined;
+  const fallbackOwnerHunkIndex =
+    target?.hunkIndex ??
+    (preferred ? reviewGapOwnerHunkIndex(hunks, preferred.side, preferred.line) : undefined);
+
+  return {
+    ...visible,
+    anchor: resolveReviewNoteAnchor(hunks, {
+      ...(note.annotation.oldRange ? { oldRange: note.annotation.oldRange } : {}),
+      ...(note.annotation.newRange ? { newRange: note.annotation.newRange } : {}),
+      ...(preferred ? { preferred } : {}),
+      ...(fallbackOwnerHunkIndex !== undefined ? { fallbackOwnerHunkIndex } : {}),
+    }),
+  };
 }
 
 function formatGithubStyleRange(prefix: "L" | "R", range: [number, number]) {

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -11,6 +11,7 @@ import {
   nextMenuItemIndex,
   type MenuEntry,
 } from "../components/chrome/menu";
+import { createVisibleAgentNote } from "./agentAnnotations";
 import { buildAgentPopoverContent, resolveAgentPopoverPlacement, wrapText } from "./agentPopover";
 import { isEscapeKey, isSaveDraftNoteKey } from "./keyboard";
 import {
@@ -491,14 +492,14 @@ describe("ui helpers", () => {
       true,
       theme,
       [
-        {
+        createVisibleAgentNote(file.metadata.hunks, {
           id: "annotation:example:0",
           annotation: {
             newRange: [1, 1],
             summary: "Explain the changed line",
             rationale: "Keep the inline note height in placeholder math.",
           },
-        },
+        }),
       ],
       120,
     );

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -336,6 +336,51 @@ export function createPtyHarness() {
     return { dir, before, after, agentContext };
   }
 
+  /**
+   * Two hunks with a collapsed gap between them, annotated on a line inside that gap.
+   *
+   * The annotated lines are unchanged context the patch omits, so no rendered row carries
+   * them: the note has to hang from the hunk owning the gap rather than from the file's
+   * first row.
+   */
+  function createGapAnnotatedAgentFilePair() {
+    const dir = makeTempDir("hunk-tuistory-gap-note-");
+    const before = join(dir, "before.ts");
+    const after = join(dir, "after.ts");
+    const agentContext = join(dir, "agent.json");
+
+    const beforeLines = Array.from(
+      { length: 12 },
+      (_, index) => `export const line${index + 1} = ${index + 1};`,
+    );
+    const afterLines = [...beforeLines];
+    afterLines[1] = "export const line2 = 200;";
+    afterLines[10] = "export const line11 = 1100;";
+
+    writeText(before, `${beforeLines.join("\n")}\n`);
+    writeText(after, `${afterLines.join("\n")}\n`);
+    writeText(
+      agentContext,
+      JSON.stringify({
+        version: 1,
+        files: [
+          {
+            path: "after.ts",
+            annotations: [
+              {
+                newRange: [6, 7],
+                summary: "GAP NOTE",
+                rationale: "Anchored to lines the patch collapsed away.",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    return { dir, before, after, agentContext };
+  }
+
   function createAgentNavigationRepoFixture() {
     const alphaBeforeLines = createNumberedExportLines(1, 80).split("\n");
     const alphaAfterLines = [...alphaBeforeLines];
@@ -983,6 +1028,7 @@ end
     countMatches,
     createAgentFilePair,
     createAgentNavigationRepoFixture,
+    createGapAnnotatedAgentFilePair,
     createBottomClampedRepoFixture,
     createCollapsedTopRepoFixture,
     createExpandableContextFilePair,

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -61,6 +61,37 @@ describe("PTY notes", () => {
     }
   });
 
+  test("a note anchored to collapsed lines renders inside its owning hunk", async () => {
+    const fixture = harness.createGapAnnotatedAgentFilePair();
+    const session = await harness.launchHunk({
+      args: [
+        "diff",
+        fixture.before,
+        fixture.after,
+        "--mode",
+        "split",
+        "--agent-context",
+        fixture.agentContext,
+      ],
+      cols: 140,
+      rows: 30,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.press("a");
+      const withNotes = await session.waitForText(/GAP NOTE/, { timeout: 5_000 });
+
+      // Lines 6-7 are collapsed away, so the note hangs from the hunk that owns the gap:
+      // it lands just below that hunk's first row, not at the top of the file.
+      const noteIndex = lineIndexOf(withNotes, "GAP NOTE");
+      expect(noteIndex).toBeGreaterThan(lineIndexOf(withNotes, "line8 = 8;"));
+      expect(noteIndex).toBeLessThan(lineIndexOf(withNotes, "line9 = 9;"));
+    } finally {
+      session.close();
+    }
+  });
+
   test("experimental launches render STML note bodies", async () => {
     const fixture = harness.createAgentFilePair();
     const session = await harness.launchHunk({


### PR DESCRIPTION
The substantive PR of the cleanup series (follows #736): the terminal was running parallel implementations of three policies that `src/core/review/` already owns, with real divergences. Each finding is one commit; the terminal now consumes core and the parallel paths are deleted.

## 1. Note placement comes from core anchor resolution — fixes a visible bug

Core's `resolveReviewNoteAnchor` decides which hunk owns a note and which line it prefers, including a fallback branch for ranges the current patch collapsed. The terminal ignored it: `reviewRenderPlan.ts` re-derived ownership by intersecting each note's raw `oldRange`/`newRange` with rendered rows, and `DiffPane` built visible notes from raw annotations, discarding the anchors `reviewProjection` had already computed. The divergence was user-visible: a note anchored to lines that no rendered row contains (collapsed into a gap, or an expanded-away range) found no matching row and fell back to `fileLineRows[0]` — **the note rendered at the top of the file instead of beside its owning hunk**. All note kinds now flow through core's resolution once, the render plan places notes by the resolved anchor (nearest row at-or-after the preferred line within the owning hunk), and the containment path is deleted. Regression tests pin the collapsed-range case at the render-plan level plus a PTY test observing the fix live; the changeset is `patch` for this fix.

## 2. Reveal target comes from `selectActiveRevealNoteId`

Core's selector (draft in the selected hunk wins; else earliest anchor line, arrival order breaking ties) had zero production importers while `DiffPane` re-decided the target geometrically — first note row whose measured top falls inside the selected hunk's bounds, i.e. *rendered* order, a different tiebreak. `DiffPane` now resolves the note row by the id the selector returns (via the existing `rowBoundsByStableKey` mapping) and the geometric scan is gone. This intentionally changes which note wins when several share a hunk; the core tiebreak is pinned in a UI-level test.

## 3. Commands execute the review effects the catalog declares

`lowerAppCommandToReviewIntent` existed so the command catalog's declared `review` effects would be the ones that run, but its only consumer was its own test — `useReviewController` restated the same three intents by hand (`notes/set-visibility`, the gap toggle, `notes/start-draft`). The three handlers now route through the lowering; terminal-owned bookkeeping (draft ids, cursor restore points, viewport reveals) stays in the hook wrapping the produced intent. Tests assert the catalog effect and the executed intent agree for all three commands.

## Gates

`bun run typecheck` clean. Full `bun test`: 2844 tests, failures limited to the environment's pre-existing baseline (two `@axe-core/playwright` website spec errors and PTY flakes under parallel load — the wiring-relevant suites plus the flaky PTY chrome test pass 88/88 in isolation). `bun run lint` 0/0; `bun run format:check` clean. Rebased onto current main (post-#736). A real-TTY smoke run isn't possible in this headless environment; PTY integration coverage stands in.

---
_Generated by [Claude Code](https://claude.ai/code/session_018L6h5GBz6RAxRXbgUS4mx4)_