### PR TITLE
perf(highlighting): broaden fast worker offload

### DIFF
--- a/.changeset/fast-files-highlight.md
+++ b/.changeset/fast-files-highlight.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Make `--fast` offload eligible syntax highlighting for files with 40 or more lines.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Hunk mirrors Git's diff-style commands, but opens the changeset in a review UI i
 
 ```bash
 hunk diff                      # review current repo changes, including untracked files
-hunk --fast                    # experimentally offload eligible large-diff highlighting
+hunk --fast                    # experimentally offload eligible syntax highlighting
 hunk diff --watch              # auto-reload as the working tree changes
 hunk show                      # review the latest commit
 hunk show HEAD~1               # review an earlier commit

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -87,7 +87,7 @@ export const COMMON_REVIEW_OPTIONS = [
   AUXILIARY_AGENT_OPTIONS.experimental,
   {
     flag: "--fast",
-    description: "experimentally offload eligible large-diff highlighting",
+    description: "experimentally offload eligible syntax highlighting",
   },
   { flag: "--line-numbers", description: "show line numbers" },
   { flag: "--no-line-numbers", description: "hide line numbers" },

--- a/src/core/run/commandInputs.ts
+++ b/src/core/run/commandInputs.ts
@@ -30,7 +30,7 @@ export interface CommonOptions {
   watch?: boolean;
   /** Enable launch-scoped experimental review features. */
   experimental?: boolean;
-  /** Offload eligible large-diff highlighting for this launch. */
+  /** Offload eligible syntax highlighting for this launch. */
   fast?: boolean;
   excludeUntracked?: boolean;
   lineNumbers?: boolean;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -112,7 +112,7 @@ async function main() {
 
   // OpenTUI stays behind the interactive plan so headless commands never materialize its embedded
   // native library. The highlighting client starts the compiled worker only when an opted-in,
-  // eligible large diff needs it, so normal sessions do not pay its startup cost.
+  // eligible diff needs it, so normal sessions do not pay its startup cost.
   try {
     const { runInteractiveApp } = await import("./ui/runInteractiveApp");
     await runInteractiveApp(startupPlan);

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -290,7 +290,7 @@ export function DiffPane({
   /** Validated alternate layouts, keyed by file id; raw Pierre remains the fallback. */
   fileViews?: ReadonlyMap<string, ResolvedFileViewLayout>;
   files: DiffFile[];
-  /** Offload eligible large-diff highlighting for this launch. */
+  /** Offload eligible syntax highlighting for this launch. */
   offloadLargeDiff?: boolean;
   /** Validated extension line marks, keyed by file id. */
   lineHighlights?: ReadonlyMap<string, readonly ValidatedLineHighlight[]>;

--- a/src/ui/diff/diffRows.test.ts
+++ b/src/ui/diff/diffRows.test.ts
@@ -124,10 +124,10 @@ function createElixirHeredocDiffFile(sourceFetcher?: DiffFile["sourceFetcher"]):
   };
 }
 
-/** Build a large changed TypeScript file that crosses the interactive worker threshold. */
-function createLargeDiffFile(): DiffFile {
+/** Build a changed TypeScript file at or above the interactive worker threshold. */
+function createWorkerEligibleDiffFile(generatedLineCount = HIGHLIGHT_WORKER_MIN_LINES): DiffFile {
   const additions = Array.from(
-    { length: HIGHLIGHT_WORKER_MIN_LINES },
+    { length: generatedLineCount },
     (_, index) => `export const generated${index} = ${index};`,
   ).join("\n");
   const metadata = parseDiffFromFile(
@@ -150,7 +150,7 @@ function createLargeDiffFile(): DiffFile {
     path: "large.ts",
     patch: "",
     language: "typescript",
-    stats: { additions: HIGHLIGHT_WORKER_MIN_LINES + 1, deletions: 1 },
+    stats: { additions: generatedLineCount + 1, deletions: 1 },
     metadata,
     agent: null,
   };
@@ -292,8 +292,32 @@ describe("Pierre diff rows", () => {
     expect(shouldHighlightDiff(createDiffFile())).toBe(true);
   });
 
-  test("matches inline spans when a large bundled-theme diff uses the worker", async () => {
-    const file = createLargeDiffFile();
+  test("offloads bundled-theme highlighting starting at 40 source lines", () => {
+    const eligible = createWorkerEligibleDiffFile(HIGHLIGHT_WORKER_MIN_LINES - 1);
+    const belowThreshold = createWorkerEligibleDiffFile(HIGHLIGHT_WORKER_MIN_LINES - 2);
+    const theme = resolveTheme("github-dark-default", null);
+
+    expect(HIGHLIGHT_WORKER_MIN_LINES).toBe(40);
+    expect(
+      Math.max(eligible.metadata.deletionLines.length, eligible.metadata.additionLines.length),
+    ).toBe(40);
+    expect(
+      Math.max(
+        belowThreshold.metadata.deletionLines.length,
+        belowThreshold.metadata.additionLines.length,
+      ),
+    ).toBe(39);
+    expect(shouldOffloadHighlight(eligible.metadata, theme, { offloadLargeDiff: true })).toBe(true);
+    expect(shouldOffloadHighlight(belowThreshold.metadata, theme, { offloadLargeDiff: true })).toBe(
+      false,
+    );
+    expect(shouldOffloadHighlight(eligible.metadata, theme, { offloadLargeDiff: false })).toBe(
+      false,
+    );
+  });
+
+  test("matches inline spans when an eligible bundled-theme diff uses the worker", async () => {
+    const file = createWorkerEligibleDiffFile();
     const theme = resolveTheme("github-dark-default", null);
 
     expect(shouldOffloadHighlight(file.metadata, theme, { offloadLargeDiff: true })).toBe(true);
@@ -408,7 +432,7 @@ describe("Pierre diff rows", () => {
   test("falls back to patch highlighting when source-backed metadata exceeds the cap", async () => {
     // A 6,000-line file produces 12,000 full-source side lines, although the visible patch has
     // only one changed line. It should use the safe patch fragment rather than render plain rows.
-    const file = createLargeSourceBackedDiffFile(HIGHLIGHT_WORKER_MIN_LINES * 3);
+    const file = createLargeSourceBackedDiffFile(6_000);
     const theme = resolveTheme("github-dark-default", null);
     const highlighted = await loadHighlightedDiff(file, theme);
     const rows = buildStackRows(file, highlighted, theme);
@@ -426,9 +450,9 @@ describe("Pierre diff rows", () => {
     );
   });
 
-  test("falls back to plain text when the large-diff worker fails", async () => {
+  test("falls back to plain text when the highlight worker fails", async () => {
     registerFailingHighlightWorkerForTest();
-    const file = createLargeDiffFile();
+    const file = createWorkerEligibleDiffFile();
     const theme = resolveTheme("github-dark-default", null);
 
     await expect(loadHighlightedDiff(file, theme, { offloadLargeDiff: true })).resolves.toEqual({

--- a/src/ui/diff/diffRows.ts
+++ b/src/ui/diff/diffRows.ts
@@ -51,10 +51,10 @@ import {
 
 type HighlightThemeInput = AppTheme | AppTheme["appearance"];
 
-export const HIGHLIGHT_WORKER_MIN_LINES = 2_000;
+export const HIGHLIGHT_WORKER_MIN_LINES = 40;
 
 export interface LoadHighlightedDiffOptions {
-  /** Allow the interactive TUI to move eligible large-file work into the Bun worker. */
+  /** Allow the interactive TUI to move eligible highlighting into the Bun worker. */
   offloadLargeDiff?: boolean;
 }
 

--- a/website/src/content/docs/docs/reference/cli.md
+++ b/website/src/content/docs/docs/reference/cli.md
@@ -24,7 +24,7 @@ This reference is generated from the command metadata used by Hunk itself. Run `
 | `--agent-context <path>`    | JSON sidecar with agent rationale                               |
 | `--pager`                   | use pager-style chrome                                          |
 | `--experimental`            | enable experimental features (currently STML agent-note markup) |
