### PR TITLE
perf(diff): reuse evicted worker highlights

### DIFF
--- a/.changeset/worker-highlight-cache.md
+++ b/.changeset/worker-highlight-cache.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reuse worker-highlighted diffs after the terminal cache evicts them.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,6 +37,8 @@ bun run bench:working-tree-load
 bun run bench:changeset-parse
 bun run bench:render-layout
 bun run bench:highlight-prefetch
+bun run bench:highlight-worker-cache
+bun run bench:highlight-cache-layers
 bun run bench:large-stream
 bun run bench:interaction-latency
 bun run bench:non-ascii-stream
@@ -58,6 +60,8 @@ bun run bench:competitors
 - `changeset-parse.ts` — measures patch normalization, Pierre parsing, patch chunking, and normalized `DiffFile` construction for many-small-files, balanced, and large-single-file patches.
 - `render-layout.ts` — measures pure split/stack row building, section geometry, and review-plan construction for many-small-files, balanced, and large-single-file streams.
 - `highlight-prefetch.ts` — measures selected-file highlight startup and adjacent prefetch readiness.
+- `worker-highlight-cache.ts` — measures a cold worker highlight against an immediate compact-result cache hit.
+- `highlight-cache-layers.ts` — measures a resident terminal-cache hit against a worker-cache revisit after the terminal cache evicts the diff.
 - `large-stream.ts` — measures large split-stream first-frame and scroll cost.
 - `interaction-latency.ts` — measures per-press `]` hunk-navigation latency and per-scroll-tick latency (median + p95) on the large stream, plus RSS/heap ceilings after first frame and after navigation (the default-suite slice of `memory.ts`).
 - `non-ascii-stream.ts` — measures first-frame and per-scroll-tick latency on a stream whose diff content embeds CJK, emoji, and box-drawing characters, exercising the string-width path on content rather than chrome glyphs.

--- a/benchmarks/highlight-cache-layers.ts
+++ b/benchmarks/highlight-cache-layers.ts
@@ -1,0 +1,74 @@
+// Compare a resident main-process cache hit with a worker-LRU revisit after main-cache eviction.
+import { performance } from "node:perf_hooks";
+import { parseDiffFromFile } from "@pierre/diffs";
+import type { DiffFile } from "../src/core/types";
+import { resolveTheme } from "../src/ui/themes";
+import { disposeHighlightWorker } from "../src/ui/diff/worker/highlightWorkerClient";
+import { prefetchHighlightedDiff } from "../src/ui/diff/useHighlightedDiff";
+
+const lineCount = 8_000;
+const theme = resolveTheme("github-dark-default", null);
+
+/** Builds one unique large diff that always qualifies for worker highlighting. */
+function createFile(index: number): DiffFile {
+  const additions = Array.from(
+    { length: lineCount },
+    (_, line) => `export const marker${index}_${line} = ${line};`,
+  ).join("\n");
+  const path = `src/benchmark-${index}.ts`;
+  const metadata = parseDiffFromFile(
+    { name: path, contents: "export const prior = 1;\n", cacheKey: `before:${index}` },
+    {
+      name: path,
+      contents: `export const prior = ${index};\n${additions}\n`,
+      cacheKey: `after:${index}`,
+    },
+    { context: 3 },
+    true,
+  );
+
+  return {
+    id: `benchmark:${index}`,
+    path,
+    patch: "",
+    language: "typescript",
+    stats: { additions: lineCount, deletions: 1 },
+    metadata,
+    agent: null,
+  };
+}
+
+/** Measures production prefetch orchestration for one large diff. */
+async function timeHighlight(file: DiffFile) {
+  const start = performance.now();
+  await prefetchHighlightedDiff({ file, offloadLargeDiff: true, theme });
+  return performance.now() - start;
+}
+
+try {
+  const files = Array.from({ length: 8 }, (_, index) => createFile(index));
+  const first = files[0];
+  if (!first) {
+    throw new Error("Expected benchmark files.");
+  }
+
+  const coldMs = await timeHighlight(first);
+  const mainCacheHitMs = await timeHighlight(first);
+
+  // Eight 8k-line entries exceed the 60k-line main-cache budget but fit in the 8 MiB compact
+  // worker cache, making the next request a worker-LRU revisit.
+  for (const file of files.slice(1)) {
+    await timeHighlight(file);
+  }
+  const workerCacheHitAfterMainEvictionMs = await timeHighlight(first);
+
+  console.log(`METRIC cold_ms=${coldMs.toFixed(2)}`);
+  console.log(`METRIC main_cache_hit_ms=${mainCacheHitMs.toFixed(2)}`);
+  console.log(
+    `METRIC worker_cache_hit_after_main_eviction_ms=${workerCacheHitAfterMainEvictionMs.toFixed(2)}`,
+  );
+  console.log(`METRIC files=${files.length}`);
+  console.log(`METRIC changed_lines=${lineCount}`);
+} finally {
+  disposeHighlightWorker();
+}

