### PR TITLE
fix(ui): toggle files pane independently

### DIFF
--- a/.changeset/independent-sidebar-panes.md
+++ b/.changeset/independent-sidebar-panes.md
@@ -2,4 +2,4 @@
 "hunkdiff": patch
 ---
 
-Keep the files pane visible independently from extension panes when toggling it with `s`.
+Toggle the files pane without hiding independently controlled extension panes.

--- a/.changeset/independent-sidebar-panes.md
+++ b/.changeset/independent-sidebar-panes.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep the files pane visible independently from extension panes when toggling it with `s`.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -617,7 +617,8 @@ pane. Defaults are `{ preferred: 34, min: 22 }` columns and
 
 Use `defaultOpen` to open a pane initially, `replaces: "hunk:files"` to replace
 the initial files pane (and override `defaultOpen`), and `available(context)` to
-hide it conditionally.
+hide it conditionally. One pane may replace each named target; the first
+registration owns that slot and later claims are skipped with a warning.
 
 `currentLine: true` opts into the opaque `currentLine.render(side, width)`
 painter. The installable

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -85,7 +85,7 @@ The built-in commands and the keys they ship with:
 | `hunk.view.toggleLineNumbers`                  | Toggle line numbers                            | `l`                          |
 | `hunk.view.toggleLineWrap`                     | Toggle line wrapping                           | `w`                          |
 | `hunk.view.toggleMenuBar`                      | Toggle menu bar                                | `M`                          |
-| `hunk.view.toggleSidebar`                      | Toggle sidebar                                 | `s`                          |
+| `hunk.view.toggleSidebar`                      | Toggle files pane                              | `s`                          |
 
 Commands marked _(none)_ ship without a key: they remain callable by command id
 and can be assigned a shortcut through `[keybindings]`. Some also appear in a

