### PR TITLE
feat(skills): add OpenTUI performance workflow

### DIFF
--- a/.changeset/open-tuis-perform.md
+++ b/.changeset/open-tuis-perform.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Bundle an agent skill for profiling and optimizing React/OpenTUI terminal applications.

--- a/.github/workflows/release-prebuilt-npm.yml
+++ b/.github/workflows/release-prebuilt-npm.yml
@@ -323,9 +323,19 @@ jobs:
               echo "Missing release binary in $directory" >&2
               exit 1
             fi
-            for skill in hunk-review hunk-extensions; do
+            for skill in hunk-review hunk-extensions opentui-performance; do
               if [ ! -f "$directory/skills/$skill/SKILL.md" ]; then
                 echo "Missing bundled Hunk $skill skill in $directory" >&2
+                exit 1
+              fi
+            done
+            for reference in \
+              rendering-and-geometry.md \
+              async-and-memory.md \
+              benchmarking-and-validation.md \
+              hunk-case-study.md; do
+              if [ ! -f "$directory/skills/opentui-performance/references/$reference" ]; then
+                echo "Missing bundled OpenTUI performance reference $reference in $directory" >&2
                 exit 1
               fi
             done

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Load the Hunk skill and use it for this review. Run `hunk skill path` to get the
 
 For the full live-session and `--agent-context` workflow guide, see [docs/agent-workflows.md](docs/agent-workflows.md). Experimental rich STML note bodies require starting the review with `--experimental`; plain agent notes remain the default.
 
