### PR TITLE
fix(session): refuse option-like VCS ranges in session reloads

### DIFF
--- a/.changeset/refuse-reload-flag-injection.md
+++ b/.changeset/refuse-reload-flag-injection.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reject session reload inputs whose VCS `range` or `ref` values look like command options. A caller reaching the session broker could otherwise inject `git` flags such as `--output=<path>` through a `/session-api` reload request and make Hunk write diff output to an arbitrary path.

--- a/src/app/session/reloadBounds.test.ts
+++ b/src/app/session/reloadBounds.test.ts
@@ -61,6 +61,61 @@ describe("session reload filesystem bounds", () => {
     }
   });
 
+  test("rejects option-like VCS ranges and refs in daemon reloads", () => {
+    const repo = mkdtempSync(join(tmpdir(), "hunk-reload-bounds-options-"));
+
+    try {
+      const bounds = createSessionReloadBounds(
+        bootstrapFor({ kind: "vcs", staged: false, options: {} }, repo),
+        { cwd: repo },
+      );
+
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "vcs",
+          range: "--output=/tmp/hunk-poc",
+          staged: false,
+          options: {},
+        }),
+      ).toThrow("diff range that looks like a VCS option");
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "show",
+          ref: "--output=/tmp/hunk-poc",
+          options: {},
+        }),
+      ).toThrow("show ref that looks like a VCS option");
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "stash-show",
+          ref: "-R",
+          options: {},
+        }),
+      ).toThrow("stash-show ref that looks like a VCS option");
+
+      // Plain revisions and ranges still reload, including literal-dash pathspecs that
+      // bundled backends append after `--` so the VCS treats them as paths.
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "vcs",
+          range: "main..feature",
+          staged: false,
+          pathspecs: ["--help"],
+          options: {},
+        }),
+      ).not.toThrow();
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "stash-show",
+          ref: "stash@{1}",
+          options: {},
+        }),
+      ).not.toThrow();
+    } finally {
+      rmSync(repo, { force: true, recursive: true });
+    }
+  });
+
   test("rejects daemon reload source paths outside the initial repo root", () => {
     const repo = mkdtempSync(join(tmpdir(), "hunk-reload-bounds-repo-"));
     const outside = mkdtempSync(join(tmpdir(), "hunk-reload-bounds-outside-"));

--- a/src/app/session/reloadBounds.ts
+++ b/src/app/session/reloadBounds.ts
@@ -22,6 +22,11 @@ import type { VcsCatalog } from "../../core/vcs/types";
  *
  * All candidate paths are realpath-normalized through existing ancestors so symlinks cannot escape
  * the roots, including paths whose final file does not exist yet.
+ *
+ * Revision-shaped fields (`vcs` `range`, `show`/`stash-show` `ref`) must name revisions, not
+ * command options: a value beginning with `-` would let a daemon caller inject flags such as
+ * `--output=<path>` into the VCS backend's spawned command. Pathspecs are exempt because every
+ * bundled backend appends them after `--`, where the VCS treats them as paths.
  */
 
 export interface SessionReloadBounds {
@@ -148,6 +153,13 @@ function assertReloadSourceWithinBounds(bounds: SessionReloadBounds, cwd: string
   return candidate;
 }
 
+/** Reject daemon-supplied revision fields that a VCS backend would parse as command options. */
+function assertReloadRevisionNotOptionLike(description: string, value: string) {
+  if (value.startsWith("-")) {
+    throw new Error(`Session reload refused ${description} that looks like a VCS option: ${value}`);
+  }
+}
+
 /** Validate common reload options that may cause filesystem reads. */
 function validateCommonReloadOptions(
   bounds: SessionReloadBounds,
@@ -199,8 +211,15 @@ export function validateSessionReloadWithinBounds(
       }
       break;
     case "vcs":
+      if (nextInput.range) {
+        assertReloadRevisionNotOptionLike("diff range", nextInput.range);
+      }
+      break;
     case "show":
     case "stash-show":
+      if (nextInput.ref) {
+        assertReloadRevisionNotOptionLike(`${nextInput.kind} ref`, nextInput.ref);
+      }
       break;
   }
 

--- a/src/extensions/default/vcs/git/commands.test.ts
+++ b/src/extensions/default/vcs/git/commands.test.ts
@@ -4,10 +4,13 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   buildGitDiffArgs,
+  buildGitDiffNumstatArgs,
   buildGitIgnoredDirectoryArgs,
+  buildGitShowArgs,
   buildGitStashShowArgs,
   buildGitStatusArgs,
   listGitIgnoredDirectoryRoots,
+  listGitUntrackedFiles,
   parseGitIgnoredDirectoryRoots,
   resolveGitDiffEndpoints,
   parseGitNumstat,
@@ -99,6 +102,27 @@ describe("git command helpers", () => {
 
   test("forces byte-safe Git path quoting before stdout decoding", () => {
     expect(buildGitDiffArgs(makeGitInput())).toContain("core.quotePath=true");
+  });
+
+  test("refuses option-like revision values before spawning Git", () => {
+    expect(() => buildGitDiffArgs(makeGitInput({ range: "--output=/tmp/hunk-poc" }))).toThrow(
+      "looks like a Git option",
+    );
+    expect(() => buildGitDiffNumstatArgs(makeGitInput({ range: "-R" }))).toThrow(
+      "looks like a Git option",
+    );
+    expect(() =>
+      buildGitShowArgs({ kind: "show", ref: "--output=/tmp/hunk-poc", options: {} }),
+    ).toThrow("looks like a Git option");
+    expect(() =>
+      buildGitStashShowArgs({ kind: "stash-show", ref: "--output=/tmp/hunk-poc", options: {} }),
+    ).toThrow("looks like a Git option");
+    // Guarded revision helpers must also refuse ranges before any rev-parse spawn.
+    expect(() => listGitUntrackedFiles(makeGitInput({ range: "--output=/tmp/hunk-poc" }))).toThrow(
+      "looks like a Git option",
+    );
+
+    expect(buildGitDiffArgs(makeGitInput({ range: "main..feature" }))).toContain("main..feature");
   });
 
   test("disables external diff tools for stash patches", () => {

--- a/src/extensions/default/vcs/git/commands.ts
+++ b/src/extensions/default/vcs/git/commands.ts
@@ -56,6 +56,23 @@ export function appendGitPathspecs(args: string[], pathspecs?: string[]) {
   args.push("--", ...pathspecs);
 }
 
+/**
+ * Return one caller-supplied revision or range argument, refusing option-like values.
+ * Revisions and ranges never start with `-`, so a leading dash is injected content (for
+ * example `--output=<path>`) that Git would parse as a flag; it fails closed here instead
+ * of reaching the spawned command.
+ */
+export function requireGitRevisionArg(input: GitBackedInput, value: string) {
+  if (value.startsWith("-")) {
+    throw new HunkExtensionUserError(
+      `\`${formatGitCommandLabel(input)}\` refused revision \`${value}\` because it looks like a Git option.`,
+      { suggestions: ["Pass a plain revision or range, such as `HEAD` or `main..feature`."] },
+    );
+  }
+
+  return value;
+}
+
 // @pierre/diffs currently assumes git-style a/ and b/ prefixes when parsing patch headers.
 // Force byte-safe path quoting and canonical prefixes so user/repo git config cannot replace raw
 // non-UTF-8 bytes during stdout decoding or break the shared parser's expected side prefixes.
@@ -130,7 +147,7 @@ export function buildGitDiffArgs(
   }
 
   if (input.range) {
-    args.push(input.range);
+    args.push(requireGitRevisionArg(input, input.range));
   }
 
   if (excludedPathspecs.length > 0) {
@@ -155,7 +172,7 @@ export function buildGitDiffNumstatArgs(input: ExtensionVcsDiffInput) {
   }
 
   if (input.range) {
-    args.push(input.range);
+    args.push(requireGitRevisionArg(input, input.range));
   }
 
   appendGitPathspecs(args, input.pathspecs);
@@ -237,7 +254,7 @@ export function buildGitShowArgs(
   ];
 
   if (input.ref) {
-    args.push(input.ref);
+    args.push(requireGitRevisionArg(input, input.ref));
   }
 
   appendGitPathspecs(args, input.pathspecs);
@@ -259,7 +276,7 @@ export function buildGitStashShowArgs(
   ];
 
   if (input.ref) {
-    args.push(input.ref);
+    args.push(requireGitRevisionArg(input, input.ref));
   }
 
   return withNormalizedDiffPrefixes(withGitMovedLineColorConfig(args, colorMoved));
@@ -564,7 +581,7 @@ function isWorkingTreeGitDiffInput(
 
   const revs = runGitText({
     input,
-    args: ["rev-parse", "--revs-only", input.range],
+    args: ["rev-parse", "--revs-only", requireGitRevisionArg(input, input.range)],
     cwd,
     gitExecutable,
     preventOptionalLocks,
@@ -825,7 +842,7 @@ function resolveRangeRevisions(
 ): { positives: string[]; negatives: string[] } {
   const revs = runGitText({
     input,
-    args: ["rev-parse", "--revs-only", range],
+    args: ["rev-parse", "--revs-only", requireGitRevisionArg(input, range)],
     cwd: repoRoot ?? cwd,
     gitExecutable,
   })

--- a/test/session/cli.test.ts
+++ b/test/session/cli.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -478,6 +478,56 @@ sessionDescribe("session CLI integration", () => {
       );
       expect(reload.proc.exitCode).not.toBe(0);
       expect(reload.stderr).toContain("outside the initial Hunk root");
+
+      const get = runSessionCli(["get", sessionId, "--json"], port);
+      expect(get.proc.exitCode).toBe(0);
+      expect(JSON.parse(get.stdout)).toMatchObject({
+        session: {
+          files: [{ path: fixture.afterName }],
+        },
+      });
+    } finally {
+      await cleanupHunkSession(session, fixture, port);
+    }
+  }, 20_000);
+
+  test("reload refuses option-like VCS ranges sent directly to the session API", async () => {
+    const port = await reserveLoopbackPort();
+    const fixture = createFixtureFiles(
+      "reload-injection",
+      ["export const visible = 1;"],
+      ["export const visible = 2;"],
+    );
+    mkdirSync(join(fixture.dir, ".git"));
+    const session = spawnHunkSession(fixture, port);
+
+    try {
+      const listed = await waitForRegisteredSessions(port);
+
+      const sessionId = listed[0]!.sessionId;
+      // Bypass the CLI parser on purpose: the raw daemon surface is the attacker-controlled
+      // path, so reproduce the injected flag exactly as a hostile /session-api caller would.
+      const sentinel = join(fixture.dir, "hunk-poc");
+      const response = await fetch(`http://127.0.0.1:${port}/session-api`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "reload",
+          selector: { sessionId },
+          nextInput: {
+            kind: "vcs",
+            range: `--output=${sentinel}`,
+            staged: false,
+            options: {},
+          },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: expect.stringContaining("looks like a VCS option"),
+      });
+      expect(existsSync(sentinel)).toBe(false);
 
       const get = runSessionCli(["get", sessionId, "--json"], port);
       expect(get.proc.exitCode).toBe(0);


### PR DESCRIPTION
Fixes #892.

## Problem

The session broker's `reload` action validates most caller-supplied paths and refs, but the `range` field of a `{kind: "vcs"}` `nextInput` reached `git diff` as a raw argument. A daemon caller could POST

```json
{"action":"reload","selector":{"sessionId":"<id>"},
 "nextInput":{"kind":"vcs","range":"--output=/tmp/hunk-poc","staged":false,"options":{}}}
```

and `git diff --output=/tmp/hunk-poc` would create or overwrite a file at an arbitrary path with the privileges of the hunk process. The same pattern existed for `show`/`stash-show` refs and for the `rev-parse --revs-only` range probes.

## Fix (two layers)

- **Reload boundary (`src/app/session/reloadBounds.ts`):** `vcs` `range` and `show`/`stash-show` `ref` values that begin with `-` are refused with a clear error, the same way `sourcePath`/`left`/`right` root containment is enforced. Revisions and ranges never legitimately begin with `-`, so this is fail-closed.
- **Git adapter (`src/extensions/default/vcs/git/commands.ts`):** defense-in-depth — `requireGitRevisionArg` guards every interpolation of a caller-supplied range/ref into a spawned command (`buildGitDiffArgs`, `buildGitDiffNumstatArgs`, `buildGitShowArgs`, `buildGitStashShowArgs`, and both `rev-parse --revs-only` probes), throwing a `HunkExtensionUserError` before any spawn.

## Audit of the other `nextInput` string fields (requested in the issue)

| Field | Status |
| --- | --- |
| `diff`/`difftool` `left`/`right` | Root-contained (`assertReloadFileWithinBounds`) — unchanged |
| `sourcePath` | Root-contained — unchanged |
| `patch.file` | Root-contained; stdin rejected — unchanged |
| `options.agentContext` | Root-contained; `-` rejected — unchanged |
| `show`/`stash-show` `ref` | **Now rejected when option-like**; blob reads also only use SHA-pinned refs resolved via `rev-parse --verify --end-of-options` |
| `vcs` `range` | **Now rejected when option-like** |
| `pathspecs` | Safe: every bundled backend (git/sapling/jujutsu) appends them after `--`, so a literal-dash pathspec like `--help` stays a path (existing CLI behavior, covered by tests) |
| `difftool.path` | Display label only, never spawned |

The sapling/jujutsu backends are covered by the boundary check; their own arg builders pass `range` as an `-r` value, which their CLI parsers refuse as hyphen values anyway.

## Tests

- `src/app/session/reloadBounds.test.ts` — rejects `--output=…`/`-R` for `vcs`/`show`/`stash-show`; allows `main..feature`, `stash@{1}`, and `--help` pathspecs.
- `src/extensions/default/vcs/git/commands.test.ts` — all four arg builders and the untracked-files range probe refuse option-like revisions before spawning; plain ranges pass through.
- `test/session/cli.test.ts` — end-to-end reproduction of the report: a raw `/session-api` POST with an injected `--output=<path>` range returns HTTP 400 with the refusal message, the sentinel file is never created, and the session keeps its original contents.

## Verification

- `bun run typecheck`
- `bun run test` (one pre-existing, unrelated failure in `src/extensions/hostRuntimeModules.test.ts` that also fails on clean `main` in this environment)
- `bun test ./test/session/cli.test.ts`
- `bun run test:integration`
- `bun run deps:check`