### PR TITLE
fix(session): reject review event frames whose id disagrees with their fields

### DIFF
--- a/.changeset/consistent-review-event-ids.md
+++ b/.changeset/consistent-review-event-ids.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reject review event frames whose event id names a different publication generation or state revision than the frame's own fields.

--- a/src/session/reviewEventProtocol.test.ts
+++ b/src/session/reviewEventProtocol.test.ts
@@ -20,6 +20,7 @@ import {
   type ReviewEventBeginV1,
   type ReviewEventChunkV1,
   type ReviewEventEndV1,
+  type ReviewEventFrameV1,
 } from "./reviewEventProtocol";
 
 const ADDRESS = { generation: "generation:test:3", stateRevision: 7 };
@@ -297,5 +298,83 @@ describe("review event envelope parsing", () => {
     expect(parseReviewEventEnd(end)).toEqual(end);
     const { chunkCount: _dropped, ...withoutCount } = end;
     expect(parseReviewEventEnd(withoutCount)).toBeUndefined();
+  });
+});
+
+describe("review event id agreement", () => {
+  const frame: ReviewEventFrameV1 = {
+    eventId: reviewEventId("publication", ADDRESS),
+    generation: ADDRESS.generation,
+    stateRevision: ADDRESS.stateRevision,
+    payload: {},
+  };
+  const begin: ReviewEventBeginV1 = {
+    eventId: reviewEventId("publication", ADDRESS),
+    generation: ADDRESS.generation,
+    stateRevision: ADDRESS.stateRevision,
+    encoding: "base64",
+    contentSize: 10,
+    contentDigest: "a".repeat(64),
+    chunkCount: 1,
+  };
+  const chunk: ReviewEventChunkV1 = {
+    eventId: begin.eventId,
+    generation: begin.generation,
+    offset: 0,
+    byteLength: 4,
+    encoding: "base64",
+    data: "AAAA",
+    contentDigest: begin.contentDigest,
+    contentSize: 10,
+    eof: true,
+  };
+  const end: ReviewEventEndV1 = {
+    eventId: begin.eventId,
+    generation: begin.generation,
+    contentSize: 10,
+    contentDigest: begin.contentDigest,
+    chunkCount: 1,
+  };
+
+  test("accepts frames whose id agrees with their fields", () => {
+    expect(parseReviewEventFrame(frame)).toEqual(frame);
+    expect(parseReviewEventBegin(begin)).toEqual(begin);
+    expect(parseReviewEventChunk(chunk)).toEqual(chunk);
+    expect(parseReviewEventEnd(end)).toEqual(end);
+  });
+
+  test("rejects a frame whose id names a different generation or revision", () => {
+    expect(parseReviewEventFrame({ ...frame, generation: "generation:test:4" })).toBeUndefined();
+    expect(
+      parseReviewEventFrame({ ...frame, stateRevision: frame.stateRevision + 1 }),
+    ).toBeUndefined();
+    // The issue's example: the id names generation 1, revision 1 while the frame claims
+    // generation 2, revision 9.
+    expect(
+      parseReviewEventFrame({
+        eventId: reviewEventId("publication", {
+          generation: "generation:producer-a:1",
+          stateRevision: 1,
+        }),
+        generation: "generation:producer-a:2",
+        stateRevision: 9,
+        payload: {},
+      }),
+    ).toBeUndefined();
+  });
+
+  test("rejects a begin envelope whose id names a different generation or revision", () => {
+    expect(parseReviewEventBegin({ ...begin, generation: "generation:test:4" })).toBeUndefined();
+    expect(
+      parseReviewEventBegin({ ...begin, stateRevision: begin.stateRevision + 1 }),
+    ).toBeUndefined();
+  });
+
+  test("rejects a chunk whose id names a different generation", () => {
+    expect(parseReviewEventChunk({ ...chunk, generation: "generation:test:4" })).toBeUndefined();
+  });
+
+  test("rejects an end envelope whose id names a different generation", () => {
+    expect(parseReviewEventEnd({ ...end, generation: "generation:test:4" })).toBeUndefined();
   });
 });

--- a/src/session/reviewEventProtocol.ts
+++ b/src/session/reviewEventProtocol.ts
@@ -211,16 +211,27 @@ function isChunkCount(value: unknown): value is number {
 /** Parse one single-frame event body. */
 export function parseReviewEventFrame(value: unknown): ReviewEventFrameV1 | undefined {
   const record = asRecord(value);
+  if (!record || !hasExactKeys(record, ["eventId", "generation", "stateRevision", "payload"])) {
+    return undefined;
+  }
+  const eventId = parseReviewEventId(record.eventId);
   if (
-    !record ||
-    !hasExactKeys(record, ["eventId", "generation", "stateRevision", "payload"]) ||
-    !isReviewEventId(record.eventId) ||
+    !eventId ||
+    // The id names the publication position an event is about; the fields the frame
+    // duplicates must name the same position, or the frame is describing two at once.
+    eventId.address.generation !== record.generation ||
+    eventId.address.stateRevision !== record.stateRevision ||
     parseReviewGeneration(record.generation) === undefined ||
     !isCount(record.stateRevision)
   ) {
     return undefined;
   }
-  return record as unknown as ReviewEventFrameV1;
+  return {
+    eventId: record.eventId as string,
+    generation: eventId.address.generation,
+    stateRevision: eventId.address.stateRevision,
+    payload: record.payload,
+  };
 }
 
 /** Parse one chunked-event begin envelope. */
@@ -237,9 +248,6 @@ export function parseReviewEventBegin(value: unknown): ReviewEventBeginV1 | unde
       "contentDigest",
       "chunkCount",
     ]) ||
