### PR TITLE
fix(session): allow max safe event revisions

### DIFF
--- a/.changeset/max-safe-event-revisions.md
+++ b/.changeset/max-safe-event-revisions.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Accept the full safe-integer revision range when resuming browser review event streams.

--- a/src/session/reviewEventProtocol.test.ts
+++ b/src/session/reviewEventProtocol.test.ts
@@ -64,6 +64,12 @@ describe("review event names and ids", () => {
       type: "publication",
       address: ADDRESS,
     });
+
+    const maximumAddress = { ...ADDRESS, stateRevision: Number.MAX_SAFE_INTEGER };
+    expect(parseReviewEventId(reviewEventId("publication", maximumAddress))).toEqual({
+      type: "publication",
+      address: maximumAddress,
+    });
   });
 
   // A client echoes `Last-Event-ID` back at the server, so the parser is the boundary an
@@ -74,6 +80,9 @@ describe("review event names and ids", () => {
     expect(parseReviewEventId("generation:test:3@1")).toBeUndefined();
     expect(
       parseReviewEventId(`revent:publication:generation:test:3@${"9".repeat(40)}`),
+    ).toBeUndefined();
+    expect(
+      parseReviewEventId("revent:publication:generation:test:3@9007199254740992"),
     ).toBeUndefined();
     expect(parseReviewEventId(42)).toBeUndefined();
   });

--- a/src/session/reviewEventProtocol.ts
+++ b/src/session/reviewEventProtocol.ts
@@ -119,7 +119,7 @@ export function parseReviewEventId(
   if (typeof value !== "string" || value.length > MAX_REVIEW_EVENT_ID_BYTES) {
     return undefined;
   }
-  const match = /^revent:([a-z-]+):(.+)@(\d{1,15})$/.exec(value);
+  const match = /^revent:([a-z-]+):(.+)@(\d{1,16})$/.exec(value);
   if (!match) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Review event IDs rejected valid 16-digit state revisions, including `Number.MAX_SAFE_INTEGER`, even though publication addresses accept all non-negative safe integers.

## Why This Change Was Made

The event ID grammar now accepts up to 16 digits and continues to use `Number.isSafeInteger` as the authoritative numeric bound.

## User Impact

SSE review event IDs now round-trip across the full supported revision range while unsafe and oversized revisions remain rejected.

## Evidence

- `bun test src/session/reviewEventProtocol.test.ts` (21 passed)
- `bunx oxfmt --check src/session/reviewEventProtocol.ts src/session/reviewEventProtocol.test.ts`
- `bunx oxlint src/session/reviewEventProtocol.ts src/session/reviewEventProtocol.test.ts --deny-warnings`
- `bun run typecheck`

Fixes #762