--- a/benchmarks/worker-highlight-cache.ts
+++ b/benchmarks/worker-highlight-cache.ts
@@ -1,0 +1,56 @@
+// Measure a cold compact-worker highlight against a worker-local result-cache hit.
+import { performance } from "node:perf_hooks";
+import { parseDiffFromFile } from "@pierre/diffs";
+import {
+  disposeHighlightWorker,
+  highlightDiffInWorker,
+} from "../src/ui/diff/worker/highlightWorkerClient";
+import { compactHighlightedDiffByteLength } from "../src/ui/diff/worker/highlightCompact";
+
+const lineCount = 8_000;
+const additions = Array.from(
+  { length: lineCount },
+  (_, index) => `export const marker${index} = ${index};`,
+).join("\n");
+const metadata = parseDiffFromFile(
+  { name: "large.ts", contents: "export const prior = 1;\n", cacheKey: "measure:before" },
+  {
+    name: "large.ts",
+    contents: `export const prior = 2;\n${additions}\n`,
+    cacheKey: "measure:after",
+  },
+  { context: 3 },
+  true,
+);
+
+/** Submit the same immutable metadata so the second call exercises the worker-owned LRU. */
+function requestHighlight() {
+  return highlightDiffInWorker({
+    aliasContext: true,
+    appearance: "dark",
+    language: "typescript",
+    metadata,
+    theme: "pierre-dark",
+  });
+}
+
+try {
+  const coldStart = performance.now();
+  const cold = await requestHighlight();
+  const coldMs = performance.now() - coldStart;
+
+  const warmStart = performance.now();
+  const warm = await requestHighlight();
+  const warmMs = performance.now() - warmStart;
+
+  if (cold.addition.starts.length !== warm.addition.starts.length) {
+    throw new Error("Worker cache returned a compact payload with different syntax runs.");
+  }
+
+  console.log(`METRIC cold_ms=${coldMs.toFixed(2)}`);
+  console.log(`METRIC worker_cache_hit_ms=${warmMs.toFixed(2)}`);
+  console.log(`METRIC compact_payload_bytes=${compactHighlightedDiffByteLength(cold)}`);
+  console.log(`METRIC changed_lines=${lineCount}`);
+} finally {
+  disposeHighlightWorker();
+}

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "bench:highlight-prefetch": "bun run benchmarks/highlight-prefetch.ts",
     "bench:highlight-compact-payload": "bun run benchmarks/compact-highlight-payload.ts",
     "bench:highlight-worker-cache": "bun run benchmarks/worker-highlight-cache.ts",
+    "bench:highlight-cache-layers": "bun run benchmarks/highlight-cache-layers.ts",
     "bench:large-stream": "bun run benchmarks/large-stream.ts",
     "bench:interaction-latency": "bun run benchmarks/interaction-latency.ts",
     "bench:non-ascii-stream": "bun run benchmarks/non-ascii-stream.ts",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "bench:render-layout": "bun run benchmarks/render-layout.ts",
     "bench:highlight-prefetch": "bun run benchmarks/highlight-prefetch.ts",
     "bench:highlight-compact-payload": "bun run benchmarks/compact-highlight-payload.ts",
+    "bench:highlight-worker-cache": "bun run benchmarks/worker-highlight-cache.ts",
     "bench:large-stream": "bun run benchmarks/large-stream.ts",
     "bench:interaction-latency": "bun run benchmarks/interaction-latency.ts",
     "bench:non-ascii-stream": "bun run benchmarks/non-ascii-stream.ts",

