### PR TITLE
fix(jj): enable unchanged-context expansion

### DIFF
--- a/.changeset/calm-pandas-expand.md
+++ b/.changeset/calm-pandas-expand.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Enable unchanged-context expansion in Jujutsu-backed reviews.

--- a/src/extensions/default/vcs/git/source.test.ts
+++ b/src/extensions/default/vcs/git/source.test.ts
@@ -135,23 +135,31 @@ describe("Git source reading", () => {
     ).resolves.toEqual({ kind: "too-large", maxBytes: 5 });
   });
 
-  test("treats oversized git stderr as a generic source failure", async () => {
+  test("force-terminates Git after oversized stderr fails source collection", async () => {
     const originalSpawn = Bun.spawn;
     const mutableBun = Bun as unknown as { spawn: typeof Bun.spawn };
+    let spawnedProcess: Bun.ReadableSubprocess | undefined;
+    let childExited = false;
 
-    mutableBun.spawn = (() =>
-      originalSpawn(
+    mutableBun.spawn = (() => {
+      const proc = originalSpawn(
         [
           process.execPath,
           "--eval",
-          "process.stdout.write('small source\\n'); process.stderr.write('x'.repeat(70000));",
+          "process.on('SIGTERM', () => {}); process.stdout.write('small source\\n'); process.stderr.write('x'.repeat(70000)); setInterval(() => {}, 1000);",
         ],
         {
           stdin: "ignore",
           stdout: "pipe",
           stderr: "pipe",
         },
-      )) as typeof Bun.spawn;
+      );
+      spawnedProcess = proc;
+      void proc.exited.then(() => {
+        childExited = true;
+      });
+      return proc;
+    }) as typeof Bun.spawn;
 
     try {
       const loggedErrors = await captureConsoleErrors(async () => {
@@ -165,10 +173,16 @@ describe("Git source reading", () => {
         ).resolves.toBeNull();
       });
 
+      expect(spawnedProcess).toBeDefined();
+      expect(childExited).toBe(true);
       expect(String(loggedErrors[0]?.[0])).toContain("failed to collect Git source");
       expect(String(loggedErrors[0]?.[1])).toContain("diagnostics exceeded");
     } finally {
       mutableBun.spawn = originalSpawn;
+      if (spawnedProcess) {
+        spawnedProcess.kill("SIGKILL");
+        await Promise.race([spawnedProcess.exited.catch(() => undefined), Bun.sleep(2_000)]);
+      }
     }
   });
 

--- a/src/extensions/default/vcs/git/source.ts
+++ b/src/extensions/default/vcs/git/source.ts
@@ -8,6 +8,7 @@ import {
   logSourceDiagnostic,
   readFileTextWithLimit,
   readStreamTextWithLimit,
+  terminateSourceSubprocess,
 } from "../../../../lib/sourceText";
 import type { GitDiffEndpoint } from "./commands";
 
@@ -105,9 +106,8 @@ async function readGitObjectSpec(
       ),
     ]);
   } catch (error) {
+    await terminateSourceSubprocess(proc);
     if (error instanceof GitSourceTooLargeError) {
-      proc.kill();
-      await proc.exited.catch(() => undefined);
       return tooLarge(error.maxBytes);
     }
 

--- a/src/extensions/default/vcs/jujutsu/commands.test.ts
+++ b/src/extensions/default/vcs/jujutsu/commands.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildJjDiffArgs, runJjText } from "./commands";
+import { buildJjDiffArgs, buildJjShowArgs, resolveJjDiffEndpoints, runJjText } from "./commands";
 import type { ExtensionVcsDiffInput as VcsDiffCommandInput } from "hunkdiff/extension";
 
 const tempDirs: string[] = [];
