### PR TITLE
perf(ui): reduce hunk navigation latency

### DIFF
--- a/.changeset/warm-frogs-navigate.md
+++ b/.changeset/warm-frogs-navigate.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reduce hunk navigation latency by avoiding unnecessary diff, sidebar, and syntax-highlighting work.

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -131,7 +131,7 @@ function estimateInitialRenderViewportHeight(rendererHeight: number, screenTop: 
   return Math.max(1, rendererHeight - Math.max(0, screenTop));
 }
 
-/** Keep syntax-highlight warm for the files immediately adjacent to the current selection. */
+/** Keep syntax highlighting warm for files immediately adjacent to the selection. */
 function buildAdjacentPrefetchFileIds(files: DiffFile[], selectedFileId?: string) {
   if (!selectedFileId) {
     return new Set<string>();
@@ -160,10 +160,8 @@ function buildAdjacentPrefetchFileIds(files: DiffFile[], selectedFileId?: string
 /**
  * Start highlight work before files visibly enter the review stream.
  *
- * We intentionally include three groups:
- * - the selected file, so direct navigation always warms the active target
- * - adjacent files, so hunk/file navigation does not wait on a cold highlight
- * - files within a larger viewport halo, so wheel/track scrolling sees colorized rows already ready
+ * Selected and adjacent files cover direct navigation, while the larger viewport halo keeps
+ * wheel and track scrolling warm. Highlight prefetch does not force these files to mount.
  */
 function buildHighlightPrefetchFileIds({
   adjacentPrefetchFileIds,
@@ -1472,7 +1470,6 @@ export function DiffPane({
       windowingEnabled
         ? buildFileRenderWindow({
             fileSectionLayouts,
-            includeFileIds: adjacentPrefetchFileIds,
             indexByFileId: fileSectionIndexById,
             overscanFiles: 1,
             scrollTop: scrollViewport.top,
@@ -1481,7 +1478,6 @@ export function DiffPane({
           })
         : null,
     [
-      adjacentPrefetchFileIds,
       fileSectionIndexById,
       fileSectionLayouts,
       scrollViewport.height,

--- a/src/ui/components/panes/ExtensionPane.tsx
+++ b/src/ui/components/panes/ExtensionPane.tsx
@@ -1,4 +1,4 @@
-import { Component, memo, useMemo, type ReactNode } from "react";
+import { Component, memo, useMemo, useRef, type ReactNode } from "react";
 import type {
   ExtensionDiffFile,
   ExtensionNotifyType,
@@ -92,22 +92,29 @@ function ExtensionPaneHostView({
 }: ExtensionPaneHostProps) {
   const { extensionId } = registered;
   const publicTheme = useMemo(() => toExtensionPaintTheme(theme), [theme]);
+  // Selection rerenders the pane host, but it does not replace the capabilities these callbacks
+  // represent. Keep the public actions stable so memoized extension rows do not all repaint when
+  // only the selected file changed; ref indirection still invokes the latest host generation.
+  const actionTargetsRef = useRef({ notify, onSelectFile, onSelectHunk, onRevealLine });
+  actionTargetsRef.current = { notify, onSelectFile, onSelectHunk, onRevealLine };
   const actions = useMemo<ExtensionPaneActions>(
     () =>
       Object.freeze({
         ...createGuardedReviewNavigation({
           extensionId,
           getFiles: () => files,
-          notify,
-          onSelectFile,
-          onSelectHunk,
-          onRevealLine,
+          notify: (message, type) => actionTargetsRef.current.notify(message, type),
+          onSelectFile: (fileId) => actionTargetsRef.current.onSelectFile(fileId),
+          onSelectHunk: (fileId, hunkIndex) =>
+            actionTargetsRef.current.onSelectHunk(fileId, hunkIndex),
+          onRevealLine: (fileId, side, line) =>
+            actionTargetsRef.current.onRevealLine(fileId, side, line),
         }),
         notify(message: string, type: ExtensionNotifyType = "info") {
-          notify(`${extensionId}: ${message}`, type);
+          actionTargetsRef.current.notify(`${extensionId}: ${message}`, type);
         },
       }),
-    [extensionId, files, notify, onRevealLine, onSelectFile, onSelectHunk],
+    [extensionId, files],
   );
   const View = registered.pane.component as (props: ExtensionPaneProps) => ReactNode;
   const viewProps: ExtensionPaneProps = {

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -74,6 +74,12 @@ interface RowHighlight {
   colRange?: CopySelectedRowRange;
 }
 
+interface CellPrefix {
+  text: string;
+  fg: string;
+  bg: string;
+}
+
 /** Column span covering a row's whole content column, in the global columns selection uses. */
 const FULL_ROW_COL_RANGE: CopySelectedRowRange = { startCol: 0, endCol: Number.MAX_SAFE_INTEGER };
 
@@ -321,6 +327,135 @@ function appendFixedInlineChunks(
       bg: styledTextColor(renderedBackground(fallbackBg)),
     });
   }
+}
+
+/** Append one horizontally windowed nowrap cell directly to OpenTUI styled-text chunks. */
+function appendPlainInlineChunks(
+  chunks: TextChunk[],
+  spans: RenderSpan[],
+  width: number,
+  horizontalOffset: number,
+  fallbackColor: string,
+  fallbackBg: string,
+) {
+  const { spans: trimmed, usedWidth } = sliceSpansWindow(
+    sanitizeTerminalSpans(spans),
+    horizontalOffset,
+    width,
+  );
+  const paddingAmount = Math.max(0, width - usedWidth);
+  const lastSpan = trimmed.at(-1);
+  let paddingMerged = false;
+  if (
+    paddingAmount > 0 &&
+    lastSpan &&
+    (lastSpan.fg ?? fallbackColor) === fallbackColor &&
+    (lastSpan.bg ?? fallbackBg) === fallbackBg
+  ) {
+    lastSpan.text += " ".repeat(paddingAmount);
+    paddingMerged = true;
+  }
+
+  for (const span of trimmed) {
+    chunks.push({
+      __isChunk: true,
+      text: span.text,
+      fg: styledTextColor(span.fg ?? fallbackColor),
+      bg: styledTextColor(span.bg ?? fallbackBg),
+    });
+  }
+  if (!paddingMerged && paddingAmount > 0) {
+    chunks.push({
+      __isChunk: true,
+      text: " ".repeat(paddingAmount),
+      fg: styledTextColor(fallbackColor),
+      bg: styledTextColor(fallbackBg),
+    });
+  }
+}
+
+/** Append one unhighlighted split cell without constructing React span fibers. */
+function appendPlainSplitCellChunks(
+  chunks: TextChunk[],
+  cell: SplitLineCell,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+  theme: AppTheme,
+  contentOffset: number,
+  prefix: CellPrefix,
+) {
+  const palette = splitCellPalette(cell.kind, theme, cell.moveKind);
+  const { gutterWidth, contentWidth } = resolveSplitCellGeometry(
+    width,
+    lineNumberDigits,
+    showLineNumbers,
+    prefix.text.length,
+  );
+  chunks.push(
+    {
+      __isChunk: true,
+      text: prefix.text,
+      fg: styledTextColor(prefix.fg),
+      bg: styledTextColor(prefix.bg),
+    },
+    {
+      __isChunk: true,
+      text: splitGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth),
+      fg: styledTextColor(palette.numberColor),
+      bg: styledTextColor(palette.gutterBg),
+    },
+  );
+  appendPlainInlineChunks(
+    chunks,
+    cell.spans,
+    contentWidth,
+    contentOffset,
+    theme.syntaxColors.default,
+    palette.contentBg,
+  );
+}
+
+/** Append one unhighlighted stack cell without constructing React span fibers. */
+function appendPlainStackCellChunks(
+  chunks: TextChunk[],
+  cell: StackLineCell,
+  width: number,
+  lineNumberDigits: number,
+  showLineNumbers: boolean,
+  theme: AppTheme,
+  contentOffset: number,
+  prefix: CellPrefix,
+) {
+  const palette = stackCellPalette(cell.kind, theme, cell.moveKind);
+  const { gutterWidth, contentWidth } = resolveStackCellGeometry(
+    width,
+    lineNumberDigits,
+    showLineNumbers,
+    prefix.text.length,
+  );
+  chunks.push(
+    {
+      __isChunk: true,
+      text: prefix.text,
+      fg: styledTextColor(prefix.fg),
+      bg: styledTextColor(prefix.bg),
+    },
+    {
+      __isChunk: true,
+      text: stackGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth),
+      fg: styledTextColor(palette.numberColor),
+      bg: styledTextColor(palette.gutterBg),
+    },
+  );
+  appendPlainInlineChunks(
+    chunks,
+    cell.spans,
+    contentWidth,
+    contentOffset,
+    theme.syntaxColors.default,
+    palette.contentBg,
+  );
 }
 
 /** Report whether a wrapped highlight can paint existing chunks without slicing token spans. */
@@ -1229,7 +1364,69 @@ function applyHighlightPrefix<P extends { bg: string }>(
   };
 }
 
-/** Render one split-view cell as prefix + gutter + content spans. */
+/** Render selection-invariant split-cell content behind its independently painted rail. */
+const SplitCellContent = memo(function SplitCellContent({
+  cell,
+  width,
+  lineNumberDigits,
+  showLineNumbers,
+  theme,
+  keyPrefix,
+  contentOffset,
+  prefixWidth,
+  highlight,
+  paneOffset,
+}: {
+  cell: SplitLineCell;
+  width: number;
+  lineNumberDigits: number;
+  showLineNumbers: boolean;
+  theme: AppTheme;
+  keyPrefix: string;
+  contentOffset: number;
+  prefixWidth: number;
+  highlight?: RowHighlight;
+  paneOffset: number;
+}) {
+  const basePalette = splitCellPalette(cell.kind, theme, cell.moveKind);
+  const palette = highlight ? applyHighlightPalette(basePalette, highlight.bg) : basePalette;
+  const { gutterWidth, contentWidth } = resolveSplitCellGeometry(
+    width,
+    lineNumberDigits,
+    showLineNumbers,
+    prefixWidth,
+  );
+  const gutterText = splitGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth);
+  const globalContentStart = paneOffset + prefixWidth + gutterWidth;
+  const colRange = highlight?.colRange;
+  const localColRange =
+    colRange && globalContentStart < colRange.endCol
+      ? {
+          start: Math.max(0, colRange.startCol - globalContentStart),
+          end: Math.min(contentWidth, Math.max(0, colRange.endCol - globalContentStart + 1)),
+        }
+      : undefined;
+
+  return (
+    <>
+      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
+        {gutterText}
+      </span>
+      {renderInlineSpans(
+        cell.spans,
+        contentWidth,
+        theme.syntaxColors.default,
+        palette.contentBg,
+        `${keyPrefix}:content`,
+        contentOffset,
+        highlight?.bg,
+        localColRange,
+      )}
+    </>
+  );
+});
+
+/** Render one split-view cell while letting a rail-only selection change skip its code spans. */
 function renderSplitCell(
   cell: SplitLineCell,
   width: number,
@@ -1246,20 +1443,64 @@ function renderSplitCell(
   highlight?: RowHighlight,
   paneOffset = 0,
 ) {
-  const basePalette = splitCellPalette(cell.kind, theme, cell.moveKind);
-  const palette = highlight ? applyHighlightPalette(basePalette, highlight.bg) : basePalette;
   const resolvedPrefix = highlight && prefix ? applyHighlightPrefix(prefix, highlight.bg) : prefix;
   const prefixWidth = resolvedPrefix?.text.length ?? 0;
-  const { gutterWidth, contentWidth } = resolveSplitCellGeometry(
+
+  return (
+    <>
+      {resolvedPrefix ? (
+        <span key={`${keyPrefix}:prefix`} fg={resolvedPrefix.fg} bg={resolvedPrefix.bg}>
+          {resolvedPrefix.text}
+        </span>
+      ) : null}
+      <SplitCellContent
+        key={`${keyPrefix}:body`}
+        cell={cell}
+        width={width}
+        lineNumberDigits={lineNumberDigits}
+        showLineNumbers={showLineNumbers}
+        theme={theme}
+        keyPrefix={keyPrefix}
+        contentOffset={contentOffset}
+        prefixWidth={prefixWidth}
+        highlight={highlight}
+        paneOffset={paneOffset}
+      />
+    </>
+  );
+}
+
+/** Render selection-invariant stack-cell content behind its independently painted rail. */
+const StackCellContent = memo(function StackCellContent({
+  cell,
+  width,
+  lineNumberDigits,
+  showLineNumbers,
+  theme,
+  keyPrefix,
+  contentOffset,
+  prefixWidth,
+  highlight,
+}: {
+  cell: StackLineCell;
+  width: number;
+  lineNumberDigits: number;
+  showLineNumbers: boolean;
+  theme: AppTheme;
+  keyPrefix: string;
+  contentOffset: number;
+  prefixWidth: number;
+  highlight?: RowHighlight;
+}) {
+  const basePalette = stackCellPalette(cell.kind, theme, cell.moveKind);
+  const palette = highlight ? applyHighlightPalette(basePalette, highlight.bg) : basePalette;
+  const { gutterWidth, contentWidth } = resolveStackCellGeometry(
     width,
     lineNumberDigits,
     showLineNumbers,
     prefixWidth,
   );
-  const gutterText = splitGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth);
-
-  // Convert global selection column range to content-local range.
-  const globalContentStart = paneOffset + prefixWidth + gutterWidth;
+  const globalContentStart = prefixWidth + gutterWidth;
   const colRange = highlight?.colRange;
   const localColRange =
     colRange && globalContentStart < colRange.endCol
@@ -1271,13 +1512,8 @@ function renderSplitCell(
 
   return (
     <>
-      {resolvedPrefix ? (
-        <span key={`${keyPrefix}:prefix`} fg={resolvedPrefix.fg} bg={resolvedPrefix.bg}>
-          {resolvedPrefix.text}
-        </span>
-      ) : null}
       <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
-        {gutterText}
+        {stackGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth)}
       </span>
       {renderInlineSpans(
         cell.spans,
@@ -1291,9 +1527,9 @@ function renderSplitCell(
       )}
     </>
   );
-}
+});
 
-/** Render one stack-view cell as prefix + combined gutter + content spans. */
+/** Render one stack-view cell while letting a rail-only selection change skip its code spans. */
 function renderStackCell(
   cell: StackLineCell,
   width: number,
@@ -1309,27 +1545,8 @@ function renderStackCell(
   },
   highlight?: RowHighlight,
 ) {
-  const basePalette = stackCellPalette(cell.kind, theme, cell.moveKind);
-  const palette = highlight ? applyHighlightPalette(basePalette, highlight.bg) : basePalette;
   const resolvedPrefix = highlight && prefix ? applyHighlightPrefix(prefix, highlight.bg) : prefix;
   const prefixWidth = resolvedPrefix?.text.length ?? 0;
-  const { gutterWidth, contentWidth } = resolveStackCellGeometry(
-    width,
-    lineNumberDigits,
-    showLineNumbers,
-    prefixWidth,
-  );
-
-  // Convert global selection column range to content-local range.
-  const globalContentStart = prefixWidth + gutterWidth;
-  const colRange = highlight?.colRange;
-  const localColRange =
-    colRange && globalContentStart < colRange.endCol
-      ? {
-          start: Math.max(0, colRange.startCol - globalContentStart),
-          end: Math.min(contentWidth, Math.max(0, colRange.endCol - globalContentStart + 1)),
-        }
-      : undefined;
 
   return (
     <>
@@ -1338,19 +1555,18 @@ function renderStackCell(
           {resolvedPrefix.text}
         </span>
       ) : null}
-      <span key={`${keyPrefix}:gutter`} fg={palette.numberColor} bg={palette.gutterBg}>
-        {stackGutterText(cell, lineNumberDigits, showLineNumbers).padEnd(gutterWidth)}
-      </span>
-      {renderInlineSpans(
-        cell.spans,
-        contentWidth,
-        theme.syntaxColors.default,
-        palette.contentBg,
-        `${keyPrefix}:content`,
-        contentOffset,
-        highlight?.bg,
-        localColRange,
-      )}
+      <StackCellContent
+        key={`${keyPrefix}:body`}
+        cell={cell}
+        width={width}
+        lineNumberDigits={lineNumberDigits}
+        showLineNumbers={showLineNumbers}
+        theme={theme}
+        keyPrefix={keyPrefix}
+        contentOffset={contentOffset}
+        prefixWidth={prefixWidth}
+        highlight={highlight}
+      />
     </>
   );
 }
@@ -1914,6 +2130,40 @@ function renderRow(
     };
 
     if (!wrapLines) {
+      const plainStyledRow =
+        !leftHighlight && !rightHighlight
+          ? (() => {
+              const chunks: TextChunk[] = [];
+              appendPlainSplitCellChunks(
+                chunks,
+                row.left,
+                leftWidth,
+                lineNumberDigits,
+                showLineNumbers,
+                theme,
+                codeHorizontalOffset,
+                leftPrefix,
+              );
+              appendPlainSplitCellChunks(
+                chunks,
+                row.right,
+                rightRenderWidth,
+                lineNumberDigits,
+                showLineNumbers,
+                theme,
+                codeHorizontalOffset,
+                rightPrefix,
+              );
+              if (guideOnNewSide) {
+                chunks.push({
+                  __isChunk: true,
+                  text: "│",
+                  fg: styledTextColor(theme.noteBorder),
+                });
+              }
+              return new StyledText(chunks);
+            })()
+          : null;
       baseRow = (
         <box
           id={anchorId}
@@ -1926,37 +2176,41 @@ function renderRow(
               height: 1,
             }}
           >
-            <text>
-              {renderSplitCell(
-                row.left,
-                leftWidth,
-                lineNumberDigits,
-                showLineNumbers,
-                theme,
-                `${row.key}:left`,
-                codeHorizontalOffset,
-                leftPrefix,
-                leftHighlight,
-                0,
-              )}
-              {renderSplitCell(
-                row.right,
-                rightRenderWidth,
-                lineNumberDigits,
-                showLineNumbers,
-                theme,
-                `${row.key}:right`,
-                codeHorizontalOffset,
-                rightPrefix,
-                rightHighlight,
-                leftWidth,
-              )}
-              {guideOnNewSide ? (
-                <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
-                  │
-                </span>
-              ) : null}
-            </text>
+            {plainStyledRow ? (
+              <text key={`${row.key}:plain`} content={plainStyledRow} />
+            ) : (
+              <text key={`${row.key}:painted`}>
+                {renderSplitCell(
+                  row.left,
+                  leftWidth,
+                  lineNumberDigits,
+                  showLineNumbers,
+                  theme,
+                  `${row.key}:left`,
+                  codeHorizontalOffset,
+                  leftPrefix,
+                  leftHighlight,
+                  0,
+                )}
+                {renderSplitCell(
+                  row.right,
+                  rightRenderWidth,
+                  lineNumberDigits,
+                  showLineNumbers,
+                  theme,
+                  `${row.key}:right`,
+                  codeHorizontalOffset,
+                  rightPrefix,
+                  rightHighlight,
+                  leftWidth,
+                )}
+                {guideOnNewSide ? (
+                  <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
+                    │
+                  </span>
+                ) : null}
+              </text>
+            )}
           </box>
           {showAddNoteBadge
             ? renderAddNoteButton(
@@ -2130,6 +2384,29 @@ function renderRow(
     };
 
     if (!wrapLines) {
+      const plainStyledRow = !cellHighlight
+        ? (() => {
+            const chunks: TextChunk[] = [];
+            appendPlainStackCellChunks(
+              chunks,
+              row.cell,
+              contentWidth,
+              lineNumberDigits,
+              showLineNumbers,
+              theme,
+              codeHorizontalOffset,
+              prefix,
+            );
+            if (guideOnNewSide) {
+              chunks.push({
+                __isChunk: true,
+                text: "│",
+                fg: styledTextColor(theme.noteBorder),
+              });
+            }
+            return new StyledText(chunks);
+          })()
+        : null;
       baseRow = (
         <box
           id={anchorId}
@@ -2142,24 +2419,28 @@ function renderRow(
               height: 1,
             }}
           >
-            <text>
-              {renderStackCell(
-                row.cell,
-                contentWidth,
-                lineNumberDigits,
-                showLineNumbers,
-                theme,
-                `${row.key}:stack`,
-                codeHorizontalOffset,
-                prefix,
-                cellHighlight,
-              )}
-              {guideOnNewSide ? (
-                <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
-                  │
-                </span>
-              ) : null}
-            </text>
+            {plainStyledRow ? (
+              <text key={`${row.key}:plain`} content={plainStyledRow} />
+            ) : (
+              <text key={`${row.key}:painted`}>
+                {renderStackCell(
+                  row.cell,
+                  contentWidth,
+                  lineNumberDigits,
+                  showLineNumbers,
+                  theme,
+                  `${row.key}:stack`,
+                  codeHorizontalOffset,
+                  prefix,
+                  cellHighlight,
+                )}
+                {guideOnNewSide ? (
+                  <span key={`${row.key}:note-guide`} fg={theme.noteBorder}>
+                    │
+                  </span>
+                ) : null}
+              </text>
+            )}
           </box>
           {showAddNoteBadge
             ? renderAddNoteButton(

--- a/test/pty/nav.test.ts
+++ b/test/pty/nav.test.ts
@@ -192,7 +192,10 @@ describe("PTY navigation", () => {
       await session.click(/M delta\.ts\s+\+2 -1/);
       const jumped = await harness.waitForSnapshot(
         session,
-        (text) => text.includes("deltaOnly = true") && !text.includes("alphaOnly = true"),
+        (text) =>
+          text.includes("deltaOnly = true") &&
+          !text.includes("alphaOnly = true") &&
+          harness.countMatches(text, /epsilon\.ts/g) >= 2,
         5_000,
       );
 


### PR DESCRIPTION
## Summary

- render ordinary nowrap diff rows directly as `StyledText` chunks instead of rebuilding React span trees; no row-content cache is retained
- keep extension pane actions stable across selection changes to avoid repainting the entire sidebar
- stop highlight prefetch from forcing adjacent files into the mounted review window while continuing to warm the selected file, its neighbors, and the viewport halo
- preserve the existing `--fast` worker-offload behavior and eligibility threshold unchanged

## Performance

### Standard interaction fixture

Nine-pair A/B against `origin/main` on the 180-file × 120-line fixture without `--fast`:

| Metric | `origin/main` | PR | Change |
| --- | ---: | ---: | ---: |
| `]` navigation median | 69.94 ms | 46.59 ms | -33% |
| `]` navigation p95 | 96.04 ms | 56.98 ms | -41% |
| Scroll median | 1.63 ms | 1.15 ms | -29% |
| Scroll p95 | 12.90 ms | 5.27 ms | -59% |
| Retained navigation heap | 147.8 MB | 101.4 MB | -31% |
| Retained navigation RSS | 590.6 MB | 429.7 MB | -27% |

### `--fast`-eligible interaction fixture

The standard fixture is below the existing 2,000-line worker threshold, so a second nine-pair A/B used 12 files × 2,100 lines per side:

| Metric | `origin/main --fast` | PR `--fast` | Change |
| --- | ---: | ---: | ---: |
| `]` navigation median | 41.71 ms | 30.17 ms | -28% |
| `]` navigation p95 | 49.39 ms | 39.14 ms | -21% |
| Scroll median | 1.31 ms | 1.32 ms | +0.01 ms |
| Scroll p95 | 36.27 ms | 3.92 ms | -89% |
| Retained navigation heap | 56.8 MB | 41.8 MB | -26% |
| Retained navigation RSS | 492.2 MB | 452.3 MB | -8% |

On the same eligible fixture without `--fast`, navigation also improved from 315.47 ms to 286.37 ms median and from 328.62 ms to 301.36 ms p95. `--fast` remains substantially faster for these worker-eligible files.

The full default benchmark suite found no reproducible material regression. The benchmark measurement helpers were unchanged; the eligible variant only enabled the existing option and raised fixture lines above its existing threshold.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` — 2,973 passed, 10 skipped
- `bun run test:integration` — 117 passed
- `bun run test:tty-smoke` — 9 passed
- real-TTY smoke run against an actual two-file diff

*This PR description was generated by Pi using gpt-5.6-sol*
