### PR TITLE
fix(session): reject ambiguous navigate targets

### DIFF
--- a/.changeset/tidy-moons-invite.md
+++ b/.changeset/tidy-moons-invite.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reject ambiguous `hunk session navigate` requests instead of silently ignoring the extra target.

--- a/packages/hunk/src/app/cli.test.ts
+++ b/packages/hunk/src/app/cli.test.ts
@@ -1628,6 +1628,32 @@ describe("parseCli", () => {
     }
   });
 
+  test("rejects session navigate when a comment direction is combined with an absolute target", async () => {
+    const conflictingOptions = [
+      ["--file", "README.md"],
+      ["--hunk", "1"],
+      ["--old-line", "10"],
+      ["--new-line", "10"],
+      ["--file", "README.md", "--hunk", "2"],
+    ];
+
+    for (const direction of ["--next-comment", "--prev-comment"]) {
+      for (const conflictingOption of conflictingOptions) {
+        await expect(
+          parseCli([
+            "bun",
+            "hunk",
+            "session",
+            "navigate",
+            "session-1",
+            direction,
+            ...conflictingOption,
+          ]),
+        ).rejects.toThrow("Specify exactly one navigation selector");
+      }
+    }
+  });
+
   test("rejects session navigate with both --next-comment and --prev-comment", async () => {
     await expect(
       parseCli([

--- a/packages/hunk/src/app/cli.ts
+++ b/packages/hunk/src/app/cli.ts
@@ -1382,16 +1382,18 @@ async function parseSessionNavigateCommand(tokens: string[]): Promise<ParsedCliI
 
   await parseStandaloneCommand(command, tokens);
 
-  // A comment id is resolved by the daemon and must not silently discard another selector.
+  // A comment id or a direction is resolved by the daemon and must not silently discard another
+  // selector, so every selector combination is rejected rather than ranked.
+  const hasAbsoluteTarget =
+    parsedOptions.file !== undefined ||
+    parsedOptions.hunk !== undefined ||
+    parsedOptions.oldLine !== undefined ||
+    parsedOptions.newLine !== undefined;
+  const hasCommentDirection =
+    parsedOptions.nextComment === true || parsedOptions.prevComment === true;
   const commentHasConflictingSelector =
-    parsedOptions.comment !== undefined &&
-    (parsedOptions.file !== undefined ||
-      parsedOptions.hunk !== undefined ||
-      parsedOptions.oldLine !== undefined ||
-      parsedOptions.newLine !== undefined ||
-      parsedOptions.nextComment === true ||
-      parsedOptions.prevComment === true);
-  if (commentHasConflictingSelector) {
+    parsedOptions.comment !== undefined && (hasAbsoluteTarget || hasCommentDirection);
+  if (commentHasConflictingSelector || (hasCommentDirection && hasAbsoluteTarget)) {
     throw new Error(
       "Specify exactly one navigation selector: --comment, --next-comment / --prev-comment, or --file with a navigation target.",
     );

--- a/packages/hunk/src/session/broker/brokerServer.helpers.test.ts
+++ b/packages/hunk/src/session/broker/brokerServer.helpers.test.ts
@@ -278,6 +278,7 @@ describe("handleSessionApiRequest", () => {
       apiRequest({
         action: "navigate",
         selector: { sessionId: "s-1" },
+        filePath: "a.ts",
         hunkNumber: 2,
       } as SessionDaemonRequest),
     );
@@ -382,6 +383,66 @@ describe("handleSessionApiRequest", () => {
     expect(response.status).toBe(400);
     expect(await response.json()).toMatchObject({
       error: expect.stringContaining("cannot be combined"),
+    });
+  });
+
+  test("rejects a comment direction combined with another navigation target", async () => {
+    const { state } = createFakeState();
+    const response = await handleSessionApiRequest(
+      state,
+      apiRequest({
+        action: "navigate",
+        selector: { sessionId: "s-1" },
+        commentDirection: "next",
+        filePath: "a.ts",
+        hunkNumber: 2,
+      } as SessionDaemonRequest),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: expect.stringContaining("commentDirection cannot be combined"),
+    });
+  });
+
+  test("rejects a hunk or line target without a file path", async () => {
+    const { state } = createFakeState();
+    for (const target of [{ hunkNumber: 2 }, { side: "new" as const, line: 12 }]) {
+      const response = await handleSessionApiRequest(
+        state,
+        apiRequest({
+          action: "navigate",
+          selector: { sessionId: "s-1" },
+          ...target,
+        } as SessionDaemonRequest),
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: expect.stringContaining("requires filePath"),
+      });
+    }
+  });
+
+  test("prefers exact line coordinates when a hunk number is also supplied", async () => {
+    const { state, calls } = createFakeState();
+    const response = await handleSessionApiRequest(
+      state,
+      apiRequest({
+        action: "navigate",
+        selector: { sessionId: "s-1" },
+        filePath: "a.ts",
+        hunkNumber: 2,
+        side: "new",
+        line: 12,
+      } as SessionDaemonRequest),
+    );
+
+    expect(response.status).toBe(200);
+    const dispatch = calls.find((c) => c.method === "dispatchCommand");
+    expect(dispatch).toBeDefined();
+    expect((dispatch!.args[0] as { input: Record<string, unknown> }).input).toMatchObject({
+      line: 12,
     });
   });
 

--- a/packages/hunk/src/session/broker/brokerServer.ts
+++ b/packages/hunk/src/session/broker/brokerServer.ts
@@ -332,6 +332,15 @@ function resolveNavigateCommandInput(
     };
   }
 
+  const hasAbsoluteTarget =
+    input.filePath !== undefined ||
+    input.hunkNumber !== undefined ||
+    input.side !== undefined ||
+    input.line !== undefined;
+  if (input.commentDirection !== undefined && hasAbsoluteTarget) {
+    throw new Error("navigate commentDirection cannot be combined with another navigation target.");
+  }
+
   if (
     !input.commentDirection &&
     input.hunkNumber === undefined &&
@@ -340,6 +349,14 @@ function resolveNavigateCommandInput(
     throw new Error(
       "navigate requires commentId, commentDirection, hunkNumber, or both side and line.",
     );
+  }
+
+  // The live terminal cannot resolve a hunk or a line without the file that owns it.
+  if (
+    input.filePath === undefined &&
+    (input.hunkNumber !== undefined || input.line !== undefined)
+  ) {
+    throw new Error("navigate requires filePath for a hunk or line target.");
   }
 
   // Exact coordinates take precedence so callers reveal the row rather than only its hunk.


### PR DESCRIPTION
## Problem

`hunk session navigate` accepted two selectors at once and silently picked one.

- A direction combined with an absolute target, for example `--next-comment --file src/app.ts --hunk 2`, let the direction win and dropped the file and hunk without a word.
- The daemon accepted a hunk or line target with no `filePath`. It dispatched the command, but the live terminal cannot resolve an absolute target without the file that owns it.

## Approach

Reject both combinations where each surface already validates, rather than adding a new validation layer.

- `src/app/cli.ts`: the existing conflicting-selector guard now also covers a direction combined with `--file`, `--hunk`, `--old-line`, or `--new-line`, and reuses the existing error text.
- `src/session/broker/brokerServer.ts`: the existing `navigate` guard now rejects a direction combined with an absolute target, and requires `filePath` for a hunk or line target.

Non-goals. The terminal bridge stays a pass-through adapter and is untouched. I left `protocolSchemas.ts` alone on purpose: the schema validates wire shape, and the acceptance criteria ask for CLI and broker validation. I did try the cross-field check in the schema first, and moved it out because it duplicated a guard the broker already owned.

Exact-line precedence is preserved. A raw API request carrying `filePath`, `hunkNumber`, `side` and `line` still prefers the line, and there is now a test pinning that.

## Tests

Added regression tests for accepted and rejected combinations:

- `src/app/cli.test.ts`: both directions against five absolute-target combinations
- `src/session/broker/brokerServer.helpers.test.ts`: direction plus target, hunk and line without `filePath`, and the exact-line precedence case

Each new rejection test was confirmed to fail without its fix:

```text
# with the CLI guard reverted
(fail) parseCli > rejects session navigate when a comment direction is combined with an absolute target
 133 pass, 1 fail

# with the broker guard reverted
(fail) handleSessionApiRequest > rejects a comment direction combined with another navigation target
(fail) handleSessionApiRequest > rejects a hunk or line target without a file path
 38 pass, 2 fail
```

## Commands run

```text
$ bun run test
 3237 pass
 25 skip
 0 fail
Ran 3262 tests across 298 files. [55.18s]

$ ./node_modules/.bin/tsc --noEmit
(exit 0)

$ ./node_modules/.bin/oxlint <changed files> --deny-warnings
Found 0 warnings and 0 errors.
```

One note on honesty. An earlier full run showed `filesystem watch observer > observes an ordinary file write after readiness` failing at about 3s. It passed on the next run with no change in between, so it looks timing dependent on this machine. It touches no navigation code.

Platform: macOS, Node 24, bun 1.3.14. Not tested on Linux or Windows.

`bun install` needed `--ignore-scripts` here because the `simple-git-hooks` postinstall exits 1 on this machine. No lockfile change is included.

## Changeset

`patch` targeting `hunkdiff`.

---
<table><tr>
<td><img src="https://github.com/rascal-sl.png?size=48" width="40" height="40" /></td>
<td><strong>Tisankan Jeyakumar</strong><br/>
<img src="https://img.shields.io/badge/Developed-Verified-2ea44f?style=flat-square&logo=github&logoColor=white" alt="Developed and verified" /></td>
</tr></table>
