### PR TITLE
fix(ui): stabilize theme picker mouse previews

### DIFF
--- a/.changeset/calm-themes-scroll.md
+++ b/.changeset/calm-themes-scroll.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Make the theme picker scroll independently, preview themes after a brief hover, and apply them on click.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1418,7 +1418,8 @@ export function App({
     [themeSelectorItems],
   );
 
-  const pickThemeSelectorItem = useCallback(
+  /** Preview the theme under the pointer without committing it. */
+  const previewThemeSelectorItem = useCallback(
     (index: number) => {
       const item = themeSelectorItems[index];
       if (!item) {
@@ -1434,16 +1435,24 @@ export function App({
     [themeSelectorItems],
   );
 
-  const acceptThemeSelector = useCallback(() => {
-    const item = themeSelectorItems[themeSelectorState.selectedIndex];
-    if (!item) {
-      return;
-    }
+  /** Commit one theme and close the selector. */
+  const acceptThemeSelectorItem = useCallback(
+    (index: number) => {
+      const item = themeSelectorItems[index];
+      if (!item) {
+        return;
+      }
 
-    selectTheme(item.id);
-    // Close without a preview id; the committed theme id now supplies the same effective theme.
-    setThemeSelectorState((current) => ({ ...current, open: false, previewThemeId: null }));
-  }, [selectTheme, themeSelectorState.selectedIndex, themeSelectorItems]);
+      selectTheme(item.id);
+      // Close without a preview id; the committed theme id now supplies the same effective theme.
+      setThemeSelectorState((current) => ({ ...current, open: false, previewThemeId: null }));
+    },
+    [selectTheme, themeSelectorItems],
+  );
+
+  const acceptThemeSelector = useCallback(() => {
+    acceptThemeSelectorItem(themeSelectorState.selectedIndex);
+  }, [acceptThemeSelectorItem, themeSelectorState.selectedIndex]);
 
   /** Toggle the sidebar, forcing it open on narrower layouts when the app can still fit both panes. */
   const toggleSidebar = () => {
@@ -2442,9 +2451,9 @@ export function App({
             terminalHeight={terminal.height}
             terminalWidth={terminal.width}
             theme={baseTheme}
+            onAcceptItem={acceptThemeSelectorItem}
             onClose={closeThemeSelector}
-            onPickItem={pickThemeSelectorItem}
-            onScroll={moveThemeSelector}
+            onPreviewItem={previewThemeSelectorItem}
           />
         </Suspense>
       ) : null}

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -847,7 +847,7 @@ describe("App interactions", () => {
         await setup.mockInput.typeText("t");
       });
       let frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("Theme selector"));
-      expect(frame).toContain("↑/↓/Tab preview  Enter accept  Esc cancel");
+      expect(frame).toContain("↑/↓/Tab/hover preview  Enter/click accept  Esc cancel");
       expect(frame).toContain("›  github-dark-default");
       expect(frame).toContain("active");
 
@@ -873,7 +873,7 @@ describe("App interactions", () => {
     }
   });
 
-  test("theme selector mouse hover does not preview and click selects without accepting", async () => {
+  test("theme selector waits for mouse hover to settle before previewing", async () => {
     const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
       width: 240,
       height: 24,
@@ -889,29 +889,36 @@ describe("App interactions", () => {
       expect(frame).toContain("›  github-dark-default");
 
       const lines = frame.split("\n");
-      const targetY = lines.findIndex((line) => line.includes("github-dark-dimmed"));
-      expect(targetY).toBeGreaterThanOrEqual(0);
-      const targetX = Math.max(0, lines[targetY]!.indexOf("github-dark-dimmed"));
+      const dimmedY = lines.findIndex((line) => line.includes("github-dark-dimmed"));
+      const highContrastY = lines.findIndex((line) => line.includes("github-dark-high-contrast"));
+      expect(dimmedY).toBeGreaterThanOrEqual(0);
+      expect(highContrastY).toBeGreaterThanOrEqual(0);
+      const targetX = Math.max(0, lines[dimmedY]!.indexOf("github-dark-dimmed"));
 
       await act(async () => {
-        await setup.mockMouse.moveTo(targetX, targetY);
+        await setup.mockMouse.moveTo(targetX, dimmedY);
+        await setup.mockMouse.moveTo(targetX, highContrastY);
       });
       await flush(setup);
       frame = setup.captureCharFrame();
       expect(frame).toContain("›  github-dark-default");
       expect(frame).not.toContain("›  github-dark-dimmed");
+      expect(frame).not.toContain("›  github-dark-high-contrast");
 
       await act(async () => {
-        await setup.mockMouse.click(targetX, targetY);
-      });
-      frame = await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
-      expect(frame).toContain("Theme selector");
-
-      await act(async () => {
-        await setup.mockInput.pressEnter();
+        await new Promise((resolve) => setTimeout(resolve, 250));
       });
       frame = await waitForFrame(setup, (nextFrame) =>
-        nextFrame.includes("Theme: github-dark-dimmed"),
+        nextFrame.includes("›  github-dark-high-contrast"),
+      );
+      expect(frame).toContain("Theme selector");
+      expect(frame).not.toContain("›  github-dark-default");
+
+      await act(async () => {
+        await setup.mockMouse.click(targetX, highContrastY);
+      });
+      frame = await waitForFrame(setup, (nextFrame) =>
+        nextFrame.includes("Theme: github-dark-high-contrast"),
       );
       expect(frame).not.toContain("Theme selector");
     } finally {
@@ -921,7 +928,7 @@ describe("App interactions", () => {
     }
   });
 
-  test("theme selector mouse wheel previews the next row", async () => {
+  test("theme selector mouse wheel scrolls the window without changing the preview", async () => {
     const setup = await testRender(<AppHost bootstrap={createSingleFileBootstrap()} />, {
       width: 240,
       height: 24,
@@ -936,13 +943,20 @@ describe("App interactions", () => {
       const frame = await waitForFrame(setup, (nextFrame) =>
         nextFrame.includes("›  github-dark-default"),
       );
+      expect(frame).not.toContain("gruvbox-dark-medium");
       const selectedY = frame.split("\n").findIndex((line) => line.includes("github-dark-default"));
       expect(selectedY).toBeGreaterThanOrEqual(0);
 
       await act(async () => {
         await setup.mockMouse.scroll(120, selectedY, "down");
       });
-      await waitForFrame(setup, (nextFrame) => nextFrame.includes("›  github-dark-dimmed"));
+      await waitForFrame(
+        setup,
+        (nextFrame) =>
+          nextFrame.includes("gruvbox-dark-medium") &&
+          nextFrame.includes("›  github-dark-default") &&
+          !nextFrame.includes("›  github-dark-dimmed"),
+      );
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/components/chrome/ThemeSelectorDialog.tsx
+++ b/src/ui/components/chrome/ThemeSelectorDialog.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent as TuiMouseEvent } from "@opentui/core";
+import { useEffect, useRef, useState } from "react";
 import { listWindowStart } from "../../lib/listWindow";
 import { fitText, padText } from "../../lib/text";
 import type { AppTheme } from "../../themes";
@@ -11,6 +12,8 @@ export interface ThemeSelectorItem {
   active: boolean;
 }
 
+const THEME_HOVER_PREVIEW_DELAY_MS = 200;
+
 /** Render an opencode-style selector for Hunk themes. */
 export function ThemeSelectorDialog({
   items,
@@ -18,26 +21,71 @@ export function ThemeSelectorDialog({
   terminalHeight,
   terminalWidth,
   theme,
+  onAcceptItem,
   onClose,
-  onPickItem,
-  onScroll,
+  onPreviewItem,
 }: {
   items: ThemeSelectorItem[];
   selectedIndex: number;
   terminalHeight: number;
   terminalWidth: number;
   theme: AppTheme;
+  onAcceptItem: (index: number) => void;
   onClose: () => void;
-  onPickItem: (index: number) => void;
-  onScroll: (delta: number) => void;
+  onPreviewItem: (index: number) => void;
 }) {
   const width = Math.min(82, Math.max(56, terminalWidth - 8));
   const modalHeight = Math.min(Math.max(12, terminalHeight - 4), 28);
   const bodyWidth = Math.max(1, width - 4);
   // ModalFrame contributes border/title/padding; reserve help/footer rows inside the body.
   const visibleRows = Math.max(4, modalHeight - 7);
-  const start = listWindowStart(selectedIndex, items.length, visibleRows);
-  const visibleItems = items.slice(start, start + visibleRows);
+  const [windowStart, setWindowStart] = useState(() =>
+    listWindowStart(selectedIndex, items.length, visibleRows),
+  );
+  const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const maxWindowStart = Math.max(0, items.length - visibleRows);
+
+  /** Cancel a hover preview that has not reached its dwell threshold. */
+  const cancelPendingPreview = () => {
+    if (previewTimeoutRef.current !== null) {
+      clearTimeout(previewTimeoutRef.current);
+      previewTimeoutRef.current = null;
+    }
+  };
+
+  /** Preview a theme only after the pointer remains over its row. */
+  const schedulePreview = (index: number) => {
+    cancelPendingPreview();
+    previewTimeoutRef.current = setTimeout(() => {
+      previewTimeoutRef.current = null;
+      onPreviewItem(index);
+    }, THEME_HOVER_PREVIEW_DELAY_MS);
+  };
+
+  // Keyboard selection changes keep their row visible and supersede pending pointer previews,
+  // while mouse-wheel scrolling can move the window without changing the current preview.
+  useEffect(() => {
+    cancelPendingPreview();
+    setWindowStart((current) => {
+      const clamped = Math.min(Math.max(current, 0), maxWindowStart);
+      if (selectedIndex < clamped) {
+        return Math.max(0, selectedIndex);
+      }
+      if (selectedIndex >= clamped + visibleRows) {
+        return Math.min(maxWindowStart, selectedIndex - visibleRows + 1);
+      }
+      return clamped;
+    });
+  }, [maxWindowStart, selectedIndex, visibleRows]);
+
+  useEffect(
+    () => () => {
+      cancelPendingPreview();
+    },
+    [],
+  );
+
+  const visibleItems = items.slice(windowStart, windowStart + visibleRows);
   const markerWidth = 3;
   const descriptionWidth = 12;
   const labelWidth = Math.max(8, bodyWidth - markerWidth - descriptionWidth - 2);
@@ -52,22 +100,23 @@ export function ThemeSelectorDialog({
       width={width}
       onClose={onClose}
       onMouseScroll={(event) => {
+        cancelPendingPreview();
         const direction = event.scroll?.direction;
         if (direction === "up") {
-          onScroll(-1);
+          setWindowStart((current) => Math.max(0, current - 1));
         } else if (direction === "down") {
-          onScroll(1);
+          setWindowStart((current) => Math.min(maxWindowStart, current + 1));
         }
       }}
     >
       <box style={{ width: "100%", height: 1 }}>
         <text fg={theme.muted}>
-          {fitText("↑/↓/Tab preview  Enter accept  Esc cancel", bodyWidth)}
+          {fitText("↑/↓/Tab/hover preview  Enter/click accept  Esc cancel", bodyWidth)}
         </text>
       </box>
       <box style={{ width: "100%", height: 1 }} />
       {visibleItems.map((item, offset) => {
-        const index = start + offset;
+        const index = windowStart + offset;
         const selected = index === selectedIndex;
         const marker = selected ? "›" : item.active ? "✓" : " ";
         const bg = selected ? theme.accentMuted : theme.panel;
@@ -77,9 +126,12 @@ export function ThemeSelectorDialog({
           <box
             key={item.id}
             style={{ width: "100%", height: 1, flexDirection: "row", backgroundColor: bg }}
+            onMouseOut={cancelPendingPreview}
+            onMouseOver={() => schedulePreview(index)}
             onMouseUp={(event: TuiMouseEvent) => {
               event.stopPropagation();
-              onPickItem(index);
+              cancelPendingPreview();
+              onAcceptItem(index);
             }}
           >
             <text fg={fg}>{padText(marker, markerWidth)}</text>
@@ -88,10 +140,10 @@ export function ThemeSelectorDialog({
           </box>
         );
       })}
-      {start + visibleRows < items.length ? (
+      {windowStart + visibleRows < items.length ? (
         <box style={{ width: "100%", height: 1 }}>
           <text fg={theme.muted}>
-            {fitText(`… ${items.length - start - visibleRows} more`, bodyWidth)}
+            {fitText(`… ${items.length - windowStart - visibleRows} more`, bodyWidth)}
           </text>
         </box>
       ) : null}

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -44,10 +44,12 @@ describe("PTY chrome", () => {
       expect(themeSelector).toContain("Theme selector");
 
       await session.click(/github-light-default/);
-      await session.press("enter");
       const themeSelected = await harness.waitForSnapshot(
         session,
-        (text) => text.includes("Adds bonus export.") && !text.includes("Theme selector"),
+        (text) =>
+          text.includes("Adds bonus export.") &&
+          text.includes("Theme: github-light-default") &&
+          !text.includes("Theme selector"),
         5_000,
       );
       expect(themeSelected).toContain("Adds bonus export.");


### PR DESCRIPTION
## Summary

- scroll the theme picker window without changing the selected or previewed theme
- preview a theme only after the pointer rests on its row for 200ms
- apply the clicked theme immediately and close the picker
- preserve immediate keyboard previews and acceptance

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun test src/ui/AppHost.interactions.test.tsx`
- `bun test test/pty/chrome.test.ts`

*This PR description was generated by Pi using gpt-5.6-sol*
