### PR TITLE
Themes: Fix washed-out diff accents and invisible word highlighting

### DIFF
--- a/.changeset/theme-guard-washout.md
+++ b/.changeset/theme-guard-washout.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Stop the theme contrast guards from washing out diff accents: low-contrast sign colors now get the smallest readable adjustment instead of a fixed 45% blend, and word-level diff emphasis stays visibly separated from row backgrounds.

--- a/.changeset/theme-guard-washout.md
+++ b/.changeset/theme-guard-washout.md
@@ -2,4 +2,4 @@
 "hunkdiff": patch
 ---
 
-Stop the theme contrast guards from washing out diff accents: low-contrast sign colors now get the smallest readable adjustment instead of a fixed 45% blend, and word-level diff emphasis stays visibly separated from row backgrounds.
+Stop the theme contrast guards from washing out diff accents: low-contrast sign colors now get the smallest readable adjustment instead of a fixed 45% blend, and word-level diff emphasis is derived to the renderer's own separation floor so the highlight you see is the one the theme defines.

--- a/src/ui/diff/diffRows.ts
+++ b/src/ui/diff/diffRows.ts
@@ -25,7 +25,7 @@ import type { DiffFile, DiffLineMoveKind } from "../../core/changeset/model";
 import { blendHex, hexColorDistance } from "../lib/color";
 import { measureTextWidth } from "../lib/text";
 import { sanitizeTerminalLine } from "../../lib/terminalText";
