### PR TITLE
fix(session): reject review event frames whose id disagrees with their publication fields

### DIFF
--- a/.changeset/common-falcons-cheer.md
+++ b/.changeset/common-falcons-cheer.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reject review event frames whose event ID names a different generation or revision than the frame's own fields.

--- a/src/session/reviewEventProtocol.test.ts
+++ b/src/session/reviewEventProtocol.test.ts
@@ -249,6 +249,62 @@ describe("review event envelope parsing", () => {
     expect(parseReviewEventBegin(begin)).toEqual(begin);
   });
 
+  test("accepts a well-formed single frame", () => {
+    const single = {
+      eventId: begin.eventId,
+      generation: begin.generation,
+      stateRevision: begin.stateRevision,
+      payload: { hello: "world" },
+    };
+
+    expect(parseReviewEventFrame(single)).toEqual(single);
+  });
+
+  test("refuses a frame whose id names another generation or revision", () => {
+    const otherGeneration = "generation:test:4";
+    const single = {
+      eventId: begin.eventId,
+      generation: begin.generation,
+      stateRevision: begin.stateRevision,
+      payload: {},
+    };
+
+    expect(parseReviewEventFrame({ ...single, generation: otherGeneration })).toBeUndefined();
+    expect(parseReviewEventFrame({ ...single, stateRevision: 9 })).toBeUndefined();
+    expect(parseReviewEventBegin({ ...begin, generation: otherGeneration })).toBeUndefined();
+    expect(parseReviewEventBegin({ ...begin, stateRevision: 9 })).toBeUndefined();
+
+    const chunk: ReviewEventChunkV1 = {
+      eventId: begin.eventId,
+      generation: otherGeneration,
+      offset: 0,
+      byteLength: 10,
+      encoding: "base64",
+      data: "",
+      contentDigest: begin.contentDigest,
+      contentSize: 10,
+      eof: true,
+    };
+    expect(parseReviewEventChunk(chunk)).toBeUndefined();
+    expect(parseReviewEventChunk({ ...chunk, generation: begin.generation })).toEqual({
+      ...chunk,
+      generation: begin.generation,
+    });
+
+    const end: ReviewEventEndV1 = {
+      eventId: begin.eventId,
+      generation: otherGeneration,
+      contentSize: 10,
+      contentDigest: begin.contentDigest,
+      chunkCount: 1,
+    };
+    expect(parseReviewEventEnd(end)).toBeUndefined();
+    expect(parseReviewEventEnd({ ...end, generation: begin.generation })).toEqual({
+      ...end,
+      generation: begin.generation,
+    });
+  });
+
   test("refuses an extra field, an unknown encoding, and a non-canonical digest", () => {
     expect(parseReviewEventBegin({ ...begin, extra: 1 })).toBeUndefined();
     expect(parseReviewEventBegin({ ...begin, encoding: "hex" })).toBeUndefined();

--- a/src/session/reviewEventProtocol.ts
+++ b/src/session/reviewEventProtocol.ts
@@ -135,11 +135,6 @@ export function parseReviewEventId(
   return { type, address: { generation: match[2]!, stateRevision } };
 }
 
-/** Whether one value could be an event id a client is echoing back at us. */
-export function isReviewEventId(value: unknown): value is string {
-  return parseReviewEventId(value) !== undefined;
-}
-
 // -- Frame payloads ---------------------------------------------------------------------
 
 /** One whole event, small enough to send in a single frame. */
@@ -208,13 +203,22 @@ function isChunkCount(value: unknown): value is number {
   return isCount(value) && (value as number) >= 1 && (value as number) <= MAX_REVIEW_EVENT_CHUNKS;
 }
 
+/** Whether one frame's id names the same publication position its own fields state. */
+function eventIdMatchesFrame(
+  record: Record<string, unknown>,
+  fields: readonly (keyof ReviewPublicationAddress)[],
+): boolean {
+  const parsed = parseReviewEventId(record.eventId);
+  return parsed !== undefined && fields.every((field) => parsed.address[field] === record[field]);
+}
+
 /** Parse one single-frame event body. */
 export function parseReviewEventFrame(value: unknown): ReviewEventFrameV1 | undefined {
   const record = asRecord(value);
   if (
     !record ||
     !hasExactKeys(record, ["eventId", "generation", "stateRevision", "payload"]) ||
-    !isReviewEventId(record.eventId) ||
+    !eventIdMatchesFrame(record, ["generation", "stateRevision"]) ||
     parseReviewGeneration(record.generation) === undefined ||
     !isCount(record.stateRevision)
   ) {
@@ -237,7 +241,7 @@ export function parseReviewEventBegin(value: unknown): ReviewEventBeginV1 | unde
       "contentDigest",
       "chunkCount",
     ]) ||
-    !isReviewEventId(record.eventId) ||
+    !eventIdMatchesFrame(record, ["generation", "stateRevision"]) ||
     parseReviewGeneration(record.generation) === undefined ||
     !isCount(record.stateRevision) ||
     record.encoding !== "base64" ||
@@ -266,7 +270,7 @@ export function parseReviewEventChunk(value: unknown): ReviewEventChunkV1 | unde
       "contentSize",
       "eof",
     ]) ||