+Hunk also bundles agent skills for extension authoring (`hunk skill path extensions`) and profiling React/OpenTUI terminal applications (`hunk skill path performance`). Load the returned file directly; for a persistent symlink, link its parent skill directory so sibling references remain available.
+
 ## Feature comparison
 
 | Capability                         | [hunk](https://github.com/modem-dev/hunk) | [lumen](https://github.com/jnsahaj/lumen) | [difftastic](https://github.com/Wilfred/difftastic) | [delta](https://github.com/dandavison/delta) | [diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) | [diff](https://www.gnu.org/software/diffutils/) |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dist/npm",
     "skills/hunk-review",
     "skills/hunk-extensions",
+    "skills/opentui-performance",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -377,6 +377,11 @@ const requiredPaths = [
   // `hunk skill path [name]` resolves them at runtime.
   "skills/hunk-review/SKILL.md",
   "skills/hunk-extensions/SKILL.md",
+  "skills/opentui-performance/SKILL.md",
+  "skills/opentui-performance/references/rendering-and-geometry.md",
+  "skills/opentui-performance/references/async-and-memory.md",
+  "skills/opentui-performance/references/benchmarking-and-validation.md",
+  "skills/opentui-performance/references/hunk-case-study.md",
 ];
 
 for (const path of requiredPaths) {

--- a/scripts/check-prebuilt-pack.ts
+++ b/scripts/check-prebuilt-pack.ts
@@ -2,6 +2,7 @@
 
 import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
+import { BUNDLED_SKILL_NAMES } from "../src/core/run/paths";
 import { releaseNpmDir } from "./prebuilt-package-helpers";
 import { npmCommand } from "./script-helpers";
 
@@ -73,10 +74,25 @@ assertPaths(metaPack, [
   "dist/npm/opentui/index.js",
   "skills/hunk-review/SKILL.md",
   "skills/hunk-extensions/SKILL.md",
+  "skills/opentui-performance/SKILL.md",
+  "skills/opentui-performance/references/rendering-and-geometry.md",
+  "skills/opentui-performance/references/async-and-memory.md",
+  "skills/opentui-performance/references/benchmarking-and-validation.md",
+  "skills/opentui-performance/references/hunk-case-study.md",
   "README.md",
   "LICENSE",
   "package.json",
 ]);
+
+const bundledSkillPrefixes = BUNDLED_SKILL_NAMES.map((name) => `skills/${name}/`);
+for (const file of metaPack.files) {
+  if (
+    file.path.startsWith("skills/") &&
+    !bundledSkillPrefixes.some((prefix) => file.path.startsWith(prefix))
+  ) {
+    throw new Error(`Unexpected maintainer-only skill in prebuilt package: ${file.path}`);
+  }
+}
 
 const packageDirectories = readdirSync(releaseRoot, { withFileTypes: true })
   .filter((entry) => entry.isDirectory() && entry.name !== "hunkdiff")

--- a/scripts/smoke-prebuilt-install.ts
+++ b/scripts/smoke-prebuilt-install.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { BUNDLED_SKILL_NAMES } from "../src/core/run/paths";
 import {
   binaryFilenameForSpec,
   getHostPlatformPackageSpec,
@@ -161,8 +162,12 @@ try {
   // also resolve by name, since the install is what users discover them through.
   const skillPathChecks: [args: string[], skillName: string][] = [
     [["skill", "path"], "hunk-review"],
-    [["skill", "path", "hunk-review"], "hunk-review"],
-    [["skill", "path", "hunk-extensions"], "hunk-extensions"],
+    ...BUNDLED_SKILL_NAMES.map((skillName): [args: string[], skillName: string] => [
+      ["skill", "path", skillName],
+      skillName,
+    ]),
+    [["skill", "path", "extensions"], "hunk-extensions"],
+    [["skill", "path", "performance"], "opentui-performance"],
   ];
 
   for (const [args, skillName] of skillPathChecks) {
@@ -171,6 +176,17 @@ try {
       throw new Error(
         `Expected installed \`hunk ${args.join(" ")}\` to resolve the bundled ${skillName} skill.\n${skillPath}`,
       );
+    }
+
+    if (skillName === "opentui-performance") {
+      const referencePath = path.join(
+        path.dirname(skillPath),
+        "references",
+        "rendering-and-geometry.md",
+      );
+      if (!existsSync(referencePath)) {
+        throw new Error(`Expected installed OpenTUI performance reference at ${referencePath}`);
+      }
     }
   }
 

--- a/scripts/stage-prebuilt-npm.ts
+++ b/scripts/stage-prebuilt-npm.ts
@@ -11,6 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { BUNDLED_SKILL_NAMES } from "../src/core/run/paths";
 import {
   binaryFilenameForSpec,
   buildOptionalDependencyMap,
@@ -85,7 +86,12 @@ function stageMetaPackage(
   cpSync(path.join(repoRoot, "dist", "npm"), path.join(metaDir, "dist", "npm"), {
     recursive: true,
   });
-  cpSync(path.join(repoRoot, "skills"), path.join(metaDir, "skills"), { recursive: true });
+  ensureDirectory(path.join(metaDir, "skills"));
+  for (const skillName of BUNDLED_SKILL_NAMES) {
+    cpSync(path.join(repoRoot, "skills", skillName), path.join(metaDir, "skills", skillName), {
+      recursive: true,
+    });
+  }
   cpSync(path.join(repoRoot, "README.md"), path.join(metaDir, "README.md"));
   cpSync(path.join(repoRoot, "LICENSE"), path.join(metaDir, "LICENSE"));
 
@@ -97,7 +103,13 @@ function stageMetaPackage(
       hunk: "./bin/hunk.cjs",
       hunkdiff: "./bin/hunk.cjs",
     },
-    files: ["bin", "dist/npm", "skills", "README.md", "LICENSE"],
+    files: [
+      "bin",
+      "dist/npm",
+      ...BUNDLED_SKILL_NAMES.map((skillName) => `skills/${skillName}`),
+      "README.md",
+      "LICENSE",
+    ],
     type: rootPackage.type,
     exports: rootPackage.exports,
     keywords: rootPackage.keywords,

--- a/skills/opentui-performance/SKILL.md
+++ b/skills/opentui-performance/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: opentui-performance
+description: Profiles and optimizes React/OpenTUI terminal applications across first-frame latency, keyboard and mouse interaction, scrolling, layout, async workers, rendering, and retained memory. Use when an OpenTUI app feels slow, stutters during navigation or scrolling, renders large lists, consumes excess memory, or needs trustworthy performance benchmarks without correctness regressions.
+compatibility: Designed for OpenTUI applications, especially React renderers on Bun; adapt commands and runtime-specific advice to the installed versions.
+---
+
+# OpenTUI performance engineering
+
+Optimize the user's complete interaction path, not one framework layer or one flattering metric.
+Treat correctness, terminal geometry, readiness, tail latency, and memory as constraints on every
+experiment.
+
+## 1. Establish the contract
+
+Before editing, record:
+
+- the exact user action that feels slow;
+- the fixture shape: item count, content size, terminal dimensions, wrapping, and layout;
+- what must be visible and ready when timing stops;
+- the primary latency metric and secondary p95/memory/readiness metrics;
+- product behavior that cannot change.
+
+Separate these questions instead of combining them into one stopwatch:
+
+1. process/bootstrap time;
+2. first correct plain frame;
+3. first fully ready frame, including async styling or data;
+4. settled keyboard/mouse interaction;
+5. interaction while background work is active;
+6. warm/cache-hit behavior;
+7. retained memory and cleanup.
+
+Do not call an interaction faster merely because work moved past the measurement boundary.
+
+## 2. Read the actual stack
+
+Inspect the repository instructions, package versions, renderer setup, benchmark harness, and tests.
+Then inspect the installed OpenTUI React host configuration and relevant core renderables. Do not
+assume a JSX element is virtual or cheap: spans, boxes, and text nodes may become persistent host
+objects with layout, dirtying, and lifecycle costs.
+
+Trace the hot action end to end:
+
+```text
+input event
+  -> semantic state transition
+  -> React reconciliation
+  -> OpenTUI host mutations
+  -> Yoga/layout and text-buffer work
+  -> terminal paint
+```
+
+Classify observed cost as semantic derivation, React work, host-renderable churn, layout, text
+measurement, native/WASM paint, I/O, worker computation, worker-result publication, or garbage
+collection. Use evidence rather than guessing.
+
+See [rendering and geometry](references/rendering-and-geometry.md) for the renderer path and
+[async work and memory](references/async-and-memory.md) for background work.
+
+## 3. Build a trustworthy baseline
+
+Prefer deterministic fixtures that assert visible output as well as timing. Run independent samples
+in fresh processes so module caches, workers, renderer state, and heap history do not leak between
+runs. Preserve raw samples and runtime metadata.
+
+For decisions:
+
+- report median and p95, plus absolute deltas;
+- use at least five samples, and nine for noisy or borderline changes;
+- remember that low-sample p95 is effectively a maximum;
+- record RSS and heap at meaningful lifecycle points;
+- compare equivalent runtime, platform, terminal dimensions, fixture, and feature eligibility.
+
+Read [benchmarking and validation](references/benchmarking-and-validation.md) before creating or
+changing a benchmark.
+
+## 4. Reduce structure before caching
+
+Investigate in this order:
+
+1. eliminate unnecessary work;
+2. create fewer React and OpenTUI objects;
+3. shrink invalidation boundaries without adding more host renderables;
+4. virtualize/window content with exact geometry;
+5. stabilize hot props, actions, and keys;
+6. schedule CPU and result publication away from interaction;
+7. cache only the remaining proven work.
+
+For already flattened, fixed-geometry text, consider passing `StyledText` directly instead of
+building a React span forest. Keep expressive fallback paths for wrapping, selection, links,
+editing, or other cases that need the text-node hierarchy. Measure: direct chunks are a technique,
+not a universal rule.
+
+## 5. Plan geometry once
+
+Prefer this architecture for large terminal surfaces:
+
+```text
+domain data
+  -> immutable item/row plan
+  -> deterministic geometry
+  -> section and item windows
+  -> paint-only projection
+```
+
+Measurement, rendering, reveal, hit testing, and scrolling must consume the same plan. Replace
+windowed content with exact-height spacers; keep selected and reveal targets mounted explicitly.
+Use sorted geometry and binary search for visible bounds. Separate paint-only state from anything
+that changes height or ordering.
+
+Use bounded adaptive overscan: tight during slow movement, temporarily wider during wheel/page
+bursts. Do not mount neighboring sections merely to prefetch their data.
+
+## 6. Make identity a performance contract
+
+For every hot memoized component, inspect whether parents recreate callbacks, arrays, maps, themes,
+bounds, row objects, or keys. Stabilize capability objects with latest-value refs when semantics
+allow it. Reuse previous objects when values are unchanged. Prefer shallow comparators backed by
+immutable upstream data over deep comparisons.
+
+Remount only at real host-geometry boundaries. Preserve the scroll container when possible; remount
+an inner content root only when OpenTUI must recompute culling or layout assumptions.
+
+## 7. Schedule background work and publication
+
+Moving CPU work to a worker is only half of the job:
+
+```text
+worker computes
+  -> result transfers
+  -> state/cache changes
+  -> plans rebuild
+  -> terminal repaints
+```
+
+Use explicit versioned request protocols, ids, bounded concurrency, failure draining, disposal, and
+compact transferable output. Deduplicate completed and in-flight work. Prioritize selected and
+visible targets above adjacent and speculative halo work. Cancel, supersede, or deprioritize stale
+queued jobs.
+
+Ask when completed work should become visible. A result committed during wheel or key input can
+still damage p95. Cache completion immediately when appropriate, but consider publishing cosmetic
+results after active input settles. Measure the readiness cost explicitly; never hide it.
+
+## 8. Run controlled experiments
+
+Change one seam at a time. For every experiment record:
+
+- hypothesis and expected affected phase;
+- primary and secondary metrics;
+- correctness checks;
+- retained memory impact;
+- complexity introduced;
+- keep/discard decision and residual risk.
+
+Reject optimizations that blank output, shrink fixtures without justification, disable styling,
+skip settling while claiming readiness, compare ineligible feature paths, report only the best
+sample, or move work outside the timer.
+
+Use the [Hunk case study](references/hunk-case-study.md) for examples of structural wins, discarded
+micro-optimizations, and worker tradeoffs. Its numbers are evidence from one application, not
+universal thresholds.
+
+## 9. Validate terminal reality
+
+Use a ladder appropriate to the change:
+
+1. pure plan/geometry/cache tests;
+2. OpenTUI test renderer with correctness assertions;
+3. PTY interaction tests for keyboard, mouse, resize, and scrolling;
+4. real-TTY transcript smoke;
+5. platform-specific CI and worker/package checks;
+6. manual verification when rendering changed materially.
+
+Include CJK, emoji, combining characters, tabs, ANSI/control sanitization, horizontal clipping,
+wrapping, resize, and pathological long lines when relevant. A fast misaligned or blank frame is a
+failure.
+
+## 10. Report the result
+
+Return a reviewable performance report:
+
+```markdown
+## Workload and environment
+
+## Baseline
+
+## Profile evidence
+
+## Experiments and raw sample summary
+
+## Retained changes
+
+## Regressions and tradeoffs
+
+## Correctness and terminal validation
+
+## Memory impact
+
+## Residual risks
+```
+
+Lead with user-perceptible effects. Distinguish framework time from complete event-to-paint wall
+time, and distinguish plain visibility from full readiness.

--- a/skills/opentui-performance/references/async-and-memory.md
+++ b/skills/opentui-performance/references/async-and-memory.md
@@ -1,0 +1,231 @@
+# Async work, workers, caches, and memory
+
+Use this reference when expensive I/O, parsing, syntax highlighting, workers, prefetching, cache
+retention, or delayed result publication affects interaction.
+
+## Workers move computation, not publication
+
+Model the whole pipeline:
+
+```text
+request
+  -> input/source loading
+  -> queue wait
+  -> worker computation
+  -> serialization/transfer
+  -> validation/cache insertion
+  -> React state publication
+  -> plan rebuild/layout/paint
+```
+
+Measure at least:
+
+- time to first correct plain frame;
+- time to fully ready/styled frame;
+- input latency while work is active;
+- queue catch-up after rapid navigation;
+- cost of applying a completed result;
+- worker and main-process RSS/heap.
+
+A worker can improve input p95 while making final styling later. Report both.
+
+## Worker protocol checklist
+
+Use an explicit protocol with:
+
+- version number;
+- unique request id;
+- structured-clone-safe request and response types;
+- success and failure variants;
+- response validation;
+- stale/unknown response rejection;
+- deterministic cleanup on worker error.
+
+On a fatal worker error, reject every active and queued promise. Do not leave callers hanging.
+Provide a disposal path, and prevent background infrastructure from keeping short-lived commands
+alive (`unref` where supported).
+
+Feature-detect runtime and packaging support. A compiled binary, development process, Windows,
+Linux, and macOS may resolve worker entrypoints differently. Degrade to a documented inline or plain
+path rather than crashing the TUI.
+
+## Bound concurrency and prioritize work
+
+Unlimited concurrency can multiply highlighter/parser state, WASM heaps, serialization buffers, and
+GC pressure. A serialized worker is predictable but creates head-of-line blocking.
+
+Use explicit priorities:
+
+1. selected destination;
+2. currently visible work;
+3. imminent navigation target;
+4. adjacent work;
+5. viewport halo;
+6. speculative background work.
+
+Allow a high-priority consumer to promote an already queued request. Consider cancellation or
+supersession for requests that have not started. If active jobs cannot be interrupted, bound their
+size so one obsolete task cannot block interaction for seconds.
+
+Do not confuse React unmount cancellation with CPU cancellation: suppressing `setState` prevents a
+stale commit but does not stop a worker or I/O request unless the underlying job receives an abort
+signal or queue cancellation.
+
+## Prefetch from geometry
+
+Derive prefetch targets from navigation and viewport geometry, not component mount. Start data work
+without mounting all of the corresponding UI.
+
+Useful target groups:
+
+- selected item;
+- visible items;
+- known next/previous target;
+- a bounded viewport halo.
+
+Keep prefetch policy separate from mount/window policy. A component should mount because it is
+visible, overscanned, selected, or explicitly revealed—not merely because its data should become
+warm.
+
+## Deduplicate completed and in-flight work
+
+Use both:
+
+- a completed-result cache;
+- a `Map<key, Promise<Result>>` for active work.
+
+Every caller—prefetch and mounted consumer—should share the same promise. Remove an active promise
+only if it is still the current promise for that key, so an older completion cannot delete a newer
+request.
+
+Do not cache transient worker failures as successful plain results if a later retry should be
+possible.
+
+## Cache identity
+
+A safe key commonly includes:
+
+- content digest or upstream version id;
+- semantic item identity;
+- theme/appearance;
+- rendering options;
+- source/provider identity;
+- any grammar/parser configuration.
+
+Prefer upstream content identities to hashing whole content on every render. If a provider has no
+version key, object identity may be a process-local fallback, not a durable cross-reload identity.
+
+Render should remain side-effect free. If LRU reads mutate recency, use a non-touching `peek` during
+render and perform recency-changing reads in an effect or commit-safe phase.
+
+## Budget by retained cost
+
+Item-count limits are rarely sufficient. Estimate or measure:
+
+- bytes in strings and typed arrays;
+- row/cell count;
+- fixed object overhead per entry;
+- worker-side and main-side copies;
+- transfer/cloning behavior.
+
+Use byte- or work-bounded LRU caches. Charge empty entries and failures if they are retained, or a
+watch/reload loop can leak keys for “zero-cost” values.
+
+Choose and document oversized-entry behavior:
+
+- reject it without evicting useful residents;
+- allow one current oversized entry temporarily;
+- render a reduced/plain representation;
+- stream or page the result.
+
+Typed-array transfer detaches buffers. A worker cache must clone retained payloads before transfer,
+or transfer a one-shot oversized payload without pretending it remains cached. Avoid transiently
+doubling very large buffers.
+
+## Publish results deliberately
+
+A completed result can still damage scroll or key p95 if publication rebuilds mounted rows during
+input.
+
+Options include:
+
+- publish immediately for selected/visible semantic data;
+- batch several cosmetic completions;
+- retain the previous paint during an active wheel/key burst;
+- publish the latest cached cosmetic result after a short idle interval;
+- prewarm the worker so completion occurs before interaction begins.
+
+Every deferral must be measured as readiness latency. Never call the app faster merely because
+color, data, or layout appears after the timer stops.
+
+React transitions and deferred values are not guaranteed solutions. External cache reads or native
+host mutations can bypass React priority, and native paint may dominate. Verify them experimentally.
+
+## Compact worker output
+
+Return only what the terminal needs. Prefer compact runs, indexes, palettes, or typed arrays over
+large AST/HAST/object graphs when practical. Validate all indexes and ranges before using them to
+paint.
+
+Compact output reduces:
+
+- structured-clone cost;
+- main-thread allocation;
+- retained cache size;
+- GC;
+- transfer time.
+
+Keep a parity test against the trusted inline implementation.
+
+## Lazy and bounded I/O
+
+Load expensive source/documents only when the feature needs them. Cap bytes before decoding or
+retaining large inputs. Represent loading, unavailable, too-large, and error states explicitly.
+
+Memoize resolved data where appropriate and deduplicate the in-flight first read; caching only the
+resolved value can still duplicate simultaneous I/O.
+
+Guard result commits with request id, content generation, provider identity, and side/key. A late
+read from old content must not overwrite a reloaded session.
+
+## Lifecycle ownership
+
+The hook/module that creates a resource should own cleanup:
+
+- unsubscribe observers;
+- close watchers;
+- clear timers;
+- abort I/O;
+- reject queued work;
+- dispose workers in controlled tests or shutdown;
+- suppress stale state commits after unmount or key change.
+
+Use latest-value refs when callback changes should not recreate an expensive watcher or controller.
+
+## Memory diagnostics
+
+Record both:
+
+- JavaScript heap used;
+- process RSS, including native/WASM/worker effects.
+
+Take snapshots after meaningful phases: fixture/bootstrap, planning, first frame, navigation,
+resize, worker startup, and cleanup. Force GC only when comparing retained memory, and label that
+fact.
+
+For leak tests, run repeated realistic cycles, discard warmup, settle cleanup, then inspect total
+growth and per-cycle slope. A lower JS heap with higher RSS may mean work moved into native or worker
+memory rather than disappearing.
+
+## Anti-patterns
+
+- unbounded FIFO queues with obsolete speculative work;
+- one worker per item;
+- caching raw object graphs when compact output is sufficient;
+- cache keys based only on array index or display position;
+- starting async work during render;
+- mounting UI solely to trigger prefetch;
+- swallowing worker failure without settling callers;
+- treating cancelled React commits as cancelled computation;
+- reporting input latency without readiness and queue catch-up;
+- using a threshold tuned to one grammar or line length as a universal constant.

--- a/skills/opentui-performance/references/benchmarking-and-validation.md
+++ b/skills/opentui-performance/references/benchmarking-and-validation.md
@@ -1,0 +1,289 @@
+# Benchmarking and validation
+
+Use this reference to build trustworthy performance evidence for an OpenTUI application.
+
+## Start from the user promise
+
+Name the exact interaction and completion condition. Useful independent metrics include:
+
+- process/bootstrap latency;
+- mount-to-first-correct-frame latency;
+- first fully ready/styled frame;
+- keypress median and p95;
+- wheel/track/page-scroll median and p95;
+- resize and wrap-settling latency;
+- queue catch-up after rapid input;
+- heap and RSS after first frame and interaction;
+- cleanup growth/slope across repeated cycles.
+
+Do not combine cold startup, async readiness, and settled interaction unless the product question
+specifically combines them.
+
+## Deterministic fixture matrix
+
+Use multiple shapes because one aggregate size hides different costs:
+
+- many small sections/items;
+- balanced sections;
+- one large section;
+- giant/pathological item;
+- fixed-height and wrapped content;
+- ASCII and non-ASCII content;
+- cold and warm cache/worker states;
+- feature-ineligible and feature-eligible boundaries;
+- mixed sizes that expose queueing and priority.
+
+Keep unrelated dimensions fixed when sweeping one variable. For example, keep the visible changed
+region constant while increasing full-source size to isolate syntax-highlighting cost.
+
+Record fixture counts, line lengths, terminal dimensions, wrapping mode, theme, runtime version,
+platform, architecture, and commit SHA.
+
+## Correctness-bearing timing
+
+Every timed scenario should also assert that:
+
+- expected content is present;
+- the frame is not blank;
+- selection/navigation reached the intended target;
+- scrolling moved the viewport;
+- split columns or table cells remain aligned;
+- wrapping did not clip required content;
+- async styling/data eventually arrived;
+- checksums or visible markers match the expected path.
+
+A benchmark that gets faster by skipping output must fail.
+
+## Fresh-process sampling
+
+Independent samples should launch the benchmark script in a fresh process. This isolates:
+
+- module and highlighter caches;
+- singleton workers;
+- React/OpenTUI renderer state;
+- global promise maps and LRUs;
+- heap/GC history;
+- process-level native allocations.
+
+Within one deliberate cold-versus-warm comparison, share a process and dispose renderers/workers in
+`finally`.
+
+A minimal output protocol is easy to aggregate:
+
+```text
+METRIC first_frame_ms=18.42
+METRIC interaction_median_ms=7.11
+METRIC interaction_p95_ms=11.84
+METRIC heap_used_bytes=48123904
+METRIC rss_bytes=272629760
+METRIC correctness=1
+```
+
+Preserve raw samples in a machine-readable artifact.
+
+## Percentiles and sample count
+
+Report median plus p95, but interpret low-N tails honestly. With nearest-rank percentiles:
+
+- three samples make p95 the maximum;
+- five samples still make p95 the maximum;
+- eight per-event samples make p95 the slowest event.
+
+Use p95 as a tail diagnostic, not a statistically rich population estimate, unless sample count is
+large. Run at least five fresh processes for clear effects and nine or more for noisy/borderline
+changes. Alternate baseline/candidate order to reduce thermal and background-process bias.
+
+Always report absolute deltas beside percentages. A 100% regression from 0.2 to 0.4 ms may be less
+important than a 10% regression from 80 to 88 ms.
+
+## Materiality
+
+Use both a relative and absolute floor. Example policies:
+
+```text
+timing regression: >=15% and >=5 ms
+memory regression: >=20% and >=8 MiB
+```
+
+Tune these to the product. Do not silently move thresholds after seeing a result. If a regression is
+accepted, name the metric and record the product reason.
+
+Secondary metrics can veto a primary win when they expose correctness, readiness, p95, or memory
+harm. A median-only improvement is not automatically a product improvement.
+
+## Interaction timing template
+
+Adapt to the installed OpenTUI test utilities:
+
+```ts
+const latencies: number[] = [];
+const keyUnderTest = "<interaction-key>";
+
+for (let index = 0; index < presses; index += 1) {
+  const start = performance.now();
+  await act(async () => {
+    await setup.mockInput.typeText(keyUnderTest);
+    await setup.renderOnce();
+    await Bun.sleep(0);
+  });
+  latencies.push(performance.now() - start);
+}
+```
+
+Label what the timer includes. If timers, worker results, viewport synchronization, or rendering
+settle later, either include them or report a separate readiness metric. Do not add sleeps merely to
+manufacture a preferred boundary.
+
+Use a fresh renderer when navigation and scrolling should be independent scenarios.
+
+## Cold, settled, and warm states
+
+A useful async benchmark reports:
+
+1. first plain/usable frame;
+2. selected item fully ready;
+3. next target ready before movement;
+4. one navigation input commit;
+5. destination fully ready;
+6. rapid input total;
+7. final destination catch-up;
+8. cache revisit.
+
+For worker thresholds, sweep source sizes around each boundary and include mixed sizes. Once a
+request is eligible, changing the numeric threshold usually does not alter worker behavior; it only
+changes which files enter that path.
+
+## Memory checkpoints
+
+Use `process.memoryUsage()` for heap and RSS where available. For retained-memory comparisons, force
+a full GC immediately before both snapshots and document it. For external long-lived processes,
+prefer OS RSS/high-water metrics and repeated cycles.
+
+Track phases such as:
+
+```text
+fixture loaded
+plan built
+first frame
+worker started
+navigation complete
+resize complete
+resources disposed
+```
+
+A falling heap paired with rising RSS may indicate native/WASM/worker migration. Report both.
+
+## Profiling workflow
+
+Use complementary evidence:
+
+- React Profiler for component actual/commit duration;
+- runtime CPU profiles for JS, native bindings, WASM, and buffer work;
+- targeted instrumentation around input, plan building, layout, worker completion, and paint;
+- mount/renderable counts;
+- memory snapshots;
+- controlled suppression experiments to isolate styling, selection paint, or async work.
+
+Do not conclude “React is slow” when event-to-paint wall time greatly exceeds React commits.
+Inspect the installed OpenTUI host config and core renderables when host mutation or text/layout work
+is implicated.
+
+## Terminal validation ladder
+
+### Test renderer
+
+Use for deterministic frames, spans, event dispatch, and profiling. Verify markers and geometry.
+
+### PTY
+
+Use a real child process and pseudoterminal for:
+
+- keyboard routing;
+- mouse wheel/click/drag;
+- resize;
+- focus and modal behavior;
+- wide-character alignment;
+- process readiness and clean exit.
+
+Isolate configuration, plugins/extensions, notices, and daemon services. Poll observable state with a
+deadline instead of sleeping a guessed duration. Always close processes and remove temporary files.
+
+### Real TTY smoke
+
+Use an actual terminal host/transcript tool where supported. Capability-probe Unix-only tools and
+skip narrowly on unsupported platforms. Verify terminal takeover, rendering, interaction, and clean
+restoration.
+
+### Cross-platform
+
+Compare benchmarks only on matching runtime/platform metadata. Exercise compiled worker resolution,
+path handling, line endings, and terminal capability separately on Windows, macOS, and Linux.
+
+## Unicode and pathological content
+
+Include fixtures with:
+
+- CJK wide cells;
+- emoji and grapheme clusters;
+- combining marks;
+- box drawing;
+- tabs crossing style boundaries;
+- control and escape sequences;
+- extremely long logical lines;
+- hundreds of wrapped physical rows.
+
+Assert terminal-cell alignment or width checksums, not merely JavaScript string length.
+
+## Benchmark-integrity checklist
+
+Reject a claimed improvement if it:
+
+- changes the benchmark implementation without justification;
+- shrinks the fixture or disables a feature;
+- stops before required readiness;
+- moves work onto an unmeasured timer;
+- compares different eligibility paths unknowingly;
+- includes warmed caches only on one side;
+- reports the best sample instead of the distribution;
+- ignores p95, memory, or correctness;
+- measures redirected stdout when the product is an interactive TTY;
+- leaves workers or renderers alive after the sample.
+
+## Performance report template
+
+```markdown
+## Workload and environment
+
+- Runtime / OpenTUI / React versions:
+- Platform and terminal dimensions:
+- Fixture:
+- Completion condition:
+
+## Baseline
+
+| Metric | Median | p95 | Samples |
+
+## Profile evidence
+
+- React:
+- Host/layout/native:
+- Async/worker:
+- Memory:
+
+## Experiments
+
+| Change | Primary | Secondary | Correctness | Decision |
+
+## Retained changes
+
+## Regressions and tradeoffs
+
+## Validation
+
+- Test renderer:
+- PTY:
+- TTY:
+- Cross-platform:
+
+## Residual risks
+```

--- a/skills/opentui-performance/references/hunk-case-study.md
+++ b/skills/opentui-performance/references/hunk-case-study.md
@@ -1,0 +1,215 @@
+# Case study: Hunk's OpenTUI review stream
+
+This case study records reusable evidence from one React/OpenTUI application. Do not copy its numeric
+thresholds, cache budgets, or domain policies into another product without measuring.
+
+## Workload
+
+Hunk renders a terminal-native, multi-file diff review stream with:
+
+- syntax-highlighted split and stack rows;
+- one global scroll coordinate system;
+- sidebar navigation;
+- selected hunk rails and current-line paint;
+- wrapped and unwrapped layouts;
+- inline notes with deterministic height;
+- file-level and row-level windowing;
+- async source loading and optional worker highlighting.
+
+A navigation benchmark used many files with one hunk per file, making each `]` press a cross-file
+jump. This intentionally stressed section mounting, syntax rows, sidebar selection, reveal, and
+OpenTUI paint.
+
+## Evidence snapshot
+
+The retained renderer work shipped in [Hunk PR #803](https://github.com/modem-dev/hunk/pull/803)
+(commit `dc66723b`). Its final comparison used Bun 1.3.10 on Linux x64, a 240×28 test-renderer
+viewport, a 180-file × 120-line fixture, and nine alternating fresh-process baseline/candidate pairs:
+
+| Metric                       |     Main | Retained change |
+| ---------------------------- | -------: | --------------: |
+| Cross-file navigation median | 69.94 ms |        46.59 ms |
+| Cross-file navigation p95    | 96.04 ms |        56.98 ms |
+| Scroll median                |  1.63 ms |         1.15 ms |
+| Scroll p95                   | 12.90 ms |         5.27 ms |
+| Post-navigation heap         | 147.8 MB |        101.4 MB |
+| Post-navigation RSS          | 590.6 MB |        429.7 MB |
+
+A later opt-in worker study behind [Hunk PR #810](https://github.com/modem-dev/hunk/pull/810)
+held the visible changed region at 16 lines while sweeping source sides. It used nine fresh processes
+through 500 lines and five above that; the table shows medians for inline versus worker execution:
+
+| Source-side lines |        Navigation | First fully colored frame penalty | Maximum render flush |
+| ----------------: | ----------------: | --------------------------------: | -------------------: |
+|                40 |  24.49 → 14.39 ms |                            +46 ms |     64.94 → 10.88 ms |
+|               100 |  33.32 → 14.88 ms |                            +49 ms |     76.70 → 11.01 ms |
+|               200 |  43.08 → 15.81 ms |                            +50 ms |      92.32 → 9.76 ms |
+|               500 |  77.95 → 17.13 ms |                            +61 ms |    132.13 → 13.89 ms |
+|             1,000 | 138.23 → 18.91 ms |                            +59 ms |    201.00 → 12.42 ms |
+|             2,000 | 257.55 → 25.25 ms |                            +69 ms |    322.78 → 14.95 ms |
+
+These snapshots explain the conclusions below; they are not universal OpenTUI baselines. Re-run raw
+samples on the target runtime, platform, fixture, and renderer version.
+
+## Profile evidence
+
+The initial hot path combined:
+
+- selection-driven React invalidation;
+- syntax token `<span>` forests;
+- newly mounted file sections;
+- adjacent files mounted only to warm highlighting;
+- unstable pane actions repainting sidebar rows;
+- main-thread syntax highlighting;
+- Yoga, text-buffer, native/WASM paint, and render flushing.
+
+Controlled runs showed that pre-highlighting helped but did not explain all latency. Suppressing
+selection paint helped independently. React Profiler commits were initially much larger, but after
+structural fixes React accounted for only a fraction of remaining wall time; CPU profiles still
+showed layout, buffer, native/WASM, and highlighting work.
+
+## Structural wins
+
+### Prefetch without mounting
+
+Adjacent syntax data was useful, but mounting adjacent file row trees was not. Separating the
+highlight prefetch set from the file render window reduced navigation work and retained memory while
+preserving selected-target mounting.
+
+Generic lesson: data horizon and render horizon are independent.
+
+### Direct `StyledText` rows
+
+Ordinary fixed-height rows already contained ordered syntax/style runs. The old path expressed them
+as many React spans, which OpenTUI converted into text-node renderables, recursively gathered into
+`StyledText`, and wrote to a text buffer.
+
+The fast path builds final chunks directly and passes one `StyledText` payload to one text host.
+Wrapping, copy selection, current-line ranges, and richer painting retain an expressive fallback.
+
+This removed React fibers and persistent host text nodes, reduced dirty notifications and recursive
+style collection, and materially lowered retained heap. It was a larger win than selection-invariant
+row caches.
+
+Generic lesson: when data is already a display list, avoid rebuilding a host object graph merely to
+flatten it again.
+
+### Stable capability objects
+
+Pane navigation callbacks changed identity on every selection render, defeating memoized sidebar
+rows. A stable action object delegates through latest-value refs, preserving behavior while stopping
+selection-wide repaint propagation.
+
+Generic lesson: extension and capability APIs are identity-bearing props in hot trees.
+
+### Shared deterministic geometry
+
+Hunk builds one row plan per file and derives measurement, rendering, anchors, reveal, and windows
+from it. File sections and rows are windowed separately with exact spacers. Paint-only selection and
+line marks do not change the geometry plan.
+
+Generic lesson: exact pre-mount geometry unlocks reliable hierarchical virtualization.
+
+## Experiments discarded
+
+### Row-content `WeakMap` caches
+
+Caches added code and retained objects for a gain inside run-to-run noise. Removing them did not hurt
+the final benchmark.
+
+Lesson: structural elimination beats caching repeated unnecessary structure.
+
+### Separate rail renderables
+
+Splitting one-character selection rails into separate text/box hosts narrowed React invalidation but
+added OpenTUI/Yoga nodes. Navigation regressed.
+
+Lesson: fewer host renderables can beat finer component granularity.
+
+### Explicit one-row dimensions
+
+Adding width/height constraints in hope of skipping intrinsic text measurement did not reduce layout
+cost and increased memory.
+
+Lesson: verify how the installed renderer marks and measures nodes before adding constraints.
+
+### Generic React deferral
+
+A `useDeferredValue` experiment barely changed scroll p95, worsened median scrolling, and increased
+memory. Completed highlights were also visible through a shared cache, so React priority did not
+control the whole publication path.
+
+Lesson: transitions cannot schedule work that bypasses them through caches or native host updates.
+
+### Smaller overscan and removed reveal settling
+
+Reducing overscan or removing a zero-delay reveal settle improved a microbenchmark but broke distant,
+backward, bottom-clamped, note, or window-mount navigation tests.
+
+Lesson: geometry and settling safeguards require adversarial interaction coverage, not only pure
+helper tests.
+
+## Worker threshold study
+
+Hunk's opt-in fast mode sends eligible highlighting to one serialized worker. Sweeping source-side
+sizes showed a consistent trade:
+
+- input and maximum event-loop stalls improved at every tested size;
+- the plain frame appeared sooner;
+- cold syntax color completed later because worker startup and queueing continued;
+- lower thresholds queued more speculative work and could delay color catch-up during rapid mixed
+  navigation;
+- worker RSS was a visible fixed cost on tiny reviews, while main-thread heap often fell.
+
+A representative sweep found that lowering a line threshold improved navigation dramatically, but
+scroll p95 could worsen when a worker result landed during a wheel tick. The threshold itself did
+not determine scroll cost once a file was eligible; file shape, token complexity, mounted rows, and
+completion timing mattered.
+
+Generic lessons:
+
+1. Benchmark the actual eligible worker path.
+2. Measure first plain frame and first fully styled frame separately.
+3. Include mixed-size rapid navigation to expose FIFO head-of-line blocking.
+4. Treat worker-result repaint as part of worker performance.
+5. Prefer selected/visible priority over file-order FIFO.
+6. Do not infer a universal threshold from line count alone.
+
+## Measurement corrections
+
+Several benchmark interpretation issues mattered:
+
+- A default fixture below the worker threshold said nothing about fast mode.
+- A scroll timer that excluded deferred viewport synchronization was not directly comparable to a
+  navigation timer that included semantic commits and queued work.
+- With eight scroll ticks, nearest-rank p95 was the slowest tick.
+- Fresh-process samples were required because highlighter, worker, cache, renderer, and heap state
+  materially changed later runs.
+- Memory reductions corroborated the claim that fewer persistent renderables—not timer movement—drove
+  the direct-text improvement.
+
+## Validation that protected the product
+
+Retained changes passed:
+
+- focused render and worker parity tests;
+- complete unit tests;
+- PTY navigation, scrolling, wrapping, notes, and highlighting tests;
+- real-TTY transcript smoke;
+- Windows and compiled-worker checks;
+- manual terminal verification.
+
+The most valuable failures were not benchmark failures: full UI tests exposed reveal and windowing
+regressions that focused geometry tests missed.
+
+## Portable conclusions
+
+- Optimize the host scene graph, not only React components.
+- Keep one geometry model across render and interaction.
+- Window React trees even when the host supports culling.
+- Do not mount to prefetch.
+- Stabilize props before trusting memoization.
+- Schedule background publication as well as computation.
+- Use memory as evidence about retained structure.
+- Preserve rich fallback paths around a common deterministic fast path.
+- Treat benchmark integrity and terminal correctness as part of performance engineering.

--- a/skills/opentui-performance/references/rendering-and-geometry.md
+++ b/skills/opentui-performance/references/rendering-and-geometry.md
@@ -1,0 +1,211 @@
+# Rendering, geometry, and windowing
+
+Use this reference when React commits, host renderables, Yoga/layout, scrolling, text measurement, or
+large mounted trees appear in the hot path.
+
+## Model the full render cost
+
+A React/OpenTUI update can allocate or mutate several layers:
+
+```text
+React element and Fiber
+  -> OpenTUI host renderable
+  -> Yoga node or text-node hierarchy
+  -> inherited style/chunk collection
+  -> text buffer
+  -> terminal draw buffer
+```
+
+Count host objects as well as React renders. An optimization that introduces more `<box>`, `<text>`,
+or `<span>` hosts can lose even when fewer components rerender.
+
+Profile both:
+
+- React actual/commit duration;
+- complete input-to-render wall time;
+- host object creation and property updates;
+- Yoga measurement/layout;
+- text width and wrapping;
+- text-buffer population and native/WASM drawing;
+- retained heap and GC.
+
+If React is only a small fraction of wall time, another memo boundary is unlikely to solve the
+problem.
+
+## Flat text versus text-node trees
+
+Use a direct `StyledText` payload when all of these are true:
+
+- the application already has ordered text/style runs;
+- geometry is fixed or independently known;
+- nested semantic text nodes are not needed;
+- links, editing, selection, and dynamic range painting have a safe path;
+- correctness tests can compare the flattened output.
+
+Conceptually:
+
+```tsx
+const chunks = runs.map((run) => ({
+  __isChunk: true,
+  text: run.text,
+  fg: resolveColor(run.fg),
+  bg: resolveColor(run.bg),
+}));
+
+return <text content={new StyledText(chunks)} />;
+```
+
+Coalesce adjacent runs with identical style, sanitize terminal controls, and preserve cell-aware
+clipping and padding. Avoid mutating shared run arrays while slicing or coalescing.
+
+Keep a richer path for wrapped text, copy/cursor ranges, editable content, links, or other cases
+where flattening would duplicate complex behavior. If a renderable must switch between manual
+content and child nodes, test the transition explicitly; some renderer versions require distinct
+keys or hosts to avoid transient invalid content.
+
+## Do not add host nodes to save trivial React work
+
+These patterns often regress:
+
+- a separate box/text renderable for a one-character rail or badge;
+- extra layout wrappers introduced only for memoization;
+- explicit dimensions added in hope of bypassing measurement without profiling;
+- one component per syntax token;
+- one closure per visible row on every parent render.
+
+A single broader text-buffer update may be cheaper than precise updates spread over more Yoga and
+host nodes.
+
+## Plan once
+
+Build an immutable ordered plan that carries stable keys and all geometry-bearing information.
+Derive measurement and rendering from that exact plan.
+
+```ts
+interface PlannedItem {
+  key: string;
+  height: number;
+  // Domain payload or a stable reference to it.
+}
+
+interface ItemGeometry {
+  key: string;
+  top: number;
+  height: number;
+  bottom: number;
+}
+```
+
+The same plan should power:
+
+- total content height;
+- viewport intersection;
+- rendering order;
+- reveal and alignment;
+- hit testing;
+- anchors and navigation;
+- top/bottom spacer sizes.
+
+Never let renderer-local height logic drift from navigation or scrolling logic.
+
+## Deterministic height is the virtualization contract
+
+Virtualization is safest when item height is a pure function of domain data plus explicit layout
+inputs such as width, wrapping, and theme metrics. Rich content that affects height must have a
+deterministic measurement representation.
+
+If exact height is unavailable before mount:
+
+- separate provisional startup geometry from authoritative geometry;
+- do not derive semantic selection from guesses;
+- preserve a bounded settling/reveal pass;
+- test bottom clamping, distant targets, and resize.
+
+## Hierarchical windowing
+
+Large surfaces often need two layers:
+
+```text
+section window
+  -> row/item window within mounted sections
+```
+
+At each layer:
+
+1. keep absolute geometry sorted;
+2. binary-search the first and last visible item;
+3. add bounded overscan;
+4. union selected/reveal/interaction targets;
+5. emit exact top and bottom spacers;
+6. preserve total content height.
+
+Sparse section windows are valid: a selected target far from the viewport can mount as an island
+between spacers without mounting every section in between.
+
+Do not rely only on OpenTUI viewport culling. Host culling may skip drawing while React still owns,
+reconciles, and retains the complete subtree.
+
+## Structural nonvisual rows
+
+Zero-height or hidden items may still preserve ordering, anchors, ownership, or stable identity.
+Include them at window boundaries when downstream logic relies on them. Removing nonvisual
+structure can make navigation or note/anchor placement drift even when the frame looks correct.
+
+## Adaptive overscan
+
+Use different policies for different motion:
+
+- slow line movement: small steady overscan;
+- wheel/page bursts: temporary larger halo;
+- selected/reveal target: explicit inclusion;
+- wrapped/variable-height content: more conservative bounds.
+
+Bound burst overscan and clear it after an idle interval. Permanent large overscan wastes memory and
+commit time; zero overscan risks blank bands while native scrolling outruns React.
+
+## Identity rules
+
+Memoization works only when upstream identities are deliberate:
+
+- stable semantic keys, never host runtime ids or array indexes for durable items;
+- immutable plans and row objects;
+- stable themes/config objects;
+- latest-value refs behind stable capability callbacks;
+- reuse `{top, height}` or bounds objects when values did not change;
+- shallow memo comparators that document their identity contract.
+
+Avoid deep comparators over mutable data. They add hot-path work and still cannot make mutation safe.
+
+## Separate geometry from paint
+
+Selection, hover, cursor, search matches, and transient color should remain below geometry planning
+unless they truly change size or order. Isolate high-frequency paint from expensive invariant text
+or row structure, but verify that isolation does not add more host renderables than it saves.
+
+## Scroll synchronization
+
+OpenTUI controls live imperative scroll state. React usually needs a coalesced snapshot for
+windowing and semantic viewport-follow behavior.
+
+Recommended pattern:
+
+- keep the scrollbox instance in a ref;
+- subscribe to native change/layout events;
+- coalesce reads on a bounded timer/frame;
+- avoid synchronous `setState` from inside host layout or commit callbacks;
+- update React state only when `{top, height}` actually changed;
+- keep explicit-navigation suppression separate from passive viewport-follow selection.
+
+When geometry-defining inputs change, prefer remounting an inner content root while retaining the
+outer scrollbox and scroll position.
+
+## Diagnostic questions
+
+- How many React elements and OpenTUI host objects mount for one viewport?
+- Which props change on one keypress or wheel tick?
+- Does selection repaint invariant syntax/token content?
+- Does prefetching force components to mount?
+- Are row heights calculated independently in more than one place?
+- Is wrapping mixed into the fixed-height fast path?
+- Does an optimization reduce React time but increase Yoga or native time?
+- Does retained heap fall in a way that corroborates object-count reduction?

--- a/src/app/cli.test.ts
+++ b/src/app/cli.test.ts
@@ -424,7 +424,12 @@ describe("parseCli", () => {
   });
 
   test("prints a named bundled skill path, by name or alias", async () => {
-    for (const requested of ["hunk-extensions", "extensions"]) {
+    for (const [requested, expected] of [
+      ["hunk-extensions", "hunk-extensions"],
+      ["extensions", "hunk-extensions"],
+      ["opentui-performance", "opentui-performance"],
+      ["performance", "opentui-performance"],
+    ] as const) {
       const parsed = await parseCli(["bun", "hunk", "skill", "path", requested]);
 
       expect(parsed.kind).toBe("help");
@@ -432,7 +437,7 @@ describe("parseCli", () => {
         throw new Error("Expected bundled skill path output.");
       }
 
-      expect(parsed.text).toEndWith(`${join("skills", "hunk-extensions", "SKILL.md")}\n`);
+      expect(parsed.text).toEndWith(`${join("skills", expected, "SKILL.md")}\n`);
     }
   });
 
@@ -445,11 +450,13 @@ describe("parseCli", () => {
         "Usage: hunk skill path [name]",
         "",
         "Print a bundled Hunk skill path.",
-        "Load or symlink that file in your coding agent to keep it in sync across Hunk upgrades.",
+        "Load that file directly in your coding agent.",
+        "For a persistent install, symlink its parent directory so referenced files remain available.",
         "",
         "Skills:",
-        `  hunk-review (default, "review")   review a live Hunk session with \`hunk session\` commands`,
-        `  hunk-extensions ("extensions")    build extensions against the hunkdiff/extension API`,
+        `  hunk-review (default, "review")     review a live Hunk session with \`hunk session\` commands`,
+        `  hunk-extensions ("extensions")      build extensions against the hunkdiff/extension API`,
+        `  opentui-performance ("performance") profile and optimize React/OpenTUI terminal apps`,
         "",
       ].join("\n"),
     });
@@ -1534,7 +1541,7 @@ describe("parseCli argument validation", () => {
       "Only `hunk skill path` is supported.",
     );
     await expect(parseCli(["bun", "hunk", "skill", "path", "bogus"])).rejects.toThrow(
-      'Unknown skill "bogus". Bundled skills are hunk-review and hunk-extensions.',
+      'Unknown skill "bogus". Bundled skills are hunk-review and hunk-extensions and opentui-performance.',
     );
     // Maintainer-only skills are not bundled, so naming one is not a path lookup.
     await expect(parseCli(["bun", "hunk", "skill", "path", "launch-video"])).rejects.toThrow(

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -447,11 +447,13 @@ function renderSkillHelp() {
     "Usage: hunk skill path [name]",
     "",
     "Print a bundled Hunk skill path.",
-    "Load or symlink that file in your coding agent to keep it in sync across Hunk upgrades.",
+    "Load that file directly in your coding agent.",
+    "For a persistent install, symlink its parent directory so referenced files remain available.",
     "",
     "Skills:",
-    `  hunk-review (default, "review")   review a live Hunk session with \`hunk session\` commands`,
-    `  hunk-extensions ("extensions")    build extensions against the hunkdiff/extension API`,
+    `  hunk-review (default, "review")     review a live Hunk session with \`hunk session\` commands`,
+    `  hunk-extensions ("extensions")      build extensions against the hunkdiff/extension API`,
+    `  opentui-performance ("performance") profile and optimize React/OpenTUI terminal apps`,
     "",
   ].join("\n");
 }

--- a/src/core/run/paths.test.ts
+++ b/src/core/run/paths.test.ts
@@ -60,6 +60,8 @@ describe("paths", () => {
   test("resolves bundled skill names and their short aliases", () => {
     expect(resolveBundledSkillName("hunk-extensions")).toBe("hunk-extensions");
     expect(resolveBundledSkillName("extensions")).toBe("hunk-extensions");
+    expect(resolveBundledSkillName("opentui-performance")).toBe("opentui-performance");
+    expect(resolveBundledSkillName("performance")).toBe("opentui-performance");
     expect(resolveBundledSkillName(" Review ")).toBe("hunk-review");
     expect(resolveBundledSkillName("launch-video")).toBeUndefined();
     expect(resolveBundledSkillName("")).toBeUndefined();

--- a/src/core/run/paths.ts
+++ b/src/core/run/paths.ts
@@ -8,7 +8,11 @@ import { basename, dirname, join, resolve } from "node:path";
  * prebuilt artifact staging; `skills/` also holds maintainer-only documents that
  * never ship, and naming them here would resolve paths users cannot have.
  */
-export const BUNDLED_SKILL_NAMES = ["hunk-review", "hunk-extensions"] as const;
+export const BUNDLED_SKILL_NAMES = [
+  "hunk-review",
+  "hunk-extensions",
+  "opentui-performance",
+] as const;
 export type BundledSkillName = (typeof BUNDLED_SKILL_NAMES)[number];
 
 /** The skill `hunk skill path` prints when the user names none. */
@@ -18,6 +22,7 @@ export const DEFAULT_BUNDLED_SKILL_NAME: BundledSkillName = "hunk-review";
 const BUNDLED_SKILL_ALIASES: Record<string, BundledSkillName> = {
   review: "hunk-review",
   extensions: "hunk-extensions",
+  performance: "opentui-performance",
 };
 
 /** Resolve one user-supplied skill name, or nothing when it names no bundled skill. */


### PR DESCRIPTION
## Summary

- bundle a new `opentui-performance` agent skill for profiling and optimizing React/OpenTUI terminal applications
- cover rendering and host-object cost, deterministic geometry and hierarchical windowing, workers/caches/publication scheduling, memory, benchmark integrity, PTY/TTY validation, and terminal text correctness through progressive reference documents
- include a measured Hunk case study while keeping Hunk-specific policies and thresholds out of the generic workflow
- expose the skill through `hunk skill path opentui-performance` and the shorter `hunk skill path performance` alias
- package the complete skill and references in npm and standalone artifacts, while tightening prebuilt npm staging to exclude maintainer-only skills

## Skill structure

```text
skills/opentui-performance/
├── SKILL.md
└── references/
    ├── rendering-and-geometry.md
    ├── async-and-memory.md
    ├── benchmarking-and-validation.md
    └── hunk-case-study.md
```

## Validation

- skill frontmatter and all progressive-disclosure links validated
- independent skill and packaging review — no remaining findings
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test` — 3,013 passed, 10 skipped
- `bun run check:pack`
- `bun run build:npm`
- host prebuilt staging and `bun run check:prebuilt-pack`
- rebuilt host binary and `bun run smoke:prebuilt-install`
- `bun run changeset:status`

## Draft questions

- Is bundling this with Hunk the right long-term distribution, or should the generic skill eventually live in its own skill repository?
- Is the Hunk case study the right amount of product-specific evidence, or should it be shortened further?
- Should a future revision include executable benchmark scaffolding, or remain methodology-first and adapt to each repository's harness?

*This PR description was generated by Pi using gpt-5.6-sol*