-    !isReviewEventId(record.eventId) ||
-    parseReviewGeneration(record.generation) === undefined ||
-    !isCount(record.stateRevision) ||
     record.encoding !== "base64" ||
     !isPayloadSize(record.contentSize) ||
     !isReviewSha256Digest(record.contentDigest) ||
@@ -247,7 +255,25 @@ export function parseReviewEventBegin(value: unknown): ReviewEventBeginV1 | unde
   ) {
     return undefined;
   }
-  return record as unknown as ReviewEventBeginV1;
+  const eventId = parseReviewEventId(record.eventId);
+  if (
+    !eventId ||
+    eventId.address.generation !== record.generation ||
+    eventId.address.stateRevision !== record.stateRevision ||
+    parseReviewGeneration(record.generation) === undefined ||
+    !isCount(record.stateRevision)
+  ) {
+    return undefined;
+  }
+  return {
+    eventId: record.eventId as string,
+    generation: eventId.address.generation,
+    stateRevision: eventId.address.stateRevision,
+    encoding: record.encoding as "base64",
+    contentSize: record.contentSize as number,
+    contentDigest: record.contentDigest as string,
+    chunkCount: record.chunkCount as number,
+  };
 }
 
 /** Parse one chunk frame. Its bytes are decoded by the transport, as resource chunks are. */
@@ -266,8 +292,6 @@ export function parseReviewEventChunk(value: unknown): ReviewEventChunkV1 | unde
       "contentSize",
       "eof",
     ]) ||
-    !isReviewEventId(record.eventId) ||
-    parseReviewGeneration(record.generation) === undefined ||
     !isCount(record.offset) ||
     !isCount(record.byteLength) ||
     (record.byteLength as number) > REVIEW_EVENT_CHUNK_BYTES ||
@@ -279,7 +303,25 @@ export function parseReviewEventChunk(value: unknown): ReviewEventChunkV1 | unde
   ) {
     return undefined;
   }
-  return record as unknown as ReviewEventChunkV1;
+  const eventId = parseReviewEventId(record.eventId);
+  if (
+    !eventId ||
+    eventId.address.generation !== record.generation ||
+    parseReviewGeneration(record.generation) === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    eventId: record.eventId as string,
+    generation: eventId.address.generation,
+    offset: record.offset as number,
+    byteLength: record.byteLength as number,
+    encoding: record.encoding as "base64",
+    data: record.data as string,
+    contentDigest: record.contentDigest as string,
+    contentSize: record.contentSize as number,
+    eof: record.eof as boolean,
+  };
 }
 
 /** Parse one chunked-event end envelope. */
@@ -294,15 +336,27 @@ export function parseReviewEventEnd(value: unknown): ReviewEventEndV1 | undefine
       "contentDigest",
       "chunkCount",
     ]) ||
-    !isReviewEventId(record.eventId) ||
-    parseReviewGeneration(record.generation) === undefined ||
     !isPayloadSize(record.contentSize) ||
     !isReviewSha256Digest(record.contentDigest) ||
     !isChunkCount(record.chunkCount)
   ) {
     return undefined;
   }
-  return record as unknown as ReviewEventEndV1;
+  const eventId = parseReviewEventId(record.eventId);
+  if (
+    !eventId ||
+    eventId.address.generation !== record.generation ||
+    parseReviewGeneration(record.generation) === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    eventId: record.eventId as string,
+    generation: eventId.address.generation,
+    contentSize: record.contentSize as number,
+    contentDigest: record.contentDigest as string,
+    chunkCount: record.chunkCount as number,
+  };
 }
 
 // -- Framing ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #761.

The review event-frame parsers (`parseReviewEventFrame`, `parseReviewEventBegin`, `parseReviewEventChunk`, `parseReviewEventEnd`) validated `eventId`, `generation`, and `stateRevision` independently but never checked that the publication address encoded in the event id matches the duplicated fields on the frame. A frame whose id names generation 1 / revision 1 while its fields claim generation 2 / revision 9 was accepted, so resume identity, publication ordering, and assembled event metadata could describe different positions.

## Change

Each parser now parses the event id via `parseReviewEventId` and requires its address to agree with the frame's fields:

- `parseReviewEventFrame` / `parseReviewEventBegin` — generation **and** state revision must match.
- `parseReviewEventChunk` / `parseReviewEventEnd` — generation must match (these frames carry no revision).

Returned values are constructed from the parsed address and validated fields rather than casting the raw record (`record as unknown as ...`), so the decoded frame's position agrees with its id by construction.

No production sender is affected: `planReviewEventFrames` always writes agreeing fields, and all in-repo consumers parse server-produced frames.

## Verification

- 5 new adversarial tests covering mismatched generations and revisions (including the exact example from the issue), plus an accept path asserting valid frames still parse.
- `bun test src/session/reviewEventProtocol.test.ts` — 26/26 pass.
- `bun run typecheck` — clean. `bun run lint` — 0 warnings/errors.
- Full canonical suite (`bun test ./src ./packages ./scripts ./test/cli ./test/session`) — 2763 pass; the 2 failures (`DiffPane add-note clicks` UI test, one `verifyPrReleaseNotes` timeout) reproduce on clean `main` in this environment and are unrelated.
- Changeset added (`patch`) per CONTRIBUTING.md.