--- a/src/core/commandCatalog.ts
+++ b/src/core/commandCatalog.ts
@@ -302,7 +302,7 @@ const BUILTIN_COMMANDS = [
   },
   {
     id: "hunk.view.toggleSidebar",
-    title: "Toggle sidebar",
+    title: "Toggle files pane",
     category: "view",
     defaultKeys: ["s"],
     locus: "client-local",

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -1120,7 +1120,8 @@ interface ExtensionPaneBase {
   defaultOpen?: boolean;
   /**
    * Start open in place of this pane, which starts closed.
-   * Replacement initial defaults take precedence over `defaultOpen`.
+   * Replacement initial defaults take precedence over `defaultOpen`. The first
+   * pane registered for a named target owns its slot; later claims are skipped.
    */
   replaces?: string;
   /** Opt into live current-line paint; unrelated panes receive stable null. */

--- a/src/extensions/apply.test.ts
+++ b/src/extensions/apply.test.ts
@@ -11,6 +11,7 @@ import type { Changeset, DiffFile } from "../core/types";
 import { extendVcsCatalog } from "../core/vcs";
 import type { VcsAdapter } from "../core/vcs/types";
 import { getBundledVcsCatalog } from "../app/vcsCatalog";
+import { HUNK_FILES_PANE_KEY } from "./extensionIds";
 import {
   applyExtensionChangesetTransforms,
   applyExtensionFileLanguages,
@@ -175,7 +176,7 @@ describe("extension panes", () => {
     const { panes, issues } = resolveExtensionPanes(result.registry);
 
     // Registration is additive: distinct panes from any extension coexist,
-    // and only an identity collision is refused.
+    // while this fixture's identity collision is refused.
     expect(panes).toEqual([
       { extensionId: "alpha", pane: tree },
       { extensionId: "beta", pane: flat },
@@ -184,6 +185,40 @@ describe("extension panes", () => {
       {
         extensionId: "alpha",
         message: 'Skipped duplicate pane "alpha:tree" from extension alpha',
+      },
+    ]);
+  });
+
+  test("keeps the first pane when several registrations replace one target", () => {
+    const result = createEmptyExtensionLoadResult();
+    const first = {
+      id: "first-files",
+      replaces: HUNK_FILES_PANE_KEY,
+      component: () => null,
+    };
+    const second = {
+      id: "second-files",
+      replaces: HUNK_FILES_PANE_KEY,
+      component: () => null,
+    };
+    const extra = { id: "extra", component: () => null };
+    result.registry.panes.push(
+      { extensionId: "alpha", pane: first },
+      { extensionId: "beta", pane: second },
+      { extensionId: "beta", pane: extra },
+    );
+
+    const { panes, issues } = resolveExtensionPanes(result.registry);
+
+    expect(panes).toEqual([
+      { extensionId: "alpha", pane: first },
+      { extensionId: "beta", pane: extra },
+    ]);
+    expect(issues).toEqual([
+      {
+        extensionId: "beta",
+        message:
+          'Skipped pane "beta:second-files" from extension beta • another pane already replaces "hunk:files"',
       },
     ]);
   });

--- a/src/extensions/apply.ts
+++ b/src/extensions/apply.ts
@@ -135,22 +135,34 @@ export interface ResolvedExtensionPanes {
   issues: ExtensionApplyIssue[];
 }
 
-/** Resolve pane identities while retaining registration order as priority. */
-export function resolveExtensionPanes(registry: ExtensionRegistry): ResolvedExtensionPanes {
+/** Resolve pane identities and replacement ownership in registration order. */
+export function resolveExtensionPanes(
+  registry: Pick<ExtensionRegistry, "panes">,
+): ResolvedExtensionPanes {
   const panes: RegisteredPane[] = [];
   const issues: ExtensionApplyIssue[] = [];
-  const claimed = new Set<string>();
+  const claimedKeys = new Set<string>();
+  const claimedReplacementTargets = new Set<string>();
 
   for (const registered of registry.panes) {
     const key = paneKey(registered);
-    if (claimed.has(key)) {
+    if (claimedKeys.has(key)) {
       issues.push({
         extensionId: registered.extensionId,
         message: `Skipped duplicate pane "${key}" from extension ${registered.extensionId}`,
       });
       continue;
     }
-    claimed.add(key);
+    const replacementTarget = registered.pane.replaces;
+    if (replacementTarget && claimedReplacementTargets.has(replacementTarget)) {
+      issues.push({
+        extensionId: registered.extensionId,
+        message: `Skipped pane "${key}" from extension ${registered.extensionId} • another pane already replaces "${replacementTarget}"`,
+      });
+      continue;
+    }
+    claimedKeys.add(key);
+    if (replacementTarget) claimedReplacementTargets.add(replacementTarget);
     panes.push(registered);
   }
   return { panes, issues };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1232,6 +1232,14 @@ export function App({
   const renderSidebar = paneLayout.panes.some(
     ({ pane }) => pane.placement === "left" || pane.placement === "right",
   );
+  const visiblePaneKeys = paneLayout.panes.map(({ pane }) => pane.key);
+  const visibleFilesPaneKey = resolvePaneSlotKey({
+    panes: sessionPanes,
+    slotKey: HUNK_FILES_PANE_KEY,
+    openKeys: visiblePaneKeys,
+    quarantined: paneAvailabilityQuarantineRef.current,
+  });
+  const filesPaneVisible = visiblePaneKeys.includes(visibleFilesPaneKey);
   const diffPaneWidth = paneLayout.reviewBounds.width;
   const diffPaneHeight = paneLayout.reviewBounds.height;
   const diffContentWidth = Math.max(0, diffPaneWidth - 2);
@@ -1565,7 +1573,9 @@ export function App({
       quarantined: paneAvailabilityQuarantineRef.current,
     });
 
-    if (!sidebarAreaVisible) {
+    const filesPane = sessionPanes.find((pane) => pane.key === filesPaneKey);
+    const usesSidebarArea = filesPane?.placement === "left" || filesPane?.placement === "right";
+    if (usesSidebarArea && !sidebarAreaVisible) {
       setPaneOpen(filesPaneKey, true);
       revealSidebarAreaRef.current();
       return;
@@ -2051,7 +2061,7 @@ export function App({
       : undefined,
     copyDecorations,
     layoutMode,
-    renderSidebar,
+    filesPaneVisible,
     showAgentNotes,
     showHelp,
     showHunkHeaders,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1457,12 +1457,19 @@ export function App({
   /** Toggle only the active files pane without changing extension pane visibility. */
   const toggleSidebar = () => {
     const replacement = sessionPanes.find(
-      (pane) => pane.registered.pane.replaces === HUNK_FILES_PANE_KEY,
+      (pane) =>
+        pane.registered.pane.replaces === HUNK_FILES_PANE_KEY &&
+        !paneAvailabilityQuarantineRef.current.has(pane.registered),
     );
     const filesPaneKey = replacement?.key ?? HUNK_FILES_PANE_KEY;
-    const filesPaneIsOpen = paneOpenStateRef.current.open.includes(filesPaneKey);
+
+    if (!sidebarAreaVisible) {
+      setPaneOpen(filesPaneKey, true);
+      revealSidebarAreaRef.current();
+      return;
+    }
+
     setPaneOpen(filesPaneKey, "toggle");
-    if (!filesPaneIsOpen) revealSidebarAreaRef.current();
   };
 
   /** Toggle visibility of hunk metadata rows without changing the actual diff lines. */
@@ -2114,6 +2121,8 @@ export function App({
               : () => {
                   paneAvailabilityQuarantineRef.current.add(pane.registered);
                   if (pane.registered.pane.replaces === HUNK_FILES_PANE_KEY) {
+                    setPaneOpen(pane.key, false);
+                    setPaneOpen(HUNK_FILES_PANE_KEY, true);
                     revealSidebarAreaRef.current();
                   }
                   setPaneFailureEpoch((value) => value + 1);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1454,23 +1454,15 @@ export function App({
     acceptThemeSelectorItem(themeSelectorState.selectedIndex);
   }, [acceptThemeSelectorItem, themeSelectorState.selectedIndex]);
 
-  /** Toggle the sidebar, forcing it open on narrower layouts when the app can still fit both panes. */
+  /** Toggle only the active files pane without changing extension pane visibility. */
   const toggleSidebar = () => {
-    if (sidebarVisible && (responsiveLayout.showSidebar || forceSidebarOpen)) {
-      setSidebarVisible(false);
-      setForceSidebarOpen(false);
-      return;
-    }
-
-    if (sidebarVisible && !responsiveLayout.showSidebar) {
-      if (canForceShowSidebar) {
-        setForceSidebarOpen(true);
-      }
-      return;
-    }
-
-    setSidebarVisible(true);
-    setForceSidebarOpen(!responsiveLayout.showSidebar && canForceShowSidebar);
+    const replacement = sessionPanes.find(
+      (pane) => pane.registered.pane.replaces === HUNK_FILES_PANE_KEY,
+    );
+    const filesPaneKey = replacement?.key ?? HUNK_FILES_PANE_KEY;
+    const filesPaneIsOpen = paneOpenStateRef.current.open.includes(filesPaneKey);
+    setPaneOpen(filesPaneKey, "toggle");
+    if (!filesPaneIsOpen) revealSidebarAreaRef.current();
   };
 
   /** Toggle visibility of hunk metadata rows without changing the actual diff lines. */

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1461,7 +1461,14 @@ export function App({
         pane.registered.pane.replaces === HUNK_FILES_PANE_KEY &&
         !paneAvailabilityQuarantineRef.current.has(pane.registered),
     );
-    const filesPaneKey = replacement?.key ?? HUNK_FILES_PANE_KEY;
+    const replacementIsOpen =
+      replacement !== undefined && paneOpenStateRef.current.open.includes(replacement.key);
+    const builtInIsOpen = paneOpenStateRef.current.open.includes(HUNK_FILES_PANE_KEY);
+    const filesPaneKey = replacementIsOpen
+      ? replacement.key
+      : builtInIsOpen
+        ? HUNK_FILES_PANE_KEY
+        : (replacement?.key ?? HUNK_FILES_PANE_KEY);
 
     if (!sidebarAreaVisible) {
       setPaneOpen(filesPaneKey, true);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -125,6 +125,7 @@ import {
   planExtensionPanes,
   reconcilePaneOpenState,
   resolvePaneKey,
+  resolvePaneSlotKey,
   type PlannedPane,
 } from "./lib/extensionPanes";
 import type { ExtensionPanePlacement } from "../extension-api/types";
@@ -1456,19 +1457,12 @@ export function App({
 
   /** Toggle only the active files pane without changing extension pane visibility. */
   const toggleSidebar = () => {
-    const replacement = sessionPanes.find(
-      (pane) =>
-        pane.registered.pane.replaces === HUNK_FILES_PANE_KEY &&
-        !paneAvailabilityQuarantineRef.current.has(pane.registered),
-    );
-    const replacementIsOpen =
-      replacement !== undefined && paneOpenStateRef.current.open.includes(replacement.key);
-    const builtInIsOpen = paneOpenStateRef.current.open.includes(HUNK_FILES_PANE_KEY);
-    const filesPaneKey = replacementIsOpen
-      ? replacement.key
-      : builtInIsOpen
-        ? HUNK_FILES_PANE_KEY
-        : (replacement?.key ?? HUNK_FILES_PANE_KEY);
+    const filesPaneKey = resolvePaneSlotKey({
+      panes: sessionPanes,
+      slotKey: HUNK_FILES_PANE_KEY,
+      openKeys: paneOpenStateRef.current.open,
+      quarantined: paneAvailabilityQuarantineRef.current,
+    });
 
     if (!sidebarAreaVisible) {
       setPaneOpen(filesPaneKey, true);

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -482,6 +482,57 @@ describe("extension sidebar views", () => {
     });
   });
 
+  test("one registered pane owns the named files slot", async () => {
+    const repo = createTestRepo("hunk-ext-sidebar-replacement-owner-");
+    const extPath = join(createTempDir("hunk-ext-sidebar-replacement-owner-ext-"), "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { createElement } from "react";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerPane({\n` +
+        `    id: "first-files",\n` +
+        `    replaces: "hunk:files",\n` +
+        `    component: () => createElement("text", { content: "FIRST FILES PANE" }),\n` +
+        `  });\n` +
+        `  hunk.registerPane({\n` +
+        `    id: "second-files",\n` +
+        `    replaces: "hunk:files",\n` +
+        `    component: () => createElement("text", { content: "SECOND FILES PANE" }),\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("FIRST FILES PANE"),
+        "the first registered files replacement to own the slot",
+      );
+      expect(setup.captureCharFrame()).not.toContain("SECOND FILES PANE");
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => !setup.captureCharFrame().includes("FIRST FILES PANE"),
+        "the files command to close the slot owner",
+      );
+      expect(setup.captureCharFrame()).not.toContain("SECOND FILES PANE");
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("FIRST FILES PANE"),
+        "the files command to reopen the same named slot owner",
+      );
+      expect(setup.captureCharFrame()).not.toContain("SECOND FILES PANE");
+    });
+  });
+
   test("closes a crashing extra view and restores the built-in sidebar", async () => {
     const repo = createTestRepo("hunk-ext-sidebar-broken-");
     const extPath = join(createTempDir("hunk-ext-sidebar-broken-ext-"), "ext.ts");

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -512,6 +512,24 @@ describe("extension sidebar views", () => {
         () => setup.captureCharFrame().includes("M alpha.txt"),
         "the built-in sidebar to reopen after the crash",
       );
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => !setup.captureCharFrame().includes("M alpha.txt"),
+        "the s key to close the visible built-in fallback",
+      );
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("M alpha.txt"),
+        "the s key to reopen the built-in fallback",
+      );
     });
   });
 

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -319,7 +319,7 @@ describe("extension sidebar views", () => {
     });
   });
 
-  test("opening a view through a command reveals a sidebar area hidden with s", async () => {
+  test("files and extension panes toggle independently", async () => {
     const repo = createTestRepo("hunk-ext-sidebar-reveal-");
     const extPath = join(createTempDir("hunk-ext-sidebar-reveal-ext-"), "ext.ts");
     writeFileSync(
@@ -355,8 +355,8 @@ describe("extension sidebar views", () => {
         "the s key to hide the sidebar area",
       );
 
-      // Opening a view is a request to see it: the hidden area reveals again,
-      // with the extension pane beside the still-open files pane.
+      // Opening an extension pane reveals only that pane; `s` closed the files
+      // pane rather than hiding one shared area around both pane states.
       await act(async () => {
         await setup.mockInput.typeText("y");
       });
@@ -364,9 +364,33 @@ describe("extension sidebar views", () => {
         setup,
         () => {
           const frame = setup.captureCharFrame();
+          return frame.includes("EXTSIDEBAR") && !frame.includes("M alpha.txt");
+        },
+        "the command to open only the extension pane",
+      );
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => {
+          const frame = setup.captureCharFrame();
           return frame.includes("EXTSIDEBAR") && frame.includes("M alpha.txt");
         },
-        "the command to reveal the sidebar area with the opened view",
+        "the s key to reopen files without closing the extension pane",
+      );
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => {
+          const frame = setup.captureCharFrame();
+          return frame.includes("EXTSIDEBAR") && !frame.includes("M alpha.txt");
+        },
+        "the s key to close files without closing the extension pane",
       );
     });
   });

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -114,9 +114,10 @@ async function launchWithExtension(repo: string, extPath: string): Promise<AppBo
 async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>) => Promise<void>,
+  width = 240,
 ) {
-  // The sidebar only renders on a "full" viewport, which starts at 220 columns.
-  const setup = await testRender(<AppHost bootstrap={bootstrap} />, { width: 240, height: 30 });
+  // Sidebars need the 240-column default; edge-specific tests may request a narrower viewport.
+  const setup = await testRender(<AppHost bootstrap={bootstrap} />, { width, height: 30 });
 
   try {
     await flush(setup);
@@ -531,6 +532,121 @@ describe("extension sidebar views", () => {
       );
       expect(setup.captureCharFrame()).not.toContain("SECOND FILES PANE");
     });
+  });
+
+  test("the View menu reflects the files slot instead of an independent side pane", async () => {
+    const repo = createTestRepo("hunk-ext-sidebar-menu-slot-");
+    const extPath = join(createTempDir("hunk-ext-sidebar-menu-slot-ext-"), "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { createElement } from "react";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerPane({\n` +
+        `    id: "files-owner",\n` +
+        `    replaces: "hunk:files",\n` +
+        `    component: () => createElement("text", { content: "FILES SLOT OWNER" }),\n` +
+        `  });\n` +
+        `  hunk.registerPane({\n` +
+        `    id: "independent",\n` +
+        `    placement: "right",\n` +
+        `    defaultOpen: true,\n` +
+        `    component: () => createElement("text", { content: "INDEPENDENT PANE" }),\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => {
+          const frame = setup.captureCharFrame();
+          return frame.includes("FILES SLOT OWNER") && frame.includes("INDEPENDENT PANE");
+        },
+        "both side panes to render",
+      );
+
+      await act(async () => {
+        await setup.mockInput.typeText("s");
+      });
+      await flushUntil(
+        setup,
+        () => {
+          const frame = setup.captureCharFrame();
+          return !frame.includes("FILES SLOT OWNER") && frame.includes("INDEPENDENT PANE");
+        },
+        "the files slot to close without hiding the independent pane",
+      );
+
+      await act(async () => {
+        await setup.mockInput.pressKey("F10");
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("Toggle files/filter focus"),
+        "the File menu to open",
+      );
+      await act(async () => {
+        await setup.mockInput.pressArrow("right");
+      });
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("Files pane"),
+        "the View menu to open",
+      );
+
+      expect(setup.captureCharFrame()).toContain("[ ] Files pane");
+      expect(setup.captureCharFrame()).not.toContain("[x] Files pane");
+    });
+  });
+
+  test("the files command toggles a bottom-edge replacement at medium width", async () => {
+    const repo = createTestRepo("hunk-ext-bottom-files-slot-");
+    const extPath = join(createTempDir("hunk-ext-bottom-files-slot-ext-"), "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { createElement } from "react";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerPane({\n` +
+        `    id: "bottom-files",\n` +
+        `    placement: "bottom",\n` +
+        `    height: { preferred: 1, min: 1, max: 1 },\n` +
+        `    replaces: "hunk:files",\n` +
+        `    component: () => createElement("text", { content: "BOTTOM FILES SLOT" }),\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("BOTTOM FILES SLOT"),
+          "the bottom-edge files replacement to render",
+        );
+
+        await act(async () => {
+          await setup.mockInput.typeText("s");
+        });
+        await flushUntil(
+          setup,
+          () => !setup.captureCharFrame().includes("BOTTOM FILES SLOT"),
+          "the files command to close the bottom-edge replacement",
+        );
+
+        await act(async () => {
+          await setup.mockInput.typeText("s");
+        });
+        await flushUntil(
+          setup,
+          () => setup.captureCharFrame().includes("BOTTOM FILES SLOT"),
+          "the files command to reopen the bottom-edge replacement",
+        );
+      },
+      180,
+    );
   });
 
   test("closes a crashing extra view and restores the built-in sidebar", async () => {

--- a/src/ui/AppHost.extensions.test.tsx
+++ b/src/ui/AppHost.extensions.test.tsx
@@ -243,9 +243,10 @@ async function withAppHost(
   bootstrap: AppBootstrap,
   body: (setup: Awaited<ReturnType<typeof testRender>>) => Promise<void>,
   hostClient?: HunkSessionBrokerClient,
+  width = 120,
 ) {
   const setup = await testRender(<AppHost bootstrap={bootstrap} hostClient={hostClient} />, {
-    width: 120,
+    width,
     height: 24,
   });
 
@@ -340,6 +341,62 @@ describe("reload keeps launch extension authority", () => {
         expect(events.filter((line) => line === "startup")).toHaveLength(1);
       },
       broker.client,
+    );
+  });
+
+  test("a reloaded files replacement does not take toggle control from the open fallback", async () => {
+    const repo = createTestRepo("hunk-apphost-sidebar-fallback-reload-");
+    const logPath = join(repo, "probe.log");
+    const extPath = join(repo, "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { appendFileSync } from "node:fs";\n` +
+        `export default function (hunk) {\n` +
+        `  appendFileSync(${JSON.stringify(logPath)}, "factory\\n");\n` +
+        `  hunk.registerSidebarView({\n` +
+        `    id: "broken",\n` +
+        `    replacesDefault: true,\n` +
+        `    component: () => { throw new Error("sidebar exploded"); },\n` +
+        `  });\n` +
+        `}\n`,
+    );
+    useTempConfigHome();
+
+    const bootstrap = await launchInSubdirectory(repo, { extensionPaths: [extPath] });
+    bootstrap.extensions = await loadStartupExtensions({
+      extensions: { enabled: true, paths: [], repoPaths: [], extensionConfigs: {} },
+      cwd: join(repo, "sub"),
+      cliExtensionPaths: [extPath],
+    });
+
+    const broker = createTestBrokerClient();
+    await withAppHost(
+      bootstrap,
+      async (setup) => {
+        await flushUntil(
+          setup,
+          () => (setup.captureCharFrame().match(/a\.txt/g) ?? []).length === 2,
+          "the built-in fallback to replace the crashed pane",
+        );
+
+        await broker.reload({ kind: "vcs", staged: false, options: {} }, repo);
+        await flushUntil(
+          setup,
+          () => readProbeLog(logPath).filter((line) => line === "factory").length === 2,
+          "the replacement extension to register again",
+        );
+
+        await act(async () => {
+          await setup.mockInput.typeText("s");
+        });
+        await flushUntil(
+          setup,
+          () => (setup.captureCharFrame().match(/a\.txt/g) ?? []).length === 1,
+          "the s key to close the visible built-in fallback",
+        );
+      },
+      broker.client,
+      240,
     );
   });
 

--- a/src/ui/AppHost.responsive.test.tsx
+++ b/src/ui/AppHost.responsive.test.tsx
@@ -156,8 +156,8 @@ describe("responsive app", () => {
       });
 
       const menuFrame = setup.captureCharFrame();
-      expect(menuFrame).toContain("[ ] Sidebar");
-      expect(menuFrame).not.toContain("[x] Sidebar");
+      expect(menuFrame).toContain("[ ] Files pane");
+      expect(menuFrame).not.toContain("[x] Files pane");
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/lib/appCommands.test.ts
+++ b/src/ui/lib/appCommands.test.ts
@@ -403,7 +403,7 @@ describe("command catalog parity", () => {
       copyDecorations: false,
       cursorLine: "row",
       layoutMode: "auto",
-      renderSidebar: true,
+      filesPaneVisible: true,
       showAgentNotes: false,
       showHelp: false,
       showHunkHeaders: true,

--- a/src/ui/lib/appMenus.test.ts
+++ b/src/ui/lib/appMenus.test.ts
@@ -18,7 +18,7 @@ const MENU_STATE: Omit<BuildAppMenusOptions, "commands" | "extensionCommands"> =
   copyDecorations: true,
   cursorLine: "row" as const,
   layoutMode: "stack",
-  renderSidebar: false,
+  filesPaneVisible: false,
   showAgentNotes: true,
   showHelp: false,
   showHunkHeaders: false,
@@ -171,7 +171,7 @@ describe("buildAppMenus", () => {
     const { commands } = createTestCommands({ resolvedKeys: keys as ResolvedCommandKeys });
     const menus = buildAppMenus({ commands, ...MENU_STATE });
 
-    expect(entry(menus, "view", "Sidebar").hint).toBe("Ctrl+B");
+    expect(entry(menus, "view", "Files pane").hint).toBe("Ctrl+B");
     // Unbound by the user, and unbound by declaration: neither advertises a key.
     expect(entry(menus, "file", "Quit").hint).toBeUndefined();
     expect(entry(menus, "view", "Copy decorations").hint).toBeUndefined();
@@ -181,7 +181,7 @@ describe("buildAppMenus", () => {
     const { commands, ran } = createTestCommands();
     const menus = buildAppMenus({ commands, ...MENU_STATE });
 
-    entry(menus, "view", "Sidebar").action();
+    entry(menus, "view", "Files pane").action();
     entry(menus, "view", "Copy decorations").action();
     entry(menus, "agent", "Agent skill").action();
     entry(menus, "agent", "Next annotated file").action();

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -8,7 +8,7 @@ import { executeAppCommand, isCommandEnabled, type AppCommand } from "./appComma
  * A menu item is a command plus presentation: nothing here re-implements an
  * action or re-states which key runs it. Labels and checkbox state are the two
  * things the menu genuinely owns — a menu reads "Sidebar" under "View" where
- * the command is titled "Toggle sidebar", and only App knows whether the
+ * the command is titled "Toggle files pane", and only App knows whether the
  * sidebar is currently showing — so those are declared per entry and everything
  * else is derived from the command the entry names.
  */

--- a/src/ui/lib/appMenus.ts
+++ b/src/ui/lib/appMenus.ts
@@ -6,11 +6,9 @@ import { executeAppCommand, isCommandEnabled, type AppCommand } from "./appComma
  * The dropdown menus, expressed as references into the command table.
  *
  * A menu item is a command plus presentation: nothing here re-implements an
- * action or re-states which key runs it. Labels and checkbox state are the two
- * things the menu genuinely owns — a menu reads "Sidebar" under "View" where
- * the command is titled "Toggle files pane", and only App knows whether the
- * sidebar is currently showing — so those are declared per entry and everything
- * else is derived from the command the entry names.
+ * action or re-states which key runs it. Labels and checkbox state are the
+ * presentation details the menu owns; App supplies whether the active files
+ * pane is visible, and everything else comes from the command it names.
  */
 
 /** One dropdown item, named by the command it runs. */
@@ -41,7 +39,7 @@ export interface BuildAppMenusOptions {
   copyDecorations: boolean;
   cursorLine: CursorLine;
   layoutMode: LayoutMode;
-  renderSidebar: boolean;
+  filesPaneVisible: boolean;
   showAgentNotes: boolean;
   showHelp: boolean;
   showHunkHeaders: boolean;
@@ -131,7 +129,7 @@ export function buildAppMenus({
   copyDecorations,
   cursorLine,
   layoutMode,
-  renderSidebar,
+  filesPaneVisible,
   showAgentNotes,
   showHelp,
   showHunkHeaders,
@@ -157,7 +155,7 @@ export function buildAppMenus({
       },
       { commandId: "hunk.view.layoutAuto", checked: layoutMode === "auto" },
       SEPARATOR,
-      { commandId: "hunk.view.toggleSidebar", label: "Sidebar", checked: renderSidebar },
+      { commandId: "hunk.view.toggleSidebar", label: "Files pane", checked: filesPaneVisible },
       { commandId: "hunk.view.toggleMenuBar", label: "Menu bar", checked: showMenuBar },
       SEPARATOR,
       { commandId: "hunk.view.openThemeSelector", label: "Themes…" },

--- a/src/ui/lib/extensionPanes.test.ts
+++ b/src/ui/lib/extensionPanes.test.ts
@@ -14,6 +14,7 @@ import {
   planExtensionPanes,
   reconcilePaneOpenState,
   resolvePaneKey,
+  resolvePaneSlotKey,
   type SessionPane,
 } from "./extensionPanes";
 
@@ -90,6 +91,42 @@ describe("extension panes", () => {
       ]),
     );
     expect(reconcilePaneOpenState(after, closed).open).toEqual([HUNK_FILES_PANE_KEY, "meta:fresh"]);
+  });
+
+  test("resolves a named pane slot to its open owner or fallback", () => {
+    const panes = buildSessionPanes(
+      loadResultWith([registeredPane("meta", "files", { replaces: HUNK_FILES_PANE_KEY })]),
+    );
+    const replacement = panes.find((pane) => pane.key === "meta:files")!;
+    const resolve = (openKeys: readonly string[], quarantined?: WeakSet<RegisteredPane>) =>
+      resolvePaneSlotKey({
+        panes,
+        slotKey: HUNK_FILES_PANE_KEY,
+        openKeys,
+        quarantined,
+      });
+
+    expect(resolve([replacement.key])).toBe(replacement.key);
+    expect(resolve([HUNK_FILES_PANE_KEY])).toBe(HUNK_FILES_PANE_KEY);
+    expect(resolve([])).toBe(replacement.key);
+
+    const quarantined = new WeakSet([replacement.registered]);
+    expect(resolve([replacement.key], quarantined)).toBe(HUNK_FILES_PANE_KEY);
+  });
+
+  test("follows named replacement chains to the pane filling the slot", () => {
+    const panes = buildSessionPanes(
+      loadResultWith([
+        registeredPane("meta", "files", { replaces: HUNK_FILES_PANE_KEY }),
+        registeredPane("other", "files", { replaces: "meta:files" }),
+      ]),
+    );
+    const resolve = (openKeys: readonly string[]) =>
+      resolvePaneSlotKey({ panes, slotKey: HUNK_FILES_PANE_KEY, openKeys });
+
+    expect(resolve(["other:files"])).toBe("other:files");
+    expect(resolve(["meta:files"])).toBe("meta:files");
+    expect(resolve([])).toBe("other:files");
   });
 
   test("resolves local, files, and qualified ids", () => {

--- a/src/ui/lib/extensionPanes.ts
+++ b/src/ui/lib/extensionPanes.ts
@@ -25,9 +25,9 @@ export interface SessionPane {
 
 /** Compose bundled UI panes before user panes, preserving stable keys and replacement defaults. */
 export function buildSessionPanes(extensions: ExtensionLoadResult | undefined): SessionPane[] {
-  const bundled = resolveExtensionPanes(getBundledUIRegistry()).panes;
-  const user = extensions ? resolveExtensionPanes(extensions.registry).panes : [];
-  const all = [...bundled, ...user];
+  const all = resolveExtensionPanes({
+    panes: [...getBundledUIRegistry().panes, ...(extensions?.registry.panes ?? [])],
+  }).panes;
   const replacements = new Set(all.map((entry) => entry.pane.replaces).filter(Boolean));
   return all.map((registered) => {
     const key = paneKey(registered);
@@ -76,6 +76,43 @@ export function reconcilePaneOpenState(
   )
     return state;
   return { known: keys, open: nextOpen };
+}
+
+/** Resolve the pane currently filling a named slot, preserving an open fallback. */
+export function resolvePaneSlotKey(options: {
+  panes: readonly SessionPane[];
+  slotKey: string;
+  openKeys: readonly string[];
+  quarantined?: WeakSet<RegisteredPane>;
+}): string {
+  const open = new Set(options.openKeys);
+  const replacementByTarget = new Map<string, SessionPane>();
+  for (const pane of options.panes) {
+    const target = pane.registered.pane.replaces;
+    if (target && !options.quarantined?.has(pane.registered)) {
+      // Pane resolution admits one replacement per target, so every named slot
+      // has at most one owner at each step of a replacement chain.
+      replacementByTarget.set(target, pane);
+    }
+  }
+
+  const replacements: SessionPane[] = [];
+  const visited = new Set<string>();
+  let target = options.slotKey;
+  while (!visited.has(target)) {
+    visited.add(target);
+    const replacement = replacementByTarget.get(target);
+    if (!replacement) break;
+    replacements.push(replacement);
+    target = replacement.key;
+  }
+
+  for (let index = replacements.length - 1; index >= 0; index -= 1) {
+    const replacement = replacements[index];
+    if (replacement && open.has(replacement.key)) return replacement.key;
+  }
+  if (open.has(options.slotKey)) return options.slotKey;
+  return replacements.at(-1)?.key ?? options.slotKey;
 }
 
 /** Resolve a bare local id, `files`, or a fully-qualified pane key. */

--- a/test/pty/extensions-integration.test.ts
+++ b/test/pty/extensions-integration.test.ts
@@ -90,6 +90,24 @@ export default function (hunk) {
 }
 `;
 
+/** A named files-slot replacement beside an independently controlled pane. */
+const FILES_SLOT_EXTENSION_SOURCE = `import { createElement } from "react";
+export default function (hunk) {
+  hunk.registerPane({
+    id: "files-slot",
+    placement: "right",
+    replaces: "hunk:files",
+    component: () => createElement("text", { content: "FILES SLOT RIGHT" }),
+  });
+  hunk.registerPane({
+    id: "aux",
+    placement: "left",
+    defaultOpen: true,
+    component: () => createElement("text", { content: "AUX PANE LEFT" }),
+  });
+}
+`;
+
 /**
  * An extension that asks before acting, so a real terminal exercises the whole
  * dialog path: a registered key opens the modal, Enter resolves the handler's
@@ -458,6 +476,55 @@ describe("PTY extensions", () => {
       // The same key toggles it away again.
       await session.press("y");
       await harness.waitForSnapshot(session, (text) => !text.includes("EXTSIDEBAR"), 20_000);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("the files shortcut and View menu follow a named pane slot", async () => {
+    const configHome = harness.createIsolatedConfigHome();
+    const fixture = harness.createRepoExtensionFixture(FILES_SLOT_EXTENSION_SOURCE);
+    const session = await harness.launchHunk({
+      args: [
+        "diff",
+        "--mode",
+        "stack",
+        "--extension",
+        join(fixture.dir, ".hunk", "extensions", "fixture.ts"),
+      ],
+      cwd: fixture.dir,
+      cols: 240,
+      rows: 24,
+      env: { XDG_CONFIG_HOME: configHome },
+    });
+
+    try {
+      await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("FILES SLOT RIGHT") && text.includes("AUX PANE LEFT"),
+        20_000,
+      );
+      await harness.ensureKeyboardIsLive(session);
+
+      await session.press("s");
+      const closed = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("FILES SLOT RIGHT") && text.includes("AUX PANE LEFT"),
+        20_000,
+      );
+      expect(closed).toContain("alpha.ts");
+
+      await session.click(/View/);
+      const menu = await session.waitForText(/Files pane/, { timeout: 20_000 });
+      expect(menu).toContain("[ ] Files pane");
+
+      await session.click(/Files pane/);
+      const reopened = await harness.waitForSnapshot(
+        session,
+        (text) => text.includes("FILES SLOT RIGHT") && text.includes("AUX PANE LEFT"),
+        20_000,
+      );
+      expect(reopened).toContain("alpha.ts");
     } finally {
       session.close();
     }

--- a/website/src/content/docs/docs/extend/custom-sidebars.md
+++ b/website/src/content/docs/docs/extend/custom-sidebars.md
@@ -43,7 +43,7 @@ export default function (hunk: HunkExtensionAPI) {
 }
 ```
 
-`placement` defaults to `"left"`. Left/right panes use `width`; top/bottom panes use `height`. Both accept `{ preferred, min?, max? }`, defaulting to `{ preferred: 34, min: 22 }` columns or `{ preferred: 8, min: 3 }` rows. Equal bounds make a fixed pane. Use `defaultOpen` to open a pane initially, `replaces: "hunk:files"` to replace it (and override `defaultOpen`), or `available(context)` to hide it conditionally.
+`placement` defaults to `"left"`. Left/right panes use `width`; top/bottom panes use `height`. Both accept `{ preferred, min?, max? }`, defaulting to `{ preferred: 34, min: 22 }` columns or `{ preferred: 8, min: 3 }` rows. Equal bounds make a fixed pane. Use `defaultOpen` to open a pane initially, `replaces: "hunk:files"` to replace it (and override `defaultOpen`), or `available(context)` to hide it conditionally. One pane may replace each named target; the first registration owns that slot and later claims are skipped with a warning.
 
 Set `currentLine: true` to receive Hunk's opaque selected-row painter. The [`current-line-lens` example](https://github.com/modem-dev/hunk/tree/main/examples/extensions/current-line-lens) uses it and is not bundled with Hunk.
 

--- a/website/src/content/docs/docs/start/keyboard-and-mouse.md
+++ b/website/src/content/docs/docs/start/keyboard-and-mouse.md
@@ -28,7 +28,7 @@ Hunk navigation stays review-wide: hunk and file shortcuts move through the same
 | Key             | Action                                           |
 | --------------- | ------------------------------------------------ |
 | `0` / `1` / `2` | Auto / split / stack layout                      |
-| `s`             | Toggle sidebar                                   |
+| `s`             | Toggle files pane                                |
 | `t`             | Choose a theme                                   |
 | `l`             | Toggle line numbers                              |
 | `w`             | Toggle line wrapping                             |


### PR DESCRIPTION
## Problem

The `s` shortcut toggles one global sidebar-area visibility flag. When an extension contributes a right-side pane, pressing `s` therefore hides both the built-in files pane and the extension pane even though the extension pane remains logically open. Reopening the extension pane can also bring the files pane back, which makes their controls feel coupled.

## Approach

- Make `hunk.view.toggleSidebar` toggle the active files pane's existing pane-open state instead of the global wrapper around every horizontal pane.
- Preserve replacement-pane behavior by targeting the pane that replaces `hunk:files` when one is registered.
- Keep extension commands authoritative for their own panes; this does not add or change extension APIs.
- Rename the user-facing action to **Toggle files pane** and update generated/user documentation.

This belongs in core because the built-in `s` command and global sidebar-area state are host-owned. Extensions cannot override the built-in chord or prevent the host from hiding every left/right pane.

## Behavior

Before:

```text
files | review | extension
  s   -> review
```

After:

```text
files | review | extension
  s   -> review | extension
Ctrl+G -> files | review
```

No change is intended to responsive omission: when the terminal cannot fit every requested pane while preserving the minimum review width, Hunk may still omit a pane from that frame. The logical open states remain independent.

## Validation

- `TMPDIR="$PWD/.tmp" bun test src/ui/AppHost.extension-sidebar.test.tsx src/ui/lib/appCommands.test.ts src/ui/lib/appMenus.test.ts src/core/commandCatalog.test.ts` (52 passed)
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:docs`
- `TMPDIR="$PWD/.tmp" bun run test:integration` (103 passed, 8 pager timeouts; the representative `pager mode hides chrome and pages forward on space` timeout reproduces unchanged on `main`)

## Manual UI check

Tested the compiled standalone binary on macOS in Ghostty with zsh at 197x56. With the built-in files pane and the `hunk-calldiff` right pane open, `s` closed and reopened only files; `Ctrl+G` closed and reopened only Call Flow.

## Release

Includes a patch Changeset for `hunkdiff`.