### PR TITLE
extensions: list hunk-gh-review

### DIFF
--- a/website/src/data/extensions.ts
+++ b/website/src/data/extensions.ts
@@ -123,6 +123,15 @@ export const EXTENSION_CATALOG: readonly ExtensionListing[] = [
     version: "0.1.0",
     apiVersion: 5,
   },
+  {
+    repo: "phl28/hunk-gh-review",
+    name: "hunk-gh-review",
+    summary:
+      "Turns Hunk into a GitHub review client: browse and reply to PR threads, then submit notes as a review.",
+    categories: ["Pane", "Keyboard mode", "Command"],
+    version: "0.1.0",
+    apiVersion: 6,
+  },
 ];
 
 /**


### PR DESCRIPTION
Adds [phl28/hunk-gh-review](https://github.com/phl28/hunk-gh-review) to the extension directory.

A hunk extension that turns the review stream into a GitHub PR review client:

- **PR threads pane** (docked, any edge): fetches the PR's review threads, keyboard-navigable (`j/k` via a session keyboard mode) with click/keys jumping the review stream to the exact line; outdated-position threads are hidden with a count
- **Reply** to threads without leaving hunk
- **Submit** (`S`): posts hunk notes as inline PR review comments + Comment/Approve/Request-changes event, one atomic call; note-less approvals work like the GitHub UI

Manifest declares `apiVersion: 6`, tagged release `v0.1.0`, repo carries the `hunk-extension` topic. Verified installable via `hunk extension install phl28/hunk-gh-review`.