### PR TITLE
fix(ui): keep comment targets fixed in viewport

### DIFF
--- a/.changeset/calm-lines-comment.md
+++ b/.changeset/calm-lines-comment.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep the active code line fixed in place while an inline comment form pushes following content down.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1933,19 +1933,21 @@ export function App({
   const startUserNote = useCallback(
     (fileId?: string, hunkIndex?: number, target?: UserNoteLineTarget) => {
       const hoverTarget = fileId === undefined ? activeAddNoteTarget : null;
-      const keyboardTarget = hoverTarget ?? (fileId === undefined ? activeLineCursor : null);
+      const keyboardTarget =
+        hoverTarget ??
+        (fileId === undefined && cursorLine !== "off" ? review.getLineCursor() : null);
       const draft = review.startUserNote(
         fileId ?? keyboardTarget?.fileId,
         hunkIndex ?? keyboardTarget?.hunkIndex,
         target ?? keyboardTarget?.target,
-        { preserveViewport: fileId !== undefined || hoverTarget !== null },
+        { preserveViewport: fileId !== undefined || keyboardTarget !== null },
       );
       if (draft) {
         setActiveAddNoteTarget(null);
         setFocusArea("note");
       }
     },
-    [activeAddNoteTarget, activeLineCursor, review.startUserNote],
+    [activeAddNoteTarget, cursorLine, review.getLineCursor, review.startUserNote],
   );
 
   /** Mark the inline draft note textarea as the active keyboard input. */

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -186,13 +186,14 @@ function createWrapBootstrap(pager = false): AppBootstrap {
   });
 }
 
