### PR TITLE
extensions: gentilfp/hunk-codeowners 

### DIFF
--- a/website/src/data/extensions.ts
+++ b/website/src/data/extensions.ts
@@ -116,6 +116,14 @@ export const EXTENSION_CATALOG: readonly ExtensionListing[] = [
     apiVersion: 5,
   },
   {
+    repo: "gentilfp/hunk-codeowners",
+    name: "hunk-codeowners",
+    summary: "Shows CODEOWNERS context for the current changeset and selected file.",
+    categories: ["Pane", "Command"],
+    version: "0.1.0",
+    apiVersion: 6,
+  },
+  {
     repo: "mikeclarke/hunk-tutor",
     name: "hunk-tutor",
     summary: "An interactive tour of Hunk, taught inside a practice review.",


### PR DESCRIPTION
Hi 👋 

This PR adds [gentilfp/hunk-codeowners](https://github.com/gentilfp/hunk-codeowners) to the extension directory.

This is local-only Hunk extension that adds CODEOWNERS context to the review UI:

- **Changeset owners**: lists every confirmed owner represented in the changeset with owned-file counts
- **Selected file context**: shows the selected file's owners and the matching CODEOWNERS source line
- **Diagnostics**: reports unowned files and unsupported or malformed CODEOWNERS rules without guessing ownership

Manifest declares `apiVersion: 6`, tagged release `v0.1.0`, and the repository carries the `hunk-extension` topic. Verified installable via `hunk extension install gentilfp/hunk-codeowners`.

https://github.com/user-attachments/assets/0ea8b6a7-ce1b-403c-be4f-b0d5e6ac2363