### PR TITLE
perf(app): skip the changeset graph for commands that never build one

### DIFF
--- a/.changeset/defer-startup-graph.md
+++ b/.changeset/defer-startup-graph.md
@@ -1,0 +1,7 @@
+---
+"hunkdiff": patch
+---
+
+Start up faster for commands that never build a changeset. `hunk --version`, `--help`,
+`daemon serve`, the markup commands, and `hunk session *` no longer load the VCS, extension, and
+diff-engine graph before answering.

--- a/.changeset/file-language-split.md
+++ b/.changeset/file-language-split.md
@@ -1,0 +1,5 @@
+---
+---
+
+Internal refactor: file-extension language registrations are recorded without loading the diff
+engine and applied at the first lookup. No user-visible behavior change.

--- a/src/app/startup.ts
+++ b/src/app/startup.ts
@@ -1,16 +1,9 @@
-import { resolveConfiguredExtensions } from "./extensionBootstrap";
-import { loadConfiguredSessionBootstrap, type SessionBootstrapResult } from "./sessionBootstrap";
-import { getBundledVcsCatalog } from "./vcsCatalog";
+import type { SessionBootstrapResult } from "./sessionBootstrap";
 import { createExtensionApplyNotices, createUnknownVcsNotice } from "../extensions/apply";
-import { loadBundledExtensions } from "../extensions/default/vcs";
-import {
-  createExtensionLoadNotices,
-  loadStartupExtensions,
-  mergeStartupNotices,
-} from "../extensions/startup";
+import type { loadStartupExtensions } from "../extensions/startup";
 import { resolveConfiguredCliInput } from "../core/config";
 import { HunkUserError } from "../core/errors";