-function createLineScrollBootstrap(pager = false): AppBootstrap {
+function createLineScrollBootstrap(pager = false, initialMode: LayoutMode = "split"): AppBootstrap {
   const before = lines(...createNumberedAssignmentLines(1, 18));
   const after = lines(...createNumberedAssignmentLines(1, 18, 100));
 
   return createTestVcsAppBootstrap({
     changesetId: "changeset:app-line-scroll",
     files: [createTestDiffFile("scroll", "scroll.ts", before, after, true)],
+    initialMode,
     pager,
   });
 }
@@ -2815,6 +2816,56 @@ describe("App interactions", () => {
 
       expect(lineIncludesBackground("betaValue", theme.addedBg)).toBe(true);
       expect(lineIncludesBackground("beta = 1", theme.removedBg)).toBe(true);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("coalesced line movement opens a draft at the latest cursor without moving its row", async () => {
+    const setup = await testRender(
+      <AppHost bootstrap={createLineScrollBootstrap(false, "stack")} />,
+      { width: 120, height: 26 },
+    );
+
+    try {
+      await flush(setup);
+      await act(async () => {
+        await Bun.sleep(60);
+        await setup.renderOnce();
+      });
+
+      const initial = setup.captureCharFrame();
+      const initialActiveRow = initial
+        .split("\n")
+        .findIndex((line) => line.includes("export const line01 = 1;"));
+      const followingRowBefore = initial
+        .split("\n")
+        .findIndex((line) => line.includes("export const line10 = 10;"));
+
+      await act(async () => {
+        await setup.mockInput.pressKeys([...Array(8).fill("\x1b[B"), "c"]);
+      });
+      await flush(setup);
+      await act(async () => {
+        await Bun.sleep(80);
+        await setup.renderOnce();
+      });
+
+      const withDraft = setup.captureCharFrame();
+      const activeRow = withDraft
+        .split("\n")
+        .findIndex((line) => line.includes("export const line09 = 9;"));
+      const draftRow = withDraft.split("\n").findIndex((line) => line.includes("Draft note"));
+      const followingRow = withDraft
+        .split("\n")
+        .findIndex((line) => line.includes("export const line10 = 10;"));
+
+      expect(withDraft).toMatch(/Draft note.*L9/);
+      expect(activeRow).toBe(initialActiveRow + 8);
+      expect(draftRow).toBe(activeRow + 1);
+      expect(followingRow).toBeGreaterThan(followingRowBefore);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -131,6 +131,20 @@ function estimateInitialRenderViewportHeight(rendererHeight: number, screenTop: 
   return Math.max(1, rendererHeight - Math.max(0, screenTop));
 }
 
+/** Resolve one file-relative measured row through its precomputed whole-stream section layout. */
+function streamRowBoundsAt(
+  layouts: FileSectionLayout[],
+  geometry: DiffSectionGeometry[],
+  sectionIndex: number,
+  stableKey: string,
+) {
+  const section = layouts[sectionIndex];
+  const bounds = geometry[sectionIndex]?.rowBoundsByStableKey.get(stableKey);
+  return section && bounds
+    ? { top: section.bodyTop + bounds.top, height: bounds.height }
+    : undefined;
+}
+
 /** Keep syntax highlighting warm for files immediately adjacent to the selection. */
 function buildAdjacentPrefetchFileIds(files: DiffFile[], selectedFileId?: string) {
   if (!selectedFileId) {
@@ -891,11 +905,7 @@ export function DiffPane({
         return undefined;
       }
 
-      const section = fileSectionLayouts[sectionIndex];
-      const bounds = sectionGeometry[sectionIndex]?.rowBoundsByStableKey.get(stableKey);
-      return section && bounds
-        ? { top: section.bodyTop + bounds.top, height: bounds.height }
-        : undefined;
+      return streamRowBoundsAt(fileSectionLayouts, sectionGeometry, sectionIndex, stableKey);
     },
     [fileSectionIndexById, fileSectionLayouts, sectionGeometry],
   );
@@ -1795,23 +1805,48 @@ export function DiffPane({
 
     if (draftChanged && previousSectionMetrics && previousFiles.length > 0) {
       const previousScrollTop = scrollRef.current?.scrollTop ?? scrollViewport.top;
+      const previousSectionHeaderHeights = buildInStreamFileHeaderHeights(previousFiles);
       const anchor =
         lastViewportRowAnchorRef.current ??
         findViewportRowAnchor(
           previousFiles,
           previousSectionMetrics,
           previousScrollTop,
-          buildInStreamFileHeaderHeights(previousFiles),
+          previousSectionHeaderHeights,
         );
-      if (anchor) {
-        const anchorTop = resolveViewportRowAnchorTop(
-          files,
-          sectionGeometry,
-          anchor,
-          sectionHeaderHeights,
-        );
+      const cursorToPreserve = scrollToNote ? null : lineCursor;
+      const previousCursorSectionIndex = cursorToPreserve
+        ? previousFiles.findIndex((file) => file.id === cursorToPreserve.fileId)
+        : -1;
+      const previousCursorBounds =
+        previousCursorSectionIndex >= 0 && cursorToPreserve
+          ? streamRowBoundsAt(
+              buildFileSectionLayouts(
+                previousFiles,
+                previousSectionMetrics.map((metrics) => metrics?.bodyHeight ?? 0),
+                previousSectionHeaderHeights,
+              ),
+              previousSectionMetrics,
+              previousCursorSectionIndex,
+              cursorToPreserve.stableKey,
+            )
+          : undefined;
+      const currentCursorBounds = cursorToPreserve
+        ? rowBoundsInStream(cursorToPreserve.fileId, cursorToPreserve.stableKey)
+        : undefined;
+      const cursorAnchoredTop =
+        previousCursorBounds && currentCursorBounds
+          ? currentCursorBounds.top - (previousCursorBounds.top - previousScrollTop)
+          : null;
+      const anchorTop =
+        cursorAnchoredTop ??
+        (anchor
+          ? resolveViewportRowAnchorTop(files, sectionGeometry, anchor, sectionHeaderHeights)
+          : null);
+
+      if (anchorTop !== null) {
         const draftBounds =
-          draftNoteId && draftNoteFileId
+          draftNoteId && draftNoteFileId && scrollToNote
             ? rowBoundsInStream(draftNoteFileId, inlineNoteStableKey(draftNoteId))
             : undefined;
         const nextTop = draftBounds
@@ -1823,10 +1858,15 @@ export function DiffPane({
             })
           : anchorTop;
         const restoreViewportAnchor = () => {
+          // Cursor- and click-targeted composers are already at the reviewer's position, so their
+          // stream geometry pushes following rows down without pulling the target line upward.
+          // Default draft starts still reveal the full composer because they may target offscreen.
           scrollRef.current?.scrollTo(nextTop);
         };
 
-        lastViewportRowAnchorRef.current = anchor;
+        if (anchor) {
+          lastViewportRowAnchorRef.current = anchor;
+        }
         suppressViewportSelectionSync();
         restoreViewportAnchor();
         const retryDelays = [0, 16, 48];
@@ -1905,6 +1945,7 @@ export function DiffPane({
     draftNoteId,
     files,
     layout,
+    lineCursor,
     layoutToggleRequestId,
     layoutToggleScrollTop,
     rowBoundsInStream,
@@ -1913,6 +1954,7 @@ export function DiffPane({
     scrollViewport.top,
     sectionGeometry,
     sectionHeaderHeights,
+    scrollToNote,
     suppressViewportSelectionSync,
     wrapLines,
     wrapToggleScrollTop,

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -131,16 +131,18 @@ describe("PTY notes", () => {
     try {
       await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
 
-      const initial = await session.text({ immediate: true });
-      const initialActiveLine = "export const line01 = 1;";
+      await session.waitIdle({ timeout: 500 });
+      for (let index = 0; index < 8; index += 1) {
+        await session.press("down");
+      }
+
+      const beforePushedDraft = await session.text({ immediate: true });
       const firstActiveLine = "export const line09 = 9;";
       const followingLine = "export const line10 = 10;";
-      const firstActiveRow = lineIndexOf(initial, initialActiveLine) + 8;
-      const followingRowBefore = lineIndexOf(initial, followingLine);
+      const firstActiveRow = lineIndexOf(beforePushedDraft, firstActiveLine);
+      const followingRowBefore = lineIndexOf(beforePushedDraft, followingLine);
 
-      // Coalesce movement and note opening into one terminal write so `c` must read the cursor
-      // synchronously rather than targeting the React render from before the arrow-key burst.
-      session.writeRaw(`${"\x1b[B".repeat(8)}c`);
+      await session.press("c");
       await session.waitForText(/Draft note - before\.ts -> after\.ts L9/, { timeout: 5_000 });
       await sleep(100);
       const pushedDraft = await session.text({ immediate: true });
@@ -514,9 +516,19 @@ describe("PTY notes", () => {
       const targetRow = lineIndexOf(initial, "keep = true");
       expect(targetRow).toBeGreaterThan(0);
 
-      await revealAddNoteOnRow(session, targetRow);
+      // Put the keyboard cursor on the deletion, then click the separate context row. Opening the
+      // clicked draft must preserve the clicked row rather than the old keyboard-cursor anchor.
+      await session.press("down");
+      const beforeDraft = await session.text({ immediate: true });
+      const clickedRowBefore = lineIndexOf(beforeDraft, "keep = true");
+      await revealAddNoteOnRow(session, clickedRowBefore);
       await session.click(/\[\+\]/);
       await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await sleep(100);
+      const withDraft = await session.text({ immediate: true });
+      expect(lineIndexOf(withDraft, "keep = true")).toBe(clickedRowBefore);
+      expect(lineIndexOf(withDraft, "Draft note")).toBeGreaterThan(clickedRowBefore);
+
       await session.type("Save this context draft.");
       await session.press(["ctrl", "s"]);
       const saved = await session.waitForText(/Your note/, { timeout: 5_000 });

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -120,6 +120,85 @@ describe("PTY notes", () => {
     }
   });
 
+  test("opening a draft keeps the active line fixed while pushing following code down", async () => {
+    const fixture = harness.createScrollableFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      cols: 120,
+      rows: 26,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+
+      const initial = await session.text({ immediate: true });
+      const initialActiveLine = "export const line01 = 1;";
+      const firstActiveLine = "export const line09 = 9;";
+      const followingLine = "export const line10 = 10;";
+      const firstActiveRow = lineIndexOf(initial, initialActiveLine) + 8;
+      const followingRowBefore = lineIndexOf(initial, followingLine);
+
+      // Coalesce movement and note opening into one terminal write so `c` must read the cursor
+      // synchronously rather than targeting the React render from before the arrow-key burst.
+      session.writeRaw(`${"\x1b[B".repeat(8)}c`);
+      await session.waitForText(/Draft note - before\.ts -> after\.ts L9/, { timeout: 5_000 });
+      await sleep(100);
+      const pushedDraft = await session.text({ immediate: true });
+
+      expect(firstActiveRow).toBeGreaterThan(0);
+      expect(lineIndexOf(pushedDraft, firstActiveLine)).toBe(firstActiveRow);
+      expect(lineIndexOf(pushedDraft, "Draft note")).toBe(firstActiveRow + 1);
+      expect(lineIndexOf(pushedDraft, followingLine)).toBeGreaterThan(followingRowBefore);
+
+      await session.press("escape");
+      await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
+      for (let index = 0; index < 8; index += 1) {
+        await session.press("down");
+      }
+
+      const beforeBottomDraft = await session.text({ immediate: true });
+      const bottomActiveLine = "export const line17 = 17;";
+      const bottomActiveRow = lineIndexOf(beforeBottomDraft, bottomActiveLine);
+      expect(bottomActiveRow).toBeGreaterThan(0);
+
+      await session.press("c");
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await sleep(100);
+      const bottomDraft = await session.text({ immediate: true });
+
+      expect(lineIndexOf(bottomDraft, bottomActiveLine)).toBe(bottomActiveRow);
+      expect(lineIndexOf(bottomDraft, "Draft note")).toBe(bottomActiveRow + 1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("cursor-line-off drafts still reveal their default target and full composer", async () => {
+    const fixture = harness.createScrollableFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "stack", "--cursor-line", "off"],
+      cols: 120,
+      rows: 12,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      await session.press("space");
+      const paged = await session.text({ immediate: true });
+      expect(paged).not.toContain("export const line01 = 1;");
+
+      await session.press("c");
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await sleep(100);
+      const draft = await session.text({ immediate: true });
+
+      expect(draft).toContain("Draft note - before.ts -> after.ts R1");
+      expect(draft).toContain("Cancel (Esc)");
+    } finally {
+      session.close();
+    }
+  });
+
   test("user notes can be drafted and saved inline in a real PTY", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
@@ -473,9 +552,9 @@ describe("PTY notes", () => {
       );
       expect(whileFocused).toContain("Draft note");
 
-      // Keyboard cancellation is covered above; click the explicit control here so this test can
-      // focus on whether app-level shortcuts are blocked only while the composer is active.
-      await session.click(/Cancel \(Esc\)/);
+      // Cancel from the focused editor so the tight viewport can keep the target line fixed even
+      // when the form's action row is intentionally below the visible bounds.
+      await session.press("escape");
       await harness.waitForSnapshot(session, (text) => !text.includes("Draft note"), 5_000);
       await session.press("]");
       const afterCancel = await harness.waitForSnapshot(


### PR DESCRIPTION
## Summary

- keep the active current-line cursor at the exact same terminal row when `c` opens an inline comment
- let the comment composer participate in stream geometry so it pushes following code down instead of pulling the target upward
- read the cursor synchronously so coalesced arrow-key input followed by `c` targets the latest line
- preserve full-composer reveal behavior when current-line navigation is disabled

## Before

![Before fix: opening the comment form shifts the active line upward](https://gist.githubusercontent.com/benvinegar/1fef0d604409d5979abf4f418004a490/raw/c58b1acbc491d21a0cec9659005c3ca5d450c00a/before.png)

The dashed guide marks the target’s original row 23. When the composer opened, the active line jumped two rows above it to row 21.

## After

![After fix: the active line remains anchored and the form opens beneath it](https://gist.githubusercontent.com/benvinegar/1fef0d604409d5979abf4f418004a490/raw/c58b1acbc491d21a0cec9659005c3ca5d450c00a/after.png)

The active line remains aligned with the row-23 guide and the composer grows directly below it.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run test:integration` (119 passed)
- `bun run test:tty-smoke` (9 passed)
- tmux reproduction at 100×30 before and after the fix

*This PR description was generated by Pi using gpt-5.6-sol*

