### PR TITLE
feat(config): make wheel scrolling configurable

### DIFF
--- a/.changeset/faster-wheels-scroll.md
+++ b/.changeset/faster-wheels-scroll.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Let reviewers configure a fixed number of rows per mouse-wheel event for faster large-diff scrolling.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ line_numbers = true
 tab_width = 4        # tab stops, 1-16
 file_gap = 1         # rows between files, including the ─ rule; 0 hides it
 hunk_gap = 0         # blank rows before later hunks
+wheel_scroll_lines = "auto" # auto acceleration, or a fixed 1-10 rows per event
 wrap_lines = false
 menu_bar = true
 animations = true
@@ -188,6 +189,7 @@ syntax scopes, and legacy syntax-table migration.
 `exclude_untracked` affects Git/Sapling working-tree `hunk diff` sessions only.
 `tab_width` controls source-code tab stops and can be overridden with `-x4` or `--tab-width 4`.
 `file_gap` is separator height between files, including the `─` rule; `hunk_gap` is blank rows before later hunks.
+`wheel_scroll_lines` is a user-only preference and can be overridden with `--wheel-scroll-lines 3`.
 Set `animations = false` to make panes open and close immediately.
 `prompt_save_view_preferences = false` disables the quit prompt for saving changed view preferences.
 `transparent_background` can also be written as `transparentBackground`.

--- a/packages/hunk/README.md
+++ b/packages/hunk/README.md
@@ -172,6 +172,7 @@ line_numbers = true
 tab_width = 4        # tab stops, 1-16
 file_gap = 1         # rows between files, including the ─ rule; 0 hides it
 hunk_gap = 0         # blank rows before later hunks
+wheel_scroll_lines = "auto" # auto acceleration, or a fixed 1-10 rows per event
 wrap_lines = false
 menu_bar = true
 animations = true
@@ -188,6 +189,7 @@ syntax scopes, and legacy syntax-table migration.
 `exclude_untracked` affects Git/Sapling working-tree `hunk diff` sessions only.
 `tab_width` controls source-code tab stops and can be overridden with `-x4` or `--tab-width 4`.
 `file_gap` is separator height between files, including the `─` rule; `hunk_gap` is blank rows before later hunks.
+`wheel_scroll_lines` is a user-only preference and can be overridden with `--wheel-scroll-lines 3`.
 Set `animations = false` to make panes open and close immediately.
 `prompt_save_view_preferences = false` disables the quit prompt for saving changed view preferences.
 `transparent_background` can also be written as `transparentBackground`.