-import { loadAppBootstrap } from "../core/changesetLoaders";
+import type { loadAppBootstrap } from "../core/changesetLoaders";
 import { looksLikePatchInput } from "../core/pager";
 import { detectTerminalThemeModeFromBackground } from "../core/theme/detection";
 import {
@@ -30,6 +23,23 @@ import type {
 import { canReloadInput } from "../core/inputReload";
 import { parseCli } from "../core/cli";
 import { resolveSessionSelectorBoundary } from "./sessionSelector";
+import type { VcsCatalog } from "../core/vcs/types";
+
+/**
+ * Load the bundled VCS catalog, memoized per call to `prepareStartupPlan`.
+ *
+ * The catalog reaches the VCS adapters, which reach changeset construction and from there the
+ * diff engine and its syntax grammars. `--version`, `--help`, `daemon serve`, and the markup
+ * and extension-management commands all answer without it, so it is resolved on demand rather
+ * than at module load; every command paid for it otherwise.
+ */
+function createBundledVcsCatalogLoader() {
+  let cached: VcsCatalog | undefined;
+  return async () => {
+    cached ??= (await import("./vcsCatalog")).getBundledVcsCatalog();
+    return cached;
+  };
+}
 
 export type StartupPlan =
   | {
@@ -113,8 +123,6 @@ export async function prepareStartupPlan(
   const resolveRuntimeCliInputImpl = deps.resolveRuntimeCliInputImpl ?? resolveRuntimeCliInput;
   const resolveConfiguredCliInputImpl =
     deps.resolveConfiguredCliInputImpl ?? resolveConfiguredCliInput;
-  const loadAppBootstrapImpl = deps.loadAppBootstrapImpl ?? loadAppBootstrap;
-  const loadStartupExtensionsImpl = deps.loadStartupExtensionsImpl ?? loadStartupExtensions;
   const usesPipedPatchInputImpl = deps.usesPipedPatchInputImpl ?? usesPipedPatchInput;
   const openControllingTerminalImpl = deps.openControllingTerminalImpl ?? openControllingTerminal;
   const detectTerminalThemeModeFromBackgroundImpl =
@@ -123,7 +131,7 @@ export async function prepareStartupPlan(
   const stdoutIsTTY = deps.stdoutIsTTY ?? Boolean(process.stdout.isTTY);
   const stdout = deps.stdout ?? process.stdout;
   const env = deps.env ?? process.env;
-  const baseVcsCatalog = getBundledVcsCatalog();
+  const loadBaseVcsCatalog = createBundledVcsCatalogLoader();
 
   let parsedCliInput = await parseCliImpl(argv);
   let controllingTerminal: ControllingTerminal | null = null;
@@ -146,7 +154,10 @@ export async function prepareStartupPlan(
       "selector" in parsedCliInput
         ? {
             ...parsedCliInput,
-            selector: resolveSessionSelectorBoundary(parsedCliInput.selector, baseVcsCatalog),
+            selector: resolveSessionSelectorBoundary(
+              parsedCliInput.selector,
+              await loadBaseVcsCatalog(),
+            ),
           }
         : parsedCliInput;
     return {
@@ -179,7 +190,7 @@ export async function prepareStartupPlan(
     const stdinText = await readStdinText();
     const pagerOptions = parsedCliInput.options;
     const capturedPagerHost = isCapturedPagerHost(env);
-    const staticPagerPlan = () => {
+    const staticPagerPlan = async () => {
       const staticPatchInput: CliInput = {
         kind: "patch",
         file: "-",
@@ -192,7 +203,7 @@ export async function prepareStartupPlan(
       const configuredStatic = resolveConfiguredCliInputImpl(
         resolveRuntimeCliInputImpl(staticPatchInput),
         {
-          vcsCatalog: baseVcsCatalog,
+          vcsCatalog: await loadBaseVcsCatalog(),
         },
       );
       const staticPlan = {
@@ -259,6 +270,9 @@ export async function prepareStartupPlan(
 
   const runtimeCliInput = resolveRuntimeCliInputImpl(parsedCliInput);
   const startupCwd = process.cwd();
+  // Past this point the plan always builds a changeset, so the catalog and the loading pipeline
+  // are needed for certain; resolve them together rather than at each use.
+  const baseVcsCatalog = await loadBaseVcsCatalog();
   let configured = resolveConfiguredCliInputImpl(runtimeCliInput, {
     cwd: startupCwd,
     env,
@@ -297,6 +311,17 @@ export async function prepareStartupPlan(
   // changeset transforms to the loading pipeline. External adapters may settle a root the
   // bundled catalog could not; the shared resolver then appends newly discovered repo
   // candidates without executing the provisional factory prefix twice.
+  const [{ resolveConfiguredExtensions }, { loadConfiguredSessionBootstrap }, startupExtensions] =
+    await Promise.all([
+      import("./extensionBootstrap"),
+      import("./sessionBootstrap"),
+      import("../extensions/startup"),
+    ]);
+  const loadAppBootstrapImpl =
+    deps.loadAppBootstrapImpl ?? (await import("../core/changesetLoaders")).loadAppBootstrap;
+  const loadStartupExtensionsImpl =
+    deps.loadStartupExtensionsImpl ?? startupExtensions.loadStartupExtensions;
+
   const resolvedExtensions = await resolveConfiguredExtensions(
     {
       runtimeInput: runtimeCliInput,
@@ -337,9 +362,12 @@ export async function prepareStartupPlan(
   // Bundled extensions load with the VCS adapters, well before this point, so a
   // failure there is reported here rather than lost. It should be unreachable —
   // these factories are Hunk's own — but the isolation contract is the contract.
-  const bundledNotices = createExtensionLoadNotices(loadBundledExtensions().issues);
+  const { loadBundledExtensions } = await import("../extensions/default/vcs");
+  const bundledNotices = startupExtensions.createExtensionLoadNotices(
+    loadBundledExtensions().issues,
+  );
 
-  bootstrap.startupNotices = mergeStartupNotices(
+  bootstrap.startupNotices = startupExtensions.mergeStartupNotices(
     // Keep the resolved array identity when extensions contributed no theme notices.
     sessionThemes.notices.length > 0 ||
       applied.issues.length > 0 ||

--- a/src/core/diffFile.ts
+++ b/src/core/diffFile.ts
@@ -1,7 +1,7 @@
 import { type FileDiffMetadata } from "@pierre/diffs";
 import { findSidecarFileContext } from "./sidecar";
 import { patchLooksBinary } from "./binary";
-import { getFiletypeFromFileName } from "./fileLanguage";
+import { fileLanguageForPath } from "./fileLanguageLookup";
 import { normalizeDiffMetadataPaths, normalizeDiffPath } from "./diffPaths";
 import type { FileSourceFetcher } from "./fileSource";
 import type { SidecarContext, DiffFile, DiffLineMoveKinds } from "./types";
@@ -81,7 +81,7 @@ export function buildDiffFile(
     path,
     previousPath: resolvedPreviousPath,
     patch,
-    language: getFiletypeFromFileName(path) ?? undefined,
+    language: fileLanguageForPath(path) ?? undefined,
     stats: stats ?? countDiffStats(normalizedMetadata),
     metadata: normalizedMetadata,
     lineMoveKinds,

--- a/src/core/fileLanguage.test.ts
+++ b/src/core/fileLanguage.test.ts
@@ -1,17 +1,44 @@
 import { describe, expect, test } from "bun:test";
-import { getFiletypeFromFileName } from "./fileLanguage";
+import { BUILT_IN_FILE_LANGUAGE_EXTENSIONS, registerFileLanguage } from "./fileLanguage";
+import { fileLanguageForPath } from "./fileLanguageLookup";
 
 describe("custom file language registration", () => {
   test("maps TypeScript module/commonjs extensions to typescript", () => {
-    expect(getFiletypeFromFileName("foo.mts")).toBe("typescript");
-    expect(getFiletypeFromFileName("foo.cts")).toBe("typescript");
-    expect(getFiletypeFromFileName("src/nested/foo.mts")).toBe("typescript");
+    expect(fileLanguageForPath("foo.mts")).toBe("typescript");
+    expect(fileLanguageForPath("foo.cts")).toBe("typescript");
+    expect(fileLanguageForPath("src/nested/foo.mts")).toBe("typescript");
   });
 
   test("preserves Pierre's built-in extension detection", () => {
-    expect(getFiletypeFromFileName("foo.ts")).toBe("typescript");
-    expect(getFiletypeFromFileName("foo.tsx")).toBe("tsx");
-    expect(getFiletypeFromFileName("foo.mjs")).toBe("javascript");
-    expect(getFiletypeFromFileName("foo.cjs")).toBe("javascript");
+    expect(fileLanguageForPath("foo.ts")).toBe("typescript");
+    expect(fileLanguageForPath("foo.tsx")).toBe("tsx");
+    expect(fileLanguageForPath("foo.mjs")).toBe("javascript");
+    expect(fileLanguageForPath("foo.cjs")).toBe("javascript");
+  });
+
+  test("reports Hunk's own extensions as built in", () => {
+    expect(BUILT_IN_FILE_LANGUAGE_EXTENSIONS.has("mts")).toBe(true);
+    expect(BUILT_IN_FILE_LANGUAGE_EXTENSIONS.has("cts")).toBe(true);
+    expect(BUILT_IN_FILE_LANGUAGE_EXTENSIONS.has("ts")).toBe(false);
+  });
+});
+
+describe("deferred registration", () => {
+  test("applies a mapping registered before the first lookup", () => {
+    registerFileLanguage("hunkdeferred", "python");
+    expect(fileLanguageForPath("foo.hunkdeferred")).toBe("python");
+  });
+
+  test("applies a mapping registered after an earlier lookup drained the queue", () => {
+    // The queue is emptied on drain, so a late registration has to survive on its own.
+    expect(fileLanguageForPath("foo.ts")).toBe("typescript");
+    registerFileLanguage("hunklate", "ruby");
+    expect(fileLanguageForPath("foo.hunklate")).toBe("ruby");
+  });
+
+  test("keeps the last registration for one extension", () => {
+    registerFileLanguage("hunkrepeat", "python");
+    registerFileLanguage("hunkrepeat", "ruby");
+    expect(fileLanguageForPath("foo.hunkrepeat")).toBe("ruby");
   });
 });

--- a/src/core/fileLanguage.ts
+++ b/src/core/fileLanguage.ts
@@ -1,18 +1,22 @@
-import {
-  getFiletypeFromFileName,
-  setCustomExtension,
-  type SupportedLanguages,
-} from "@pierre/diffs";
+import type { SupportedLanguages } from "@pierre/diffs";
 
-// Pierre omits these TypeScript extensions, so register them before lookups or rendering.
+/**
+ * Records file-extension → highlight-language mappings without loading the diff engine.
+ *
+ * Registration happens during startup, on every invocation, while the mappings are only read
+ * when a changeset is built. Applying them eagerly would pull the whole diff engine — and its
+ * syntax grammars — into commands that never render anything, so this module holds them as
+ * plain data and `fileLanguageLookup` applies them at the first lookup instead.
+ *
+ * Keep this module free of runtime imports from `@pierre/diffs`; that is the only thing making
+ * the deferral worth anything.
+ */
+
+// Pierre omits these TypeScript extensions, so Hunk registers them itself.
 const HUNK_CUSTOM_EXTENSIONS: Record<string, SupportedLanguages> = {
   mts: "typescript",
   cts: "typescript",
 };
-
-for (const [extension, language] of Object.entries(HUNK_CUSTOM_EXTENSIONS)) {
-  setCustomExtension(extension, language);
-}
 
 /**
  * Extensions Hunk itself registers, in Pierre's dotless lowercase form.
@@ -25,15 +29,33 @@ export const BUILT_IN_FILE_LANGUAGE_EXTENSIONS: ReadonlySet<string> = new Set(
   Object.keys(HUNK_CUSTOM_EXTENSIONS),
 );
 
+// Hunk's own mappings are seeded here rather than applied on import, so they land in the same
+// pass as extension-contributed ones. `apply.ts` refuses extension mappings that collide with
+// BUILT_IN_FILE_LANGUAGE_EXTENSIONS, so seeding first cannot lose to a later registration.
+const pendingFileLanguages = new Map<string, string>(Object.entries(HUNK_CUSTOM_EXTENSIONS));
+
 /**
  * Map one dotless, lowercased file extension to a highlight language.
  *
  * Pierre's language union is closed, but extensions supply plain strings; an
  * unknown language simply fails to match a grammar at render time, which is a
  * better failure than refusing the registration outright.
+ *
+ * The mapping takes effect at the next lookup rather than immediately. Nothing reads the
+ * language table except `fileLanguageLookup`, so the delay is not observable.
  */
 export function registerFileLanguage(extension: string, language: string) {
-  setCustomExtension(extension, language as SupportedLanguages);
+  pendingFileLanguages.set(extension, language);
 }
 
-export { getFiletypeFromFileName };
+/**
+ * Hand over every mapping registered since the last drain, emptying the queue.
+ *
+ * Draining rather than replaying keeps repeat lookups free once the queue is empty, while a
+ * registration made after the first lookup still lands on the next one.
+ */
+export function drainPendingFileLanguages(): Array<[string, string]> {
+  const drained = [...pendingFileLanguages];
+  pendingFileLanguages.clear();
+  return drained;
+}

--- a/src/core/fileLanguageLookup.ts
+++ b/src/core/fileLanguageLookup.ts
@@ -1,0 +1,28 @@
+import {
+  getFiletypeFromFileName,
+  setCustomExtension,
+  type SupportedLanguages,
+} from "@pierre/diffs";
+import { drainPendingFileLanguages } from "./fileLanguage";
+
+/**
+ * Resolves a path to a highlight language, applying deferred registrations first.
+ *
+ * This is the only module that reads or writes Pierre's process-global extension table, which
+ * is what lets `fileLanguage` defer registrations: a mapping cannot be observed before it is
+ * applied, because every read goes through here. Importing this module loads the diff engine,
+ * so call it from changeset construction, never from startup.
+ */
+
+/** Push every queued mapping into Pierre's extension table. */
+function applyPendingFileLanguages() {
+  for (const [extension, language] of drainPendingFileLanguages()) {
+    setCustomExtension(extension, language as SupportedLanguages);
+  }
+}
+
+/** Return the highlight language for one path, or undefined when no grammar matches. */
+export function fileLanguageForPath(path: string) {
+  applyPendingFileLanguages();
+  return getFiletypeFromFileName(path);
+}

--- a/src/extensions/apply.test.ts
+++ b/src/extensions/apply.test.ts
@@ -105,7 +105,7 @@ describe("extension file languages", () => {
   });
 
   test("lets the last extension registration win for the same file extension", async () => {
-    const { getFiletypeFromFileName } = await import("../core/fileLanguage");
+    const { fileLanguageForPath } = await import("../core/fileLanguageLookup");
     const { result } = createTestLoadResult();
     result.registry.fileLanguages.push(
       { extensionId: "first", extension: "hunkfixture", language: "python" },
@@ -113,7 +113,7 @@ describe("extension file languages", () => {
     );
 
     expect(applyExtensionFileLanguages(result.registry)).toEqual([]);
-    expect(getFiletypeFromFileName("sample.hunkfixture")).toBe("ruby");
+    expect(fileLanguageForPath("sample.hunkfixture")).toBe("ruby");
   });
 });
 


### PR DESCRIPTION
`hunk --version` cost ~170ms, of which ~13ms is Bun itself. Everything else was module
evaluation: `prepareStartupPlan` returns early for `--help`, `--version`, `daemon serve`, the
markup commands, `extension-manage`, and `session`, but it statically imported the VCS catalog,
the extension bootstrap, and the loading pipeline — and called `getBundledVcsCatalog()` before
the first branch. Those reach changeset construction, and from there the diff engine and its
syntax grammars. Every invocation paid for machinery most commands never touch.

Two edges had to close, one per commit.

**`refactor(core): record file-language registrations without loading the diff engine`**

`core/fileLanguage.ts` had a top-level loop calling into `@pierre/diffs`, so importing the module
pulled the whole diff engine. The startup path imports it through `extensions/apply.ts` on every
invocation, to build a two-element Set and register mappings nothing reads until a changeset
exists. Registrations are now recorded as plain data and applied at the first lookup.
`core/fileLanguageLookup.ts` owns the only read and the only write of Pierre's process-global
extension table, so a mapping cannot be observed before it is applied and the deferral is not
detectable. Draining rather than replaying keeps repeat lookups free while letting a late
registration land on the next one.

`extensions/apply.ts` is unchanged: its "extensions never override Hunk's built-ins" policy is
decided against Pierre-free data.

**`perf(app): load the changeset graph only when a command needs one`**

The catalog now resolves through a memoized loader, and the five modules used only past the early
returns are imported at their use sites, matching the pattern `main.tsx` already uses for
`extension-manage`. The dependency-injection defaults for `loadAppBootstrap` and
`loadStartupExtensions` move to the same place, so supplying either still short-circuits the
import and the test seams are intact.

Note that the first commit's message says the change "does not deliver the startup win on its
own" and names the second edge as remaining. That was accurate when written; the second commit
closes exactly that edge. Read the two together.

## Measurements

Run from source, against this PR's base:

| command | before | after | |
| --- | --- | --- | --- |
| `hunk --version` | 170ms | 86ms | −49% |
| `hunk session list --json` | 189ms | 111ms | −41% |

`session` matters because it is how agents review, per `skills/hunk-review/SKILL.md`.

Importing `src/app/startup.ts` now costs ~31ms and no longer loads `@pierre/diffs` at all.

The second edge is not removed, only moved off the startup path: `core/diffFile.ts` still reaches
Pierre through the lookup, which is correct — building a changeset genuinely needs the diff
engine. Printing `--version` does not, so it is no longer reachable from there.

## Known gap

The compiled binary gains less than source: `--version` goes from roughly 185ms to 147ms, about
−20%, against −49% from source. A trivial compiled binary starts in 11ms, so the remainder is
Hunk's own module evaluation rather than a fixed cost of `bun build --compile`. The lazy
boundaries hold when Bun resolves modules at runtime and largely collapse once everything is
bundled into one file. Closing that is a build-configuration question rather than another import
change, and it is not attempted here.

Binary timings are noisier than the source ones; the figures above are the settled values across
repeated runs.

## Verification

- `bun run typecheck` clean.
- CLI contract suite, all of `src/app` including `startup.test.ts` and
  `startup.vcsExtensions.test.ts`, plus the fileLanguage, diffFile, apply, and changesetLoaders
  suites: 182 pass, 0 fail.
- Full `bun test` run on the pre-rebase content: 2900 pass, with 3 failures (2 PTY, 1 DiffPane)
  confirmed pre-existing by A/B against a clean tree.
- Four tests added for the deferral, including a registration made after an earlier lookup
  drained the queue.
- Manual `hunk diff` smoke run rendered correctly: menu bar, `+3 -2`, syntax highlighting, and
  intraline highlights.

Rebased onto #748, which renamed `core/loaders.ts` to `core/changesetLoaders.ts`; both the type
import and the deferred `await import()` were repointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxpS9muCVHNbSdsA1y8zF8