### PR TITLE
fix(npm): restore executable platform binaries

### DIFF
--- a/.changeset/restore-platform-binary-execution.md
+++ b/.changeset/restore-platform-binary-execution.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Restore executable permissions for platform binaries installed through npm.

--- a/scripts/prebuilt-package-helpers.test.ts
+++ b/scripts/prebuilt-package-helpers.test.ts
@@ -84,7 +84,7 @@ describe("prebuilt package helpers", () => {
     );
   });
 
-  test("buildPlatformPackageManifest carries provenance metadata without a native bin script", () => {
+  test("buildPlatformPackageManifest carries provenance metadata and a native bin script", () => {
     const repository = {
       type: "git",
       url: "git+https://github.com/modem-dev/hunk.git",
@@ -103,7 +103,7 @@ describe("prebuilt package helpers", () => {
 
     expect(manifest.name).toBe("hunkdiff-linux-x64");
     expect(manifest.version).toBe("1.2.3");
-    expect(manifest).not.toHaveProperty("bin");
+    expect(manifest.bin).toEqual({ hunk: "bin/hunk" });
     expect(manifest.repository).toEqual(repository);
     expect(manifest.homepage).toBe("https://github.com/modem-dev/hunk#readme");
     expect(manifest.bugs).toEqual({ url: "https://github.com/modem-dev/hunk/issues" });
@@ -122,7 +122,7 @@ describe("prebuilt package helpers", () => {
     );
 
     expect(manifest.name).toBe("hunkdiff-windows-x64");
-    expect(manifest).not.toHaveProperty("bin");
+    expect(manifest.bin).toEqual({ hunk: "bin/hunk.exe" });
     expect(manifest.os).toEqual(["win32"]);
     expect(manifest.cpu).toEqual(["x64"]);
   });

--- a/scripts/prebuilt-package-helpers.ts
+++ b/scripts/prebuilt-package-helpers.ts
@@ -127,9 +127,9 @@ export function binaryFilenameForSpec(spec: PlatformPackageSpec) {
 /**
  * Build the published manifest for one prebuilt platform package.
  *
- * Platform packages are implementation dependencies, so their native executables
- * stay out of `bin`; npm 11 rejects native files there as invalid scripts. The
- * staged executable bit and top-level wrapper preserve direct execution instead.
+ * Declaring the native executable in `bin` makes npm restore its execute bits
+ * during installation, including when release artifact transfer strips the
+ * staged mode before publishing.
  */
 export function buildPlatformPackageManifest(
   rootPackage: {
@@ -148,6 +148,9 @@ export function buildPlatformPackageManifest(
     description: `${rootPackage.description} (${spec.os} ${spec.cpu} binary)`,
     os: [spec.os === "windows" ? "win32" : spec.os],
     cpu: [spec.cpu],
+    bin: {
+      hunk: spec.binaryRelativePath,
+    },
     files: ["bin", "LICENSE"],
     repository: rootPackage.repository,
     homepage: rootPackage.homepage,

--- a/scripts/smoke-prebuilt-install.ts
+++ b/scripts/smoke-prebuilt-install.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import {
+  chmodSync,
   cpSync,
   existsSync,
   mkdtempSync,
@@ -85,8 +86,17 @@ try {
   // but the Windows `hunk.cmd` shim does not need bash on PATH.
   const bashDir = process.platform === "win32" ? undefined : commandDirectory("bash");
 
+  // Artifact transfer normalizes file modes before the publish job. Reproduce
+  // that boundary so this test proves npm restores execution from the platform
+  // package's `bin` declaration rather than relying on the staged mode.
+  const smokePlatformDir = path.join(smokeMetaDir, hostSpec.packageName);
+  cpSync(path.join(releaseRoot, hostSpec.packageName), smokePlatformDir, { recursive: true });
+  if (process.platform !== "win32") {
+    chmodSync(path.join(smokePlatformDir, "bin", binaryFilenameForSpec(hostSpec)), 0o644);
+  }
+
   run([npmCommand, "pack", "--pack-destination", packageDir], {
-    cwd: path.join(releaseRoot, hostSpec.packageName),
+    cwd: smokePlatformDir,
   });
 
   const platformTarball = path.join(packageDir, `${hostSpec.packageName}-${packageVersion}.tgz`);


### PR DESCRIPTION
## Summary

- restore each platform package's native `bin` declaration using npm's canonical `bin/hunk` or `bin/hunk.exe` path
- preserve the provenance metadata added in #661 while letting npm restore execute bits during installation
- make the prebuilt install smoke test strip the staged execute bit before packing, reproducing the release artifact boundary and asserting npm repairs the installed binary before the wrapper runs

The npm 11 warning that motivated removing `bin` came from the leading `./` in `./bin/hunk`, not from declaring a native executable. The canonical path used here passes an npm 11.17.0 publish dry run without manifest corrections.

## Validation

- `bun test ./scripts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build:prebuilt:npm`
- `bun run check:prebuilt-pack`
- `bun run smoke:prebuilt-install`
- negative control: removing the generated platform `bin` field makes the strengthened smoke test fail on the installed `0644` binary
- npm 11.17.0 publish dry run of the staged platform manifest completed without warnings or corrections

Fixes #831.

*This PR description was generated by Pi using gpt-5.6-sol*
