### PR TITLE
fix(ui): keep moved-line colors on wrapped diff rows

### DIFF
--- a/.changeset/wrapped-moved-line-tint.md
+++ b/.changeset/wrapped-moved-line-tint.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Git's `color.moved` highlights are no longer lost when `wrap_lines` is on.

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -726,7 +726,7 @@ function buildWrappedSplitCell(
   prefixWidth: number,
   theme: AppTheme,
 ) {
-  const palette = splitCellPalette(cell.kind, theme);
+  const palette = splitCellPalette(cell.kind, theme, cell.moveKind);
   const { gutterWidth, contentWidth } = resolveSplitCellGeometry(
     width,
     lineNumberDigits,
@@ -758,7 +758,7 @@ function buildWrappedStackCell(
   prefixWidth: number,
   theme: AppTheme,
 ) {
-  const palette = stackCellPalette(cell.kind, theme);
+  const palette = stackCellPalette(cell.kind, theme, cell.moveKind);
   const { gutterWidth, contentWidth } = resolveStackCellGeometry(
     width,
     lineNumberDigits,

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -617,6 +617,44 @@ export function createPtyHarness() {
     return { dir };
   }
 
+  /**
+   * Build a block that moves between two files, with Git's move detection enabled.
+   *
+   * `plainAddition` is an ordinary added line in the same diff, so tests can tell a moved tint
+   * from the added tint instead of only asserting that some tint was painted.
+   */
+  function createMovedLinesRepoFixture() {
+    const movedBlock = [
+      "MOVED BLOCK ALPHA",
+      "MOVED BLOCK BRAVO",
+      "MOVED BLOCK CHARLIE",
+      "MOVED BLOCK DELTA",
+    ];
+    const plainAddition = "brand new destination line";
+    const fixture = createGitRepoFixture([
+      {
+        path: "source.txt",
+        before: ["source header one", "source header two", ...movedBlock, "source footer"].join(
+          "\n",
+        ),
+        after: ["source header one", "source header two", "source footer"].join("\n"),
+      },
+      {
+        path: "destination.txt",
+        before: ["destination header one", "destination header two"].join("\n"),
+        after: [
+          "destination header one",
+          "destination header two",
+          ...movedBlock,
+          plainAddition,
+        ].join("\n"),
+      },
+    ]);
+
+    runGit(["config", "diff.colorMoved", "zebra"], fixture.dir);
+    return { ...fixture, movedBlock, plainAddition };
+  }
+
   /** Build the long-path fixture used to verify narrow file-header layout. */
   function createNarrowHeaderTestRepoFixture() {
     return createGitRepoFixture([
@@ -1039,6 +1077,7 @@ end
     createRepoExtensionFixture,
     createLinkedWorktreeWatchFixture,
     createLongWrapFilePair,
+    createMovedLinesRepoFixture,
     createMultiFilePagerPatchFixture,
     createMultiHunkFilePair,
     createNarrowHeaderTestRepoFixture,

--- a/test/pty/moved-lines.test.ts
+++ b/test/pty/moved-lines.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { DEFAULT_DARK_THEME_ID, resolveTheme } from "../../src/ui/themes";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+const theme = resolveTheme(DEFAULT_DARK_THEME_ID, "dark");
+
+setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+/**
+ * Moved-line tinting is asserted through the rendered screen rather than at the row model or
+ * the palette helper because both of those stayed correct while the wrapped renderer painted
+ * moved rows as ordinary additions and deletions. Wrapping and layout are covered as a matrix
+ * for the same reason: each combination reaches the palette through its own cell builder.
+ */
+describe("PTY moved-line coloring", () => {
+  for (const layout of ["stack", "split"] as const) {
+    for (const wrap of ["--wrap", "--no-wrap"] as const) {
+      test(`tints moved rows apart from ordinary added rows in ${layout} with ${wrap}`, async () => {
+        const fixture = harness.createMovedLinesRepoFixture();
+        const session = await harness.launchHunk({
+          args: ["diff", "--mode", layout, wrap],
+          cwd: fixture.dir,
+          cols: 160,
+          rows: 40,
+        });
+
+        try {
+          await session.waitForText(/MOVED BLOCK ALPHA/, { timeout: 15_000 });
+
+          const movedTinted = await session.text({
+            immediate: true,
+            only: { background: theme.movedAddedBg },
+          });
+          const addedTinted = await session.text({
+            immediate: true,
+            only: { background: theme.addedBg },
+          });
+          const removedTinted = await session.text({
+            immediate: true,
+            only: { background: theme.removedBg },
+          });
+
+          // Both sides of the move carry the moved tint: the deletion in source.txt and the
+          // addition in destination.txt.
+          for (const line of fixture.movedBlock) {
+            expect(movedTinted).toContain(line);
+          }
+          expect(addedTinted).not.toContain("MOVED BLOCK");
+          expect(removedTinted).not.toContain("MOVED BLOCK");
+
+          // A genuinely new line in the same diff still paints as an ordinary addition.
+          expect(addedTinted).toContain(fixture.plainAddition);
+          expect(movedTinted).not.toContain(fixture.plainAddition);
+        } finally {
+          session.close();
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
Moved-line coloring never reached anyone with `wrap_lines = true`. Rows have two paint paths, and only the unwrapped one forwarded the move classification to the palette: the wrapped cell builders called `splitCellPalette`/`stackCellPalette` without the `moveKind` argument, so every moved row fell back to the ordinary added or removed tint.