### PR TITLE
fix(vcs): backport untracked diff synthesis to 0.18.x

### DIFF
--- a/.changeset/slow-untracked-diff.md
+++ b/.changeset/slow-untracked-diff.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix `hunk diff` taking tens of seconds in repos with many untracked files by synthesizing untracked diffs in-process instead of spawning one `git diff --no-index` subprocess per file.

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { SourceTextTooLargeError } from "./fileSource";
@@ -439,7 +447,8 @@ describe("loadAppBootstrap", () => {
       "example.ts",
       "new-file.ts",
     ]);
-    expect(bootstrap.changeset.files[1]?.patch).toContain("new file mode");
+    expect(bootstrap.changeset.files[1]?.metadata.type).toBe("new");
+    expect(bootstrap.changeset.files[1]?.patch).toContain("+export const added = true;");
   });
 
   slTest(
@@ -564,6 +573,59 @@ describe("loadAppBootstrap", () => {
       "tracked.ts",
       "new-file.ts",
     ]);
+  });
+
+  test("reviews untracked file symlinks as links without following their targets", async () => {
+    const dir = createTempRepo("hunk-git-untracked-file-symlink-");
+
+    writeFileSync(join(dir, "target.txt"), "real contents\n");
+    git(dir, "add", "target.txt");
+    git(dir, "commit", "-m", "initial");
+
+    symlinkSync("target.txt", join(dir, "good-link"));
+    symlinkSync("missing-file", join(dir, "dangling-link"));
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    const good = bootstrap.changeset.files.find((file) => file.path === "good-link");
+    expect(good?.metadata.type).toBe("new");
+    expect(good?.patch).toContain("new file mode 120000");
+    expect(good?.patch).toContain("+target.txt");
+    expect(good?.patch).not.toContain("real contents");
+
+    // A dangling symlink has no target to read, but its link line still reviews.
+    const dangling = bootstrap.changeset.files.find((file) => file.path === "dangling-link");
+    expect(dangling?.patch).toContain("new file mode 120000");
+    expect(dangling?.patch).toContain("+missing-file");
+  });
+
+  // Windows has no Unix execute bits, so the mode distinction only exists on POSIX.
+  const unixTest = platform() === "win32" ? test.skip : test;
+  unixTest("reports untracked executable files with git's 100755 mode", async () => {
+    const dir = createTempRepo("hunk-git-untracked-exec-");
+
+    writeFileSync(join(dir, "tracked.ts"), "export const tracked = 1;\n");
+    git(dir, "add", "tracked.ts");
+    git(dir, "commit", "-m", "initial");
+
+    writeFileSync(join(dir, "script.sh"), "#!/bin/sh\necho hi\n");
+    chmodSync(join(dir, "script.sh"), 0o755);
+    writeFileSync(join(dir, "plain.txt"), "not executable\n");
+
+    const bootstrap = await loadFromRepo(dir, {
+      kind: "vcs",
+      staged: false,
+      options: { mode: "auto" },
+    });
+
+    const script = bootstrap.changeset.files.find((file) => file.path === "script.sh");
+    expect(script?.patch).toContain("new file mode 100755");
+    const plain = bootstrap.changeset.files.find((file) => file.path === "plain.txt");
+    expect(plain?.patch).toContain("new file mode 100644");
   });
 
   test("can exclude untracked files from working tree reviews", async () => {
@@ -741,7 +803,8 @@ describe("loadAppBootstrap", () => {
     });
 
     expect(bootstrap.changeset.files.map((file) => file.path)).toEqual(["untracked.ts"]);
-    expect(bootstrap.changeset.files[0]?.patch).toContain("new file mode");
+    expect(bootstrap.changeset.files[0]?.metadata.type).toBe("new");
+    expect(bootstrap.changeset.files[0]?.patch).toContain("+export const added = true;");
   });
 
   test("still shows an untracked agent sidecar when it lives inside the repo", async () => {

--- a/src/core/loaders.test.ts
+++ b/src/core/loaders.test.ts
@@ -18,6 +18,8 @@ import { computeWatchSignature } from "./watch";
 
 const tempDirs: string[] = [];
 
+// Git setup for source-cap coverage can exceed Bun's default 5s timeout on Windows CI.
+const GitLargeSourceLoaderIntegrationTestTimeoutMs = 30_000;
 // Jujutsu subprocess setup can exceed Bun's default 5s test timeout on Windows CI.
 const JjLoaderIntegrationTestTimeoutMs = 20_000;
 // Sapling subprocess setup can exceed Bun's default 5s test timeout on slower machines.
@@ -1931,31 +1933,35 @@ describe("loadAppBootstrap source fetcher attachment", () => {
     expect(await file?.sourceFetcher?.getFullText("old")).toBe("first\n");
   });
 
-  test("`hunk show <ref>` refuses to expand source blobs above the source cap", async () => {
-    const dir = createTempRepo("hunk-source-show-large-");
-    const lines = Array.from({ length: 130_000 }, (_, index) => `line ${index + 1}`);
-    writeFileSync(join(dir, "large.txt"), `${lines.join("\n")}\n`);
-    git(dir, "add", "large.txt");
-    git(dir, "commit", "-m", "initial");
+  test(
+    "`hunk show <ref>` refuses to expand source blobs above the source cap",
+    async () => {
+      const dir = createTempRepo("hunk-source-show-large-");
+      const lines = Array.from({ length: 130_000 }, (_, index) => `line ${index + 1}`);
+      writeFileSync(join(dir, "large.txt"), `${lines.join("\n")}\n`);
+      git(dir, "add", "large.txt");
+      git(dir, "commit", "-m", "initial");
 
-    lines[65_000] = "line 65001 changed";
-    writeFileSync(join(dir, "large.txt"), `${lines.join("\n")}\n`);
-    git(dir, "add", "large.txt");
-    git(dir, "commit", "-m", "change middle line");
+      lines[65_000] = "line 65001 changed";
+      writeFileSync(join(dir, "large.txt"), `${lines.join("\n")}\n`);
+      git(dir, "add", "large.txt");
+      git(dir, "commit", "-m", "change middle line");
 
-    const bootstrap = await loadFromRepo(dir, {
-      kind: "show",
-      ref: "HEAD",
-      options: { mode: "auto" },
-    });
+      const bootstrap = await loadFromRepo(dir, {
+        kind: "show",
+        ref: "HEAD",
+        options: { mode: "auto" },
+      });
 
-    const file = bootstrap.changeset.files[0];
-    expect(file?.sourceFetcher).toBeDefined();
-    expect(file?.metadata.hunks.length).toBeGreaterThan(0);
-    await expect(file?.sourceFetcher?.getFullText("new")).rejects.toBeInstanceOf(
-      SourceTextTooLargeError,
-    );
-  });
+      const file = bootstrap.changeset.files[0];
+      expect(file?.sourceFetcher).toBeDefined();
+      expect(file?.metadata.hunks.length).toBeGreaterThan(0);
+      await expect(file?.sourceFetcher?.getFullText("new")).rejects.toBeInstanceOf(
+        SourceTextTooLargeError,
+      );
+    },
+    GitLargeSourceLoaderIntegrationTestTimeoutMs,
+  );
 
   test("`hunk show <ref>` pins expansion sources after the ref moves", async () => {
     const dir = createTempRepo("hunk-source-show-pinned-");

--- a/src/core/vcs/git.ts
+++ b/src/core/vcs/git.ts
@@ -7,7 +7,6 @@ import {
   type ExtensionVcsStashShowInput,
 } from "../../extension-api/types";
 import { LARGE_DIFF_FILE_MAX_BYTES, LARGE_DIFF_FILE_MAX_LINES } from "./largeFile";
-import { escapeUntrackedPatchPath } from "../patch/normalize";
 import { normalizePathForOS } from "../../lib/osPath";
 
 /**
@@ -222,21 +221,6 @@ export function buildGitIgnoredDirectoryArgs() {
     "--directory",
     "-z",
   ];
-}
-
-/** Build the synthetic patch used to render one untracked file as a new-file diff. */
-function buildGitNewFileDiffArgs(filePath: string) {
-  // `--no-ext-diff` keeps user-configured `diff.external` tools (difftastic, delta, etc.)
-  // from replacing the unified-diff output Pierre needs to parse this synthetic patch.
-  return withNormalizedDiffPrefixes([
-    "diff",
-    "--no-ext-diff",
-    "--no-index",
-    "--no-color",
-    "--",
-    "/dev/null",
-    filePath,
-  ]);
 }
 
 /** Build the exact `git show` arguments used for commit review. */
@@ -660,7 +644,7 @@ function isReviewableUntrackedPath(repoRoot: string, filePath: string) {
   try {
     pathInfo = fs.lstatSync(absolutePath);
   } catch {
-    // If the path disappeared after `git status`, let the downstream Git diff
+    // If the path disappeared after `git status`, let downstream synthesis
     // surface the same error path users would have seen before this filter.
     return true;
   }
@@ -674,8 +658,8 @@ function isReviewableUntrackedPath(repoRoot: string, filePath: string) {
   }
 
   try {
-    // Git reports directory symlinks as untracked paths, but `git diff --no-index`
-    // cannot synthesize a parseable file patch for them.
+    // Git reports directory symlinks as untracked paths, but Hunk cannot
+    // synthesize a file patch from a directory's contents.
     return !fs.statSync(absolutePath).isDirectory();
   } catch {
     // Broken symlinks still diff as reviewable path entries, so keep them.
@@ -715,52 +699,6 @@ export function listGitUntrackedFiles(
   return untrackedFiles.filter((filePath) =>
     isReviewableUntrackedPath(normalizedRepoRoot, filePath),
   );
-}
-
-/** Rewrite Git's quoted untracked-file headers into parser-friendly paths. */
-export function normalizeUntrackedPatchHeaders(patchText: string, filePath: string) {
-  const safePath = escapeUntrackedPatchPath(filePath);
-
-  return patchText
-    .replaceAll("\r\n", "\n")
-    .split("\n")
-    .map((line) => {
-      if (line.startsWith("diff --git ")) {
-        return `diff --git a/${safePath} b/${safePath}`;
-      }
-
-      if (line.startsWith("+++ ")) {
-        return `+++ b/${safePath}`;
-      }
-
-      if (line.startsWith("Binary files /dev/null and ")) {
-        return `Binary files /dev/null and b/${safePath} differ`;
-      }
-
-      return line;
-    })
-    .join("\n");
-}
-
-/** Return the raw Git patch text for one untracked file using `git diff --no-index`. */
-export function runGitUntrackedFileDiffText(
-  input: ExtensionVcsDiffInput,
-  filePath: string,
-  {
-    cwd = process.cwd(),
-    repoRoot,
-    gitExecutable = "git",
-  }: Omit<RunGitTextOptions, "input" | "args"> & { repoRoot?: string } = {},
-) {
-  const normalizedRepoRoot = repoRoot ?? resolveGitRepoRoot(input, { cwd, gitExecutable });
-
-  return runGitCommand({
-    input,
-    args: buildGitNewFileDiffArgs(filePath),
-    cwd: normalizedRepoRoot,
-    gitExecutable,
-    acceptedExitCodes: [0, 1],
-  }).stdout;
 }
 
 export interface GitMetadata {

--- a/src/core/vcs/untracked.ts
+++ b/src/core/vcs/untracked.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { join } from "node:path";
 import { createSkippedBinaryMetadata, isProbablyBinaryFile } from "../binary";
 import { buildDiffFile, createSkippedLargeMetadata } from "../diffFile";
+import { createFileSourceFetcher } from "../fileSource";
 import { inspectLargeUntrackedFile } from "./largeFile";
 import { escapeUntrackedPatchPath } from "../patch/normalize";
 import { parseSingleFilePatch } from "../patch/singleFile";
@@ -31,6 +32,24 @@ export function buildSkippedLargeUntrackedDiffFile(
   });
 }
 
+/** Wrap synthesized added-file hunks in the git-style header patch consumers parse. */
+function buildUntrackedPatchText(safePath: string, mode: string, contents: string) {
+  const body = createTwoFilesPatch("/dev/null", safePath, "", contents, "", "", {
+    context: 3,
+  }).replaceAll("\r\n", "\n");
+
+  // Replace jsdiff's "===" banner with the git-style header every patch
+  // consumer parses, so the file is typed as an addition, not a change.
+  return [
+    `diff --git a/${safePath} b/${safePath}`,
+    `new file mode ${mode}`,
+    ...body
+      .split("\n")
+      .slice(1)
+      .map((line) => (line.startsWith("+++ ") ? `+++ b/${safePath}` : line)),
+  ].join("\n");
+}
+
 /** Build one filesystem-backed untracked file diff from its current contents. */
 export function buildFilesystemUntrackedDiffFile(
   repoRoot: string,
@@ -39,6 +58,29 @@ export function buildFilesystemUntrackedDiffFile(
   sourcePrefix: string,
 ) {
   const absolutePath = join(repoRoot, filePath);
+  const safePath = escapeUntrackedPatchPath(filePath);
+
+  // Diff a symlink as Git does — mode 120000 whose one line is the link target —
+  // instead of dereferencing it. This also keeps dangling symlinks reviewable
+  // rather than failing the whole load on the missing target.
+  let linkTarget: string | null = null;
+  try {
+    if (fs.lstatSync(absolutePath).isSymbolicLink()) {
+      linkTarget = fs.readlinkSync(absolutePath);
+    }
+  } catch {
+    // A path that vanished after being listed falls through to the regular
+    // read below, which surfaces the same missing-file error as before.
+  }
+  if (linkTarget !== null) {
+    const patch = buildUntrackedPatchText(safePath, "120000", linkTarget);
+    // No source fetcher: reading the path would dereference the link, and the
+    // patch already carries the only content a symlink has.
+    return buildDiffFile(parseSingleFilePatch(patch, filePath), patch, index, sourcePrefix, null, {
+      isUntracked: true,
+    });
+  }
+
   const largeFileCheck = inspectLargeUntrackedFile(repoRoot, filePath);
   if (largeFileCheck.shouldSkip) {
     return buildSkippedLargeUntrackedDiffFile(filePath, index, sourcePrefix, largeFileCheck);
@@ -55,17 +97,28 @@ export function buildFilesystemUntrackedDiffFile(
     );
   }
 
-  const patch = createTwoFilesPatch(
-    "/dev/null",
-    escapeUntrackedPatchPath(filePath),
-    "",
-    fs.readFileSync(absolutePath, "utf8"),
-    "",
-    "",
-    { context: 3 },
-  ).replaceAll("\r\n", "\n");
+  // Git records exactly two regular-file modes: 100755 when any execute bit
+  // is set, 100644 otherwise.
+  let mode = "100644";
+  try {
+    if (fs.statSync(absolutePath).mode & 0o111) {
+      mode = "100755";
+    }
+  } catch {
+    // A vanished path surfaces its missing-file error from the read below.
+  }
+  const patch = buildUntrackedPatchText(safePath, mode, fs.readFileSync(absolutePath, "utf8"));
 
   return buildDiffFile(parseSingleFilePatch(patch, filePath), patch, index, sourcePrefix, null, {
     isUntracked: true,
+    // An added file has no old side; the new side reads the working copy so
+    // source-backed features treat synthesized untracked files like any other.
+    sourceFetcherBuilder: (file) =>
+      file.isBinary
+        ? undefined
+        : createFileSourceFetcher({
+            old: { kind: "none" },
+            new: { kind: "fs", absolutePath },
+          }),
   });
 }

--- a/src/extensions/default/vcs/git/index.test.ts
+++ b/src/extensions/default/vcs/git/index.test.ts
@@ -105,7 +105,7 @@ describe("GitVcsAdapter", () => {
     expect(result.title).toContain("working tree");
     expect(result.patchText).toContain("diff --git a/tracked.txt b/tracked.txt");
     expect(result.patchText).toContain("+new");
-    expect(result.extraFiles?.map((file) => file.path)).toContain("untracked.txt");
+    expect(result.untrackedPaths).toContain("untracked.txt");
     expect(result.sourceCacheKey).toContain("git-source-v1");
 
     const equivalentResult = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, {
@@ -125,12 +125,10 @@ describe("GitVcsAdapter", () => {
     });
     expect(changedIndexResult.sourceCacheKey).not.toBe(result.sourceCacheKey);
 
-    // The untracked file is reported as its own one-file patch rather than as a
-    // path Hunk reads back, so Git's own binary detection and quoting decide
-    // what it says.
-    const untracked = result.extraFiles?.find((file) => file.path === "untracked.txt");
-    expect(untracked?.kind).toBe("patch");
-    expect(untracked?.isUntracked).toBe(true);
+    // Untracked files come back as paths for Hunk to synthesize in-process:
+    // one `git status` covers all of them instead of one `git diff --no-index`
+    // subprocess per file, which made review scale with the untracked count.
+    expect(result.extraFiles ?? []).toHaveLength(0);
   });
 
   test("loads revision and stash patches through adapter operations", async () => {

--- a/src/extensions/default/vcs/git/index.ts
+++ b/src/extensions/default/vcs/git/index.ts
@@ -8,7 +8,6 @@ import {
   buildGitStashShowArgs,
   listGitIgnoredDirectoryRoots,
   listGitUntrackedFiles,
-  normalizeUntrackedPatchHeaders,
   parseGitNumstat,
   resolveGitColorMovedOptions,
   resolveGitCommitRef,
@@ -16,13 +15,11 @@ import {
   resolveGitMetadata,
   resolveGitRepoRoot,
   runGitText,
-  runGitUntrackedFileDiffText,
   shouldSkipLargeTrackedDiff,
   type GitBackedInput,
   type GitDiffEndpoints,
 } from "../../../../core/vcs/git";
 import { gitEndpointSourceSpec, readGitFileSource } from "../../../../core/vcs/gitSource";
-import { inspectLargeUntrackedFile } from "../../../../core/vcs/largeFile";
 import {
   HUNK_CORE_VCS_DETECTION_PRIORITY,
   type ExtensionVcsAdapter,
@@ -191,47 +188,6 @@ function createGitDiffSourceCapability(
 }
 
 /* -------------------------------------------------------------------------- */
-/* Files reviewed outside the main patch                                       */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Describe one untracked file for review.
- *
- * Git renders the addition itself rather than Hunk reading the working copy, so
- * its own binary detection and path quoting decide what the patch says — the
- * same output `git diff` would have produced for a tracked file.
- */
-function buildUntrackedExtraFile(
-  input: ExtensionVcsDiffInput,
-  filePath: string,
-  repoRoot: string,
-  gitExecutable: string,
-): ExtensionVcsExtraFile {
-  const largeFileCheck = inspectLargeUntrackedFile(repoRoot, filePath);
-  if (largeFileCheck.shouldSkip) {
-    return {
-      kind: "skipped",
-      path: filePath,
-      reason: "too-large",
-      changeType: "new",
-      isUntracked: true,
-      stats: largeFileCheck.stats,
-      statsTruncated: largeFileCheck.statsTruncated,
-    };
-  }
-
-  return {
-    kind: "patch",
-    path: filePath,
-    isUntracked: true,
-    patchText: normalizeUntrackedPatchHeaders(
-      runGitUntrackedFileDiffText(input, filePath, { repoRoot, gitExecutable }),
-      filePath,
-    ),
-  };
-}
-
-/* -------------------------------------------------------------------------- */
 /* Watch plans                                                                 */
 /* -------------------------------------------------------------------------- */
 
@@ -347,20 +303,20 @@ export const GitVcsAdapter = {
             gitExecutable,
           }),
           ...sourceCapability,
-          extraFiles: [
-            ...largeTrackedFiles.map(
-              (file): ExtensionVcsExtraFile => ({
-                kind: "skipped",
-                path: file.path,
-                reason: "too-large",
-                changeType: "change",
-                stats: { additions: file.additions, deletions: file.deletions },
-              }),
-            ),
-            ...listGitUntrackedFiles(input, { cwd, repoRoot, gitExecutable }).map((filePath) =>
-              buildUntrackedExtraFile(input, filePath, repoRoot, gitExecutable),
-            ),
-          ],
+          extraFiles: largeTrackedFiles.map(
+            (file): ExtensionVcsExtraFile => ({
+              kind: "skipped",
+              path: file.path,
+              reason: "too-large",
+              changeType: "change",
+              stats: { additions: file.additions, deletions: file.deletions },
+            }),
+          ),
+          // One `git status` lists the paths; Hunk synthesizes each added-file
+          // diff in-process. Rendering them through `git diff --no-index`
+          // instead costs one subprocess per file, which made working-tree
+          // review scale with the untracked file count.
+          untrackedPaths: listGitUntrackedFiles(input, { cwd, repoRoot, gitExecutable }),
         };
       },
       watchPlan(input, { cwd, gitExecutable = "git" }) {


### PR DESCRIPTION
## Summary

- Backport the untracked-file performance fix from #738 onto the `0.18.x` release line.
- Use the existing `untrackedPaths` contract so one `git status` replaces one synchronous `git diff --no-index` subprocess per untracked file.
- Preserve Git-style new-file modes, symlink handling, parser-safe paths, large/binary placeholders, and working-copy source fetching.
- Add a patch changeset for the prospective 0.18.2 release.

## Backport notes

The release branch still owns Git command helpers in `src/core/vcs/git.ts`, while main moved them into the bundled Git extension. This adapts the upstream helper removal to the 0.18.x layout without backporting the intervening architecture changes. The unrelated scrollbar timing-test change bundled into the upstream squash commit is intentionally omitted.

## Validation

- `bun test src/core/loaders.test.ts src/core/vcs src/extensions/default/vcs/git` — 134 passed, 3 skipped
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- Synthetic 100-untracked-file check: 106 Git calls / 100 `--no-index` calls on v0.18.1, reduced to 6 / 0 with this backport

*This PR description was generated by Pi using gpt-5.6-sol*