@@ -92,6 +92,23 @@ afterEach(() => {
 const jjTest = Bun.which("jj") ? test : test.skip;
 
 describe("jj command helpers", () => {
+  test("uses an immutable revision override without changing fileset arguments", () => {
+    expect(buildJjDiffArgs(diffInput({ pathspecs: ["src/a b.ts"] }), "abc123")).toEqual([
+      "diff",
+      "--git",
+      "-r",
+      "abc123",
+      "--",
+      "src/a b.ts",
+    ]);
+    expect(
+      buildJjShowArgs(
+        { kind: "show", ref: "moving", pathspecs: ["-odd.ts"], options: {} },
+        "abc123",
+      ),
+    ).toEqual(["diff", "--git", "-r", "abc123", "--", "-odd.ts"]);
+  });
+
   test("reports a friendly error when jj is not installed or not on PATH", () => {
     expect(() =>
       runJjText({
@@ -127,6 +144,76 @@ describe("jj command helpers", () => {
         cwd: dir,
       }),
     ).toThrow("`hunk diff missing_revision` could not resolve Jujutsu revset `missing_revision`.");
+  });
+
+  jjTest("resolves a single revision to immutable commit and parent endpoints", () => {
+    const dir = createTempJjRepo("hunk-jj-endpoints-");
+    writeFileSync(join(dir, "file.txt"), "one\n");
+    jj(dir, "commit", "-m", "first");
+    const firstCommitId = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+    writeFileSync(join(dir, "file.txt"), "two\n");
+    const secondCommitId = jj(dir, "log", "--no-graph", "-r", "@", "-T", "commit_id");
+
+    expect(resolveJjDiffEndpoints(diffInput(), "@", { cwd: dir })).toEqual({
+      newCommitId: secondCommitId,
+      parentCommitIds: [firstCommitId],
+    });
+  });
+
+  jjTest("ignores template aliases when resolving immutable endpoints", () => {
+    const dir = createTempJjRepo("hunk-jj-endpoints-template-alias-");
+    writeFileSync(join(dir, "file.txt"), "one\n");
+    jj(dir, "commit", "-m", "first");
+    const firstCommitId = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "self.commit_id()");
+
+    writeFileSync(join(dir, "file.txt"), "two\n");
+    jj(dir, "commit", "-m", "second");
+    const secondCommitId = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "self.commit_id()");
+
+    writeFileSync(join(dir, "file.txt"), "three\n");
+    const thirdCommitId = jj(dir, "log", "--no-graph", "-r", "@", "-T", "self.commit_id()");
+    jj(dir, "config", "set", "--repo", "template-aliases.commit_id", `'"${firstCommitId}"'`);
+
+    expect(resolveJjDiffEndpoints(diffInput(), "@", { cwd: dir })).toEqual({
+      newCommitId: thirdCommitId,
+      parentCommitIds: [secondCommitId],
+    });
+  });
+
+  jjTest("omits endpoints when a revset resolves to multiple revisions", () => {
+    const dir = createTempJjRepo("hunk-jj-endpoints-multi-");
+    writeFileSync(join(dir, "file.txt"), "one\n");
+    jj(dir, "commit", "-m", "first");
+    writeFileSync(join(dir, "file.txt"), "two\n");
+    jj(dir, "commit", "-m", "second");
+
+    expect(resolveJjDiffEndpoints(diffInput(), "@- | @--", { cwd: dir })).toBeUndefined();
+  });
+
+  jjTest("marks a merge base as synthesized instead of choosing one parent", () => {
+    const dir = createTempJjRepo("hunk-jj-endpoints-merge-");
+    writeFileSync(join(dir, "base.txt"), "base\n");
+    jj(dir, "commit", "-m", "base");
+    const baseCommitId = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    writeFileSync(join(dir, "left.txt"), "left\n");
+    jj(dir, "commit", "-m", "left");
+    const leftCommitId = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    jj(dir, "new", baseCommitId);
+    writeFileSync(join(dir, "right.txt"), "right\n");
+    jj(dir, "commit", "-m", "right");
+    const rightCommitId = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    jj(dir, "new", leftCommitId, rightCommitId);
+    writeFileSync(join(dir, "merge.txt"), "merge\n");
+    const mergeCommitId = jj(dir, "log", "--no-graph", "-r", "@", "-T", "commit_id");
+    const endpoints = resolveJjDiffEndpoints(diffInput(), "@", { cwd: dir });
+
+    expect(endpoints).toEqual({
+      newCommitId: mergeCommitId,
+      parentCommitIds: [leftCommitId, rightCommitId].sort(),
+    });
   });
 
   jjTest(

--- a/src/extensions/default/vcs/jujutsu/commands.ts
+++ b/src/extensions/default/vcs/jujutsu/commands.ts
@@ -14,6 +14,23 @@ export interface RunJjTextOptions {
   jjExecutable?: string;
 }
 
+/** Identifies the reviewed commit and every parent JJ used to build the old side. */
+export interface JjDiffEndpoints {
+  newCommitId: string;
+  parentCommitIds: string[];
+}
+
+/** Bypass user template aliases while rendering full commit IDs. */
+const JjCommitIdTemplate = 'self.commit_id() ++ "\\n"';
+
+/** Parse newline-delimited full commit IDs emitted by a Jujutsu template. */
+function parseJjCommitIds(output: string) {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^[0-9a-f]+$/i.test(line));
+}
+
 /** Append Jujutsu filesets only when the caller requested path filtering. */
 function appendJjFilesets(args: string[], pathspecs?: string[]) {
   if (!pathspecs || pathspecs.length === 0) {
@@ -24,11 +41,11 @@ function appendJjFilesets(args: string[], pathspecs?: string[]) {
 }
 
 /** Build the `jj diff --git` arguments for working-copy and revset reviews. */
-export function buildJjDiffArgs(input: ExtensionVcsDiffInput) {
+export function buildJjDiffArgs(input: ExtensionVcsDiffInput, pinnedRevision?: string) {
   const args = ["diff", "--git"];
 
-  if (input.range) {
-    args.push("-r", input.range);
+  if (pinnedRevision || input.range) {
+    args.push("-r", pinnedRevision ?? input.range!);
   }
 
   appendJjFilesets(args, input.pathspecs);
@@ -36,8 +53,8 @@ export function buildJjDiffArgs(input: ExtensionVcsDiffInput) {
 }
 
 /** Build the `jj diff --git -r` arguments used for `hunk show` in Jujutsu mode. */
-export function buildJjShowArgs(input: ExtensionVcsShowInput) {
-  const args = ["diff", "--git", "-r", input.ref ?? "@"];
+export function buildJjShowArgs(input: ExtensionVcsShowInput, pinnedRevision?: string) {
+  const args = ["diff", "--git", "-r", pinnedRevision ?? input.ref ?? "@"];
 
   appendJjFilesets(args, input.pathspecs);
   return args;
@@ -184,6 +201,63 @@ function runJjCommand({ input, args, cwd = process.cwd(), jjExecutable = "jj" }:
 /** Run a Jujutsu command and translate common failures into user-facing Hunk errors. */
 export function runJjText(options: RunJjTextOptions) {
   return runJjCommand(options).stdout;
+}
+
+/**
+ * Resolve a JJ revset once so the patch and later source reads use the same commit.
+ *
+ * A patch contains only changed lines and a small amount of surrounding context. Hunk
+ * therefore waits until a user expands a gap before loading the complete file. Names
+ * such as `@` and bookmarks can move between those two moments, so this lookup returns
+ * full commit IDs that callers reuse for both patch generation and `jj file show`.
+ * The first lookup intentionally allows JJ to snapshot the working copy so `@` includes
+ * current filesystem changes; commands that use the returned IDs can then pass
+ * `--ignore-working-copy` because the commit has already been fixed.
+ *
+ * A revset that selects several commits produces a valid aggregate patch, but it does
+ * not identify one old/new pair from which to load complete files. In that case this
+ * function returns `undefined`, and Hunk shows the patch without expandable gaps. For
+ * a merge commit, JJ builds the old side by merging all parent trees. We retain every
+ * parent ID to identify that virtual old side, but callers must not substitute one
+ * parent and present its contents as the merge baseline.
+ */
+export function resolveJjDiffEndpoints(
+  input: JjBackedInput,
+  revset: string,
+  options: Omit<RunJjTextOptions, "input" | "args"> = {},
+): JjDiffEndpoints | undefined {
+  const commitIds = parseJjCommitIds(
+    runJjText({
+      input,
+      args: ["log", "--no-graph", "-r", revset, "-T", JjCommitIdTemplate],
+      ...options,
+    }),
+  );
+  if (commitIds.length !== 1) {
+    return undefined;
+  }
+
+  const commitId = commitIds[0]!;
+  const parentCommitIds = parseJjCommitIds(
+    runJjText({
+      input,
+      args: [
+        "log",
+        "--no-graph",
+        "--ignore-working-copy",
+        "-r",
+        `${commitId}-`,
+        "-T",
+        JjCommitIdTemplate,
+      ],
+      ...options,
+    }),
+  );
+
+  return {
+    newCommitId: commitId,
+    parentCommitIds: parentCommitIds.sort(),
+  };
 }
 
 export function resolveJjRepoRoot(

--- a/src/extensions/default/vcs/jujutsu/index.test.ts
+++ b/src/extensions/default/vcs/jujutsu/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { JjVcsAdapter } from ".";
@@ -108,6 +108,19 @@ describe("JjVcsAdapter", () => {
       expect(diffResult.title).toContain("working copy");
       expect(diffResult.patchText).toContain("diff --git a/file.txt b/file.txt");
       expect(diffResult.patchText).toContain("+two");
+      expect(diffResult.sourceCacheKey).toContain("jj-source-v1");
+      const reviewedFile = {
+        path: "file.txt",
+        changeType: "change",
+        isUntracked: false,
+      } as const;
+      expect(await diffResult.readFileSource?.({ ...reviewedFile, side: "old" })).toBe("one\n");
+      expect(await diffResult.readFileSource?.({ ...reviewedFile, side: "new" })).toBe("two\n");
+      const equivalentDiffResult = await JjVcsAdapter.operations["working-tree-diff"]!.load(
+        diffInput,
+        { cwd: repo },
+      );
+      expect(equivalentDiffResult.sourceCacheKey).toBe(diffResult.sourceCacheKey);
 
       const showInput = {
         kind: "show",
@@ -120,12 +133,256 @@ describe("JjVcsAdapter", () => {
 
       expect(showResult.title).toContain("show @");
       expect(showResult.patchText).toContain("diff --git a/file.txt b/file.txt");
+      expect(showResult.sourceCacheKey).toContain("jj-source-v1");
+      expect(await showResult.readFileSource?.({ ...reviewedFile, side: "old" })).toBe("one\n");
+      expect(await showResult.readFileSource?.({ ...reviewedFile, side: "new" })).toBe("two\n");
+
+      // Lazy source reads stay attached to the revision that produced the patch,
+      // even after `@` is resnapshotted with different working-copy contents.
+      writeFileSync(join(repo, "file.txt"), "three\n");
+      jj(repo, "status");
+      expect(await showResult.readFileSource?.({ ...reviewedFile, side: "new" })).toBe("two\n");
+      const changedDiffResult = await JjVcsAdapter.operations["working-tree-diff"]!.load(
+        diffInput,
+        {
+          cwd: repo,
+        },
+      );
+      expect(changedDiffResult.sourceCacheKey).not.toBe(diffResult.sourceCacheKey);
+
       expect(
         JjVcsAdapter.operations["working-tree-diff"]!.watchSignature!(diffInput, { cwd: repo }),
-      ).toContain("+two");
+      ).toContain("+three");
       expect(
         JjVcsAdapter.operations["revision-show"]!.watchSignature!(showInput, { cwd: repo }),
       ).toContain("diff --git");
+    },
+    JjAdapterIntegrationTestTimeoutMs,
+  );
+
+  jjTest(
+    "preserves nested cwd filesets across loaded patches and watch signatures",
+    async () => {
+      const repo = createTempJjRepo("hunk-jj-adapter-nested-cwd-");
+      const nested = join(repo, "sub");
+      mkdirSync(nested);
+      writeFileSync(join(repo, "file.txt"), "root old\n");
+      writeFileSync(join(nested, "file.txt"), "nested old\n");
+      jj(repo, "commit", "-m", "initial");
+      writeFileSync(join(repo, "file.txt"), "root new\n");
+      writeFileSync(join(nested, "file.txt"), "nested new\n");
+
+      const diffInput = {
+        kind: "vcs",
+        staged: false,
+        pathspecs: ["file.txt"],
+        options: {},
+      } satisfies ExtensionVcsDiffInput;
+      const showInput = {
+        kind: "show",
+        ref: "@",
+        pathspecs: ["file.txt"],
+        options: {},
+      } satisfies ExtensionVcsShowInput;
+      const diffResult = await JjVcsAdapter.operations["working-tree-diff"]!.load(diffInput, {
+        cwd: nested,
+      });
+      const showResult = await JjVcsAdapter.operations["revision-show"]!.load(showInput, {
+        cwd: nested,
+      });
+      const patchTexts = [
+        diffResult.patchText,
+        JjVcsAdapter.operations["working-tree-diff"]!.watchSignature!(diffInput, { cwd: nested }),
+        showResult.patchText,
+        JjVcsAdapter.operations["revision-show"]!.watchSignature!(showInput, { cwd: nested }),
+      ];
+
+      for (const patchText of patchTexts) {
+        expect(patchText).toContain("sub/file.txt");
+        expect(patchText).toContain("+nested new");
+        expect(patchText).not.toContain("+root new");
+      }
+
+      const reviewedFile = {
+        path: "sub/file.txt",
+        changeType: "change",
+        isUntracked: false,
+      } as const;
+      expect(await showResult.readFileSource?.({ ...reviewedFile, side: "old" })).toBe(
+        "nested old\n",
+      );
+      expect(await showResult.readFileSource?.({ ...reviewedFile, side: "new" })).toBe(
+        "nested new\n",
+      );
+    },
+    JjAdapterIntegrationTestTimeoutMs,
+  );
+
+  jjTest(
+    "ignores a shadowing parents alias when loading the old source",
+    async () => {
+      const repo = createTempJjRepo("hunk-jj-adapter-parent-alias-");
+      writeFileSync(join(repo, "file.txt"), "grandparent version\ncontext\n");
+      jj(repo, "commit", "-m", "grandparent");
+      writeFileSync(join(repo, "file.txt"), "parent version\ncontext\n");
+      jj(repo, "commit", "-m", "parent");
+      writeFileSync(join(repo, "file.txt"), "child version\ncontext\n");
+      jj(repo, "config", "set", "--repo", 'revset-aliases."parents(x)"', "x--");
+
+      const result = await JjVcsAdapter.operations["revision-show"]!.load(
+        { kind: "show", ref: "@", options: {} },
+        { cwd: repo },
+      );
+      const reviewedFile = {
+        path: "file.txt",
+        changeType: "change",
+        isUntracked: false,
+      } as const;
+
+      expect(result.patchText).toContain("-parent version");
+      expect(result.patchText).not.toContain("-grandparent version");
+      expect(await result.readFileSource?.({ ...reviewedFile, side: "old" })).toBe(
+        "parent version\ncontext\n",
+      );
+      expect(await result.readFileSource?.({ ...reviewedFile, side: "new" })).toBe(
+        "child version\ncontext\n",
+      );
+    },
+    JjAdapterIntegrationTestTimeoutMs,
+  );
+
+  jjTest(
+    "reads rename, addition, and deletion sides from their exact paths",
+    async () => {
+      const repo = createTempJjRepo("hunk-jj-adapter-source-kinds-");
+      writeFileSync(join(repo, "old-name.txt"), "old name\n");
+      writeFileSync(join(repo, "deleted.txt"), "deleted source\n");
+      jj(repo, "commit", "-m", "initial");
+
+      renameSync(join(repo, "old-name.txt"), join(repo, "new-name.txt"));
+      writeFileSync(join(repo, "new-name.txt"), "renamed source\n");
+      writeFileSync(join(repo, "added.txt"), "added source\n");
+      rmSync(join(repo, "deleted.txt"));
+
+      const result = await JjVcsAdapter.operations["revision-show"]!.load(
+        { kind: "show", ref: "@", options: {} },
+        { cwd: repo },
+      );
+      const readSource = result.readFileSource!;
+
+      expect(
+        await readSource({
+          path: "new-name.txt",
+          previousPath: "old-name.txt",
+          changeType: "rename-changed",
+          isUntracked: false,
+          side: "old",
+        }),
+      ).toBe("old name\n");
+      expect(
+        await readSource({
+          path: "new-name.txt",
+          previousPath: "old-name.txt",
+          changeType: "rename-changed",
+          isUntracked: false,
+          side: "new",
+        }),
+      ).toBe("renamed source\n");
+      expect(
+        await readSource({
+          path: "added.txt",
+          changeType: "new",
+          isUntracked: false,
+          side: "old",
+        }),
+      ).toBeNull();
+      expect(
+        await readSource({
+          path: "added.txt",
+          changeType: "new",
+          isUntracked: false,
+          side: "new",
+        }),
+      ).toBe("added source\n");
+      expect(
+        await readSource({
+          path: "deleted.txt",
+          changeType: "deleted",
+          isUntracked: false,
+          side: "old",
+        }),
+      ).toBe("deleted source\n");
+      expect(
+        await readSource({
+          path: "deleted.txt",
+          changeType: "deleted",
+          isUntracked: false,
+          side: "new",
+        }),
+      ).toBeNull();
+    },
+    JjAdapterIntegrationTestTimeoutMs,
+  );
+
+  jjTest(
+    "preserves multi-revision patches without attaching guessed sources",
+    async () => {
+      const repo = createTempJjRepo("hunk-jj-adapter-multi-");
+      writeFileSync(join(repo, "file.txt"), "one\n");
+      jj(repo, "commit", "-m", "first");
+      writeFileSync(join(repo, "file.txt"), "two\n");
+      jj(repo, "commit", "-m", "second");
+      const revset = "@- | @--";
+
+      const diffResult = await JjVcsAdapter.operations["working-tree-diff"]!.load(
+        { kind: "vcs", staged: false, range: revset, options: {} },
+        { cwd: repo },
+      );
+      const showResult = await JjVcsAdapter.operations["revision-show"]!.load(
+        { kind: "show", ref: revset, options: {} },
+        { cwd: repo },
+      );
+
+      expect(diffResult.patchText).toContain("diff --git");
+      expect(showResult.patchText).toBe(diffResult.patchText);
+      expect(diffResult.readFileSource).toBeUndefined();
+      expect(diffResult.sourceCacheKey).toBeUndefined();
+      expect(showResult.readFileSource).toBeUndefined();
+      expect(showResult.sourceCacheKey).toBeUndefined();
+    },
+    JjAdapterIntegrationTestTimeoutMs,
+  );
+
+  jjTest(
+    "expands a merge from its exact new side without guessing the merged-parent source",
+    async () => {
+      const repo = createTempJjRepo("hunk-jj-adapter-merge-");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      jj(repo, "commit", "-m", "base");
+      const baseCommitId = jj(repo, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+      writeFileSync(join(repo, "left.txt"), "left\n");
+      jj(repo, "commit", "-m", "left");
+      const leftCommitId = jj(repo, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+      jj(repo, "new", baseCommitId);
+      writeFileSync(join(repo, "right.txt"), "right\n");
+      jj(repo, "commit", "-m", "right");
+      const rightCommitId = jj(repo, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+      jj(repo, "new", leftCommitId, rightCommitId);
+      writeFileSync(join(repo, "file.txt"), "merge result\n");
+      const result = await JjVcsAdapter.operations["revision-show"]!.load(
+        { kind: "show", ref: "@", options: {} },
+        { cwd: repo },
+      );
+      const file = { path: "file.txt", changeType: "change", isUntracked: false } as const;
+
+      expect(result.sourceCacheKey).toContain(
+        `merged-parents:${[leftCommitId, rightCommitId].sort().join(",")}`,
+      );
+      expect(await result.readFileSource?.({ ...file, side: "old" })).toBeNull();
+      expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("merge result\n");
     },
     JjAdapterIntegrationTestTimeoutMs,
   );

--- a/src/extensions/default/vcs/jujutsu/index.ts
+++ b/src/extensions/default/vcs/jujutsu/index.ts
@@ -4,12 +4,16 @@ import {
   buildJjDiffArgs,
   buildJjShowArgs,
   createJjStagedError,
+  resolveJjDiffEndpoints,
   resolveJjRepoRoot,
   runJjText,
+  type JjDiffEndpoints,
 } from "./commands";
+import { readJjFileSource } from "./source";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
+  type ExtensionVcsFileSourceReader,
   type HunkExtensionAPI,
 } from "hunkdiff/extension";
 
@@ -42,51 +46,156 @@ function detectJjRepo(cwd: string) {
   }
 }
 
-/** VCS adapter translating neutral review operations to Jujutsu commands. */
-export const JjVcsAdapter = {
-  id: "jj",
-  name: "Jujutsu",
-  detect: detectJjRepo,
-  // Above Git: a colocated jj repository carries a `.git` directory too, and
-  // reviewing it as plain Git would show the wrong working copy.
-  detectionPriority: HUNK_VCS_DETECTION_BASELINE_PRIORITY + 200,
-  operations: {
-    "working-tree-diff": {
-      async load(input, { cwd }) {
-        if (input.staged) {
-          throw createJjStagedError(input);
+/* -------------------------------------------------------------------------- */
+/* Exact file sources                                                          */
+/* -------------------------------------------------------------------------- */
+
+/** Lets Hunk load complete files later and recognize when cached source is still current. */
+interface JjSourceCapability {
+  readFileSource: ExtensionVcsFileSourceReader;
+  sourceCacheKey: string;
+}
+
+/** Include every resolved parent in the identity Hunk uses to retain cached source text. */
+function jjParentCacheKey(parentCommitIds: string[]) {
+  return parentCommitIds.length === 1
+    ? `commit:${parentCommitIds[0]}`
+    : `merged-parents:${parentCommitIds.join(",")}`;
+}
+
+/**
+ * Let Hunk load complete file text when a user expands context omitted from the patch.
+ *
+ * `jj diff` includes changed lines and only a few unchanged lines around them. When the
+ * user expands a collapsed gap, Hunk calls `readFileSource` for the rest of the file.
+ * This reader uses commit IDs resolved before the patch was generated, so the returned
+ * text still matches the review even if `@` or a bookmark has moved. The cache key names
+ * both sides of that resolved diff so Hunk never carries source text across a change to
+ * either side.
+ *
+ * With exactly one parent, the old text comes from that commit and the new text comes
+ * from the reviewed commit. The old side of a rename uses `previousPath`; added files
+ * and root commits have no old text, while deleted files have no new text. A merge is
+ * different: JJ compares it with a virtual tree made by merging all parents, but
+ * `jj file show` cannot read that virtual tree. The new side is still exact and can
+ * expand gaps, while old-side reads return `null` rather than showing content from an
+ * arbitrary parent.
+ */
+function createJjSourceCapability(
+  repoRoot: string,
+  endpoints: JjDiffEndpoints,
+  jjExecutable: string,
+): JjSourceCapability {
+  const oldCommitId =
+    endpoints.parentCommitIds.length === 1 ? endpoints.parentCommitIds[0] : undefined;
+
+  return {
+    sourceCacheKey: [
+      "jj-source-v1",
+      jjParentCacheKey(endpoints.parentCommitIds),
+      `commit:${endpoints.newCommitId}`,
+    ].join(":"),
+    readFileSource: ({ path, previousPath, changeType, side }) => {
+      if (side === "old") {
+        if (changeType === "new" || oldCommitId === undefined) {
+          return Promise.resolve(null);
         }
-        const repoRoot = resolveJjRepoRoot(input, { cwd });
-        const repoName = basename(repoRoot);
-        return {
-          repoRoot,
-          sourceLabel: repoRoot,
-          title: input.range ? `${repoName} ${input.range}` : `${repoName} working copy`,
-          patchText: runJjText({ input, args: buildJjDiffArgs(input), cwd }),
-        };
+        return readJjFileSource(
+          { repoRoot, commitId: oldCommitId, path: previousPath ?? path },
+          { jjExecutable },
+        );
+      }
+
+      return changeType === "deleted"
+        ? Promise.resolve(null)
+        : readJjFileSource({ repoRoot, commitId: endpoints.newCommitId, path }, { jjExecutable });
+    },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* The adapter                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export interface JjVcsAdapterOptions {
+  jjExecutable?: string;
+}
+
+/** Create a Jujutsu adapter, optionally using a caller-supplied `jj` executable. */
+export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapterOptions> = {}) {
+  return {
+    id: "jj",
+    name: "Jujutsu",
+    detect: detectJjRepo,
+    // Above Git: a colocated jj repository carries a `.git` directory too, and
+    // reviewing it as plain Git would show the wrong working copy.
+    detectionPriority: HUNK_VCS_DETECTION_BASELINE_PRIORITY + 200,
+    operations: {
+      "working-tree-diff": {
+        async load(input, { cwd }) {
+          if (input.staged) {
+            throw createJjStagedError(input);
+          }
+          const repoRoot = resolveJjRepoRoot(input, { cwd, jjExecutable });
+          const repoName = basename(repoRoot);
+          const sourceEndpoints = resolveJjDiffEndpoints(input, input.range ?? "@", {
+            cwd,
+            jjExecutable,
+          });
+          const sourceCapability = sourceEndpoints
+            ? createJjSourceCapability(repoRoot, sourceEndpoints, jjExecutable)
+            : undefined;
+          return {
+            repoRoot,
+            sourceLabel: repoRoot,
+            title: input.range ? `${repoName} ${input.range}` : `${repoName} working copy`,
+            patchText: runJjText({
+              input,
+              args: buildJjDiffArgs(input, sourceEndpoints?.newCommitId),
+              cwd,
+              jjExecutable,
+            }),
+            ...sourceCapability,
+          };
+        },
+        watchSignature(input, { cwd }) {
+          return runJjText({ input, args: buildJjDiffArgs(input), cwd, jjExecutable });
+        },
       },
-      watchSignature(input, { cwd }) {
-        return runJjText({ input, args: buildJjDiffArgs(input), cwd });
+      "revision-show": {
+        async load(input, { cwd }) {
+          const repoRoot = resolveJjRepoRoot(input, { cwd, jjExecutable });
+          const repoName = basename(repoRoot);
+          const revset = input.ref ?? "@";
+          const sourceEndpoints = resolveJjDiffEndpoints(input, revset, {
+            cwd,
+            jjExecutable,
+          });
+          const sourceCapability = sourceEndpoints
+            ? createJjSourceCapability(repoRoot, sourceEndpoints, jjExecutable)
+            : undefined;
+          return {
+            repoRoot,
+            sourceLabel: repoRoot,
+            title: `${repoName} show ${revset}`,
+            patchText: runJjText({
+              input,
+              args: buildJjShowArgs(input, sourceEndpoints?.newCommitId),
+              cwd,
+              jjExecutable,
+            }),
+            ...sourceCapability,
+          };
+        },
+        watchSignature(input, { cwd }) {
+          return runJjText({ input, args: buildJjShowArgs(input), cwd, jjExecutable });
+        },
       },
     },
-    "revision-show": {
-      async load(input, { cwd }) {
-        const repoRoot = resolveJjRepoRoot(input, { cwd });
-        const repoName = basename(repoRoot);
-        const revset = input.ref ?? "@";
-        return {
-          repoRoot,
-          sourceLabel: repoRoot,
-          title: `${repoName} show ${revset}`,
-          patchText: runJjText({ input, args: buildJjShowArgs(input), cwd }),
-        };
-      },
-      watchSignature(input, { cwd }) {
-        return runJjText({ input, args: buildJjShowArgs(input), cwd });
-      },
-    },
-  },
-} satisfies ExtensionVcsAdapter;
+  } satisfies ExtensionVcsAdapter;
+}
+
+export const JjVcsAdapter = createJjVcsAdapter();
 
 export default function (hunk: HunkExtensionAPI) {
   hunk.registerVcsAdapter(JjVcsAdapter);

--- a/src/extensions/default/vcs/jujutsu/source.test.ts
+++ b/src/extensions/default/vcs/jujutsu/source.test.ts
@@ -59,12 +59,14 @@ afterEach(() => {
 });
 
 const jjTest = Bun.which("jj") ? test : test.skip;
+const unixJjTest = Bun.which("jj") && process.platform !== "win32" ? test : test.skip;
 
 describe("Jujutsu source reading", () => {
   jjTest("reads exact commit contents through `jj file show`", async () => {
     const repoRoot = createTempJjRepo("hunk-source-jj-");
     const filePath = "-note [exact] file.txt";
     writeFileSync(join(repoRoot, filePath), "first revision\n");
+    writeFileSync(join(repoRoot, "-note e file.txt"), "glob decoy\n");
     jj(repoRoot, "commit", "-m", "first");
     const firstCommitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
 
@@ -78,6 +80,18 @@ describe("Jujutsu source reading", () => {
     await expect(
       readJjFileSource({ repoRoot, commitId: secondCommitId, path: filePath }),
     ).resolves.toBe("second revision\n");
+  });
+
+  unixJjTest("reads Unix filenames containing backslashes", async () => {
+    const repoRoot = createTempJjRepo("hunk-source-jj-backslash-");
+    const filePath = "a\\b.txt";
+    writeFileSync(join(repoRoot, filePath), "backslash source\n");
+    jj(repoRoot, "commit", "-m", "backslash");
+    const commitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "self.commit_id()");
+
+    await expect(readJjFileSource({ repoRoot, commitId, path: filePath })).resolves.toBe(
+      "backslash source\n",
+    );
   });
 
   jjTest("ignores fileset aliases and file-show templates", async () => {
@@ -184,7 +198,7 @@ describe("Jujutsu source reading", () => {
           {
             repoRoot: process.cwd(),
             commitId: "0123456789abcdef",
-            path: '-leading [fileset] "path".txt',
+            path: '-leading *?[fileset]{path} "file".txt',
           },
           { jjExecutable: "custom-jj" },
         ),
@@ -207,7 +221,7 @@ describe("Jujutsu source reading", () => {
         "-T",
         '""',
         "--",
-        '"-leading \\\\[fileset\\\\] \\"path\\".txt"',
+        '"-leading [*][?][[]fileset[]][{]path[}] \\"file\\".txt"',
       ],
     ]);
   });

--- a/src/extensions/default/vcs/jujutsu/source.test.ts
+++ b/src/extensions/default/vcs/jujutsu/source.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readJjFileSource } from "./source";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string) {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function jj(cwd: string, ...cmd: string[]) {
+  const proc = Bun.spawnSync(
+    [
+      "jj",
+      "--config",
+      "signing.behavior=drop",
+      "--config",
+      'user.name="Test User"',
+      "--config",
+      "user.email=test@example.com",
+      ...cmd,
+    ],
+    { cwd, stdout: "pipe", stderr: "pipe", stdin: "ignore" },
+  );
+  if (proc.exitCode !== 0) {
+    const stderr = Buffer.from(proc.stderr).toString("utf8");
+    throw new Error(stderr.trim() || `jj ${cmd.join(" ")} failed`);
+  }
+  return Buffer.from(proc.stdout).toString("utf8");
+}
+
+function createTempJjRepo(prefix: string) {
+  const dir = createTempDir(prefix);
+  jj(tmpdir(), "git", "init", "--colocate", dir);
+  return dir;
+}
+
+/** Capture console.error calls while exercising diagnostic paths. */
+async function captureConsoleErrors(fn: () => Promise<void>) {
+  const originalConsoleError = console.error;
+  const loggedErrors: unknown[][] = [];
+  console.error = (...args: unknown[]) => loggedErrors.push(args);
+  try {
+    await fn();
+  } finally {
+    console.error = originalConsoleError;
+  }
+  return loggedErrors;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const jjTest = Bun.which("jj") ? test : test.skip;
+
+describe("Jujutsu source reading", () => {
+  jjTest("reads exact commit contents through `jj file show`", async () => {
+    const repoRoot = createTempJjRepo("hunk-source-jj-");
+    const filePath = "-note [exact] file.txt";
+    writeFileSync(join(repoRoot, filePath), "first revision\n");
+    jj(repoRoot, "commit", "-m", "first");
+    const firstCommitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    writeFileSync(join(repoRoot, filePath), "second revision\n");
+    jj(repoRoot, "commit", "-m", "second");
+    const secondCommitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    await expect(
+      readJjFileSource({ repoRoot, commitId: firstCommitId, path: filePath }),
+    ).resolves.toBe("first revision\n");
+    await expect(
+      readJjFileSource({ repoRoot, commitId: secondCommitId, path: filePath }),
+    ).resolves.toBe("second revision\n");
+  });
+
+  jjTest("ignores fileset aliases and file-show templates", async () => {
+    const repoRoot = createTempJjRepo("hunk-source-jj-user-config-");
+    writeFileSync(join(repoRoot, "a.txt"), "one\n");
+    writeFileSync(join(repoRoot, "b.txt"), "bee\n");
+    jj(repoRoot, "commit", "-m", "first");
+    const commitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "self.commit_id()");
+
+    jj(repoRoot, "config", "set", "--repo", 'fileset-aliases."root-file:x"', "'all()'");
+    jj(repoRoot, "config", "set", "--repo", "templates.file_show", `'"PREFIX:" ++ path ++ "\\n"'`);
+
+    await expect(readJjFileSource({ repoRoot, commitId, path: "a.txt" })).resolves.toBe("one\n");
+  });
+
+  jjTest("reports source reads that exceed the configured byte cap", async () => {
+    const repoRoot = createTempJjRepo("hunk-source-jj-large-");
+    writeFileSync(join(repoRoot, "note.txt"), "committed source\n");
+    jj(repoRoot, "commit", "-m", "first");
+    const commitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    await expect(
+      readJjFileSource({ repoRoot, commitId, path: "note.txt" }, { maxSourceBytes: 5 }),
+    ).resolves.toEqual({ kind: "too-large", maxBytes: 5 });
+  });
+
+  jjTest("returns null without diagnostics when a path is absent", async () => {
+    const repoRoot = createTempJjRepo("hunk-source-jj-missing-");
+    writeFileSync(join(repoRoot, "tracked.txt"), "x\n");
+    jj(repoRoot, "commit", "-m", "first");
+    const commitId = jj(repoRoot, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+
+    const loggedErrors = await captureConsoleErrors(async () => {
+      await expect(
+        readJjFileSource({ repoRoot, commitId, path: "missing-from-history.txt" }),
+      ).resolves.toBeNull();
+    });
+    expect(loggedErrors).toHaveLength(0);
+  });
+
+  test("force-terminates Jujutsu after oversized stderr fails source collection", async () => {
+    const originalSpawn = Bun.spawn;
+    const mutableBun = Bun as unknown as { spawn: typeof Bun.spawn };
+    let spawnedProcess: Bun.ReadableSubprocess | undefined;
+    let childExited = false;
+
+    mutableBun.spawn = (() => {
+      const proc = originalSpawn(
+        [
+          process.execPath,
+          "--eval",
+          "process.on('SIGTERM', () => {}); process.stdout.write('small source\\n'); process.stderr.write('x'.repeat(70000)); setInterval(() => {}, 1000);",
+        ],
+        { stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+      );
+      spawnedProcess = proc;
+      void proc.exited.then(() => {
+        childExited = true;
+      });
+      return proc;
+    }) as typeof Bun.spawn;
+
+    try {
+      const loggedErrors = await captureConsoleErrors(async () => {
+        await expect(
+          readJjFileSource({
+            repoRoot: process.cwd(),
+            commitId: "0123456789abcdef",
+            path: "note.txt",
+          }),
+        ).resolves.toBeNull();
+      });
+
+      expect(spawnedProcess).toBeDefined();
+      expect(childExited).toBe(true);
+      expect(String(loggedErrors[0]?.[0])).toContain("failed to collect Jujutsu source");
+      expect(String(loggedErrors[0]?.[1])).toContain("diagnostics exceeded");
+    } finally {
+      mutableBun.spawn = originalSpawn;
+      if (spawnedProcess) {
+        spawnedProcess.kill("SIGKILL");
+        await Promise.race([spawnedProcess.exited.catch(() => undefined), Bun.sleep(2_000)]);
+      }
+    }
+  });
+
+  test("passes revisions and files as separate argv entries to a custom executable", async () => {
+    const originalSpawn = Bun.spawn;
+    const mutableBun = Bun as unknown as { spawn: typeof Bun.spawn };
+    const spawnCalls: string[][] = [];
+
+    mutableBun.spawn = ((command: string[]) => {
+      spawnCalls.push(command);
+      return originalSpawn([process.execPath, "--eval", "process.stdout.write('safe source\\n')"], {
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    }) as typeof Bun.spawn;
+
+    try {
+      await expect(
+        readJjFileSource(
+          {
+            repoRoot: process.cwd(),
+            commitId: "0123456789abcdef",
+            path: '-leading [fileset] "path".txt',
+          },
+          { jjExecutable: "custom-jj" },
+        ),
+      ).resolves.toBe("safe source\n");
+    } finally {
+      mutableBun.spawn = originalSpawn;
+    }
+
+    expect(spawnCalls).toEqual([
+      [
+        "custom-jj",
+        "--no-pager",
+        "--color",
+        "never",
+        "file",
+        "show",
+        "--ignore-working-copy",
+        "-r",
+        "0123456789abcdef",
+        "-T",
+        '""',
+        "--",
+        '"-leading \\\\[fileset\\\\] \\"path\\".txt"',
+      ],
+    ]);
+  });
+
+  test("logs unexpected source failures with revision and path context", async () => {
+    const repoRoot = createTempDir("hunk-source-jj-not-repo-");
+    const loggedErrors = await captureConsoleErrors(async () => {
+      await expect(
+        readJjFileSource({ repoRoot, commitId: "0123456789abcdef", path: "note.txt" }),
+      ).resolves.toBeNull();
+    });
+
+    expect(loggedErrors).toHaveLength(1);
+    expect(String(loggedErrors[0]?.[0])).toContain("0123456789abcdef:note.txt");
+    expect(String(loggedErrors[0]?.[0])).toContain(repoRoot);
+  });
+});

--- a/src/extensions/default/vcs/jujutsu/source.ts
+++ b/src/extensions/default/vcs/jujutsu/source.ts
@@ -42,11 +42,28 @@ function tooLarge(maxBytes: number): ExtensionVcsFileSourceTooLarge {
   return { kind: "too-large", maxBytes };
 }
 
-/** Encode a repo-relative path as one literal Jujutsu fileset. */
+/** Encode a repo-relative path as one alias-insensitive literal Jujutsu fileset. */
 function jjFilePathFileset(path: string) {
-  const literalPath = Array.from(path, (character) =>
-    "\\*?[]{}".includes(character) ? `\\${character}` : character,
-  ).join("");
+  const literalPath = Array.from(path, (character) => {
+    switch (character) {
+      case "*":
+        return "[*]";
+      case "?":
+        return "[?]";
+      case "[":
+        return "[[]";
+      case "]":
+        return "[]]";
+      case "{":
+        return "[{]";
+      case "}":
+        return "[}]";
+      case "\\":
+        return process.platform === "win32" ? "/" : "[\\\\]";
+      default:
+        return character;
+    }
+  }).join("");
   return JSON.stringify(literalPath);
 }
 

--- a/src/extensions/default/vcs/jujutsu/source.ts
+++ b/src/extensions/default/vcs/jujutsu/source.ts
@@ -1,0 +1,148 @@
+import type {
+  ExtensionVcsFileSourceResult,
+  ExtensionVcsFileSourceTooLarge,
+} from "hunkdiff/extension";
+import {
+  DEFAULT_SOURCE_TEXT_MAX_BYTES,
+  logSourceDiagnostic,
+  readStreamTextWithLimit,
+  terminateSourceSubprocess,
+} from "../../../../lib/sourceText";
+
+/** Stops a Jujutsu source read as soon as it crosses Hunk's byte limit. */
+class JjSourceTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Source text exceeds ${maxBytes} bytes.`);
+    this.name = "JjSourceTooLargeError";
+  }
+}
+
+/** Names one file in an already-resolved Jujutsu commit. */
+export interface JjFileSourceSpec {
+  repoRoot: string;
+  commitId: string;
+  path: string;
+}
+
+export interface JjFileSourceOptions {
+  jjExecutable?: string;
+  maxSourceBytes?: number;
+}
+
+/** Return whether Jujutsu reported that the requested path has no source at this revision. */
+function isExpectedMissingJjSource(stderr: string) {
+  const normalized = stderr.toLowerCase();
+  return ["no such path:", "path does not exist:", "path doesn't exist:"].some((fragment) =>
+    normalized.includes(fragment),
+  );
+}
+
+/** Tell Hunk that expansion is unavailable because the source exceeded its byte limit. */
+function tooLarge(maxBytes: number): ExtensionVcsFileSourceTooLarge {
+  return { kind: "too-large", maxBytes };
+}
+
+/** Encode a repo-relative path as one literal Jujutsu fileset. */
+function jjFilePathFileset(path: string) {
+  const literalPath = Array.from(path, (character) =>
+    "\\*?[]{}".includes(character) ? `\\${character}` : character,
+  ).join("");
+  return JSON.stringify(literalPath);
+}
+
+/**
+ * Read one complete file from the commit that produced the patch under review.
+ *
+ * Hunk calls this lazily when it needs lines that `jj diff` left out of the patch. The
+ * caller has already resolved a moving name such as `@` to a full commit ID. Passing
+ * that ID to `-r` fixes which commit supplies the file, while `--ignore-working-copy`
+ * separately prevents this later read from snapshotting unrelated workspace changes.
+ *
+ * The process runs at the repository root, and the path is escaped and encoded as a
+ * bare quoted fileset passed as one command argument. Avoiding a named fileset pattern
+ * prevents a user alias from broadening the selection. An explicit empty metadata
+ * template also prevents `templates.file_show` from injecting bytes into the file contents.
+ *
+ * Standard output is streamed only up to `maxSourceBytes`. Crossing that limit stops JJ
+ * and returns Hunk's explicit `too-large` result instead of holding an unexpectedly
+ * large file in memory.
+ */
+export async function readJjFileSource(
+  spec: JjFileSourceSpec,
+  {
+    jjExecutable = "jj",
+    maxSourceBytes = DEFAULT_SOURCE_TEXT_MAX_BYTES,
+  }: Readonly<JjFileSourceOptions> = {},
+): Promise<ExtensionVcsFileSourceResult> {
+  let proc: Bun.ReadableSubprocess;
+  const command = [
+    jjExecutable,
+    "--no-pager",
+    "--color",
+    "never",
+    "file",
+    "show",
+    "--ignore-working-copy",
+    "-r",
+    spec.commitId,
+    "-T",
+    '""',
+    "--",
+    jjFilePathFileset(spec.path),
+  ];
+
+  try {
+    proc = Bun.spawn(command, {
+      cwd: spec.repoRoot,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch (error) {
+    logSourceDiagnostic(
+      `failed to run Jujutsu while reading source ${spec.commitId}:${spec.path}`,
+      error,
+    );
+    return null;
+  }
+
+  let output: [number, string, string];
+  try {
+    output = await Promise.all([
+      proc.exited,
+      readStreamTextWithLimit(
+        proc.stdout,
+        maxSourceBytes,
+        () => proc.kill(),
+        (limit) => new JjSourceTooLargeError(limit),
+      ),
+      readStreamTextWithLimit(
+        proc.stderr,
+        64 * 1024,
+        undefined,
+        (limit) => new Error(`Jujutsu source diagnostics exceeded ${limit} bytes.`),
+      ),
+    ]);
+  } catch (error) {
+    await terminateSourceSubprocess(proc);
+    if (error instanceof JjSourceTooLargeError) {
+      return tooLarge(error.maxBytes);
+    }
+
+    logSourceDiagnostic(`failed to collect Jujutsu source ${spec.commitId}:${spec.path}`, error);
+    return null;
+  }
+
+  const [exitCode, stdout, stderr] = output;
+  if (exitCode !== 0) {
+    if (!isExpectedMissingJjSource(stderr)) {
+      logSourceDiagnostic(
+        `failed to read Jujutsu source ${spec.commitId}:${spec.path} in ${spec.repoRoot}`,
+        stderr,
+      );
+    }
+    return null;
+  }
+
+  return stdout;
+}

--- a/src/lib/sourceText.test.ts
+++ b/src/lib/sourceText.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readFileTextWithLimit } from "./sourceText";
+import { readFileTextWithLimit, terminateSourceSubprocess } from "./sourceText";
 
 const tempDirs: string[] = [];
 
@@ -28,5 +28,24 @@ describe("readFileTextWithLimit", () => {
     expect(await readFileTextWithLimit(source, 100)).toBe("source text\n");
     expect(await readFileTextWithLimit(join(dir, "missing.txt"), 100)).toBeNull();
     expect(await readFileTextWithLimit(source, 5)).toEqual({ kind: "too-large", maxBytes: 5 });
+  });
+});
+
+describe("terminateSourceSubprocess", () => {
+  test("forces termination and stops waiting when a subprocess never reports exit", async () => {
+    const signals: Array<string | number | undefined> = [];
+    const neverExits = new Promise<number>(() => undefined);
+    const proc = {
+      exited: neverExits,
+      kill(signal?: string | number) {
+        signals.push(signal);
+      },
+    } as unknown as Bun.ReadableSubprocess;
+    const startedAt = performance.now();
+
+    await terminateSourceSubprocess(proc);
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 });

--- a/src/lib/sourceText.ts
+++ b/src/lib/sourceText.ts
@@ -41,6 +41,49 @@ export async function readFileTextWithLimit(
   }
 }
 
+const SOURCE_SUBPROCESS_GRACE_MS = 100;
+const SOURCE_SUBPROCESS_FORCE_WAIT_MS = 250;
+
+/** Wait a bounded interval for a source-reader subprocess to exit. */
+function waitForSourceSubprocessExit(proc: Bun.ReadableSubprocess, timeoutMs: number) {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(exited);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+
+    void proc.exited.then(
+      () => finish(true),
+      () => finish(true),
+    );
+  });
+}
+
+/** Terminate a source-reader subprocess without letting cleanup block indefinitely. */
+export async function terminateSourceSubprocess(proc: Bun.ReadableSubprocess) {
+  try {
+    proc.kill("SIGTERM");
+  } catch {
+    // The process may have exited between the stream failure and cleanup.
+  }
+  if (await waitForSourceSubprocessExit(proc, SOURCE_SUBPROCESS_GRACE_MS)) {
+    return;
+  }
+
+  try {
+    proc.kill("SIGKILL");
+  } catch {
+    // A concurrent exit needs no further signal.
+  }
+  await waitForSourceSubprocessExit(proc, SOURCE_SUBPROCESS_FORCE_WAIT_MS);
+}
+
 /** Read a byte stream as text while enforcing a caller-defined resource limit. */
 export async function readStreamTextWithLimit(
   stream: ReadableStream<Uint8Array> | null,


### PR DESCRIPTION
## Problem

Git-backed reviews can load complete file contents and expand context omitted from a patch. The Jujutsu adapter returned only patch text, so the same gaps appeared as static `··· N unchanged lines ···` rows in `hunk show` and `hunk diff`.

## Approach

- Resolve single-revision JJ reviews to immutable commit IDs before generating the patch, so lazy source reads cannot race a moving `@` or bookmark.
- Load complete files with a bounded, path-safe `jj file show --ignore-working-copy` reader and expose it through the existing VCS extension contract.
- Preserve rename, addition, deletion, source-cache, and custom-executable behavior.
- Keep aggregate multi-revision patches reviewable without attaching a guessed source pair.
- For merges, expose the exact new side used by gap expansion without pretending that any one parent is JJ's virtual merged-parent baseline.

The resulting JJ review uses the existing expandable row and `z` interaction:

```text
Before: ··· 6 unchanged lines ···
After:  ▾ 6 unchanged lines
```

And here's some screenshot of it in action: 

<img width="1435" height="1159" alt="image" src="https://github.com/user-attachments/assets/e728752a-f084-49c0-9a63-ef8bbacd66fc" />
<img width="1435" height="1159" alt="image" src="https://github.com/user-attachments/assets/898022ed-1cc3-40a2-b975-209555a2e218" />

## Validation

- `bun test src/extensions/default/vcs/jujutsu/commands.test.ts src/extensions/default/vcs/jujutsu/source.test.ts src/extensions/default/vcs/jujutsu/index.test.ts` — 24 passed
- `bun run test` — 1627 passed, 3 skipped
- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run deps:check`
- `git diff --check`
- Manually verified `hunk show mq` in a pure JJ workspace: the previously static gap expanded and collapsed with `z`.

Tested on NixOS/Linux with JJ 0.41.0. macOS and Windows were not tested manually.
