### PR TITLE
fix(ui): cache complex Unicode cluster widths

### DIFF
--- a/.changeset/swift-clusters-measure.md
+++ b/.changeset/swift-clusters-measure.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Accelerate complex Unicode text width measurement in reviews.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -66,7 +66,7 @@ bun run bench:competitors
 - `interaction-latency.ts` — measures per-press `]` hunk-navigation latency and per-scroll-tick latency (median + p95) on the large stream, plus RSS/heap ceilings after first frame and after navigation (the default-suite slice of `memory.ts`).
 - `non-ascii-stream.ts` — measures first-frame and per-scroll-tick latency on a stream whose diff content embeds CJK, emoji, and box-drawing characters, exercising the string-width path on content rather than chrome glyphs.
 - `wrapped-cjk.ts` — reproduces issue #579 with 518 wrapped Japanese Markdown lines plus one pathological long logical line, includes renderer setup in first-frame latency, and measures immediate/coalesced frames from a real wheel burst.
-- `terminal-width.ts` — measures scalar-heavy CJK and emoji width calls plus the complex-cluster fallback against equivalent `string-width` reference paths, verifying identical width checksums.
+- `terminal-width.ts` — measures scalar-heavy CJK and emoji width calls plus cached complex-cluster measurements against equivalent `string-width` reference paths, verifying identical width checksums.
 - `huge-stream.ts` — opt-in huge tier (`--include-huge` or `HUNK_BENCH_INCLUDE_HUGE=1`): cold first frame, scroll-tick and hunk-navigation latency, and memory ceilings on ~1k files / 300k+ diff lines plus one giant ~50k-line file.
 - `large-stream-profile.ts` — optional local profiler for the main pure planning stages behind the large split-stream benchmark.
 - `memory.ts` — optional local RSS/heap profiler after fixture loading, planning, first frame, and next-hunk navigation.

--- a/benchmarks/terminal-width.ts
+++ b/benchmarks/terminal-width.ts
@@ -1,4 +1,4 @@
-// Benchmark Hunk's scalar fast path and complex-cluster fallback against string-width.
+// Benchmark Hunk's scalar fast path and cached complex-cluster path against string-width.
 import { performance } from "node:perf_hooks";
 import stringWidth from "string-width";
 import { measureTextWidth } from "../src/ui/lib/text";

--- a/src/ui/lib/text.ts
+++ b/src/ui/lib/text.ts
@@ -8,17 +8,11 @@ const printableAsciiRegex = /^[\u0020-\u007E]*$/;
 export function isPrintableAsciiText(text: string) {
   return printableAsciiRegex.test(text);
 }
-const graphemeSegmenter =
-  typeof Intl !== "undefined" && "Segmenter" in Intl
-    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
-    : null;
+// Hunk and string-width both require Intl.Segmenter to preserve terminal grapheme semantics.
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 /** Iterate user-visible text clusters so wide and combining characters stay together. */
 export function textClusters(text: string) {
-  if (!graphemeSegmenter) {
-    return Array.from(text);
-  }
-
   return Array.from(graphemeSegmenter.segment(text), (segment) => segment.segment);
 }
 
@@ -101,14 +95,75 @@ export function measureSimpleSanitizedTextWidth(text: string) {
   return width;
 }
 
