### PR TITLE
docs: note mise installs Hunk on Windows

### DIFF
--- a/.changeset/mise-windows-install.md
+++ b/.changeset/mise-windows-install.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Document that `mise use -g hunk` now installs Hunk on Windows with mise 2026.8.6 or newer.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ brew install hunk
 > [!NOTE]
 > If you previously installed hunk via `modem-dev/tap`, be sure to uninstall it first with `brew uninstall modem-dev/tap/hunk`.
 
-Or with [mise](https://mise.jdx.dev) (on Windows, use mise 2026.8.6 or newer):
+Or with [mise](https://mise.jdx.dev) (Windows requires mise 2026.8.6 or newer):
 
 ```bash
 mise use -g hunk

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ brew install hunk
 > [!NOTE]
 > If you previously installed hunk via `modem-dev/tap`, be sure to uninstall it first with `brew uninstall modem-dev/tap/hunk`.
 
-Or with [mise](https://mise.jdx.dev) (macOS and Linux):
+Or with [mise](https://mise.jdx.dev) (on Windows, use mise 2026.8.6 or newer):
 
 ```bash
 mise use -g hunk

--- a/website/src/content/docs/docs/start/install.md
+++ b/website/src/content/docs/docs/start/install.md
@@ -32,12 +32,14 @@ brew install hunk
 
 ## mise
 
-[mise](https://mise.jdx.dev) knows Hunk by the short name `hunk` (alias `hunkdiff`) and installs the prebuilt binary on macOS and Linux:
+[mise](https://mise.jdx.dev) knows Hunk by the short name `hunk` (alias `hunkdiff`) and installs the prebuilt binary on macOS, Linux, and Windows:
 
 ```bash
 mise use -g hunk
 hunk --version
 ```
+
+On Windows, use mise 2026.8.6 or newer; earlier releases fail with `unsupported env: windows/amd64`.
 
 Hunk also ships as a default tool in [Omarchy](https://omarchy.org), which installs it through mise.
 


### PR DESCRIPTION
`mise use -g hunk` now installs Hunk on Windows, so the docs no longer scope the mise path to macOS and Linux.

[aqua-registry#58616](https://github.com/aquaproj/aqua-registry/pull/58616) added `windows/amd64` to Hunk's `supported_envs`, but mise vendors an aqua-registry snapshot into each of its own releases. mise v2026.8.5 shipped a snapshot cut before that merge, so Windows kept failing. **v2026.8.6** is the first release whose snapshot carries the fix.

Older mise on Windows still fails with `unsupported env: windows/amd64`, so each mise section gets a short version clause. macOS and Linux have no such constraint and get no extra caveat.

## Verification

Windows 11 Pro 25H2 x64, fresh mise download, fully isolated `MISE_DATA_DIR`/`CACHE_DIR`/`STATE_DIR`/`CONFIG_DIR`, and **no** `MISE_AQUA_BAKED_REGISTRY` or `MISE_REGISTRY_FLOATING` overrides. `Get-Command hunk -All` was empty beforehand, so nothing could shadow the result.

```powershell
> mise.exe --version
2026.8.6 windows-x64 (2026-08-14)

> mise.exe settings --all | Select-String "baked_registry|registry_floating"
registry_floating       false        # stock
aqua.baked_registry     true         # stock

> mise.exe use -g hunk
mise hunk@0.18.2     [1/3] download hunkdiff-windows-x64.tar.gz
mise hunk@0.18.2     [2/3] checksum hunkdiff-windows-x64.tar.gz
mise hunk@0.18.2     [3/3] extract hunkdiff-windows-x64.tar.gz
mise hunk@0.18.2   ✓ installed
EXIT=0
```

The **aqua** backend resolved, not the `github:` fallback — a github-backend install would have been a false positive:

```powershell
> Get-Content …\installs\hunk\.mise.backend.toml
short = "hunk"
full = "aqua:modem-dev/hunk"
explicit_backend = false

> mise.exe tool hunk
Backend:            aqua:modem-dev/hunk
Active Version:     0.18.2

> mise.exe which hunk
C:\misev86\A\data\installs\hunk\0.18.2\hunkdiff-windows-x64\hunk.exe
```

`installs\hunk\…` is the aqua layout; the github backend would have installed to `installs\github-modem-dev-hunk\…`.

```powershell
> C:\misev86\A\data\installs\hunk\0.18.2\hunkdiff-windows-x64\hunk.exe --version
0.18.2

> mise.exe exec hunk -- hunk --version
0.18.2
```

Docs-only change; `bun run format` and `bun run lint` are clean.