-import { TRANSPARENT_BACKGROUND, type AppTheme } from "../themes";
+import { MIN_EMPHASIS_SEPARATION, TRANSPARENT_BACKGROUND, type AppTheme } from "../themes";
 import { expandDiffTabs } from "./codeColumns";
 import type { DiffRow, RenderSpan, SplitLineCell, StackLineCell } from "./diffRowModel";
 import {
@@ -116,7 +116,6 @@ function tabify(text: string, tabWidth: number, initialColumn = 0) {
 // into terminal spans. The same highlighted line objects are reused when files remount or when
 // we build both split and stack rows, so memoize flattened spans by line node + theme/background.
 const flattenedHighlightedLineCache = new WeakMap<HastNode, Map<string, RenderSpan[]>>();
-const MIN_WORD_DIFF_BG_DISTANCE = 28;
 const WORD_DIFF_BLEND_STEP = 0.005;
 const WORD_DIFF_MAX_BLEND = 0.2;
 const wordDiffBackgroundCache = new Map<string, Record<SplitLineCell["kind"], string>>();
@@ -131,7 +130,7 @@ function strengthenWordDiffBg(lineBg: string, signColor: string) {
     const candidate = blendHex(signColor, lineBg, blendRatio);
     strongestCandidate = candidate;
 
-    if (hexColorDistance(candidate, lineBg) >= MIN_WORD_DIFF_BG_DISTANCE) {
+    if (hexColorDistance(candidate, lineBg) >= MIN_EMPHASIS_SEPARATION) {
       return candidate;
     }
   }
@@ -144,8 +143,8 @@ function isHexThemeColor(color: string) {
   return /^#[0-9a-f]{6}$/i.test(color);
 }
 
-/** Resolve one word-diff background without turning transparent surfaces into black blends. */
-function resolveWordDiffHighlightBg(contentBg: string, lineBg: string, signColor: string) {
+/** Strengthen custom-theme overrides whose pair sits too close together. */
+export function resolveWordDiffHighlightBg(contentBg: string, lineBg: string, signColor: string) {
   if (contentBg === TRANSPARENT_BACKGROUND || lineBg === TRANSPARENT_BACKGROUND) {
     return contentBg;
   }
@@ -154,7 +153,7 @@ function resolveWordDiffHighlightBg(contentBg: string, lineBg: string, signColor
     return contentBg;
   }
 
-  return hexColorDistance(contentBg, lineBg) >= MIN_WORD_DIFF_BG_DISTANCE
+  return hexColorDistance(contentBg, lineBg) >= MIN_EMPHASIS_SEPARATION
     ? contentBg
     : strengthenWordDiffBg(lineBg, signColor);
 }

--- a/src/ui/diff/rowStyle.ts
+++ b/src/ui/diff/rowStyle.ts
@@ -185,7 +185,7 @@ export function stackCellPalette(
   };
 }
 
-// Word-diff emphasis guarantees 28 (`MIN_WORD_DIFF_BG_DISTANCE` in diffRows.ts),
+// Word-diff emphasis guarantees 28 (`MIN_EMPHASIS_SEPARATION` in themes.ts),
 // but that floor is tuned for subtle tinting inside already-tinted lines.
 // Extension marks are things the user is looking *for* — search hits,
 // diagnostics — so they target a substantially higher floor: distances are

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_DARK_THEME_ID,
   DEFAULT_LIGHT_THEME_ID,
   MIN_DIFF_SIGN_CONTRAST,
+  MIN_EMPHASIS_SEPARATION,
   resolveTheme,
   TRANSPARENT_BACKGROUND,
   withTransparentSurfaces,
@@ -311,6 +312,27 @@ describe("themes", () => {
         }
         const drift = hueDistance(sourceHue, derivedHue);
         return drift <= MAX_RESCUE_HUE_DRIFT ? [] : [`${label}, hue drifted ${drift.toFixed(1)}°`];
+      });
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  test("keeps word-level emphasis visibly separated from row backgrounds on every bundled theme", () => {
+    const failures = BUNDLED_SHIKI_THEME_IDS.flatMap((themeId) => {
+      const theme = resolveTheme(themeId, null);
+      return (
+        [
+          ["added", theme.addedBg, theme.addedContentBg],
+          ["removed", theme.removedBg, theme.removedContentBg],
+        ] as const
+      ).flatMap(([slot, rowBackground, contentBackground]) => {
+        const separation = hexColorDistance(rowBackground, contentBackground);
+        return separation >= MIN_EMPHASIS_SEPARATION
+          ? []
+          : [
+              `${themeId} ${slot}: ${rowBackground} vs ${contentBackground} (distance ${separation})`,
+            ];
       });
     });
 

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { createTestCustomThemes } from "../../test/helpers/theme-helpers";
 import { blendHex, contrastRatio, hexColorDistance } from "./lib/color";
-import { BUNDLED_SHIKI_THEME_IDS } from "../core/theme/catalog";
+import {
+  BUNDLED_SHIKI_THEME_IDS,
+  getBundledShikiThemeBackground,
+  getBundledShikiThemeDiffColors,
+} from "../core/theme/catalog";
 import {
   availableThemeIds,
   availableThemes,
   DEFAULT_DARK_THEME_ID,
   DEFAULT_LIGHT_THEME_ID,
+  MIN_DIFF_SIGN_CONTRAST,
   resolveTheme,
   TRANSPARENT_BACKGROUND,
   withTransparentSurfaces,
 } from "./themes";
 
 const MIN_READABLE_TEXT_CONTRAST = 4.5;
+const MAX_RESCUE_HUE_DRIFT = 2;
 const SYNTAX_ROLES = [
   "default",
   "keyword",
@@ -26,6 +32,46 @@ const SYNTAX_ROLES = [
   "operator",
   "punctuation",
 ] as const;
+
+/** Return the HSL hue in degrees for a #rrggbb color, or null when achromatic. */
+function hexHueDegrees(hex: string): number | null {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  if (max === min) {
+    return null;
+  }
+  const chroma = max - min;
+  const segment =
+    max === r ? ((g - b) / chroma) % 6 : max === g ? (b - r) / chroma + 2 : (r - g) / chroma + 4;
+  return (segment * 60 + 360) % 360;
+}
+
+/** Return the shortest angular distance between two hues in degrees. */
+function hueDistance(left: number, right: number) {
+  const delta = Math.abs(left - right) % 360;
+  return delta > 180 ? 360 - delta : delta;
+}
+
+/** List each bundled theme's catalog diff accents beside the derived theme slots. */
+function bundledDiffSignSlots(themeId: string) {
+  const background = getBundledShikiThemeBackground(themeId) ?? "#0d1117";
+  const diffColors = getBundledShikiThemeDiffColors(themeId);
+  const theme = resolveTheme(themeId, null);
+  const slots: Array<{ slot: string; source: string; derived: string }> = [];
+  if (diffColors?.added) {
+    slots.push({ slot: "added", source: diffColors.added, derived: theme.addedSignColor });
+  }
+  if (diffColors?.removed) {
+    slots.push({ slot: "removed", source: diffColors.removed, derived: theme.removedSignColor });
+  }
+  if (diffColors?.modified) {
+    slots.push({ slot: "modified", source: diffColors.modified, derived: theme.accent });
+  }
+  return { background, slots };
+}
 
 /** Return a compact failure list for semantic theme foreground/background pairs. */
 function themeContrastFailures(
@@ -229,6 +275,46 @@ describe("themes", () => {
         hexColorDistance(theme.removedBg, theme.contextBg),
       );
     }
+  });
+
+  test("keeps catalog diff accents untouched when they already meet the sign contrast floor", () => {
+    const failures = BUNDLED_SHIKI_THEME_IDS.flatMap((themeId) => {
+      const { background, slots } = bundledDiffSignSlots(themeId);
+      return slots.flatMap(({ slot, source, derived }) => {
+        if (contrastRatio(source, background) < MIN_DIFF_SIGN_CONTRAST) {
+          return [];
+        }
+        return derived === source ? [] : [`${themeId} ${slot}: ${source} rescued to ${derived}`];
+      });
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  test("rescued diff signs keep the source accent hue and clear the contrast floor", () => {
+    const failures = BUNDLED_SHIKI_THEME_IDS.flatMap((themeId) => {
+      const { background, slots } = bundledDiffSignSlots(themeId);
+      return slots.flatMap(({ slot, source, derived }) => {
+        if (contrastRatio(source, background) >= MIN_DIFF_SIGN_CONTRAST) {
+          return [];
+        }
+        const label = `${themeId} ${slot}: ${source} rescued to ${derived}`;
+        const rescuedContrast = contrastRatio(derived, background);
+        if (rescuedContrast < MIN_DIFF_SIGN_CONTRAST) {
+          return [`${label} but contrast is ${rescuedContrast.toFixed(2)}`];
+        }
+        const sourceHue = hexHueDegrees(source);
+        const derivedHue = hexHueDegrees(derived);
+        if (sourceHue === null || derivedHue === null) {
+          // Achromatic accents (e.g. slack-ochin's white removed slot) have no hue to keep.
+          return [];
+        }
+        const drift = hueDistance(sourceHue, derivedHue);
+        return drift <= MAX_RESCUE_HUE_DRIFT ? [] : [`${label}, hue drifted ${drift.toFixed(1)}°`];
+      });
+    });
+
+    expect(failures).toEqual([]);
   });
 
   test("layers custom theme overrides on a bundled base", () => {

--- a/src/ui/themes.test.ts
+++ b/src/ui/themes.test.ts
@@ -6,6 +6,7 @@ import {
   getBundledShikiThemeBackground,
   getBundledShikiThemeDiffColors,
 } from "../core/theme/catalog";
+import { resolveWordDiffHighlightBg } from "./diff/diffRows";
 import {
   availableThemeIds,
   availableThemes,
@@ -13,6 +14,7 @@ import {
   DEFAULT_LIGHT_THEME_ID,
   MIN_DIFF_SIGN_CONTRAST,
   MIN_EMPHASIS_SEPARATION,
+  readableDiffSign,
   resolveTheme,
   TRANSPARENT_BACKGROUND,
   withTransparentSurfaces,
@@ -125,7 +127,7 @@ describe("themes", () => {
     expect(dark.syntaxColors.default).toBe("#e6edf3");
     expect(dark.addedSignColor).toBe("#3fb950");
     expect(dark.removedSignColor).toBe("#f85149");
-    expect(dark.addedBg).toBe(blendHex("#3fb950", "#0d1117", 0.2));
+    expect(dark.addedBg).toBe(blendHex("#3fb950", "#0d1117", 0.18));
     expect(dark.removedBg).toBe(blendHex("#f85149", "#0d1117", 0.2));
 
     expect(light.background).toBe("#ffffff");
@@ -318,21 +320,65 @@ describe("themes", () => {
     expect(failures).toEqual([]);
   });
 
-  test("keeps word-level emphasis visibly separated from row backgrounds on every bundled theme", () => {
+  test("rescues diff signs with the smallest blend that clears the contrast floor", () => {
+    const failures = BUNDLED_SHIKI_THEME_IDS.flatMap((themeId) => {
+      const { background, slots } = bundledDiffSignSlots(themeId);
+      return slots.flatMap(({ slot, source, derived }) => {
+        if (contrastRatio(source, background) >= MIN_DIFF_SIGN_CONTRAST) {
+          return [];
+        }
+        const minimalRescues = ["#000000", "#ffffff"].flatMap((anchor) => {
+          for (let amount = 0.02; amount < 1; amount += 0.02) {
+            const candidate = blendHex(anchor, source, amount);
+            if (contrastRatio(candidate, background) >= MIN_DIFF_SIGN_CONTRAST) {
+              return [candidate];
+            }
+          }
+          return [];
+        });
+        return minimalRescues.includes(derived)
+          ? []
+          : [
+              `${themeId} ${slot}: ${source} rescued to ${derived}, expected a minimal rescue (${minimalRescues.join(", ")})`,
+            ];
+      });
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  test("nudges catppuccin-latte's near-miss green instead of washing it out", () => {
+    expect(resolveTheme("catppuccin-latte", null).addedSignColor).toBe("#3f9d2a");
+  });
+
+  test("readableDiffSign upholds the contrast floor on mid-luminance backgrounds", () => {
+    const rescued = readableDiffSign("#b0b0b0", "#aaaaaa");
+    expect(contrastRatio(rescued, "#aaaaaa")).toBeGreaterThanOrEqual(MIN_DIFF_SIGN_CONTRAST);
+  });
+
+  test("keeps the rendered word-level emphasis separated and readable on every bundled theme", () => {
     const failures = BUNDLED_SHIKI_THEME_IDS.flatMap((themeId) => {
       const theme = resolveTheme(themeId, null);
       return (
         [
-          ["added", theme.addedBg, theme.addedContentBg],
-          ["removed", theme.removedBg, theme.removedContentBg],
+          ["added", theme.addedBg, theme.addedContentBg, theme.addedSignColor],
+          ["removed", theme.removedBg, theme.removedContentBg, theme.removedSignColor],
         ] as const
-      ).flatMap(([slot, rowBackground, contentBackground]) => {
-        const separation = hexColorDistance(rowBackground, contentBackground);
-        return separation >= MIN_EMPHASIS_SEPARATION
-          ? []
-          : [
-              `${themeId} ${slot}: ${rowBackground} vs ${contentBackground} (distance ${separation})`,
-            ];
+      ).flatMap(([slot, rowBackground, contentBackground, signColor]) => {
+        const rendered = resolveWordDiffHighlightBg(contentBackground, rowBackground, signColor);
+        const problems: string[] = [];
+        if (rendered !== contentBackground) {
+          problems.push(`renderer rewrote ${contentBackground} to ${rendered}`);
+        }
+        const separation = hexColorDistance(rowBackground, rendered);
+        if (separation < MIN_EMPHASIS_SEPARATION) {
+          problems.push(`separation ${separation} vs ${rowBackground}`);
+        }
+        const textContrast = contrastRatio(theme.text, rendered);
+        if (textContrast + 0.005 < MIN_READABLE_TEXT_CONTRAST) {
+          problems.push(`text contrast ${textContrast.toFixed(2)} on ${rendered}`);
+        }
+        return problems.map((problem) => `${themeId} ${slot}: ${problem}`);
       });
     });
 

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -21,7 +21,7 @@ export const DEFAULT_LIGHT_THEME_ID = "github-light-default";
 
 const MIN_GUTTER_CONTRAST = 4.5;
 export const MIN_DIFF_SIGN_CONTRAST = 3;
-export const MIN_EMPHASIS_SEPARATION = 12;
+export const MIN_EMPHASIS_SEPARATION = 28;
 
 const FALLBACK_DIFF_COLORS = {
   dark: { added: "#5ecc71", removed: "#ff6762", modified: "#69b1ff" },
@@ -49,12 +49,15 @@ function readableDimForeground(preferred: string, background: string) {
 }
 
 /** Return a semantic diff marker color that remains legible on a theme editor surface. */
-function readableDiffSign(preferred: string, background: string) {
+export function readableDiffSign(preferred: string, background: string) {
   if (contrastRatio(preferred, background) >= MIN_DIFF_SIGN_CONTRAST) {
     return preferred;
   }
 
-  const anchor = relativeLuminance(background) > 0.45 ? "#000000" : "#ffffff";
+  let anchor = relativeLuminance(background) > 0.45 ? "#000000" : "#ffffff";
+  if (contrastRatio(anchor, background) < MIN_DIFF_SIGN_CONTRAST) {
+    anchor = anchor === "#000000" ? "#ffffff" : "#000000";
+  }
   for (let amount = 0.02; amount < 1; amount += 0.02) {
     const candidate = blendHex(anchor, preferred, amount);
     if (contrastRatio(candidate, background) >= MIN_DIFF_SIGN_CONTRAST) {

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -20,7 +20,7 @@ export const DEFAULT_DARK_THEME_ID = "github-dark-default";
 export const DEFAULT_LIGHT_THEME_ID = "github-light-default";
 
 const MIN_GUTTER_CONTRAST = 4.5;
-const MIN_DIFF_SIGN_CONTRAST = 3;
+export const MIN_DIFF_SIGN_CONTRAST = 3;
 
 const FALLBACK_DIFF_COLORS = {
   dark: { added: "#5ecc71", removed: "#ff6762", modified: "#69b1ff" },
@@ -53,9 +53,15 @@ function readableDiffSign(preferred: string, background: string) {
     return preferred;
   }
 
-  return relativeLuminance(background) > 0.45
-    ? blendHex("#000000", preferred, 0.45)
-    : blendHex("#ffffff", preferred, 0.45);
+  const anchor = relativeLuminance(background) > 0.45 ? "#000000" : "#ffffff";
+  for (let amount = 0.02; amount < 1; amount += 0.02) {
+    const candidate = blendHex(anchor, preferred, amount);
+    if (contrastRatio(candidate, background) >= MIN_DIFF_SIGN_CONTRAST) {
+      return candidate;
+    }
+  }
+
+  return anchor;
 }
 
 /** Build Hunk's fallback semantic syntax palette for non-Shiki custom highlighting. */

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -2,7 +2,7 @@ import type { ThemeMode } from "@opentui/core";
 import { LEGACY_CUSTOM_THEME_ID } from "../core/theme/customThemes";
 import { resolveSyntaxScopeOverrides } from "../core/theme/legacySyntaxScopes";
 import type { NamedCustomThemeConfig } from "../extension-api/types";
-import { blendHex, contrastRatio, relativeLuminance } from "./lib/color";
+import { blendHex, contrastRatio, hexColorDistance, relativeLuminance } from "./lib/color";
 import {
   BUNDLED_SHIKI_THEME_IDS,
   resolveBundledShikiThemeId,
@@ -21,6 +21,7 @@ export const DEFAULT_LIGHT_THEME_ID = "github-light-default";
 
 const MIN_GUTTER_CONTRAST = 4.5;
 export const MIN_DIFF_SIGN_CONTRAST = 3;
+export const MIN_EMPHASIS_SEPARATION = 12;
 
 const FALLBACK_DIFF_COLORS = {
   dark: { added: "#5ecc71", removed: "#ff6762", modified: "#69b1ff" },
@@ -98,6 +99,29 @@ function readableTintedBackground(
   return background;
 }
 
+/** Return the strongest readable row tint that stays visibly apart from the word-emphasis tint. */
+function readableSeparatedRowBackground(
+  tintColor: string,
+  background: string,
+  foreground: string,
+  preferredAmount: number,
+  contentBackground: string,
+) {
+  let readableFallback: string | undefined;
+  for (let amount = preferredAmount; amount >= 0.02; amount -= 0.02) {
+    const candidate = blendHex(tintColor, background, amount);
+    if (contrastRatio(foreground, candidate) < MIN_GUTTER_CONTRAST) {
+      continue;
+    }
+    if (hexColorDistance(candidate, contentBackground) >= MIN_EMPHASIS_SEPARATION) {
+      return candidate;
+    }
+    readableFallback ??= candidate;
+  }
+
+  return readableFallback ?? background;
+}
+
 /** Keep semantic status colors readable on sidebar and menu surfaces. */
 function readableChromeColor(preferred: string, panel: string, panelAlt: string) {
   if (
@@ -157,24 +181,6 @@ function buildShikiTheme(themeId: BundledShikiThemeId): AppTheme {
     diffColors?.modified ?? fallbackDiffColors.modified,
     editorBackground,
   );
-  const addedBg = readableTintedBackground(
-    addedSignColor,
-    editorBackground,
-    textForeground,
-    rowTint,
-  );
-  const removedBg = readableTintedBackground(
-    removedSignColor,
-    editorBackground,
-    textForeground,
-    rowTint,
-  );
-  const movedBg = readableTintedBackground(
-    modifiedColor,
-    editorBackground,
-    textForeground,
-    rowTint,
-  );
   const addedContentBg = readableTintedBackground(
     addedSignColor,
     editorBackground,
@@ -186,6 +192,26 @@ function buildShikiTheme(themeId: BundledShikiThemeId): AppTheme {
     editorBackground,
     textForeground,
     contentTint,
+  );
+  const addedBg = readableSeparatedRowBackground(
+    addedSignColor,
+    editorBackground,
+    textForeground,
+    rowTint,
+    addedContentBg,
+  );
+  const removedBg = readableSeparatedRowBackground(
+    removedSignColor,
+    editorBackground,
+    textForeground,
+    rowTint,
+    removedContentBg,
+  );
+  const movedBg = readableTintedBackground(
+    modifiedColor,
+    editorBackground,
+    textForeground,
+    rowTint,
   );
   const accentMuted = readableTintedBackground(
     modifiedColor,


### PR DESCRIPTION
- close https://github.com/modem-dev/hunk/issues/824

The two contrast guards in `src/ui/themes.ts` protected readability but destroyed theme identity in the process. This fixes both while keeping every existing contrast invariant.

## Changes

- `readableDiffSign` now rescues low-contrast accents with the smallest black/white blend that clears the 3:1 floor, stepping up from 2%, instead of a fixed 45% wash.
  - Saturation loss is proportional to how far out of range the accent actually is. catppuccin-latte's green (contrast 2.96, missing the floor by 0.04) now gets a ~2% nudge (`#40a02b` → `#3f9d2a`) instead of being crushed to `#235818`.
- Word-emphasis tints (`addedContentBg`/`removedContentBg`) now derive first at full readable strength, and the row tints step further down until the pair clears a 12 channel-distance separation floor (`readableSeparatedRowBackground`).
  - This fixes invisible word-level highlighting on everforest-light, one-dark-pro, and material-theme-palenight (row and content had collapsed to identical colors) and near-invisible highlighting on plastic (distance 6).
  - Pushing content higher would break the readability guarantee that caused the collapse. This is a deliberate deviation from the issue's suggestion.

### Tests

- Table-driven regression tests across all 66 bundled themes: accents that already meet the floor pass through unrescued, rescued accents stay within 2° of the source hue and clear the floor, and row-vs-content separation stays ≥ 12.

## QA

- Spot-check in a real terminal: `--theme catppuccin-latte` (sign colors), `--theme one-dark-pro` or `--theme everforest-light` (word-level highlighting on changed rows).

```
bun run src/main.tsx -- diff --theme catppuccin-latte
```

| Theme | 0.19.0 | Feature |
| -- | -- | -- |
| `catpuccin-latte` (light rescue) | <img width="498" height="284" alt="image" src="https://github.com/user-attachments/assets/423711b4-f79b-4a6e-abfa-4cb130631c7a" /> | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/7fc388b5-ec4e-4ed0-98d3-19f073d290c6" /> |
| `gruvbox-dark-hard` (dark rescue) | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/d4c62942-9b71-42a5-8560-78b0d32eecf0" /> | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/77d29a9b-a80e-4f5c-bc0b-1e91c760b18d" /> |
| `snazzy-light` (light rescue) | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/9d632ea3-5ce4-4dc0-ba5e-5344dd5af611" /> | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/82ab480d-4d08-4a66-a668-653b1cf73699" /> |
| `one-dark-pro` (tint) | <img width="498" height="284" alt="image" src="https://github.com/user-attachments/assets/2352c95e-7ec5-457b-830d-82052097f82a" /> | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/e54c2b03-bf28-4235-beb5-7e494e6d9243" /> |
| `poimandres` (tint) | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/796e43ba-efdb-494c-a772-98a736386c9d" /> | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/6e212fd0-e85f-44ae-9433-bf49e52254dc" /> |
| `everforest-light` (rescue and tint) | <img width="498" height="284" alt="image" src="https://github.com/user-attachments/assets/c5f1ac43-1f4b-470e-a4a4-0b655d2a83ad" /> | <img width="492" height="271" alt="image" src="https://github.com/user-attachments/assets/7a67893c-c4ea-4958-b2e8-8b821dd4b68c" /> |