-    !isReviewEventId(record.eventId) ||
+    !eventIdMatchesFrame(record, ["generation"]) ||
     parseReviewGeneration(record.generation) === undefined ||
     !isCount(record.offset) ||
     !isCount(record.byteLength) ||
@@ -294,7 +298,7 @@ export function parseReviewEventEnd(value: unknown): ReviewEventEndV1 | undefine
       "contentDigest",
       "chunkCount",
     ]) ||
-    !isReviewEventId(record.eventId) ||
+    !eventIdMatchesFrame(record, ["generation"]) ||
     parseReviewGeneration(record.generation) === undefined ||
     !isPayloadSize(record.contentSize) ||
     !isReviewSha256Digest(record.contentDigest) ||


### PR DESCRIPTION
Fixes #761

## Problem

Event frames carry their publication position twice: inside `eventId` (`revent:<type>:<generation>@<revision>`) and as the loose `generation` / `stateRevision` fields. The four frame parsers validated each part but never checked they agree, so an id naming generation 1 / revision 1 on a frame claiming generation 2 / revision 9 was accepted. The id drives SSE resume and chunk assembly; the fields are what consumers report, so they must name the same position.

## Approach

- One module-private helper, `eventIdMatchesFrame(record, fields)`: parses the id with the existing `parseReviewEventId` (still the only id grammar) and compares the listed address fields to the frame's own.
- Each parser swaps its `isReviewEventId` gate for that helper. Frame and begin compare `generation` + `stateRevision`; chunk and end compare `generation` only (they don't carry a revision).
- Delete `isReviewEventId`, which has no remaining callers.

Non-goals: parsers keep returning the validated record via the existing casts (`hasExactKeys` doesn't narrow; rebuilding each object adds casts without changing behavior). Checking the id's event `type` against the SSE `event:` name is out of scope; the parsers never see it.

Belongs in `src/session/reviewEventProtocol.ts`: both ends of the stream import this one contract; not expressible as an extension.

## Tests

New cases in `src/session/reviewEventProtocol.test.ts`: a well-formed single frame parses; each of the four parsers rejects an id whose generation (and, where carried, revision) disagrees with the frame while every value is individually valid. The rejection test fails against the previous code. Existing round-trip/framing/reassembly tests, `browserReviewServer.integration.test.ts`, and the review-conformance consumers cover the unchanged accept path.

Ran:

```
bun test src/session/reviewEventProtocol.test.ts
bun test src/session/broker/browserReviewServer.integration.test.ts
bun test test/review-conformance
bun run typecheck
bun run lint
bun run knip
bun run format
```

Two pre-existing failures reproduce identically on `main` at 5ebe975 and are unrelated to this change:

- `test/review-conformance`: 3 failures in `pure-deletion-hunk (A1, A2)` (geometry fixtures).
- `bun run knip`: unused file `test/cli/fixtures/compiled-highlight-worker-control.ts` and unused exports in `src/ui/diff/worker/index.ts` (from #759).

Knip reports nothing for `src/session/reviewEventProtocol.ts`, including the removed `isReviewEventId`.

Tested on macOS (Bun 1.3.14). Not run on Linux/Windows; change is platform-neutral validation with no I/O. No UI change.

## AI assistance

An AI coding agent helped scope the change, draft the helper/tests, and this description. I wrote and reviewed the final diff, ran every command above, and can speak to each decision here.
