### PR TITLE
fix(extensions): isolate legacy sidebar files

### DIFF
--- a/.changeset/legacy-sidebar-files.md
+++ b/.changeset/legacy-sidebar-files.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fix deprecated sidebar extensions that mutate their received file list.

--- a/src/extensions/runExtension.ts
+++ b/src/extensions/runExtension.ts
@@ -449,7 +449,16 @@ export function createExtensionApi(
         width: defaultExtensionPaneSize("left"),
         defaultOpen: view.defaultOpen,
         replaces: view.replacesDefault ? "hunk:files" : undefined,
-        component: view.component as unknown as ExtensionPane["component"],
+        component: (props) =>
+          view.component({
+            files: [...props.files],
+            selectedFileId: props.selectedFileId,
+            selectedHunkIndex: props.selectedHunkIndex,
+            width: props.width,
+            theme: props.theme,
+            keybindings: props.keybindings,
+            actions: props.actions,
+          }),
       });
     },
     registerFileView(view: ExtensionFileView) {

--- a/src/ui/AppHost.extension-sidebar.test.tsx
+++ b/src/ui/AppHost.extension-sidebar.test.tsx
@@ -221,6 +221,34 @@ describe("extension sidebar views", () => {
     });
   });
 
+  test("a legacy sidebar can sort its mutable files array", async () => {
+    const repo = createTestRepo("hunk-ext-legacy-sidebar-");
+    const extPath = join(createTempDir("hunk-ext-legacy-sidebar-ext-"), "ext.ts");
+    writeFileSync(
+      extPath,
+      `import { createElement } from "react";\n` +
+        `export default function (hunk) {\n` +
+        `  hunk.registerSidebarView({\n` +
+        `    id: "legacy-sort",\n` +
+        `    defaultOpen: true,\n` +
+        `    component: (props) => {\n` +
+        `      props.files.sort((left, right) => right.path.localeCompare(left.path));\n` +
+        `      return createElement("text", { content: "LEGACY " + props.files[0]?.path });\n` +
+        `    },\n` +
+        `  });\n` +
+        `}\n`,
+    );
+
+    const bootstrap = await launchWithExtension(repo, extPath);
+    await withAppHost(bootstrap, async (setup) => {
+      await flushUntil(
+        setup,
+        () => setup.captureCharFrame().includes("LEGACY beta.txt"),
+        "the legacy sidebar to sort its private files array",
+      );
+    });
+  });
+
   test("injects the user's resolved command bindings into a sidebar view", async () => {
     const repo = createTestRepo("hunk-ext-sidebar-keybindings-");
     const extPath = join(createTempDir("hunk-ext-sidebar-keybindings-ext-"), "ext.ts");


### PR DESCRIPTION
## Summary
- adapt deprecated sidebar views to receive a mutable copy of host-owned files
- preserve the readonly projection for modern panes
- add a render-level regression test for legacy `files.sort()`

Closes #764

## Verification
- `npx --yes bun test src/ui/AppHost.extension-sidebar.test.tsx --test-name-pattern "legacy sidebar can sort"` (RED before fix: frozen-array TypeError; GREEN after)
- `npx --yes bun test src/ui/AppHost.extension-sidebar.test.tsx`
- `npx --yes bun run format:check`
- `git diff --check`

## Scope
This preserves the deprecated mutable `ExtensionSidebarViewProps.files` contract without changing modern `ExtensionPaneProps.files`.