-| `--fast`                    | experimentally offload eligible large-diff highlighting         |
+| `--fast`                    | experimentally offload eligible syntax highlighting             |
 | `--line-numbers`            | show line numbers                                               |
 | `--no-line-numbers`         | hide line numbers                                               |
 | `-x, --tab-width <columns>` | tab stop width: 1-16 Default: 4.                                |


### PR DESCRIPTION
## Summary

- lower the opt-in `--fast` syntax-highlight worker threshold from 2,000 to 40 source lines per side
- cover the exact 39/40-line eligibility boundary and keep worker output parity/failure coverage
- decouple the 6,000-line source-cap fixture from the independently tunable worker threshold
- describe `--fast` as offloading eligible syntax highlighting rather than only large-diff highlighting

Normal launches remain unchanged; the lower threshold applies only when `--fast` is explicitly enabled.

## Performance

Nine fresh-process paired runs against `origin/main` on the 180-file × 120-line interaction fixture with `--fast`:

| Metric | `origin/main --fast` | PR `--fast` | Change |
| --- | ---: | ---: | ---: |
| First render pass | 20.58 ms | 6.08 ms | -70% |
| `]` navigation median | 47.91 ms | 25.74 ms | -46% |
| `]` navigation p95 | 57.81 ms | 33.75 ms | -42% |
| Retained navigation heap | 101.4 MB | 56.6 MB | -44% |
| Retained navigation RSS | 437.6 MB | 457.6 MB | +20.0 MB |
| Scroll median | 1.19 ms | 1.66 ms | +0.47 ms |
| Scroll p95 | 5.46 ms | 10.21 ms | +4.75 ms |

The threshold sweep covered 40, 100, 200, 500, 1,000, 2,000, and 4,000 source lines. At 40 lines, worker offload reduced navigation from 24.49 ms to 14.39 ms and the maximum render stall from 64.94 ms to 10.88 ms.

### Tradeoff

On a cold moderate diff, the plain review frame appears sooner while syntax color finishes roughly 45–50 ms later as the worker starts. Rapid navigation can also leave color work queued behind earlier files. The diff remains correct and interactive during that interval; this PR intentionally applies that responsiveness tradeoff only to the experimental opt-in `--fast` mode.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run generate:docs -- --check`
- `bun run test` — 3,003 passed, 10 skipped
- `bun run test:integration` — 119 passed
- `bun run test:tty-smoke` — 9 passed
- focused highlight worker parity, cache, failure, and exact-threshold tests — 48 passed

*This PR description was generated by Pi using gpt-5.6-sol*
