### PR TITLE
fix(packaging): omit Pierre from CLI installs

### DIFF
--- a/.changeset/quiet-diffs-travel.md
+++ b/.changeset/quiet-diffs-travel.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Stop installing Pierre dependencies for CLI-only npm users.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "hunk",
       "dependencies": {
-        "@pierre/diffs": "1.3.5",
         "bun": "^1.3.14",
         "chokidar": "^4.0.3",
         "commander": "^14.0.3",
@@ -23,6 +22,7 @@
         "@hunk/term-video": "workspace:*",
         "@opentui/core": "^0.5.1",
         "@opentui/react": "^0.5.1",
+        "@pierre/diffs": "1.3.5",
         "@types/bun": "1.3.14",
         "@types/react": "^19.2.14",
         "@types/ws": "^8.18.1",
@@ -40,8 +40,12 @@
       "peerDependencies": {
         "@opentui/core": "^0.5.1",
         "@opentui/react": "^0.5.1",
+        "@pierre/diffs": "1.3.5",
         "react": "^19.2.4",
       },
+      "optionalPeers": [
+        "@pierre/diffs",
+      ],
     },
     "packages/session-broker": {
       "name": "@hunk/session-broker",

--- a/docs/opentui-component.md
+++ b/docs/opentui-component.md
@@ -7,10 +7,10 @@ Use `HunkDiffView` when you want a batteries-included single-file diff, or compo
 ## Install
 
 ```bash
-npm i hunkdiff @opentui/core@^0.5.1 @opentui/react@^0.5.1 react
+npm i hunkdiff @pierre/diffs@1.3.5 @opentui/core@^0.5.1 @opentui/react@^0.5.1 react
 ```
 
-`hunkdiff` declares OpenTUI and React as peer dependencies, so install them in your app.
+`hunkdiff` declares Pierre diffs, OpenTUI, and React as peer dependencies, so install them in your app. Pierre diffs is optional for CLI-only installs but required when importing `hunkdiff/opentui`.
 
 ## Quick start
 
@@ -222,7 +222,7 @@ If you need direct access to Pierre's parser, `parsePatchFiles(...)` is still re
 - `HunkDiffSelection`
 - component prop types
 
-`parseDiffFromFile`, `parsePatchFiles`, and `FileDiffMetadata` are re-exported from `@pierre/diffs` so you can build metadata without adding a second diff dependency.
+`parseDiffFromFile`, `parsePatchFiles`, and `FileDiffMetadata` are re-exported from the `@pierre/diffs` peer dependency so the component and your app share one diff implementation.
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "nix:update-lock": "nix run .#update-bun-lock"
   },
   "dependencies": {
-    "@pierre/diffs": "1.3.5",
     "bun": "^1.3.14",
     "chokidar": "^4.0.3",
     "commander": "^14.0.3",
@@ -136,6 +135,7 @@
     "@hunk/term-video": "workspace:*",
     "@opentui/core": "^0.5.1",
     "@opentui/react": "^0.5.1",
+    "@pierre/diffs": "1.3.5",
     "@types/bun": "1.3.14",
     "@types/react": "^19.2.14",
     "@types/ws": "^8.18.1",
@@ -153,7 +153,13 @@
   "peerDependencies": {
     "@opentui/core": "^0.5.1",
     "@opentui/react": "^0.5.1",
+    "@pierre/diffs": "1.3.5",
     "react": "^19.2.4"
+  },
+  "peerDependenciesMeta": {
+    "@pierre/diffs": {
+      "optional": true
+    }
   },
   "overrides": {
     "shell-quote": "1.9.0"

--- a/scripts/check-prebuilt-pack.ts
+++ b/scripts/check-prebuilt-pack.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { releaseNpmDir } from "./prebuilt-package-helpers";
 import { npmCommand } from "./script-helpers";
@@ -13,6 +13,48 @@ interface PackResult {
   name: string;
   version: string;
   files: PackedFile[];
+}
+
+interface PackageManifest {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+/** Read one package manifest from disk. */
+function readPackageManifest(directory: string) {
+  return JSON.parse(readFileSync(path.join(directory, "package.json"), "utf8")) as PackageManifest;
+}
+
+/** Verify CLI installs can omit Pierre while OpenTUI consumers can provide it. */
+function assertPierreDependencyContract(root: PackageManifest, staged: PackageManifest) {
+  const packageName = "@pierre/diffs";
+  const expectedVersion = root.devDependencies?.[packageName];
+
+  if (!expectedVersion) {
+    throw new Error(`Expected ${packageName} to remain a development dependency.`);
+  }
+  if (root.dependencies?.[packageName] !== undefined) {
+    throw new Error(`Expected ${packageName} to stay out of runtime dependencies.`);
+  }
+  if (
+    root.peerDependencies?.[packageName] !== expectedVersion ||
+    root.peerDependenciesMeta?.[packageName]?.optional !== true
+  ) {
+    throw new Error(
+      `Expected ${packageName}@${expectedVersion} to be an optional peer dependency.`,
+    );
+  }
+  if (staged.dependencies?.[packageName] !== undefined) {
+    throw new Error(`Expected staged ${packageName} to stay out of runtime dependencies.`);
+  }
+  if (
+    staged.peerDependencies?.[packageName] !== expectedVersion ||
+    staged.peerDependenciesMeta?.[packageName]?.optional !== true
+  ) {
+    throw new Error(`Expected the staged package to preserve the optional ${packageName} peer.`);
+  }
 }
 
 function runPackDryRun(cwd: string) {
@@ -62,6 +104,8 @@ const metaDir = path.join(releaseRoot, "hunkdiff");
 if (!existsSync(metaDir)) {
   throw new Error(`Missing staged top-level package at ${metaDir}`);
 }
+
+assertPierreDependencyContract(readPackageManifest(repoRoot), readPackageManifest(metaDir));
 
 const metaPack = runPackDryRun(metaDir);
 assertPaths(metaPack, [

--- a/scripts/check-prebuilt-pack.ts
+++ b/scripts/check-prebuilt-pack.ts
@@ -2,7 +2,11 @@
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
-import { releaseNpmDir } from "./prebuilt-package-helpers";
+import {
+  assertOptionalPeerDependencyContract,
+  releaseNpmDir,
+  type PackageDependencyManifest,
+} from "./prebuilt-package-helpers";
 import { npmCommand } from "./script-helpers";
 
 interface PackedFile {
@@ -15,46 +19,11 @@ interface PackResult {
   files: PackedFile[];
 }
 
-interface PackageManifest {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
-}
-
 /** Read one package manifest from disk. */
 function readPackageManifest(directory: string) {
-  return JSON.parse(readFileSync(path.join(directory, "package.json"), "utf8")) as PackageManifest;
-}
-
-/** Verify CLI installs can omit Pierre while OpenTUI consumers can provide it. */
-function assertPierreDependencyContract(root: PackageManifest, staged: PackageManifest) {
-  const packageName = "@pierre/diffs";
-  const expectedVersion = root.devDependencies?.[packageName];
-
-  if (!expectedVersion) {
-    throw new Error(`Expected ${packageName} to remain a development dependency.`);
-  }
-  if (root.dependencies?.[packageName] !== undefined) {
-    throw new Error(`Expected ${packageName} to stay out of runtime dependencies.`);
-  }
-  if (
-    root.peerDependencies?.[packageName] !== expectedVersion ||
-    root.peerDependenciesMeta?.[packageName]?.optional !== true
-  ) {
-    throw new Error(
-      `Expected ${packageName}@${expectedVersion} to be an optional peer dependency.`,
-    );
-  }
-  if (staged.dependencies?.[packageName] !== undefined) {
-    throw new Error(`Expected staged ${packageName} to stay out of runtime dependencies.`);
-  }
-  if (
-    staged.peerDependencies?.[packageName] !== expectedVersion ||
-    staged.peerDependenciesMeta?.[packageName]?.optional !== true
-  ) {
-    throw new Error(`Expected the staged package to preserve the optional ${packageName} peer.`);
-  }
+  return JSON.parse(
+    readFileSync(path.join(directory, "package.json"), "utf8"),
+  ) as PackageDependencyManifest;
 }
 
 function runPackDryRun(cwd: string) {
@@ -105,7 +74,11 @@ if (!existsSync(metaDir)) {
   throw new Error(`Missing staged top-level package at ${metaDir}`);
 }
 
-assertPierreDependencyContract(readPackageManifest(repoRoot), readPackageManifest(metaDir));
+assertOptionalPeerDependencyContract(
+  readPackageManifest(repoRoot),
+  readPackageManifest(metaDir),
+  "@pierre/diffs",
+);
 
 const metaPack = runPackDryRun(metaDir);
 assertPaths(metaPack, [

--- a/scripts/prebuilt-package-helpers.test.ts
+++ b/scripts/prebuilt-package-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   PLATFORM_PACKAGE_MATRIX,
+  assertOptionalPeerDependencyContract,
   binaryFilenameForSpec,
   buildOptionalDependencyMap,
   buildPlatformPackageManifest,
@@ -10,8 +11,27 @@ import {
   normalizeHostArch,
   normalizeHostPlatform,
   sortPlatformPackageSpecs,
+  type PackageDependencyManifest,
   type PlatformPackageSpec,
 } from "./prebuilt-package-helpers";
+
+/** Build matching source and staged manifests for optional-peer tests. */
+function createOptionalPeerContract(): {
+  root: PackageDependencyManifest;
+  staged: PackageDependencyManifest;
+} {
+  return {
+    root: {
+      devDependencies: { "@pierre/diffs": "1.3.5" },
+      peerDependencies: { "@pierre/diffs": "1.3.5" },
+      peerDependenciesMeta: { "@pierre/diffs": { optional: true } },
+    },
+    staged: {
+      peerDependencies: { "@pierre/diffs": "1.3.5" },
+      peerDependenciesMeta: { "@pierre/diffs": { optional: true } },
+    },
+  };
+}
 
 describe("prebuilt package helpers", () => {
   test("buildOptionalDependencyMap includes every supported platform package at one version", () => {
@@ -22,6 +42,45 @@ describe("prebuilt package helpers", () => {
       PLATFORM_PACKAGE_MATRIX.map((spec) => spec.packageName).sort(),
     );
     expect(new Set(Object.values(dependencies))).toEqual(new Set([version]));
+  });
+
+  test("assertOptionalPeerDependencyContract accepts a preserved optional peer", () => {
+    const { root, staged } = createOptionalPeerContract();
+
+    expect(() => assertOptionalPeerDependencyContract(root, staged, "@pierre/diffs")).not.toThrow();
+  });
+
+  test("assertOptionalPeerDependencyContract rejects dependency contract drift", () => {
+    const mutations: Array<
+      (root: PackageDependencyManifest, staged: PackageDependencyManifest) => void
+    > = [
+      (root) => delete root.devDependencies?.["@pierre/diffs"],
+      (root) => {
+        root.dependencies = { "@pierre/diffs": "1.3.5" };
+      },
+      (root) => {
+        root.peerDependencies = { "@pierre/diffs": "1.3.4" };
+      },
+      (root) => {
+        root.peerDependenciesMeta = { "@pierre/diffs": { optional: false } };
+      },
+      (_root, staged) => {
+        staged.dependencies = { "@pierre/diffs": "1.3.5" };
+      },
+      (_root, staged) => {
+        staged.peerDependencies = { "@pierre/diffs": "1.3.4" };
+      },
+      (_root, staged) => {
+        staged.peerDependenciesMeta = { "@pierre/diffs": { optional: false } };
+      },
+    ];
+
+    for (const mutate of mutations) {
+      const { root, staged } = createOptionalPeerContract();
+      mutate(root, staged);
+
+      expect(() => assertOptionalPeerDependencyContract(root, staged, "@pierre/diffs")).toThrow();
+    }
   });
 
   test("binaryFilenameForSpec keeps unix package binaries extensionless", () => {

--- a/scripts/prebuilt-package-helpers.ts
+++ b/scripts/prebuilt-package-helpers.ts
@@ -14,6 +14,13 @@ export interface PlatformPackageSpec {
   binaryRelativePath: string;
 }
 
+export interface PackageDependencyManifest {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
 const PLATFORM_NAME_MAP: Partial<Record<NodeJS.Platform, SupportedPlatform>> = {
   darwin: "darwin",
   linux: "linux",
@@ -117,6 +124,39 @@ export function buildOptionalDependencyMap(
   specs: readonly PlatformPackageSpec[] = PLATFORM_PACKAGE_MATRIX,
 ) {
   return Object.fromEntries(specs.map((spec) => [spec.packageName, version]));
+}
+
+/** Verify a package stays development-only and an optional peer after staging. */
+export function assertOptionalPeerDependencyContract(
+  root: PackageDependencyManifest,
+  staged: PackageDependencyManifest,
+  packageName: string,
+) {
+  const expectedVersion = root.devDependencies?.[packageName];
+
+  if (!expectedVersion) {
+    throw new Error(`Expected ${packageName} to remain a development dependency.`);
+  }
+  if (root.dependencies?.[packageName] !== undefined) {
+    throw new Error(`Expected ${packageName} to stay out of runtime dependencies.`);
+  }
+  if (
+    root.peerDependencies?.[packageName] !== expectedVersion ||
+    root.peerDependenciesMeta?.[packageName]?.optional !== true
+  ) {
+    throw new Error(
+      `Expected ${packageName}@${expectedVersion} to be an optional peer dependency.`,
+    );
+  }
+  if (staged.dependencies?.[packageName] !== undefined) {
+    throw new Error(`Expected staged ${packageName} to stay out of runtime dependencies.`);
+  }
+  if (
+    staged.peerDependencies?.[packageName] !== expectedVersion ||
+    staged.peerDependenciesMeta?.[packageName]?.optional !== true
+  ) {
+    throw new Error(`Expected the staged package to preserve the optional ${packageName} peer.`);
+  }
 }
 
 /** Return the executable filename for a platform package. */

--- a/scripts/smoke-prebuilt-install.ts
+++ b/scripts/smoke-prebuilt-install.ts
@@ -140,6 +140,15 @@ try {
     binaryFilenameForSpec(hostSpec),
   );
   const commandEnv = envWithPath(sanitizedPath);
+  const pierreInstallCandidates = [
+    path.join(installedPackageRoot, "node_modules", "@pierre", "diffs"),
+    path.join(path.dirname(installedPackageRoot), "@pierre", "diffs"),
+    path.join(installDir, "node_modules", "@pierre", "diffs"),
+  ];
+
+  if (pierreInstallCandidates.some((candidate) => existsSync(candidate))) {
+    throw new Error("Expected a CLI-only Hunk install to omit the optional @pierre/diffs peer.");
+  }
 
   if (process.platform !== "win32") {
     const installedBinaryMode = statSync(installedPlatformBinary).mode & 0o777;

--- a/scripts/stage-prebuilt-npm.ts
+++ b/scripts/stage-prebuilt-npm.ts
@@ -36,6 +36,7 @@ type RootPackageJson = {
   exports?: unknown;
   dependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
 };
 
 interface BinaryArtifactMetadata {
@@ -107,6 +108,7 @@ function stageMetaPackage(
     engines: rootPackage.engines,
     dependencies: rootPackage.dependencies,
     peerDependencies: rootPackage.peerDependencies,
+    peerDependenciesMeta: rootPackage.peerDependenciesMeta,
     optionalDependencies: buildOptionalDependencyMap(rootPackage.version, specs),
     license: rootPackage.license,
     publishConfig: {

--- a/website/src/content/docs/docs/reference/opentui-components.md
+++ b/website/src/content/docs/docs/reference/opentui-components.md
@@ -8,8 +8,10 @@ The `hunkdiff/opentui` export exposes Hunk's renderer without the CLI shell, glo
 ## Install peers
 
 ```bash
-npm install hunkdiff @opentui/core@^0.4.3 @opentui/react@^0.4.3 react
+npm install hunkdiff @pierre/diffs@1.3.5 @opentui/core@^0.5.1 @opentui/react@^0.5.1 react
 ```
+
+Pierre diffs is optional for CLI-only installs but required when importing `hunkdiff/opentui`.
 
 ## Render one file
 


### PR DESCRIPTION
## Summary

- move `@pierre/diffs@1.3.5` from runtime dependencies to an exact optional peer while retaining it for development
- preserve optional-peer metadata in staged npm releases and verify CLI-only installs omit Pierre
- document the explicit Pierre dependency required by `hunkdiff/opentui`

This keeps the bundled CLI and prebuilt binaries self-contained while allowing OpenTUI consumers to provide the external Pierre instance they use. It also prevents CLI-only package managers from resolving the unattested `@pierre/theme@2.0.0` transitive dependency.

Closes #836.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build:prebuilt:npm`
- `bun run check:prebuilt-pack`
- `bun run smoke:prebuilt-install`
- `bun run check:pack`
- `bun run website:check`

*This PR description was generated by Pi using gpt-5.6-sol*
