### PR TITLE
feat(ui): select exact diff lines with mouse

### DIFF
--- a/.changeset/mouse-lines-select.md
+++ b/.changeset/mouse-lines-select.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Let mouse clicks reliably select exact code lines, including blank lines, for keyboard review actions.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2215,7 +2215,6 @@ export function App({
   const diffHeaderStatsWidth = maxFileHeaderStatsWidth(filteredFiles);
   const diffHeaderLabelWidth = Math.max(0, diffContentWidth - diffHeaderStatsWidth - 1);
   const diffSeparatorWidth = Math.max(0, diffContentWidth - 2);
-  const diffPaneScreenLeft = bodyPadding / 2 + paneLayout.reviewBounds.x;
   const diffPaneScreenTop = (showMenuBar ? 1 : 0) + paneLayout.reviewBounds.y;
 
   /** Render one pane from the exact accepted host rectangle. */
@@ -2370,7 +2369,6 @@ export function App({
             offloadLargeDiff={bootstrap.input.options.fast === true}
             lineHighlights={paintedLineHighlights}
             pagerMode={pagerMode}
-            screenLeft={diffPaneScreenLeft}
             screenTop={diffPaneScreenTop}
             showTopChrome={showMenuBar}
             headerLabelWidth={diffHeaderLabelWidth}

--- a/src/ui/AppHost.selection.test.tsx
+++ b/src/ui/AppHost.selection.test.tsx
@@ -177,6 +177,34 @@ describe("DiffPane copy selection", () => {
     }
   });
 
+  test("mouse-up extends a copy through drag events coalesced by the terminal host", async () => {
+    const { setup, copied } = await renderSelectionApp(createSelectionBootstrap());
+
+    try {
+      const frame = setup.captureCharFrame();
+      const start = locateText(frame, "item01");
+      const firstMotion = locateText(frame, "item02");
+      const end = locateText(frame, "item05");
+      expect(start).not.toBeNull();
+      expect(firstMotion).not.toBeNull();
+      expect(end).not.toBeNull();
+
+      await act(async () => {
+        await setup.mockMouse.pressDown(start!.x + 2, start!.y, MouseButtons.LEFT);
+        await setup.mockMouse.moveTo(firstMotion!.x + 2, firstMotion!.y);
+        await setup.mockMouse.release(end!.x + 8, end!.y, MouseButtons.LEFT);
+      });
+      await flush(setup);
+
+      expect(copied.length).toBeGreaterThan(0);
+      expect(copied.at(-1)).toContain("item05");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
   test("dragging across wide (CJK) characters copies exactly the selected cells", async () => {
     const { setup, copied } = await renderSelectionApp(createWideCharSelectionBootstrap());
 
@@ -281,6 +309,34 @@ describe("DiffPane copy selection", () => {
 
       // endCopySelection returns early when the drag never moved, so nothing is copied.
       expect(copied.length).toBe(0);
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("one-cell drags still copy when current-line selection is disabled", async () => {
+    const bootstrap = { ...createSelectionBootstrap(), initialCursorLine: "off" as const };
+    const { setup, copied } = await renderSelectionApp(bootstrap);
+
+    try {
+      const frame = setup.captureCharFrame();
+      const target = locateText(frame, "item07");
+      expect(target).not.toBeNull();
+
+      await act(async () => {
+        await setup.mockMouse.drag(
+          target!.x + 2,
+          target!.y,
+          target!.x + 3,
+          target!.y,
+          MouseButtons.LEFT,
+        );
+      });
+      await flush(setup);
+
+      expect(copied.length).toBeGreaterThan(0);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1,5 +1,6 @@
 import {
   MouseButton,
+  type CliRenderer,
   type MouseEvent as TuiMouseEvent,
   type ScrollBoxRenderable,
 } from "@opentui/core";
@@ -26,7 +27,7 @@ import {
 } from "../../../core/review/state";
 import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/DiffSectionBody";
-import type { CursorHighlight } from "../../diff/renderRows";
+import { isNestedRowMouseAction, type CursorHighlight } from "../../diff/renderRows";
 import type { DraftReviewNote } from "../../lib/reviewNoteMapping";
 import {
   createVisibleAgentNote,
@@ -98,10 +99,12 @@ import {
 import {
   buildCopySelectedRowKeys,
   clampCopyColumn,
+  copySelectionDragIsClick,
   copySelectionPointsEqual,
   copySelectionPointsShareRow,
   expandSelectionPoint,
   findCopySelectionPoint,
+  findLineCursorForClick,
   normalizeCopySelectionRange,
   renderCopySelectionText,
   resolveCopySelectionSide,
@@ -221,6 +224,18 @@ const EMPTY_LINE_HIGHLIGHTS: ReadonlyMap<string, readonly ValidatedLineHighlight
 const EMPTY_SOURCE_STATUS_BY_FILE_ID: Record<string, FileSourceStatus> = {};
 const NOOP_TOGGLE_GAP = () => {};
 
+/** Keep OpenTUI's drag capture on the persistent scrollbox instead of a repainting text row. */
+function retainCopySelectionCapture(renderer: CliRenderer, scrollBox: ScrollBoxRenderable) {
+  // OpenTUI exposes capture internally but has no public pointer-capture API yet. Its dispatcher
+  // otherwise captures the first dragged text node, which selection highlighting immediately
+  // replaces and leaves unable to receive the rest of the gesture.
+  (
+    renderer as unknown as {
+      setCapturedRenderable: (renderable: ScrollBoxRenderable) => void;
+    }
+  ).setCapturedRenderable(scrollBox);
+}
+
 /** Render the main multi-file review stream. */
 export function DiffPane({
   codeHorizontalOffset = 0,
@@ -246,7 +261,6 @@ export function DiffPane({
   separatorWidth,
   pagerMode = false,
   copyDecorations = false,
-  screenLeft = 0,
   screenTop = 0,
   showTopChrome,
   showAgentNotes,
@@ -310,7 +324,6 @@ export function DiffPane({
   separatorWidth: number;
   pagerMode?: boolean;
   copyDecorations?: boolean;
-  screenLeft?: number;
   screenTop?: number;
   showTopChrome?: boolean;
   showAgentNotes: boolean;
@@ -1142,31 +1155,34 @@ export function DiffPane({
         return null;
       }
 
-      const reviewPaneTopChromeRows = renderTopChrome ? 2 : 0;
-      const pinnedHeaderHeight = pinnedHeaderFileId ? 1 : 0;
-      const paneY = Math.floor(event.y - screenTop);
-      const pinnedHeaderY = reviewPaneTopChromeRows;
-      if (copyDecorations && pinnedHeaderFileId && paneY === pinnedHeaderY) {
+      // Resolve against OpenTUI's measured viewport instead of reconstructing its screen position
+      // from borders, padding, chrome, and the pinned-header lane. Those decorations can shift by
+      // a row as layouts settle, while the measured viewport and translated content coordinates
+      // always match what OpenTUI actually painted and hit-tested.
+      const viewportScreenX = scrollBox.viewport.screenX;
+      const viewportScreenY = scrollBox.viewport.screenY;
+      const contentScreenY = scrollBox.content.screenY;
+      const column = Math.floor(event.x - viewportScreenX);
+      if (copyDecorations && pinnedHeaderFileId && Math.floor(event.y) === viewportScreenY - 1) {
         return {
           kind: "pinned-header",
-          column: clampCopyColumn(Math.floor(event.x - screenLeft), diffContentWidth),
+          column: clampCopyColumn(column, diffContentWidth),
           fileId: pinnedHeaderFileId,
-          nextVisualRow: Math.floor(scrollBox.scrollTop ?? 0),
+          nextVisualRow: Math.floor(viewportScreenY - contentScreenY),
         };
       }
 
-      const paneChromeHeight = reviewPaneTopChromeRows + pinnedHeaderHeight;
-      const viewportY = Math.floor(event.y - screenTop - paneChromeHeight);
+      const viewportY = Math.floor(event.y - viewportScreenY);
       if (viewportY < 0 || viewportY >= Math.max(1, scrollBox.viewport.height ?? 0)) {
         return null;
       }
 
       return findCopySelectionPoint({
-        column: Math.floor(event.x - screenLeft),
+        column,
         copyDecorations,
         fileSectionLayouts,
         sectionGeometry,
-        visualRow: Math.floor((scrollBox.scrollTop ?? 0) + viewportY),
+        visualRow: Math.floor(event.y - contentScreenY),
         width: diffContentWidth,
       });
     },
@@ -1175,9 +1191,6 @@ export function DiffPane({
       diffContentWidth,
       fileSectionLayouts,
       pinnedHeaderFileId,
-      renderTopChrome,
-      screenLeft,
-      screenTop,
       scrollRef,
       sectionGeometry,
     ],
@@ -1234,6 +1247,7 @@ export function DiffPane({
             anchor: { ...point, column: expanded.startCol },
             focus: { ...point, column: expanded.endCol },
             moved: true,
+            expanded: true,
           };
           copySelectionDragRef.current = drag;
           setCopySelectionDrag(drag);
@@ -1273,6 +1287,7 @@ export function DiffPane({
           anchor: current.anchor,
           focus: point,
           moved: current.moved || !copySelectionPointsEqual(point, current.anchor),
+          expanded: current.expanded,
         };
       });
 
@@ -1287,34 +1302,67 @@ export function DiffPane({
             anchor: refDrag.anchor,
             focus: point,
             moved: refDrag.moved || !copySelectionPointsEqual(point, refDrag.anchor),
+            expanded: refDrag.expanded,
           };
         }
       }
 
       if (copySelectionDragRef.current) {
+        const scrollBox = scrollRef.current;
+        if (scrollBox) {
+          retainCopySelectionCapture(renderer, scrollBox);
+        }
         suppressNativeSelection();
         event.preventDefault();
         event.stopPropagation();
       }
     },
-    [resolveCopySelectionPoint, suppressNativeSelection],
+    [renderer, resolveCopySelectionPoint, scrollRef, suppressNativeSelection],
   );
 
-  /** Finish a drag selection and copy its rendered text. */
+  /** Finish a mouse gesture by selecting its clicked line or copying its deliberate drag. */
   const endCopySelection = useCallback(
     (event?: TuiMouseEvent) => {
-      const current = copySelectionDragRef.current;
-      if (!current) {
+      const pending = copySelectionDragRef.current;
+      if (!pending) {
         return;
       }
+
+      // Resolve mouse-up itself because terminal hosts may coalesce the final motion event.
+      const endPoint = event && !pending.expanded ? resolveCopySelectionPoint(event) : null;
+      const current = endPoint
+        ? {
+            anchor: pending.anchor,
+            focus: endPoint,
+            moved: pending.moved || !copySelectionPointsEqual(endPoint, pending.anchor),
+            expanded: pending.expanded,
+          }
+        : pending;
 
       copySelectionDragRef.current = null;
       setCopySelectionDrag(null);
       event?.preventDefault();
       event?.stopPropagation();
 
-      if (!current.moved) {
-        return;
+      if (copySelectionDragIsClick(current)) {
+        if (event && isNestedRowMouseAction(event)) {
+          return;
+        }
+
+        const clickedCursor = findLineCursorForClick({
+          cursors: lineCursors,
+          fileSectionLayouts,
+          point: current.anchor,
+          sectionGeometry,
+          side: resolveCopySelectionSide(current.anchor.column, layout, diffContentWidth),
+        });
+        if (clickedCursor && onViewportLineCursorChange) {
+          onViewportLineCursorChange(clickedCursor);
+          return;
+        }
+        if (!current.moved) {
+          return;
+        }
       }
 
       const { start, end } = normalizeCopySelectionRange(current.anchor, current.focus);
@@ -1326,7 +1374,18 @@ export function DiffPane({
       });
       copySelectionText(text);
     },
-    [copySelectionContext, copySelectionSide, copySelectionText],
+    [
+      copySelectionContext,
+      copySelectionSide,
+      copySelectionText,
+      diffContentWidth,
+      fileSectionLayouts,
+      layout,
+      lineCursors,
+      onViewportLineCursorChange,
+      resolveCopySelectionPoint,
+      sectionGeometry,
+    ],
   );
 
   // Expose the cancel hook so an ancestor (App's outer container) can release a stuck drag when

--- a/src/ui/components/panes/copySelection.test.ts
+++ b/src/ui/components/panes/copySelection.test.ts
@@ -7,10 +7,12 @@ import { buildFileSectionLayouts } from "../../lib/fileSectionLayout";
 import {
   buildCopySelectedRowKeys,
   clampCopyColumn,
+  copySelectionDragIsClick,
   copySelectionPointsEqual,
   copySelectionPointsShareRow,
   expandSelectionPoint,
   findCopySelectionPoint,
+  findLineCursorForClick,
   normalizeCopySelectionRange,
   renderCopySelectionText,
   resolveCopySelectionSide,
@@ -24,6 +26,7 @@ import {
   resolveSplitPaneWidths,
 } from "../../diff/codeColumns";
 import { measureTextWidth } from "../../lib/text";
+import { buildLineCursors } from "../../lib/lineCursors";
 
 const OSC52_CLIPBOARD = "\x1b]52;c;SGVsbG8=\x07";
 const CSI_CLEAR_SCREEN = "\x1b[2J";
@@ -176,6 +179,133 @@ describe("clampCopyColumn", () => {
 
   test("returns zero when width is zero", () => {
     expect(clampCopyColumn(5, 0)).toBe(0);
+  });
+});
+
+describe("findLineCursorForClick", () => {
+  test("resolves exact split sides and treats context rows as one cursor", () => {
+    const file = createDiffFile();
+    const { fileSectionLayouts, sectionGeometry } = buildContext("split", 120, file);
+    const cursors = buildLineCursors([file], sectionGeometry);
+    const oldCursor = cursors.find(
+      (cursor) => cursor.target.side === "old" && cursor.target.line === 1,
+    );
+    const newCursor = cursors.find(
+      (cursor) => cursor.target.side === "new" && cursor.target.line === 1,
+    );
+    const contextCursor = cursors.find((cursor) => cursor.target.line === 2);
+    expect(oldCursor).toBeDefined();
+    expect(newCursor).toBeDefined();
+    expect(contextCursor).toBeDefined();
+
+    const section = fileSectionLayouts[0]!;
+    const changedBounds = sectionGeometry[0]!.rowBoundsByStableKey.get(oldCursor!.stableKey)!;
+    const changedPoint: CopySelectionPoint = {
+      kind: "review-row",
+      column: 10,
+      visualRow: section.bodyTop + changedBounds.top,
+    };
+    expect(
+      findLineCursorForClick({
+        cursors,
+        fileSectionLayouts,
+        point: changedPoint,
+        sectionGeometry,
+        side: "left",
+      }),
+    ).toBe(oldCursor!);
+    expect(
+      findLineCursorForClick({
+        cursors,
+        fileSectionLayouts,
+        point: changedPoint,
+        sectionGeometry,
+        side: "right",
+      }),
+    ).toBe(newCursor!);
+
+    const contextBounds = sectionGeometry[0]!.rowBoundsByStableKey.get(contextCursor!.stableKey)!;
+    expect(
+      findLineCursorForClick({
+        cursors,
+        fileSectionLayouts,
+        point: {
+          kind: "review-row",
+          column: 10,
+          visualRow: section.bodyTop + contextBounds.top,
+        },
+        sectionGeometry,
+        side: "left",
+      }),
+    ).toBe(contextCursor!);
+  });
+
+  test("resolves a stacked row and ignores non-line rows", () => {
+    const file = createDiffFile();
+    const { fileSectionLayouts, sectionGeometry } = buildContext("stack", 120, file);
+    const cursors = buildLineCursors([file], sectionGeometry);
+    const cursor = cursors.find(
+      (candidate) => candidate.target.side === "new" && candidate.target.line === 1,
+    )!;
+    const section = fileSectionLayouts[0]!;
+    const bounds = sectionGeometry[0]!.rowBoundsByStableKey.get(cursor.stableKey)!;
+
+    expect(
+      findLineCursorForClick({
+        cursors,
+        fileSectionLayouts,
+        point: {
+          kind: "review-row",
+          column: 10,
+          visualRow: section.bodyTop + bounds.top,
+        },
+        sectionGeometry,
+      }),
+    ).toBe(cursor);
+    expect(
+      findLineCursorForClick({
+        cursors,
+        fileSectionLayouts,
+        point: { kind: "review-row", column: 10, visualRow: section.bodyTop },
+        sectionGeometry,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("copySelectionDragIsClick", () => {
+  const point = (column: number, visualRow: number): CopySelectionPoint => ({
+    kind: "review-row",
+    column,
+    visualRow,
+  });
+
+  test("accepts one-cell mouse jitter around a click", () => {
+    expect(
+      copySelectionDragIsClick({
+        anchor: point(20, 8),
+        focus: point(21, 9),
+        moved: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects deliberate drags and double-click expansion", () => {
+    expect(
+      copySelectionDragIsClick({
+        anchor: point(20, 8),
+        focus: point(22, 8),
+        moved: true,
+      }),
+    ).toBe(false);
+    expect(
+      copySelectionDragIsClick({
+        anchor: point(20, 8),
+        focus: point(21, 8),
+        moved: true,
+        expanded: true,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/ui/components/panes/copySelection.ts
+++ b/src/ui/components/panes/copySelection.ts
@@ -16,6 +16,8 @@ import type { FileSectionLayout } from "../../lib/fileSectionLayout";
 import { fileHeaderStats, fitFileHeaderLabel } from "../../lib/fileHeader";
 import { cellRangeToCharRange, measureTextWidth, sliceTextByWidth } from "../../lib/text";
 import type { AppTheme } from "../../themes";
+import type { LineCursor } from "../../lib/lineCursors";
+import { contextLineStableKeySides } from "../../diff/reviewRenderPlan";
 
 export type CopySelectionPoint =
   | {
@@ -38,6 +40,8 @@ export interface CopySelectionDrag {
   anchor: CopySelectionPoint;
   focus: CopySelectionPoint;
   moved: boolean;
+  /** Double/triple-click expansion always copies, even when its range is within click slop. */
+  expanded?: boolean;
 }
 
 export interface CopySelectionContext {
@@ -92,6 +96,94 @@ function copySelectionBodyRange(start: CopySelectionPoint, end: CopySelectionPoi
   const endRow = end.kind === "pinned-header" ? end.nextVisualRow - 1 : end.visualRow;
 
   return { startRow, endRow };
+}
+
+/** Resolve the keyboard line cursor addressed by one un-dragged review-row click. */
+export function findLineCursorForClick({
+  cursors,
+  fileSectionLayouts,
+  point,
+  sectionGeometry,
+  side,
+}: {
+  cursors: LineCursor[];
+  fileSectionLayouts: FileSectionLayout[];
+  point: CopySelectionPoint;
+  sectionGeometry: DiffSectionGeometry[];
+  side?: CopySelectionSide;
+}) {
+  if (point.kind !== "review-row") {
+    return null;
+  }
+
+  for (const section of fileSectionLayouts) {
+    if (point.visualRow < section.bodyTop || point.visualRow >= section.sectionBottom) {
+      continue;
+    }
+
+    const geometry = sectionGeometry[section.sectionIndex];
+    if (!geometry) {
+      return null;
+    }
+
+    const bodyRow = point.visualRow - section.bodyTop;
+    const bounds = geometry.rowBounds.find((candidate) =>
+      rowBoundsContainsVisualRow(candidate, bodyRow),
+    );
+    if (!bounds) {
+      return null;
+    }
+
+    const stableKeys = new Set([bounds.stableKey, ...bounds.stableKeys]);
+    const rowCursors = cursors.filter(
+      (cursor) => cursor.fileId === section.fileId && stableKeys.has(cursor.stableKey),
+    );
+    if (side === undefined) {
+      return rowCursors[0] ?? null;
+    }
+
+    const targetSide = side === "left" ? "old" : "new";
+    return (
+      rowCursors.find((cursor) => cursor.target.side === targetSide) ??
+      (contextLineStableKeySides(bounds.stableKey) ? (rowCursors[0] ?? null) : null)
+    );
+  }
+
+  return null;
+}
+
+const COPY_SELECTION_CLICK_SLOP_CELLS = 1;
+
+/** Treat one-cell pointer jitter as a click while preserving deliberate and expanded drags. */
+export function copySelectionDragIsClick(drag: CopySelectionDrag) {
+  if (drag.expanded) {
+    return false;
+  }
+  if (!drag.moved) {
+    return true;
+  }
+  if (drag.anchor.kind !== drag.focus.kind) {
+    return false;
+  }
+
+  const columnDelta = Math.abs(drag.anchor.column - drag.focus.column);
+  if (columnDelta > COPY_SELECTION_CLICK_SLOP_CELLS) {
+    return false;
+  }
+
+  if (drag.anchor.kind === "pinned-header" && drag.focus.kind === "pinned-header") {
+    return (
+      drag.anchor.fileId === drag.focus.fileId &&
+      Math.abs(drag.anchor.nextVisualRow - drag.focus.nextVisualRow) <=
+        COPY_SELECTION_CLICK_SLOP_CELLS
+    );
+  }
+
+  return (
+    drag.anchor.kind === "review-row" &&
+    drag.focus.kind === "review-row" &&
+    Math.abs(drag.anchor.visualRow - drag.focus.visualRow) <= COPY_SELECTION_CLICK_SLOP_CELLS
+  );
 }
 
 /** Return whether two points represent the same selectable terminal cell. */

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 import type { ScrollBoxRenderable } from "@opentui/core";
+import { MouseButtons } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { act, createRef, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type { AppBootstrap } from "../../core/bootstrap";
@@ -602,6 +603,106 @@ describe("UI components", () => {
         await setup.mockMouse.click(addNoteX + 1, addNoteY);
       });
       expect(startUserNote).toHaveBeenCalledWith(0, { side: "new", line: 2 });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("DiffPane selects the exact split line side on click without consuming add-note clicks", async () => {
+    const file = createTestDiffFile(
+      "click-line",
+      "click-line.ts",
+      lines("export const answer = 41;", "", "export const stable = true;"),
+      lines("export const answer = 42;", "", "export const stable = true;"),
+    );
+    const theme = resolveTheme("github-dark-default", null);
+    const copyText = mock((_text: string) => undefined);
+    const selectLine = mock((_cursor: LineCursor) => undefined);
+    const startUserNote = mock(() => undefined);
+    const setup = await testRender(
+      <DiffPane
+        {...createDiffPaneProps([file], theme, {
+          cursorLine: "row",
+          onCopySelectionText: copyText,
+          onStartUserNoteAtHunk: startUserNote,
+          onViewportLineCursorChange: selectLine,
+        })}
+      />,
+      { width: 80, height: 8 },
+    );
+
+    try {
+      await settleDiffPane(setup);
+      const frame = setup.captureCharFrame();
+      const changedY = frame.split("\n").findIndex((line) => line.includes("answer = 41"));
+      const changedLine = frame.split("\n")[changedY] ?? "";
+      const oldX = changedLine.indexOf("answer = 41") + 2;
+      const newX = changedLine.indexOf("answer = 42") + 2;
+      expect(changedY).toBeGreaterThanOrEqual(0);
+      expect(oldX).toBeGreaterThan(1);
+      expect(newX).toBeGreaterThan(oldX);
+
+      await act(async () => {
+        await setup.mockMouse.click(oldX, changedY);
+      });
+      expect(selectLine).toHaveBeenLastCalledWith(
+        expect.objectContaining({ fileId: file.id, target: { side: "old", line: 1 } }),
+      );
+
+      await act(async () => {
+        await setup.mockMouse.click(newX, changedY);
+      });
+      expect(selectLine).toHaveBeenLastCalledWith(
+        expect.objectContaining({ fileId: file.id, target: { side: "new", line: 1 } }),
+      );
+
+      selectLine.mockClear();
+      await act(async () => {
+        await setup.mockMouse.click(newX, changedY + 1);
+      });
+      expect(selectLine).toHaveBeenLastCalledWith(
+        expect.objectContaining({ fileId: file.id, target: { side: "new", line: 2 } }),
+      );
+
+      await act(async () => {
+        await Bun.sleep(400);
+        selectLine.mockClear();
+        await setup.mockMouse.drag(oldX, changedY, oldX + 1, changedY, MouseButtons.LEFT);
+      });
+      expect(selectLine).toHaveBeenLastCalledWith(
+        expect.objectContaining({ fileId: file.id, target: { side: "old", line: 1 } }),
+      );
+      expect(copyText).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await Bun.sleep(400);
+        selectLine.mockClear();
+        await setup.mockMouse.drag(oldX, changedY, oldX + 4, changedY, MouseButtons.LEFT);
+      });
+      expect(copyText).toHaveBeenCalled();
+      expect(selectLine).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await setup.mockMouse.moveTo(newX, changedY);
+        await setup.renderOnce();
+      });
+      const affordanceFrame = await waitForFrame(
+        setup,
+        (nextFrame) => nextFrame.split("\n")[changedY]?.includes("[+]") === true,
+        12,
+      );
+      const addNoteX = affordanceFrame.split("\n")[changedY]?.indexOf("[+]") ?? -1;
+      expect(addNoteX).toBeGreaterThanOrEqual(0);
+      selectLine.mockClear();
+
+      await act(async () => {
+        await setup.mockMouse.click(addNoteX + 1, changedY);
+      });
+      expect(startUserNote).toHaveBeenCalled();
+      expect(selectLine).not.toHaveBeenCalled();
+      expect(setup.renderer.hasSelection).toBe(false);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/src/ui/diff/renderRows.tsx
+++ b/src/ui/diff/renderRows.tsx
@@ -1,5 +1,10 @@
 import { Fragment, isValidElement, memo, type ReactNode } from "react";
-import { parseColor, StyledText, type TextChunk } from "@opentui/core";
+import {
+  parseColor,
+  StyledText,
+  type MouseEvent as TuiMouseEvent,
+  type TextChunk,
+} from "@opentui/core";
 import type { DiffFile } from "../../core/changeset/model";
 import type { UserNoteLineTarget } from "../../core/liveComments";
 import type { AppTheme } from "../themes";
@@ -1815,13 +1820,28 @@ function renderHeaderRow(
         <box
           key={badge.key}
           style={{ width: badge.text.length + 1, height: 1 }}
-          onMouseUp={badge.onClick}
+          onMouseUp={(event) => {
+            markNestedRowMouseAction(event);
+            badge.onClick();
+          }}
         >
           <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>{` ${badge.text}`}</text>
         </box>
       ))}
     </box>
   );
+}
+
+const nestedRowMouseActions = new WeakSet<TuiMouseEvent>();
+
+/** Mark an event so the parent completes mouse cleanup without selecting the containing line. */
+export function markNestedRowMouseAction(event: TuiMouseEvent) {
+  nestedRowMouseActions.add(event);
+}
+
+/** Return whether a nested control, rather than the diff line, owns this mouse event. */
+export function isNestedRowMouseAction(event: TuiMouseEvent) {
+  return nestedRowMouseActions.has(event);
 }
 
 /** Render the hover-only add-note target as a separate clickable hit area. */
@@ -1836,7 +1856,10 @@ function renderAddNoteButton(
     <box
       key={key}
       style={{ width: addNoteBadgeText.length, height: 1 }}
-      onMouseUp={() => onStartUserNoteAtHunk?.(hunkIndex, target)}
+      onMouseUp={(event) => {
+        markNestedRowMouseAction(event);
+        onStartUserNoteAtHunk?.(hunkIndex, target);
+      }}
     >
       <text fg={theme.noteTitleText} bg={theme.noteTitleBackground}>
         {addNoteBadgeText}

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { createPtyHarness, lineIndexOf, measureKeyScroll } from "./harness";
+import {
+  createPtyHarness,
+  dragMouse,
+  lineIndexOf,
+  measureKeyScroll,
+  rowCellBackgrounds,
+  sleep,
+} from "./harness";
 
 const harness = createPtyHarness();
 const CURRENT_LINE_LENS_EXTENSION = resolve(
@@ -44,6 +51,94 @@ describe("PTY current line", () => {
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "k", 12)).toBe(0);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("one-cell mouse jitter still selects the exact clicked line", async () => {
+    const fixture = harness.createScrollableFilePair();
+    const session = await harness.launchHunk({
+      args: [
+        "diff",
+        fixture.before,
+        fixture.after,
+        "--mode",
+        "split",
+        "--extension",
+        CURRENT_LINE_LENS_EXTENSION,
+      ],
+      cols: 120,
+      rows: 16,
+    });
+
+    try {
+      await session.waitForText(/Current line · old above, new below/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 400 });
+      const beforeClick = await session.text({ immediate: true });
+      const clickedRow = lineIndexOf(beforeClick, "export const line05 = 5;") - 1;
+      expect(clickedRow).toBeGreaterThan(0);
+
+      await dragMouse(session, 30, clickedRow, 31, clickedRow);
+      const clicked = await session.text({ immediate: true });
+      const clickedLens = clicked.split("Current line").at(-1) ?? "";
+      expect(clickedLens).toContain("export const line05 = 5;");
+      expect(clicked).not.toContain("Copied selection to clipboard");
+
+      // The old-side cursor steps to the same row's new side before advancing to line 6.
+      await session.press("down");
+      const stepped = await session.text({ immediate: true });
+      const steppedLens = stepped.split("Current line").at(-1) ?? "";
+      expect(steppedLens).toContain("export const line05 = 5;");
+
+      await session.press("pagedown");
+      const scrolled = await session.text({ immediate: true });
+      expect(scrolled).not.toContain("export const line01 = 1;");
+      const scrolledRow = lineIndexOf(scrolled, "export const line12 = 12;") - 1;
+      expect(scrolledRow).toBeGreaterThan(0);
+
+      await dragMouse(session, 30, scrolledRow, 30, scrolledRow);
+      const scrolledClick = await session.text({ immediate: true });
+      const scrolledLens = scrolledClick.split("Current line").at(-1) ?? "";
+      expect(scrolledLens).toContain("export const line12 = 12;");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("multi-row copy drag keeps extending after highlighted rows repaint", async () => {
+    const fixture = harness.createScrollableFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      cols: 120,
+      rows: 20,
+    });
+
+    try {
+      const initial = await session.waitForText(/export const line06 = 6;/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+      const startRow = lineIndexOf(initial, "export const line02 = 2;") - 1;
+      const endRow = lineIndexOf(initial, "export const line06 = 6;") - 1;
+      expect(startRow).toBeGreaterThan(0);
+      expect(endRow).toBeGreaterThan(startRow + 2);
+      const rows = Array.from({ length: endRow - startRow + 1 }, (_, index) => startRow + index);
+      const before = rows.map((row) => rowCellBackgrounds(session, row));
+
+      session.writeRaw(`\x1b[<0;31;${startRow + 1}M`);
+      await sleep(20);
+      for (const row of rows.slice(1)) {
+        session.writeRaw(`\x1b[<32;31;${row + 1}M`);
+        await sleep(20);
+      }
+      await session.waitIdle();
+
+      const selected = rows.map((row) => rowCellBackgrounds(session, row));
+      for (let index = 0; index < rows.length; index += 1) {
+        expect(selected[index]).not.toEqual(before[index]);
+      }
+
+      session.writeRaw(`\x1b[<0;31;${endRow + 1}m`);
+      await session.waitForText(/Copied selection to clipboard/, { timeout: 5_000 });
     } finally {
       session.close();
     }


### PR DESCRIPTION
## Summary

- select the exact diff line and split side when clicking anywhere on a rendered row, including blank lines
- use OpenTUI's painted viewport/content coordinates so selection remains accurate after scrolling and pinned-header handoffs
- keep multi-row copy drags captured by the persistent scrollbox while highlighted rows repaint, and resolve coalesced motion at mouse-up
- treat one-cell pointer jitter as a click while preserving deliberate drag, double-click, triple-click, and `--cursor-line off` copy behavior
- isolate the `[+]` affordance so it only opens the note composer

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bunx oxfmt --check` on changed files
- full PTY suite: 120 passed; the sole local `ENOEXEC` spawn failure passed on focused rerun after removing a shadowing `node_modules/.bin/bun` left by dependency repair
- focused component and unit tests, including double/triple-click copy expansion
- raw SGR mouse verification in a live Herdr/tmux pane: selection visibly extended row-by-row across eight rows and copied on release
- independent subagent review (no remaining actionable findings)

## Local environment note

- `bun test`: 3241 passed and 19 skipped; the remaining failures/errors come from the globally installed `hunk-lens` extension being discovered by the local test run

*This PR description was generated by Pi using OpenAI Codex gpt-5.6-sol*
