### PR TITLE
build(deps): move to Pierre diffs 1.3.5

### DIFF
--- a/.changeset/pierre-diffs-1-3-5.md
+++ b/.changeset/pierre-diffs-1-3-5.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Improved diff alignment when a change block adds and removes different numbers of lines: the changed line now pairs with the line it actually resembles instead of whichever line happened to sit in the same position, so split view lines up correctly and the word-level highlight marks just the edited part instead of most of an unrelated line.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "hunk",
       "dependencies": {
-        "@pierre/diffs": "1.2.2",
+        "@pierre/diffs": "1.3.5",
         "bun": "^1.3.14",
         "chokidar": "^4.0.3",
         "commander": "^14.0.3",
@@ -311,9 +311,11 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.2", "", { "dependencies": { "@pierre/theme": "1.0.3", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.5", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-BhaLEiUvR+BdIyOYdogA4JLQjluWPubuwySmmIqEkcE0FwIWRbgJgHNC/r884dlxEr89fO4hTk/sBln0a7NSOw=="],
 
-    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+    "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
+
+    "@pierre/theming": ["@pierre/theming@1.0.1", "", { "peerDependencies": { "@pierre/theme": "^1.1.0 || ^2.0.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA=="],
 
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
@@ -644,6 +646,8 @@
     "@opentui/core/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "@opentui/core/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 

--- a/nix/bun.lock.nix
+++ b/nix/bun.lock.nix
@@ -466,13 +466,17 @@
     url = "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.56.0.tgz";
     hash = "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ==";
   };
-  "@pierre/diffs@1.2.2" = fetchurl {
-    url = "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.2.2.tgz";
-    hash = "sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==";
+  "@pierre/diffs@1.3.5" = fetchurl {
+    url = "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.3.5.tgz";
+    hash = "sha512-BhaLEiUvR+BdIyOYdogA4JLQjluWPubuwySmmIqEkcE0FwIWRbgJgHNC/r884dlxEr89fO4hTk/sBln0a7NSOw==";
   };
-  "@pierre/theme@1.0.3" = fetchurl {
-    url = "https://registry.npmjs.org/@pierre/theme/-/theme-1.0.3.tgz";
-    hash = "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==";
+  "@pierre/theme@2.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/@pierre/theme/-/theme-2.0.0.tgz";
+    hash = "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==";
+  };
+  "@pierre/theming@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/@pierre/theming/-/theming-1.0.1.tgz";
+    hash = "sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==";
   };
   "@shikijs/core@3.23.0" = fetchurl {
     url = "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz";

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "nix:update-lock": "nix run .#update-bun-lock"
   },
   "dependencies": {
-    "@pierre/diffs": "1.2.2",
+    "@pierre/diffs": "1.3.5",
     "bun": "^1.3.14",
     "chokidar": "^4.0.3",
     "commander": "^14.0.3",

--- a/src/core/diffFile.test.ts
+++ b/src/core/diffFile.test.ts
@@ -80,6 +80,33 @@ describe("buildDiffFile", () => {
   });
 });
 
+describe("change-block line pairing", () => {
+  // Split view places paired lines side by side, and Pierre word-diffs a deletion against the
+  // addition it is paired with. When a change block has unequal addition and deletion counts,
+  // pairing by position would align unrelated lines and smear the inline highlight across the
+  // whole row, so the engine has to re-split the block by content similarity instead.
+  test("pairs a deletion with the similar addition, not the positionally first one", () => {
+    const metadata = metadataFor(
+      "start();\n  return computeTotal(items, taxRate);\nend();\n",
+      "start();\n  const items = loadItems();\n  const taxRate = getTaxRate();\n  return computeTotal(items, taxRate, discount);\nend();\n",
+    );
+
+    const changes = metadata.hunks.flatMap((hunk) =>
+      hunk.hunkContent.filter((content) => content.type === "change"),
+    );
+    const paired = changes.filter((change) => change.additions > 0 && change.deletions > 0);
+
+    expect(paired).toHaveLength(1);
+    expect(paired[0]).toMatchObject({ additions: 1, deletions: 1 });
+    expect(metadata.deletionLines[paired[0]!.deletionLineIndex]).toContain(
+      "return computeTotal(items, taxRate);",
+    );
+    expect(metadata.additionLines[paired[0]!.additionLineIndex]).toContain(
+      "return computeTotal(items, taxRate, discount);",
+    );
+  });
+});
+
 describe("createSkippedLargeMetadata", () => {
   test("produces partial, hunk-free placeholder metadata with a stable cache key", () => {
     const metadata = createSkippedLargeMetadata("big.ts", "change");

--- a/src/core/diffFile.test.ts
+++ b/src/core/diffFile.test.ts
@@ -94,14 +94,16 @@ describe("change-block line pairing", () => {
     const changes = metadata.hunks.flatMap((hunk) =>
       hunk.hunkContent.filter((content) => content.type === "change"),
     );
-    const paired = changes.filter((change) => change.additions > 0 && change.deletions > 0);
+    expect(changes).toEqual([
+      { additions: 2, deletions: 0, additionLineIndex: 1, deletionLineIndex: 1, type: "change" },
+      { additions: 1, deletions: 1, additionLineIndex: 3, deletionLineIndex: 1, type: "change" },
+    ]);
 
-    expect(paired).toHaveLength(1);
-    expect(paired[0]).toMatchObject({ additions: 1, deletions: 1 });
-    expect(metadata.deletionLines[paired[0]!.deletionLineIndex]).toContain(
+    const paired = changes[1]!;
+    expect(metadata.deletionLines[paired.deletionLineIndex]).toContain(
       "return computeTotal(items, taxRate);",
     );
-    expect(metadata.additionLines[paired[0]!.additionLineIndex]).toContain(
+    expect(metadata.additionLines[paired.additionLineIndex]).toContain(
       "return computeTotal(items, taxRate, discount);",
     );
   });


### PR DESCRIPTION
Upgrades `@pierre/diffs` from `1.2.2` to `1.3.5`. Drop-in: no source changes were needed.

## Why

Pierre 1.3.5 added `realignChangeContentBySimilarity`, which re-splits change blocks whose addition and deletion counts differ, pairing lines by **content similarity** instead of by **position**.

This matters to Hunk specifically because `diffRows.ts`, `review/geometry.ts`, and `lineHighlightPaint.ts` all build from the same `hunkContent` blocks, and Pierre word-diffs a deletion against whatever addition it is paired with. Bad pairing therefore shows up twice: split view puts unrelated lines side by side, and the word-level highlight marks real code as an edit of something it has nothing to do with.

## Before / after

Demo changeset — two setup lines added, and one extra argument on the existing `return`:

```diff
 export function renderInvoice(order: Order) {
   const header = buildHeader(order);
-  return formatInvoice(header, order.items, order.taxRate);
+  assertOrderIsPayable(order);
+  const discount = resolveDiscount(order.region);
+  return formatInvoice(header, order.items, order.taxRate, discount);
 }
```

**Before — Pierre 1.2.2.** The deleted `return` is paired with `assertOrderIsPayable(order);`, so split view sets them opposite each other and the two lines that are genuinely new fall to the bottom:

```
 1   export function renderInvoice(order: Order) {   │ 1   export function renderInvoice(order: Order) {
 2     const header = buildHeader(order);            │ 2     const header = buildHeader(order);
 3 -   return formatInvoice(header, order.items, …); │ 3 +   assertOrderIsPayable(order);
                                                     │ 4 +   const discount = resolveDiscount(order.region);
                                                     │ 5 +   return formatInvoice(header, …, discount);
 4   }                                               │ 6   }
```

**After — Pierre 1.3.5.** The two inserted lines are reported as pure additions, and the deleted `return` is paired with the added `return`:

```
 1   export function renderInvoice(order: Order) {   │ 1   export function renderInvoice(order: Order) {
 2     const header = buildHeader(order);            │ 2     const header = buildHeader(order);
                                                     │ 3 +   assertOrderIsPayable(order);
                                                     │ 4 +   const discount = resolveDiscount(order.region);
 3 -   return formatInvoice(header, order.items, …); │ 5 +   return formatInvoice(header, …, discount);
 4   }                                               │ 6   }
```

The word-level highlight follows the same pairing. Reading the emphasis spans straight off a real PTY render of that diff, identical in `--mode split` and `--mode stack`:

| | emphasised on the deletion side | emphasised on the addition side |
|---|---|---|
| **1.2.2** | `return`, ` formatInvoice`, `(header, `, `.items, order.taxRate` | `assertOrderIsPayable`, `(` |
| **1.3.5** | *(nothing)* | `, discount` |

1.2.2 paints most of an untouched `return` as changed, against a line it never had anything to do with. 1.3.5 marks exactly the edit.

## How often this fires

Parsed 50 commits of this repo's own history under both versions and compared the resulting block structure:

- **3.1%** of files (59 / 1878) get different line pairing
- those files appear in **26 of 50 commits** — about half of real changesets

Small per file, regularly visible in practice.

## Performance

Measured A/B in a single process with both copies loaded, interleaved and median-of-N, so machine drift and process startup cancel out.

| workload | 1.2.2 | 1.3.5 | delta |
|---|---|---|---|
| `parsePatchFiles`, 50 real commits (3.5 MB) | 72.8 ms | 78.2 ms | **+8%** |
| `parseDiffFromFile` (where Pierre's bundled `diff` went 8→9) | — | — | flat, ±2% |
| launch → first painted diff row (compiled binary) | ~750 ms | ~750 ms | no measurable difference |

The +8% is the realignment pass. Note it is paid more broadly than it pays off: the similarity scan runs on **every** change block with mismatched counts, but only 3.1% of files actually come out different. Synthetic worst cases — patches where every block is mismatched — cost **+37% to +102%** on parse, though even the worst measured case is 9.2 ms vs 4.6 ms for a 290 KB patch.

Two caveats worth recording:

- **`bench:changeset-parse` is blind to this change.** Its three fixtures contain **zero** mismatched change blocks, so they never execute the realignment path at all. Run against those fixtures 1.3.5 looks 8–21% *faster* (the file-splitting rewrite is a genuine win); that number just does not describe real diffs. Worth teaching the fixtures a mismatched-block shape in a follow-up.
- Importing `@pierre/diffs` from source costs ~11% more (94.8 ms → 105.7 ms), but that does not survive into the shipped binary, which tree-shakes — end-to-end launch time is unchanged.

## Other costs

- Compiled binary grows **268 KiB on 144 MiB** (0.18%)
- Pulls in `@pierre/theme` 2.0.0 + `@pierre/theming`; `diff` 9.0.0 joins the existing 8.0.3

## What this does *not* fix

1.2.2 throws and silently drops any file whose `diff --git` header has a quoted path (non-ASCII or spaces) — it read only the unquoted regex capture groups. 1.3.5 fixes that, but it **doesn't reach Hunk**: `src/core/patch/gitFormat.ts` already canonicalises those headers before Pierre sees them. And 1.3.5 still returns the octal-escaped name (`caf\303\251.ts`), so that decoding stays either way. No code to delete here.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run format:check` — clean
- `bun test` — 2688 pass, 0 fail
- `bun run test:tty-smoke` — 9/9
- `bun run test:integration` — 109/111. Both failures pass in isolation, and the 1.2.2 baseline fails one of the same tests under full-suite load, so they are pre-existing timing flakes rather than regressions from this change.
- Real TTY run on a working tree containing a non-ASCII filename
- Added a regression test in `src/core/diffFile.test.ts` for the pairing, and confirmed it **fails on 1.2.2** rather than being a tautology

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNJ2ERAzujufYixffz9iR5