+// Real source reuses a small vocabulary of multi-scalar clusters, while a diff can supply
+// unbounded input. Cap both the entry count and cached key length to bound retained text.
+export const CLUSTER_WIDTH_CACHE_MAX_ENTRIES = 256;
+export const CLUSTER_WIDTH_CACHE_MAX_KEY_CODE_UNITS = 64;
+
+/** Store terminal widths without retaining an unbounded set or size of source clusters. */
+export class BoundedClusterWidthCache {
+  readonly #entries = new Map<string, number>();
+
+  constructor(
+    private readonly maxEntries: number,
+    private readonly maxKeyCodeUnits: number,
+  ) {}
+
+  /** Return one cached width without changing the FIFO eviction order. */
+  get(cluster: string) {
+    return this.#entries.get(cluster);
+  }
+
+  /** Cache one eligible width and remove the oldest entry when the limit is exceeded. */
+  set(cluster: string, width: number) {
+    if (cluster.length > this.maxKeyCodeUnits) {
+      return;
+    }
+
+    this.#entries.set(cluster, width);
+    while (this.#entries.size > this.maxEntries) {
+      const oldest = this.#entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.#entries.delete(oldest);
+    }
+  }
+
+  /** Return the number of retained cluster widths. */
+  get size() {
+    return this.#entries.size;
+  }
+}
+
+const cachedClusterWidths = new BoundedClusterWidthCache(
+  CLUSTER_WIDTH_CACHE_MAX_ENTRIES,
+  CLUSTER_WIDTH_CACHE_MAX_KEY_CODE_UNITS,
+);
+
+/** Measure one complex cluster with a small FIFO cache for repeated source glyphs. */
+function measureCachedClusterWidth(cluster: string) {
+  const cached = cachedClusterWidths.get(cluster);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const width = stringWidth(cluster);
+  cachedClusterWidths.set(cluster, width);
+  return width;
+}
+
 /**
  * Measure one grapheme cluster in terminal cells, matching string-width on every input.
  *
  * A single-scalar cluster can never be an emoji sequence, and every single-scalar emoji is East
  * Asian Wide, so a zero-width check plus the EAW table reproduces string-width exactly.
- * Multi-scalar clusters delegate to string-width itself.
+ * Multi-scalar clusters delegate to string-width through a bounded cluster cache.
  */
 export function measureClusterWidth(cluster: string): number {
+  // Complex source lines still contain mostly ASCII clusters after segmentation.
+  if (cluster.length === 1 && cluster.charCodeAt(0) >= 0x20 && cluster.charCodeAt(0) <= 0x7e) {
+    return 1;
+  }
+
   const codePoint = cluster.codePointAt(0);
   if (codePoint === undefined) {
     return 0;
@@ -120,7 +175,7 @@ export function measureClusterWidth(cluster: string): number {
     return zeroWidthScalarRegex.test(cluster) ? 0 : eastAsianWidth(codePoint);
   }
 
-  return stringWidth(cluster);
+  return measureCachedClusterWidth(cluster);
 }
 
 /**
@@ -167,8 +222,19 @@ export function measureSanitizedTextWidth(text: string) {
   }
 
   // Most source text is a sequence of independent scalars. Scan code points directly instead of
-  // allocating Intl.Segmenter records; composition-sensitive text keeps the whole-string fallback.
-  return measureSimpleSanitizedTextWidth(text) ?? stringWidth(text);
+  // allocating Intl.Segmenter records. Composition-sensitive text segments once and reuses the
+  // bounded cluster cache, avoiding string-width's full emoji-regex pass for every source line.
+  const simpleWidth = measureSimpleSanitizedTextWidth(text);
+  if (simpleWidth !== null) {
+    return simpleWidth;
+  }
+
+  // Avoid materializing cluster strings in an array for a width-only traversal.
+  let width = 0;
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    width += measureClusterWidth(segment);
+  }
+  return width;
 }
 
 /** Measure text in terminal cells, treating CJK and emoji clusters as wide. */

--- a/src/ui/lib/ui-lib.test.ts
+++ b/src/ui/lib/ui-lib.test.ts
@@ -15,6 +15,9 @@ import { createVisibleAgentNote } from "./agentAnnotations";
 import { buildAgentPopoverContent, resolveAgentPopoverPlacement } from "./agentPopover";
 import { isEscapeKey, isSaveDraftNoteKey } from "./keyboard";
 import {
+  BoundedClusterWidthCache,
+  CLUSTER_WIDTH_CACHE_MAX_ENTRIES,
+  CLUSTER_WIDTH_CACHE_MAX_KEY_CODE_UNITS,
   cellRangeToCharRange,
   fitText,
   measureClusterWidth,
@@ -322,6 +325,48 @@ describe("ui helpers", () => {
     for (const line of complexLines) {
       expect(measureTextWidth(line)).toBe(stringWidth(line));
     }
+  });
+
+  test("bounded cluster cache evicts FIFO entries and rejects oversized keys", () => {
+    const cache = new BoundedClusterWidthCache(
+      CLUSTER_WIDTH_CACHE_MAX_ENTRIES,
+      CLUSTER_WIDTH_CACHE_MAX_KEY_CODE_UNITS,
+    );
+    for (let index = 0; index < CLUSTER_WIDTH_CACHE_MAX_ENTRIES; index += 1) {
+      cache.set(`cluster-${index}`, index);
+    }
+
+    // Reads do not change FIFO order, so the oldest entry is still evicted.
+    expect(cache.get("cluster-0")).toBe(0);
+    cache.set("cluster-new", CLUSTER_WIDTH_CACHE_MAX_ENTRIES);
+    expect(cache.size).toBe(CLUSTER_WIDTH_CACHE_MAX_ENTRIES);
+    expect(cache.get("cluster-0")).toBeUndefined();
+    expect(cache.get("cluster-new")).toBe(CLUSTER_WIDTH_CACHE_MAX_ENTRIES);
+
+    const oversizedKey = "x".repeat(CLUSTER_WIDTH_CACHE_MAX_KEY_CODE_UNITS + 1);
+    cache.set(oversizedKey, 999);
+    expect(cache.size).toBe(CLUSTER_WIDTH_CACHE_MAX_ENTRIES);
+    expect(cache.get(oversizedKey)).toBeUndefined();
+    expect(cache.get("cluster-1")).toBe(1);
+  });
+
+  test("complex cluster widths stay exact across bounded-cache churn", () => {
+    const clusters = Array.from(
+      { length: 300 },
+      (_, index) =>
+        `${String.fromCodePoint(0x61 + (index % 26))}${String.fromCodePoint(
+          0x300 + (index % 112),
+        )}${String.fromCodePoint(0x300 + (Math.floor(index / 112) % 112))}`,
+    );
+
+    for (const cluster of clusters) {
+      expect(measureTextWidth(cluster)).toBe(stringWidth(cluster));
+    }
+
+    // An oversized combining cluster stays exact without becoming a retained cache key.
+    const oversizedCluster = `a${"\u0301".repeat(64)}`;
+    expect(measureTextWidth(oversizedCluster)).toBe(stringWidth(oversizedCluster));
+    expect(measureTextWidth(clusters[0]!)).toBe(stringWidth(clusters[0]!));
   });
 
   test("repeated single-character runs use the fast width path without losing correctness", () => {


### PR DESCRIPTION
## Summary
- segment composition-sensitive text once instead of measuring the full line with `string-width`
- cache exact multi-scalar cluster widths with a 256-entry / 64-code-unit FIFO bound
- add cache-bound and Unicode-parity coverage plus a patch changeset

## Validation
- `bun test src/ui/lib/ui-lib.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run bench:terminal-width` — checksum remains `196000`; complex-cluster hot path measured ~28.5× faster locally

`bun test` still has unrelated fresh-main failures in review-conformance/diff pairing plus Playwright test discovery.

*This PR description was generated by Pi using gpt-5.6-terra*