--- a/src/ui/diff/diffRows.ts
+++ b/src/ui/diff/diffRows.ts
@@ -628,12 +628,15 @@ async function loadWorkerHighlightedDiff(
   theme: AppTheme,
   sourcePlan: SourceBackedHighlightPlan | null,
 ) {
+  const aliasContext = sourcePlan === null;
+  const language = file.language ?? "text";
+  const syntaxTheme = syntaxHighlightThemeName(theme);
   const payload = await highlightDiffInWorker({
-    aliasContext: sourcePlan === null,
+    aliasContext,
     appearance: theme.appearance,
-    language: file.language ?? "text",
+    language,
     metadata,
-    theme: syntaxHighlightThemeName(theme),
+    theme: syntaxTheme,
   });
   validateCompactHighlightedDiff(payload, compactHighlightLineLengths(metadata));
 

--- a/src/ui/diff/worker/highlightCompact.ts
+++ b/src/ui/diff/worker/highlightCompact.ts
@@ -174,6 +174,26 @@ export function compactHighlightTransferList(payload: CompactHighlightedDiff) {
   return [...sideTransferList(payload.deletion), ...sideTransferList(payload.addition)];
 }
 
+/** Clone one payload before transferring it so a worker-owned cache keeps its buffers. */
+export function cloneCompactHighlightedDiff(
+  payload: CompactHighlightedDiff,
+): CompactHighlightedDiff {
+  const cloneSide = (side: CompactHighlightSide): CompactHighlightSide => ({
+    lineOffsets: side.lineOffsets.slice(),
+    starts: side.starts.slice(),
+    ends: side.ends.slice(),
+    styleIds: side.styleIds.slice(),
+    flags: side.flags.slice(),
+  });
+
+  return {
+    version: payload.version,
+    foregroundPalette: [...payload.foregroundPalette],
+    deletion: cloneSide(payload.deletion),
+    addition: cloneSide(payload.addition),
+  };
+}
+
 /** Estimate the retained wire size, including the small cloned color palette. */
 export function compactHighlightedDiffByteLength(payload: CompactHighlightedDiff) {
   const numericBytes = compactHighlightTransferList(payload).reduce(

--- a/src/ui/diff/worker/highlightWorker.ts
+++ b/src/ui/diff/worker/highlightWorker.ts
@@ -13,11 +13,14 @@ import {
 } from "@pierre/diffs";
 import { aliasContextHighlightLines } from "./highlightContext";
 import {
+  cloneCompactHighlightedDiff,
   compactHighlightTransferList,
   encodeCompactHighlightedDiff,
   type CompactHighlightedDiff,
+  type HighlightedHastLines,
 } from "./highlightCompact";
-import type { HighlightedHastLines } from "./highlightCompact";
+import { HighlightWorkerCache } from "./highlightWorkerCache";
+import { highlightWorkerCacheKey } from "./highlightWorkerIdentity";
 
 interface HighlightWorkerRequest {
   version: 3;
@@ -37,6 +40,8 @@ type HighlightWorkerResponse =
       code: CompactHighlightedDiff;
     }
   | { version: 3; id: number; ok: false; message: string };
+
+const highlightedDiffCache = new HighlightWorkerCache();
 
 /** Build the fixed Pierre render options shared with the terminal highlighter. */
 function workerRenderOptions(theme: string) {
@@ -71,20 +76,38 @@ self.onmessage = async (event: MessageEvent<HighlightWorkerRequest>) => {
   }
 
   try {
-    const options = getHighlighterOptions(language, { theme: theme as never });
-    const highlighter = await getSharedHighlighter({
-      ...options,
-      preferredHighlighter: "shiki-wasm",
-    });
-    const result = renderDiffWithHighlighter(metadata, highlighter, workerRenderOptions(theme));
-    const highlighted = result.code as {
-      deletionLines: HighlightedHastLines;
-      additionLines: HighlightedHastLines;
-    };
-    const code = encodeCompactHighlightedDiff(
-      aliasContext ? aliasContextHighlightLines(metadata, highlighted) : highlighted,
+    const cacheKey = highlightWorkerCacheKey({
+      aliasContext,
       appearance,
-    );
+      language,
+      metadata,
+      theme,
+    });
+    // A transferred response detaches its buffers. Cache hits therefore return a fresh typed-array
+    // copy, while the worker retains its own compact payload for a later request.
+    let code = highlightedDiffCache.get(cacheKey);
+    if (!code) {
+      const highlighter = await getSharedHighlighter({
+        ...getHighlighterOptions(language, { theme: theme as never }),
+        preferredHighlighter: "shiki-wasm",
+      });
+      const result = renderDiffWithHighlighter(metadata, highlighter, workerRenderOptions(theme));
+      const highlighted = result.code as {
+        deletionLines: HighlightedHastLines;
+        additionLines: HighlightedHastLines;
+      };
+      const cachedCode = encodeCompactHighlightedDiff(
+        aliasContext ? aliasContextHighlightLines(metadata, highlighted) : highlighted,
+        appearance,
+      );
+
+      // Oversized payloads stay uncached and transfer their only copy, avoiding a temporary
+      // second typed-array payload that would violate the worker cache's memory bound.
+      code = highlightedDiffCache.set(cacheKey, cachedCode)
+        ? cloneCompactHighlightedDiff(cachedCode)
+        : cachedCode;
+    }
+
     const response: HighlightWorkerResponse = {
       version: 3,
       id,

--- a/src/ui/diff/worker/highlightWorkerCache.test.ts
+++ b/src/ui/diff/worker/highlightWorkerCache.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { compactHighlightTransferList, type CompactHighlightedDiff } from "./highlightCompact";
+import { HighlightWorkerCache } from "./highlightWorkerCache";
+
+/** Builds one valid compact payload with a predictable retained size. */
+function createTestCompactPayload(lineCount = 1): CompactHighlightedDiff {
+  return {
+    version: 1,
+    foregroundPalette: ["#keyword"],
+    deletion: {
+      lineOffsets: Uint32Array.from({ length: lineCount + 1 }, (_, index) => index),
+      starts: Uint32Array.from({ length: lineCount }, () => 0),
+      ends: Uint32Array.from({ length: lineCount }, () => 4),
+      styleIds: Uint16Array.from({ length: lineCount }, () => 1),
+      flags: new Uint8Array(lineCount),
+    },
+    addition: {
+      lineOffsets: Uint32Array.of(0),
+      starts: new Uint32Array(),
+      ends: new Uint32Array(),
+      styleIds: new Uint16Array(),
+      flags: new Uint8Array(),
+    },
+  };
+}
+
+describe("highlight worker cache", () => {
+  test("returns a transferable clone without detaching its retained payload", () => {
+    const cache = new HighlightWorkerCache();
+    const payload = createTestCompactPayload();
+    cache.set("first", payload);
+
+    const firstResponse = cache.get("first");
+    expect(firstResponse).toBeDefined();
+    expect(firstResponse).not.toBe(payload);
+    expect(firstResponse?.deletion.starts).not.toBe(payload.deletion.starts);
+
+    const transferred = structuredClone(firstResponse!, {
+      transfer: compactHighlightTransferList(firstResponse!),
+    });
+    expect(firstResponse?.deletion.starts.byteLength).toBe(0);
+    expect(transferred.deletion.starts).toEqual(Uint32Array.of(0));
+    expect(cache.get("first")?.deletion.starts).toEqual(Uint32Array.of(0));
+  });
+
+  test("evicts the least-recently-used payload under its byte budget", () => {
+    const payload = createTestCompactPayload();
+    const onePayloadBytes = new HighlightWorkerCache();
+    onePayloadBytes.set("measure", payload);
+    const cache = new HighlightWorkerCache(onePayloadBytes.getCachedBytes() * 2);
+
+    cache.set("first", createTestCompactPayload());
+    cache.set("second", createTestCompactPayload());
+    expect(cache.get("first")).toBeDefined();
+    cache.set("third", createTestCompactPayload());
+
+    expect(cache.get("first")).toBeDefined();
+    expect(cache.get("second")).toBeUndefined();
+    expect(cache.get("third")).toBeDefined();
+  });
+
+  test("skips an oversized payload without evicting a fitting resident entry", () => {
+    const payload = createTestCompactPayload();
+    const measured = new HighlightWorkerCache();
+    measured.set("measure", payload);
+    const cache = new HighlightWorkerCache(measured.getCachedBytes());
+    expect(cache.set("fitting", payload)).toBe(true);
+    expect(cache.set("oversized", createTestCompactPayload(2))).toBe(false);
+
+    expect(cache.get("fitting")).toBeDefined();
+    expect(cache.get("oversized")).toBeUndefined();
+  });
+
+  test("releases a replaced payload's previous byte charge", () => {
+    const payload = createTestCompactPayload();
+    const measured = new HighlightWorkerCache();
+    measured.set("measure", payload);
+    const cache = new HighlightWorkerCache(measured.getCachedBytes() * 2);
+
+    cache.set("reloaded", createTestCompactPayload());
+    cache.set("reloaded", createTestCompactPayload(2));
+    cache.set("kept", createTestCompactPayload());
+
+    expect(cache.get("reloaded")).toBeUndefined();
+    expect(cache.get("kept")).toBeDefined();
+  });
+});

--- a/src/ui/diff/worker/highlightWorkerCache.ts
+++ b/src/ui/diff/worker/highlightWorkerCache.ts
@@ -1,0 +1,71 @@
+import {
+  cloneCompactHighlightedDiff,
+  compactHighlightedDiffByteLength,
+  type CompactHighlightedDiff,
+} from "./highlightCompact";
+
+/** Bounds compact worker response bytes retained after the terminal-owned cache evicts them. */
+export const MAX_WORKER_HIGHLIGHT_CACHE_BYTES = 8 * 1024 * 1024;
+
+interface HighlightWorkerCacheEntry {
+  bytes: number;
+  payload: CompactHighlightedDiff;
+}
+
+/** Holds a byte-bounded LRU of compact worker results without surrendering response buffers. */
+export class HighlightWorkerCache {
+  private readonly entries = new Map<string, HighlightWorkerCacheEntry>();
+  private readonly maxBytes: number;
+  private cachedBytes = 0;
+
+  constructor(maxBytes = MAX_WORKER_HIGHLIGHT_CACHE_BYTES) {
+    this.maxBytes = Number.isFinite(maxBytes) ? Math.max(1, Math.floor(maxBytes)) : 1;
+  }
+
+  /** Returns a transferable copy while preserving the worker-owned cached payload. */
+  get(cacheKey: string) {
+    const entry = this.entries.get(cacheKey);
+    if (!entry) {
+      return undefined;
+    }
+
+    this.entries.delete(cacheKey);
+    this.entries.set(cacheKey, entry);
+    return cloneCompactHighlightedDiff(entry.payload);
+  }
+
+  /** Retains one worker-owned payload and evicts least-recently-used entries over budget. */
+  set(cacheKey: string, payload: CompactHighlightedDiff) {
+    const entry = { bytes: compactHighlightedDiffByteLength(payload), payload };
+    if (entry.bytes > this.maxBytes) {
+      return false;
+    }
+
+    const previous = this.entries.get(cacheKey);
+    if (previous) {
+      this.cachedBytes -= previous.bytes;
+      this.entries.delete(cacheKey);
+    }
+
+    this.entries.set(cacheKey, entry);
+    this.cachedBytes += entry.bytes;
+
+    while (this.cachedBytes > this.maxBytes) {
+      const leastRecentlyUsed = this.entries.entries().next().value;
+      if (!leastRecentlyUsed) {
+        return false;
+      }
+
+      const [key, evicted] = leastRecentlyUsed;
+      this.entries.delete(key);
+      this.cachedBytes -= evicted.bytes;
+    }
+
+    return true;
+  }
+
+  /** Reports retained payload bytes for focused cache tests. */
+  getCachedBytes() {
+    return this.cachedBytes;
+  }
+}

--- a/src/ui/diff/worker/highlightWorkerIdentity.test.ts
+++ b/src/ui/diff/worker/highlightWorkerIdentity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { parseDiffFromFile } from "@pierre/diffs";
+import { highlightWorkerCacheKey } from "./highlightWorkerIdentity";
+
+/** Build worker inputs from actual Pierre metadata rather than an incomplete test shape. */
+function createTestIdentity({ after = "const answer = 42;\n", name = "example.ts" } = {}) {
+  return {
+    aliasContext: true,
+    appearance: "dark" as const,
+    language: "typescript",
+    metadata: parseDiffFromFile(
+      { name, contents: "const answer = 41;\n", cacheKey: "before" },
+      { name, contents: after, cacheKey: "after" },
+      { context: 3 },
+      true,
+    ),
+    theme: "pierre-dark",
+  };
+}
+
+describe("highlight worker cache identity", () => {
+  test("matches equivalent full worker inputs", () => {
+    expect(highlightWorkerCacheKey(createTestIdentity())).toBe(
+      highlightWorkerCacheKey(createTestIdentity()),
+    );
+  });
+
+  test("changes for same-length diff text and rendering inputs", () => {
+    const base = createTestIdentity();
+    const sameLengthText = createTestIdentity({ after: "const answer = 24;\n" });
+
+    expect(highlightWorkerCacheKey(sameLengthText)).not.toBe(highlightWorkerCacheKey(base));
+    expect(highlightWorkerCacheKey({ ...base, aliasContext: false })).not.toBe(
+      highlightWorkerCacheKey(base),
+    );
+    expect(
+      highlightWorkerCacheKey({ ...base, appearance: "light", theme: "pierre-light" }),
+    ).not.toBe(highlightWorkerCacheKey(base));
+    expect(highlightWorkerCacheKey({ ...base, language: "javascript" })).not.toBe(
+      highlightWorkerCacheKey(base),
+    );
+    expect(highlightWorkerCacheKey(createTestIdentity({ name: "example.js" }))).not.toBe(
+      highlightWorkerCacheKey(base),
+    );
+  });
+});

--- a/src/ui/diff/worker/highlightWorkerIdentity.ts
+++ b/src/ui/diff/worker/highlightWorkerIdentity.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import type { FileDiffMetadata } from "@pierre/diffs";
+
+const HIGHLIGHT_WORKER_CACHE_REVISION = 1;
+
+/** Hash every worker-render input so compact payloads never rely on caller cache-key discipline. */
+export function highlightWorkerCacheKey({
+  aliasContext,
+  appearance,
+  language,
+  metadata,
+  theme,
+}: {
+  aliasContext: boolean;
+  appearance: "dark" | "light";
+  language: string;
+  metadata: FileDiffMetadata;
+  theme: string;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        aliasContext,
+        appearance,
+        language,
+        metadata,
+        revision: HIGHLIGHT_WORKER_CACHE_REVISION,
+        theme,
+      }),
+    )
+    .digest("hex");
+}


### PR DESCRIPTION
## Summary

- retain compact syntax-highlight payloads in Hunk's existing Bun worker under an 8 MiB byte-bounded LRU
- safely clone cached typed-array buffers before transferring responses to the terminal process
- add content-addressed worker cache identity, coverage, and focused cache-layer benchmarks

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test src/ui/diff/diffRows.test.ts src/ui/diff/worker/highlightCompact.test.ts src/ui/diff/worker/highlightWorkerCache.test.ts src/ui/diff/worker/highlightWorkerIdentity.test.ts src/ui/diff/worker/highlightWorkerClient.test.ts`
- `bun run bench:highlight-cache-layers`

## v0.19.0 comparison

Seven fresh processes each highlighted the same 8,000-line TypeScript diff, then made five sequential identical worker requests.

| Metric (median) | v0.19.0 | This PR |
| --- | ---: | ---: |
| Cold request | 374.29 ms | 380.73 ms |
| Repeated direct worker request | 234.65 ms | 1.48 ms |

The worker cache makes repeated direct worker requests about 159× faster in this controlled revisit workload. Cold performance is effectively unchanged.

`bench:highlight-cache-layers` also tests the real `prefetchHighlightedDiff` path: it makes eight unique 8,000-line requests (exceeding the 60k-line main cache) and revisits the first. Across five fresh-process samples, the resident main-cache hit remained 0.32 ms in both revisions; the post-eviction revisit fell from 233.24 ms on v0.19.0 to 3.25 ms on this PR. The main cache remains worthwhile: it is about 10× faster than a worker-LRU hit and supplies a highlighted snapshot during render instead of waiting for an effect.

`bun test` was also attempted; its three failures are pre-existing missing website test dependencies (`@axe-core/playwright` and `@playwright/test`) in this worktree.

*This PR description was generated by Pi using gpt-5.6-terra*