--- a/packages/hunk/src/app/cli.test.ts
+++ b/packages/hunk/src/app/cli.test.ts
@@ -133,6 +133,8 @@ describe("parseCli", () => {
       "notes.json",
       "--no-line-numbers",
       "-x4",
+      "--wheel-scroll-lines",
+      "3",
       "--wrap",
       "--no-hunk-headers",
       "--agent-notes",
@@ -153,12 +155,27 @@ describe("parseCli", () => {
         experimental: true,
         lineNumbers: false,
         tabWidth: 4,
+        wheelScrollLines: 3,
         wrapLines: true,
         hunkHeaders: false,
         agentNotes: true,
         transparentBackground: true,
       },
     });
+  });
+
+  test("parses wheel scroll lines and rejects invalid values", async () => {
+    const automatic = await parseCli(["bun", "hunk", "diff", "--wheel-scroll-lines", "auto"]);
+    const fixed = await parseCli(["bun", "hunk", "diff", "--wheel-scroll-lines", "5"]);
+
+    expect(automatic).toMatchObject({ kind: "vcs", options: { wheelScrollLines: "auto" } });
+    expect(fixed).toMatchObject({ kind: "vcs", options: { wheelScrollLines: 5 } });
+
+    for (const invalid of ["0", "11", "fast"]) {
+      await expect(
+        parseCli(["bun", "hunk", "diff", "--wheel-scroll-lines", invalid]),
+      ).rejects.toThrow(/wheel scroll lines/);
+    }
   });
 
   test("parses the current-line style and rejects an unknown one", async () => {

--- a/packages/hunk/src/app/cli.ts
+++ b/packages/hunk/src/app/cli.ts
@@ -57,6 +57,11 @@ import {
 import { DEFAULT_FILE_GAP, DEFAULT_HUNK_GAP, parseReviewGap } from "../core/run/reviewGap";
 import { DEFAULT_TAB_WIDTH, parseTabWidth } from "../core/run/tabWidth";
 import { resolveCliVersion } from "../core/run/version";
+import {
+  DEFAULT_WHEEL_SCROLL_LINES,
+  parseWheelScrollLines,
+  type WheelScrollLines,
+} from "../core/run/wheelScrollLines";
 import type { ExtensionVcsHistoryReviewAction } from "../extension-api/types";
 
 /** Structured option metadata shared by Commander registration and generated CLI docs. */
@@ -71,6 +76,7 @@ export interface CliReferenceOption {
     | "tabWidth"
     | "fileGap"
     | "hunkGap"
+    | "wheelScrollLines"
     | "collect";
   readonly defaultValue?: string;
   /** Default applied directly by Commander (as opposed to a config-resolved default). */
@@ -138,6 +144,12 @@ export const COMMON_REVIEW_OPTIONS = [
     description: "blank rows before each later hunk: 0-8",
     parse: "hunkGap",
     defaultValue: String(DEFAULT_HUNK_GAP),
+  },
+  {
+    flag: "--wheel-scroll-lines <lines>",
+    description: "rows per wheel event: auto or 1-10",
+    parse: "wheelScrollLines",
+    defaultValue: DEFAULT_WHEEL_SCROLL_LINES,
   },
   { flag: "--wrap", description: "wrap long diff lines" },
   { flag: "--no-wrap", description: "truncate long diff lines to one row" },
@@ -452,6 +464,7 @@ function buildCommonOptions(
     tabWidth?: number;
     fileGap?: number;
     hunkGap?: number;
+    wheelScrollLines?: WheelScrollLines;
     extension?: string[];
   },
   argv: string[],
@@ -478,6 +491,7 @@ function buildCommonOptions(
     tabWidth: options.tabWidth,
     fileGap: options.fileGap,
     hunkGap: options.hunkGap,
+    wheelScrollLines: options.wheelScrollLines,
     wrapLines: resolveBooleanFlag(argv, "--wrap", "--no-wrap"),
     hunkHeaders: resolveBooleanFlag(argv, "--hunk-headers", "--no-hunk-headers"),
     sidebar: resolveBooleanFlag(argv, "--sidebar", "--no-sidebar"),
@@ -508,6 +522,8 @@ function applyReferenceOption(command: Command, option: CliReferenceOption) {
     commanderOption.argParser((value: string) => parseReviewGap(value, "file gap"));
   } else if (option.parse === "hunkGap") {
     commanderOption.argParser((value: string) => parseReviewGap(value, "hunk gap"));
+  } else if (option.parse === "wheelScrollLines") {
+    commanderOption.argParser(parseWheelScrollLines);
   } else if (option.parse === "collect") {
     commanderOption.argParser(collectRepeatedValue);
   }

--- a/packages/hunk/src/core/bootstrap.ts
+++ b/packages/hunk/src/core/bootstrap.ts
@@ -15,6 +15,7 @@ import type { ExtensionReviewDescriptor, NamedCustomThemeConfig } from "../exten
 import type { Changeset } from "./changeset/model";
 import type { CliInput, CursorLine, LayoutMode, SidebarVisibility } from "./run/commandInputs";
 import type { UserKeyBinding } from "./run/config";
+import type { WheelScrollLines } from "./run/wheelScrollLines";
 import type { StartupNotice } from "./process/startupNotice";
 import type { TerminalThemeMode } from "./theme/detection";
 import type { VcsCatalog } from "./vcs/types";
@@ -47,6 +48,7 @@ export interface AppBootstrap<ExtensionState = unknown> {
   initialTabWidth?: number;
   initialFileGap?: number;
   initialHunkGap?: number;
+  initialWheelScrollLines?: WheelScrollLines;
   initialWrapLines?: boolean;
   initialShowHunkHeaders?: boolean;
   initialShowMenuBar?: boolean;

--- a/packages/hunk/src/core/changeset/loaders.ts
+++ b/packages/hunk/src/core/changeset/loaders.ts
@@ -17,6 +17,7 @@ import { changesetFromPatch } from "./fromPatch";
 
 import { DEFAULT_FILE_GAP, DEFAULT_HUNK_GAP } from "../run/reviewGap";
 import { DEFAULT_TAB_WIDTH } from "../run/tabWidth";
+import { DEFAULT_WHEEL_SCROLL_LINES } from "../run/wheelScrollLines";
 import {
   getConfiguredVcsAdapter,
   isVcsReviewInput,
@@ -345,6 +346,7 @@ export async function loadAppBootstrap(
     initialTabWidth: input.options.tabWidth ?? DEFAULT_TAB_WIDTH,
     initialFileGap: input.options.fileGap ?? DEFAULT_FILE_GAP,
     initialHunkGap: input.options.hunkGap ?? DEFAULT_HUNK_GAP,
+    initialWheelScrollLines: input.options.wheelScrollLines ?? DEFAULT_WHEEL_SCROLL_LINES,
     initialWrapLines: input.options.wrapLines ?? false,
     initialShowHunkHeaders: input.options.hunkHeaders ?? true,
     initialShowMenuBar: input.options.menuBar ?? true,

--- a/packages/hunk/src/core/run/commandInputs.ts
+++ b/packages/hunk/src/core/run/commandInputs.ts
@@ -14,6 +14,7 @@ import type {
   ExtensionVcsStashShowInput,
 } from "../../extension-api/types";
 import type { InstallSource } from "../install/installSource";
+import type { WheelScrollLines } from "./wheelScrollLines";
 
 export type LayoutMode = "auto" | "split" | "unified";
 export type LayoutModeInput = LayoutMode | "stack";
@@ -51,6 +52,8 @@ export interface CommonOptions {
   fileGap?: number;
   /** Blank rows before each hunk after the first in a file. */
   hunkGap?: number;
+  /** Review rows to move per vertical mouse-wheel event. */
+  wheelScrollLines?: WheelScrollLines;
   wrapLines?: boolean;
   hunkHeaders?: boolean;
   menuBar?: boolean;

--- a/packages/hunk/src/core/run/config.test.ts
+++ b/packages/hunk/src/core/run/config.test.ts
@@ -383,6 +383,43 @@ describe("config resolution", () => {
     }
   });
 
+  test("resolves wheel scroll lines from user config and CLI but not repository config", () => {
+    const home = createTempDir("hunk-config-wheel-home-");
+    const repo = createTempDir("hunk-config-wheel-repo-");
+    createRepo(repo);
+    const input = createPatchPagerInput();
+    const env = { HOME: home };
+
+    expect(
+      resolveConfiguredCliInput(input, { cwd: repo, env }).input.options.wheelScrollLines,
+    ).toBe("auto");
+
+    mkdirSync(join(home, ".config", "hunk"), { recursive: true });
+    writeFileSync(join(home, ".config", "hunk", "config.toml"), "wheel_scroll_lines = 3\n");
+    mkdirSync(join(repo, ".hunk"), { recursive: true });
+    writeFileSync(join(repo, ".hunk", "config.toml"), "wheel_scroll_lines = 8\n");
+
+    expect(
+      resolveConfiguredCliInput(input, { cwd: repo, env }).input.options.wheelScrollLines,
+    ).toBe(3);
+    expect(
+      resolveConfiguredCliInput(createPatchPagerInput({ wheelScrollLines: 6 }), {
+        cwd: repo,
+        env,
+      }).input.options.wheelScrollLines,
+    ).toBe(6);
+
+    for (const invalid of ["0", "11", '"fast"']) {
+      writeFileSync(
+        join(home, ".config", "hunk", "config.toml"),
+        `wheel_scroll_lines = ${invalid}\n`,
+      );
+      expect(() => resolveConfiguredCliInput(input, { cwd: repo, env })).toThrow(
+        /wheel_scroll_lines/,
+      );
+    }
+  });
+
   test("resolves the sidebar preference from config, CLI flags, and the auto default", () => {
     const home = createTempDir("hunk-config-home-");
     const repo = createTempDir("hunk-config-repo-");
@@ -1094,6 +1131,7 @@ describe("config resolution", () => {
         "tab_width = 8",
         "file_gap = 3",
         "hunk_gap = 1",
+        "wheel_scroll_lines = 4",
         "wrap_lines = true",
         "menu_bar = false",
         "sidebar = true",
@@ -1125,6 +1163,7 @@ describe("config resolution", () => {
     expect(bootstrap.initialTabWidth).toBe(8);
     expect(bootstrap.initialFileGap).toBe(3);
     expect(bootstrap.initialHunkGap).toBe(1);
+    expect(bootstrap.initialWheelScrollLines).toBe(4);
     expect(bootstrap.initialWrapLines).toBe(true);
     expect(bootstrap.initialShowMenuBar).toBe(false);
     expect(bootstrap.initialSidebar).toBe(true);

--- a/packages/hunk/src/core/run/config.ts
+++ b/packages/hunk/src/core/run/config.ts
@@ -26,6 +26,7 @@ import {
   validateReviewGap,
 } from "./reviewGap";
 import { DEFAULT_TAB_WIDTH, validateTabWidth } from "./tabWidth";
+import { DEFAULT_WHEEL_SCROLL_LINES, validateWheelScrollLines } from "./wheelScrollLines";
 import { findProjectRootCandidate } from "../process/projectRoot";
 import { createVcsCatalog, detectVcs } from "../vcs";
 import type { VcsCatalog } from "../vcs/types";
@@ -297,6 +298,19 @@ function normalizeReviewGap(value: unknown, key: "file_gap" | "hunk_gap") {
   return validateReviewGap(value, key);
 }
 
+/** Accept `auto` or a bounded integer wheel step from TOML configuration. */
+function normalizeWheelScrollLines(value: unknown) {
+  if (value === undefined || value === DEFAULT_WHEEL_SCROLL_LINES) {
+    return value;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error("Expected wheel_scroll_lines to be auto or an integer from 1 to 10.");
+  }
+
+  return validateWheelScrollLines(value, "wheel_scroll_lines");
+}
+
 /** One top-level configuration key shared by runtime parsing and generated reference docs. */
 export interface ConfigReferenceOption {
   readonly key: string;
@@ -311,6 +325,8 @@ export interface ConfigReferenceOption {
   readonly aliases?: readonly { key: string; deprecated?: boolean }[];
   /** Ordered source keys preserve compatibility precedence where an old alias historically won. */
   readonly runtimeKeys?: readonly string[];
+  /** Machine-local input preferences do not resolve from repository config. */
+  readonly userOnly?: boolean;
 }
 
 /**
@@ -400,6 +416,16 @@ export const CONFIG_REFERENCE_OPTIONS: readonly ConfigReferenceOption[] = [
     accepted: `${MIN_REVIEW_GAP} through ${MAX_REVIEW_GAP}`,
     runtimeDefault: DEFAULT_HUNK_GAP,
     description: "Blank rows before each hunk after the first in a file.",
+  },
+  {
+    key: "wheel_scroll_lines",
+    property: "wheelScrollLines",
+    type: "string or integer",
+    accepted: "`auto` or 1 through 10",
+    runtimeDefault: DEFAULT_WHEEL_SCROLL_LINES,
+    description:
+      "Set review rows per vertical wheel event. `auto` keeps cadence-based acceleration from one to three rows.",
+    userOnly: true,
   },
   {
     key: "wrap_lines",
@@ -986,6 +1012,8 @@ function normalizeConfigReferenceValue(property: keyof CommonOptions, value: unk
       return normalizeReviewGap(value, "file_gap");
     case "hunkGap":
       return normalizeReviewGap(value, "hunk_gap");
+    case "wheelScrollLines":
+      return normalizeWheelScrollLines(value);
     case "sidebar":
       return normalizeSidebarVisibility(value);
     default:
@@ -994,11 +1022,18 @@ function normalizeConfigReferenceValue(property: keyof CommonOptions, value: unk
 }
 
 /** Read the view preferences stored at one TOML object level. */
-function readConfigPreferences(source: Record<string, unknown>): CommonOptions {
+function readConfigPreferences(
+  source: Record<string, unknown>,
+  { includeUserOnly = true }: { includeUserOnly?: boolean } = {},
+): CommonOptions {
   const preferences: CommonOptions = {};
   const mutable = preferences as Record<string, unknown>;
 
   for (const option of CONFIG_REFERENCE_OPTIONS) {
+    if (option.userOnly && !includeUserOnly) {
+      continue;
+    }
+
     const runtimeKeys = option.runtimeKeys ?? [
       option.key,
       ...(option.aliases?.map(({ key }) => key) ?? []),
@@ -1046,6 +1081,7 @@ function mergeOptions(base: CommonOptions, overrides: CommonOptions): CommonOpti
     tabWidth: overrides.tabWidth ?? base.tabWidth,
     fileGap: overrides.fileGap ?? base.fileGap,
     hunkGap: overrides.hunkGap ?? base.hunkGap,
+    wheelScrollLines: overrides.wheelScrollLines ?? base.wheelScrollLines,
     wrapLines: overrides.wrapLines ?? base.wrapLines,
     hunkHeaders: overrides.hunkHeaders ?? base.hunkHeaders,
     menuBar: overrides.menuBar ?? base.menuBar,
@@ -1063,17 +1099,21 @@ function mergeOptions(base: CommonOptions, overrides: CommonOptions): CommonOpti
 }
 
 /** Apply one parsed config object, including command/pager sections, to the current invocation. */
-function resolveConfigLayer(source: Record<string, unknown>, input: CliInput): CommonOptions {
-  let resolved = readConfigPreferences(source);
+function resolveConfigLayer(
+  source: Record<string, unknown>,
+  input: CliInput,
+  { includeUserOnly = true }: { includeUserOnly?: boolean } = {},
+): CommonOptions {
+  let resolved = readConfigPreferences(source, { includeUserOnly });
 
   const commandSection = CONFIG_COMMAND_SECTIONS[input.kind] ? source[input.kind] : undefined;
   if (isRecord(commandSection)) {
-    resolved = mergeOptions(resolved, readConfigPreferences(commandSection));
+    resolved = mergeOptions(resolved, readConfigPreferences(commandSection, { includeUserOnly }));
   }
 
   const pagerSection = source.pager;
   if (input.options.pager && isRecord(pagerSection)) {
-    resolved = mergeOptions(resolved, readConfigPreferences(pagerSection));
+    resolved = mergeOptions(resolved, readConfigPreferences(pagerSection, { includeUserOnly }));
   }
 
   return resolved;
@@ -1299,7 +1339,7 @@ export function resolveConfiguredCliInput(
 
   if (repoConfigPath && sources.repoConfig) {
     const repoConfig = sources.repoConfig;
-    const repoLayer = resolveConfigLayer(repoConfig, input);
+    const repoLayer = resolveConfigLayer(repoConfig, input, { includeUserOnly: false });
     explicitVcsId = repoLayer.vcs ?? explicitVcsId;
     resolvedOptions = mergeOptions(resolvedOptions, repoLayer);
     applyCustomThemeLayer(readCustomThemes(repoConfig));
@@ -1323,6 +1363,7 @@ export function resolveConfiguredCliInput(
     tabWidth: resolvedOptions.tabWidth ?? DEFAULT_TAB_WIDTH,
     fileGap: resolvedOptions.fileGap ?? DEFAULT_FILE_GAP,
     hunkGap: resolvedOptions.hunkGap ?? DEFAULT_HUNK_GAP,
+    wheelScrollLines: resolvedOptions.wheelScrollLines ?? DEFAULT_WHEEL_SCROLL_LINES,
     wrapLines: resolvedOptions.wrapLines ?? DEFAULT_VIEW_PREFERENCES.wrapLines,
     hunkHeaders: resolvedOptions.hunkHeaders ?? DEFAULT_VIEW_PREFERENCES.showHunkHeaders,
     menuBar: resolvedOptions.menuBar ?? DEFAULT_VIEW_PREFERENCES.showMenuBar,

--- a/packages/hunk/src/core/run/wheelScrollLines.test.ts
+++ b/packages/hunk/src/core/run/wheelScrollLines.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_WHEEL_SCROLL_LINES,
+  parseWheelScrollLines,
+  validateWheelScrollLines,
+} from "./wheelScrollLines";
+
+describe("wheel scroll lines", () => {
+  test("accepts auto and bounded integer CLI values", () => {
+    expect(parseWheelScrollLines("auto")).toBe(DEFAULT_WHEEL_SCROLL_LINES);
+    expect(parseWheelScrollLines("1")).toBe(1);
+    expect(parseWheelScrollLines("10")).toBe(10);
+  });
+
+  test("rejects malformed and out-of-range values", () => {
+    for (const value of ["0", "11", "1.5", "fast"]) {
+      expect(() => parseWheelScrollLines(value)).toThrow(/wheel scroll lines/);
+    }
+
+    expect(() => validateWheelScrollLines(Number.NaN)).toThrow(/wheel scroll lines/);
+  });
+});

--- a/packages/hunk/src/core/run/wheelScrollLines.ts
+++ b/packages/hunk/src/core/run/wheelScrollLines.ts
@@ -1,0 +1,33 @@
+export const DEFAULT_WHEEL_SCROLL_LINES = "auto" as const;
+export const MIN_WHEEL_SCROLL_LINES = 1;
+export const MAX_WHEEL_SCROLL_LINES = 10;
+
+export type WheelScrollLines = typeof DEFAULT_WHEEL_SCROLL_LINES | number;
+
+/** Validate one wheel-scroll preference while keeping each event within a practical range. */
+export function validateWheelScrollLines(value: number, label = "wheel scroll lines") {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < MIN_WHEEL_SCROLL_LINES ||
+    value > MAX_WHEEL_SCROLL_LINES
+  ) {
+    throw new Error(
+      `Invalid ${label}: ${String(value)} (expected ${MIN_WHEEL_SCROLL_LINES}-${MAX_WHEEL_SCROLL_LINES} or auto)`,
+    );
+  }
+
+  return value;
+}
+
+/** Parse one CLI wheel-scroll argument. */
+export function parseWheelScrollLines(value: string): WheelScrollLines {
+  if (value === DEFAULT_WHEEL_SCROLL_LINES) {
+    return value;
+  }
+
+  if (!/^[1-9]\d*$/.test(value)) {
+    throw new Error(`Invalid wheel scroll lines: ${value}`);
+  }
+
+  return validateWheelScrollLines(Number(value));
+}

--- a/packages/hunk/src/ui/App.tsx
+++ b/packages/hunk/src/ui/App.tsx
@@ -1541,6 +1541,7 @@ export function App({
             tabWidth={tabWidth}
             fileGap={fileGap}
             hunkGap={hunkGap}
+            wheelScrollLines={bootstrap.initialWheelScrollLines}
             wrapLines={wrapLines}
             wrapToggleScrollTop={wrapToggleScrollTopRef.current}
             layoutToggleScrollTop={layoutToggleScrollTopRef.current}

--- a/packages/hunk/src/ui/components/panes/DiffPane.tsx
+++ b/packages/hunk/src/ui/components/panes/DiffPane.tsx
@@ -11,6 +11,10 @@ import {
 } from "react";
 import { DEFAULT_FILE_GAP, DEFAULT_HUNK_GAP } from "../../../core/run/reviewGap";
 import { DEFAULT_TAB_WIDTH } from "../../../core/run/tabWidth";
+import {
+  DEFAULT_WHEEL_SCROLL_LINES,
+  type WheelScrollLines,
+} from "../../../core/run/wheelScrollLines";
 import type { DiffFile } from "../../../core/changeset/model";
 import type { CursorLine, LayoutMode } from "../../../core/run/commandInputs";
 import type { ReviewNoteTargetV1 } from "../../../core/review/types";
@@ -347,6 +351,7 @@ export function DiffPane({
   tabWidth = DEFAULT_TAB_WIDTH,
   fileGap = DEFAULT_FILE_GAP,
   hunkGap = DEFAULT_HUNK_GAP,
+  wheelScrollLines = DEFAULT_WHEEL_SCROLL_LINES,
   wrapLines,
   wrapToggleScrollTop,
   layoutToggleScrollTop = null,
@@ -431,6 +436,7 @@ export function DiffPane({
   tabWidth?: number;
   fileGap?: number;
   hunkGap?: number;
+  wheelScrollLines?: WheelScrollLines;
   wrapLines: boolean;
   wrapToggleScrollTop: number | null;
   layoutToggleScrollTop?: number | null;
@@ -477,8 +483,8 @@ export function DiffPane({
   const renderTopChrome = showTopChrome ?? !pagerMode;
   const renderer = useRenderer();
   const mouseWheelScrollAcceleration = useMemo(
-    () => createReviewMouseWheelScrollAcceleration(),
-    [],
+    () => createReviewMouseWheelScrollAcceleration(wheelScrollLines),
+    [wheelScrollLines],
   );
   const [currentLineRowPlan, setCurrentLineRowPlan] = useState<{
     source: { file: DiffFile; theme: AppTheme; tabWidth: number };

--- a/packages/hunk/src/ui/lib/scrollAcceleration.test.ts
+++ b/packages/hunk/src/ui/lib/scrollAcceleration.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { createReviewMouseWheelScrollAcceleration } from "./scrollAcceleration";
+
+describe("review mouse wheel acceleration", () => {
+  test("keeps the first auto tick precise", () => {
+    const acceleration = createReviewMouseWheelScrollAcceleration("auto");
+
+    expect(acceleration.tick(1_000)).toBe(1);
+  });
+
+  test("returns an exact configured row count for every wheel event", () => {
+    const acceleration = createReviewMouseWheelScrollAcceleration(3);
+
+    expect(acceleration.tick(1_000)).toBe(3);
+    expect(acceleration.tick(1_001)).toBe(3);
+    acceleration.reset();
+    expect(acceleration.tick(2_000)).toBe(3);
+  });
+});

--- a/packages/hunk/src/ui/lib/scrollAcceleration.ts
+++ b/packages/hunk/src/ui/lib/scrollAcceleration.ts
@@ -1,12 +1,22 @@
 import { MacOSScrollAccel, type ScrollAcceleration } from "@opentui/core";
+import { DEFAULT_WHEEL_SCROLL_LINES, type WheelScrollLines } from "../../core/run/wheelScrollLines";
 
 /**
- * Keep the first wheel tick precise, then ramp up during sustained bursts.
+ * Resolve wheel movement from the user's fixed row count or Hunk's cadence-based acceleration.
  *
- * This matches the general pattern used by terminal UIs better than scaling by total diff size:
- * short diffs stay controllable, while long repeated wheel gestures still speed up.
+ * Auto mode keeps the first tick precise, then ramps up during sustained bursts. A numeric
+ * preference returns that exact row count for every event so coarse wheels remain predictable.
  */
-export function createReviewMouseWheelScrollAcceleration(): ScrollAcceleration {
+export function createReviewMouseWheelScrollAcceleration(
+  lines: WheelScrollLines = DEFAULT_WHEEL_SCROLL_LINES,
+): ScrollAcceleration {
+  if (lines !== DEFAULT_WHEEL_SCROLL_LINES) {
+    return {
+      tick: () => lines,
+      reset: () => {},
+    };
+  }
+
   return new MacOSScrollAccel({
     A: 0.4,
     tau: 4,

--- a/scripts/generate/generate-docs.ts
+++ b/scripts/generate/generate-docs.ts
@@ -266,7 +266,8 @@ export function renderConfigReference() {
       option.runtimeDefault !== undefined
         ? `\`${String(option.runtimeDefault)}\``
         : (option.defaultValue ?? "—");
-    return `**\`${option.key}\`**\n\n${option.description}\n\n- **Type:** ${option.type}\n- **Accepted:** ${option.accepted}\n- **Built-in default:** ${defaultValue}${aliasDetails}`;
+    const scopeDetails = option.userOnly ? "\n- **Scope:** user config only" : "";
+    return `**\`${option.key}\`**\n\n${option.description}\n\n- **Type:** ${option.type}\n- **Accepted:** ${option.accepted}\n- **Built-in default:** ${defaultValue}${scopeDetails}${aliasDetails}`;
   });
   const sectionRows = Object.entries(CONFIG_COMMAND_SECTIONS).map(
     ([section, description]) => `| \`[${section}]\` | ${description} |`,

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -92,6 +92,35 @@ export async function measureKeyScroll(session: Session, key: Key, anchorRow: nu
   return anchorRow - movedTo;
 }
 
+/** Count how many rows one mouse-wheel event moves the review stream. */
+export async function measureMouseWheelScroll(
+  session: Session,
+  direction: "down" | "up",
+  anchorRow: number,
+) {
+  const before = (await session.text({ immediate: true })).split("\n");
+  const anchor = before[anchorRow]?.trim() ?? "";
+  if (anchor.length === 0) {
+    throw new Error(`measureMouseWheelScroll: anchor row ${anchorRow} is empty.`);
+  }
+
+  if (direction === "down") {
+    await session.scrollDown(1);
+  } else {
+    await session.scrollUp(1);
+  }
+
+  const after = (await session.text({ immediate: true })).split("\n");
+  const movedTo = after.findIndex((line) => line.trim() === anchor);
+  if (movedTo < 0) {
+    throw new Error(
+      `measureMouseWheelScroll: anchor ${JSON.stringify(anchor)} left the screen after scrolling ${direction}.`,
+    );
+  }
+
+  return anchorRow - movedTo;
+}
+
 /** Send an SGR mouse motion event at zero-based terminal coordinates. */
 export async function moveMouse(session: Session, x: number, y: number) {
   session.writeRaw(`\x1b[<35;${x + 1};${y + 1}M`);

--- a/test/pty/scroll.test.ts
+++ b/test/pty/scroll.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { createPtyHarness, dragMouse, measureKeyScroll } from "./harness";
+import { createPtyHarness, dragMouse, measureKeyScroll, measureMouseWheelScroll } from "./harness";
 
 const harness = createPtyHarness();
 
@@ -67,6 +67,26 @@ describe("PTY scrolling", () => {
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "k", 12)).toBe(-1);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("a fixed wheel-scroll setting moves exactly that many rows per event", async () => {
+    const fixture = harness.createPagerPatchFixture(60);
+    const session = await harness.launchHunkWithFileBackedStdin({
+      stdinFile: fixture.patchFile,
+      args: ["pager", "--cursor-line", "off", "--wheel-scroll-lines", "3"],
+      cols: 140,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/scroll\.ts/, { timeout: 15_000 });
+      await session.waitIdle({ timeout: 300 });
+
+      expect(await measureMouseWheelScroll(session, "down", 12)).toBe(3);
+      expect(await measureMouseWheelScroll(session, "up", 9)).toBe(-3);
     } finally {
       session.close();
     }

--- a/website/src/content/docs/docs/reference/cli.md
+++ b/website/src/content/docs/docs/reference/cli.md
@@ -16,32 +16,33 @@ This reference is generated from the command metadata used by Hunk itself. Run `
 
 ## Common review options
 
-| Option                      | Description                                                     |
-| --------------------------- | --------------------------------------------------------------- |
-| `--mode <mode>`             | layout mode: auto, split, unified                               |
-| `--cursor-line <style>`     | current-line marker: row, number, off                           |
-| `--theme <theme>`           | named theme override                                            |
-| `--agent-context <path>`    | JSON sidecar with agent rationale                               |
-| `--pager`                   | use pager-style chrome                                          |
-| `--experimental`            | enable experimental features (currently STML agent-note markup) |
-| `--fast`                    | experimentally offload eligible syntax highlighting             |
-| `--line-numbers`            | show line numbers                                               |
-| `--no-line-numbers`         | hide line numbers                                               |
-| `-x, --tab-width <columns>` | tab stop width: 1-16 Default: 4.                                |
-| `--file-gap <rows>`         | file separator rows, including the ─ rule: 0-8 Default: 1.      |
-| `--hunk-gap <rows>`         | blank rows before each later hunk: 0-8 Default: 0.              |
-| `--wrap`                    | wrap long diff lines                                            |
-| `--no-wrap`                 | truncate long diff lines to one row                             |
-| `--hunk-headers`            | show hunk metadata rows                                         |
-| `--no-hunk-headers`         | hide hunk metadata rows                                         |
-| `--sidebar`                 | show files pane                                                 |
-| `--no-sidebar`              | hide files pane                                                 |
-| `--agent-notes`             | show agent notes by default                                     |
-| `--no-agent-notes`          | hide agent notes by default                                     |
-| `--transparent-bg`          | let terminal background show through Hunk surfaces              |
-| `--no-transparent-bg`       | paint Hunk surfaces with the active theme                       |
-| `--extension <path>`        | load an extension entry file or directory (repeatable)          |
-| `--no-extensions`           | disable user extensions for this run                            |
+| Option                         | Description                                                     |
+| ------------------------------ | --------------------------------------------------------------- |
+| `--mode <mode>`                | layout mode: auto, split, unified                               |
+| `--cursor-line <style>`        | current-line marker: row, number, off                           |
+| `--theme <theme>`              | named theme override                                            |
+| `--agent-context <path>`       | JSON sidecar with agent rationale                               |
+| `--pager`                      | use pager-style chrome                                          |
+| `--experimental`               | enable experimental features (currently STML agent-note markup) |
+| `--fast`                       | experimentally offload eligible syntax highlighting             |
+| `--line-numbers`               | show line numbers                                               |
+| `--no-line-numbers`            | hide line numbers                                               |
+| `-x, --tab-width <columns>`    | tab stop width: 1-16 Default: 4.                                |
+| `--file-gap <rows>`            | file separator rows, including the ─ rule: 0-8 Default: 1.      |
+| `--hunk-gap <rows>`            | blank rows before each later hunk: 0-8 Default: 0.              |
+| `--wheel-scroll-lines <lines>` | rows per wheel event: auto or 1-10 Default: auto.               |
+| `--wrap`                       | wrap long diff lines                                            |
+| `--no-wrap`                    | truncate long diff lines to one row                             |
+| `--hunk-headers`               | show hunk metadata rows                                         |
+| `--no-hunk-headers`            | hide hunk metadata rows                                         |
+| `--sidebar`                    | show files pane                                                 |
+| `--no-sidebar`                 | hide files pane                                                 |
+| `--agent-notes`                | show agent notes by default                                     |
+| `--no-agent-notes`             | hide agent notes by default                                     |
+| `--transparent-bg`             | let terminal background show through Hunk surfaces              |
+| `--no-transparent-bg`          | paint Hunk surfaces with the active theme                       |
+| `--extension <path>`           | load an extension entry file or directory (repeatable)          |
+| `--no-extensions`              | disable user extensions for this run                            |
 
 `--experimental` may also be placed before the review command, as in `hunk --experimental diff`.
 

--- a/website/src/content/docs/docs/reference/config.md
+++ b/website/src/content/docs/docs/reference/config.md
@@ -120,6 +120,17 @@ Blank rows before each hunk after the first in a file.
 
 ---
 
+**`wheel_scroll_lines`**
+
+Set review rows per vertical wheel event. `auto` keeps cadence-based acceleration from one to three rows.
+
+- **Type:** string or integer
+- **Accepted:** `auto` or 1 through 10
+- **Built-in default:** `auto`
+- **Scope:** user config only
+
+---
+
 **`wrap_lines`**
 
 Wrap long diff lines instead of keeping one visual row.


### PR DESCRIPTION
## Summary

- add a user-only `wheel_scroll_lines` preference accepting `"auto"` or a fixed 1–10 rows per wheel event
- add `--wheel-scroll-lines` as a launch-scoped override for review commands
- preserve the existing cadence-based 1→3 row acceleration in `auto` mode while making numeric values exact and predictable
- document the option, add a patch changeset, and cover config, CLI, helper, bootstrap, and real PTY behavior

## Example

```toml
# ~/.config/hunk/config.toml
wheel_scroll_lines = 3
```

```bash
hunk diff --wheel-scroll-lines 3
```

Repository config intentionally cannot set this machine-local input preference.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:docs`
- `bun run deps:check`
- `bun run test`
- `bun run test:integration` — 133 passed, 1 platform skip
- `bun run test:tty-smoke` — 9 passed
- source invocation in a real PTY against a two-file diff with `--wheel-scroll-lines 3`

*This PR description was generated by Pi using OpenAI GPT-5.6 Sol*
