### PR TITLE
fix(watch): refuse deadlocking Bun runtimes

### DIFF
--- a/.changeset/watch-runtime-deadlock.md
+++ b/.changeset/watch-runtime-deadlock.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Refuse to start watch mode under Bun versions older than 1.3.14, which can deadlock filesystem watcher cleanup and leave Hunk unresponsive.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Keep the change focused on one user problem. Before adding another helper, state
 
 Requirements:
 
-- Bun 1.3+
+- Bun 1.3.14+
 - Node.js 18+
 - Git
 - macOS, Linux, or Windows

--- a/src/app/startup.test.ts
+++ b/src/app/startup.test.ts
@@ -375,6 +375,37 @@ describe("startup planning", () => {
     }
   });
 
+  test("rejects watch mode before affected Bun runtimes can deadlock", async () => {
+    const cliInput: CliInput = {
+      kind: "vcs",
+      staged: false,
+      options: { watch: true },
+    };
+    let loaded = false;
+    let opened = false;
+
+    await expect(
+      prepareStartupPlan(["bun", "hunk", "diff", "--watch"], {
+        bunVersion: "1.3.10",
+        parseCliImpl: async () => cliInput as ParsedCliInput,
+        resolveRuntimeCliInputImpl: (input) => input,
+        resolveConfiguredCliInputImpl: (input) => createTestConfigResolution(input),
+        loadAppBootstrapImpl: async (input) => {
+          loaded = true;
+          return createBootstrap(input);
+        },
+        openControllingTerminalImpl: () => {
+          opened = true;
+          return { stdin: {} as never, close: () => {} };
+        },
+        stdinIsTTY: false,
+        stdoutIsTTY: true,
+      }),
+    ).rejects.toThrow("can deadlock while closing filesystem watchers");
+    expect(loaded).toBe(false);
+    expect(opened).toBe(false);
+  });
+
   test("rejects watch mode for stdin-backed patch inputs", async () => {
     const cliInput: CliInput = {
       kind: "patch",

--- a/src/app/startup.ts
+++ b/src/app/startup.ts
@@ -22,6 +22,7 @@ import type {
   SessionCommandInput,
 } from "../core/run/commandInputs";
 import { canReloadInput } from "../core/run/inputReload";
+import { assertReliableWatchRuntime } from "../core/watch/runtime";
 import { parseCli } from "./cli";
 import { resolveSessionSelectorBoundary } from "./sessionSelector";
 import type { VcsCatalog } from "../core/vcs/types";
@@ -115,6 +116,7 @@ export interface StartupDeps {
   stdoutIsTTY?: boolean;
   stdout?: NodeJS.WriteStream;
   env?: NodeJS.ProcessEnv;
+  bunVersion?: string;
 }
 
 /** Normalize startup work so help, pager, and app-bootstrap paths can be tested directly. */
@@ -136,6 +138,7 @@ export async function prepareStartupPlan(
   const stdoutIsTTY = deps.stdoutIsTTY ?? Boolean(process.stdout.isTTY);
   const stdout = deps.stdout ?? process.stdout;
   const env = deps.env ?? process.env;
+  const bunVersion = deps.bunVersion ?? Bun.version;
   const loadBaseVcsCatalog = createBundledVcsCatalogLoader();
 
   let parsedCliInput = await parseCliImpl(argv);
@@ -293,6 +296,18 @@ export async function prepareStartupPlan(
   // Reassigned once below if an extension VCS backend claims this checkout.
   let cliInput = configured.input;
 
+  if (cliInput.options.watch) {
+    assertReliableWatchRuntime(bunVersion);
+    if (!canReloadInput(cliInput)) {
+      throw new HunkUserError(
+        "`--watch` requires a file- or Git-backed input that Hunk can reopen.",
+        [
+          "Use a patch file path instead of stdin, and avoid `--agent-context -` for watched sessions.",
+        ],
+      );
+    }
+  }
+
   // Any app session launched with piped stdin still needs a real terminal input stream for
   // keyboard, mouse, and terminal query responses. Auto-theme happened to open this path during
   // probing; make it unconditional so concrete themes behave the same way.
@@ -308,15 +323,6 @@ export async function prepareStartupPlan(
         (await detectTerminalThemeModeFromBackgroundImpl({ input: themeInput, output: stdout })) ??
         undefined;
     }
-  }
-
-  if (cliInput.options.watch && !canReloadInput(cliInput)) {
-    throw new HunkUserError(
-      "`--watch` requires a file- or Git-backed input that Hunk can reopen.",
-      [
-        "Use a patch file path instead of stdin, and avoid `--agent-context -` for watched sessions.",
-      ],
-    );
   }
 
   // Extensions load before the changeset so later stages can hand their VCS adapters and

--- a/src/core/watch/runtime.test.ts
+++ b/src/core/watch/runtime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { HunkUserError } from "../run/errors";
+import {
+  assertReliableWatchRuntime,
+  MINIMUM_RELIABLE_WATCH_BUN_VERSION,
+  supportsReliableWatchMode,
+} from "./runtime";
+
+describe("watch runtime compatibility", () => {
+  test("accepts the fixed Bun release and newer runtimes", () => {
+    expect(MINIMUM_RELIABLE_WATCH_BUN_VERSION).toBe("1.3.14");
+    expect(supportsReliableWatchMode("1.3.14")).toBe(true);
+    expect(supportsReliableWatchMode("1.3.14+abc123")).toBe(true);
+    expect(supportsReliableWatchMode("1.4.0")).toBe(true);
+    expect(supportsReliableWatchMode("1.4.0-canary.1")).toBe(true);
+    expect(supportsReliableWatchMode("2.0.0-canary.1")).toBe(true);
+  });
+
+  test("rejects affected and malformed runtime versions", () => {
+    expect(supportsReliableWatchMode("1.3.10")).toBe(false);
+    expect(supportsReliableWatchMode("1.3.13")).toBe(false);
+    expect(supportsReliableWatchMode("1.3.14-canary.1")).toBe(false);
+    expect(supportsReliableWatchMode("not-a-version")).toBe(false);
+  });
+
+  test("reports the deadlock risk and recovery options", () => {
+    expect(() => assertReliableWatchRuntime("1.3.10")).toThrow(HunkUserError);
+    expect(() => assertReliableWatchRuntime("1.3.10")).toThrow(
+      "can deadlock while closing filesystem watchers",
+    );
+
+    try {
+      assertReliableWatchRuntime("1.3.10");
+    } catch (error) {
+      expect(error).toMatchObject({
+        suggestions: ["Upgrade Bun with `bun upgrade`, or run Hunk without `--watch`."],
+      });
+    }
+  });
+});

--- a/src/core/watch/runtime.ts
+++ b/src/core/watch/runtime.ts
@@ -1,0 +1,46 @@
+import { HunkUserError } from "../run/errors";
+
+// Bun 1.3.14 removes the PathWatcher lock inversion documented in oven-sh/bun#31166.
+export const MINIMUM_RELIABLE_WATCH_BUN_VERSION = "1.3.14";
+
+/** Parse the stable numeric prefix Bun reports for release and canary runtimes. */
+function parseBunVersion(version: string) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.exec(version.trim());
+  if (!match) {
+    return null;
+  }
+
+  return {
+    numbers: [Number(match[1]), Number(match[2]), Number(match[3])] as const,
+    prerelease: match[4] !== undefined,
+  };
+}
+
+/** Return whether one Bun runtime includes the filesystem-watcher deadlock fix. */
+export function supportsReliableWatchMode(version: string) {
+  const actual = parseBunVersion(version);
+  const minimum = parseBunVersion(MINIMUM_RELIABLE_WATCH_BUN_VERSION)!;
+  if (!actual) {
+    return false;
+  }
+
+  for (let index = 0; index < minimum.numbers.length; index += 1) {
+    if (actual.numbers[index] !== minimum.numbers[index]) {
+      return actual.numbers[index]! > minimum.numbers[index]!;
+    }
+  }
+
+  return !actual.prerelease;
+}
+
+/** Refuse watch mode before an affected Bun runtime can deadlock filesystem watcher cleanup. */
+export function assertReliableWatchRuntime(version: string) {
+  if (supportsReliableWatchMode(version)) {
+    return;
+  }
+
+  throw new HunkUserError(
+    `Watch mode requires Bun ${MINIMUM_RELIABLE_WATCH_BUN_VERSION} or newer; Bun ${version} can deadlock while closing filesystem watchers.`,
+    ["Upgrade Bun with `bun upgrade`, or run Hunk without `--watch`."],
+  );
+}

--- a/src/ui/AppHost.reload.test.tsx
+++ b/src/ui/AppHost.reload.test.tsx
@@ -106,6 +106,59 @@ async function settleHighlights(setup: Awaited<ReturnType<typeof testRender>>) {
   }
 }
 
+describe("reload watch runtime compatibility", () => {
+  test("refuses a live reload that enables watch mode under an affected Bun runtime", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-reload-watch-runtime-"));
+    const file = join(dir, "test.txt");
+
+    execSync("git init && git config user.email test@test && git config user.name test", {
+      cwd: dir,
+      stdio: "ignore",
+    });
+    writeFileSync(file, "original line\n");
+    execSync("git add . && git commit -m init", { cwd: dir, stdio: "ignore" });
+    writeFileSync(file, "original line\nfirst change\n");
+
+    const bootstrap = await loadAppBootstrap(
+      { kind: "vcs", staged: false, options: { mode: "stack", excludeUntracked: true } },
+      { cwd: dir, vcsCatalog: getBundledVcsCatalog() },
+    );
+    const { dispatchCommand, hostClient } = createTestHostClient();
+    const setup = await testRender(
+      <AppHost bootstrap={bootstrap} hostClient={hostClient} bunVersion="1.3.10" />,
+      { width: 120, height: 20 },
+    );
+
+    try {
+      await flush(setup);
+
+      await expect(
+        dispatchCommand({
+          type: "command",
+          requestId: "reload-watch-runtime",
+          command: "reload_session",
+          input: {
+            sessionId: "session-1",
+            nextInput: {
+              kind: "vcs",
+              staged: false,
+              options: { mode: "stack", excludeUntracked: true, watch: true },
+            },
+          },
+        }),
+      ).rejects.toThrow("can deadlock while closing filesystem watchers");
+
+      await flush(setup);
+      expect(setup.captureCharFrame()).toContain("first change");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      await removeTestDirectory(dir);
+    }
+  });
+});
+
 describe("reload stale highlight cache", () => {
   test("r key picks up new file content for file-pair diffs", async () => {
     const dir = mkdtempSync(join(process.cwd(), ".hunk-reload-file-"));

--- a/src/ui/AppHost.tsx
+++ b/src/ui/AppHost.tsx
@@ -34,6 +34,7 @@ import type {
   WorkspaceFileWriter,
   WorkspaceWriteRunner,
 } from "./hooks/useExtensionWorkspaceControls";
+import { assertReliableWatchRuntime } from "../core/watch/runtime";
 import type { WatchedInputRuntime } from "./hooks/useWatchedInput";
 
 /** A replacement registry prepared for adoption and optionally already retiring. */
@@ -56,6 +57,7 @@ export function AppHost({
   startupNoticeResolver,
   watchRuntime,
   workspaceFileWriter,
+  bunVersion = Bun.version,
 }: {
   bootstrap: AppBootstrap;
   /** Process and terminal interrupts routed through host-owned extension retirement. */
@@ -71,6 +73,8 @@ export function AppHost({
   startupNoticeResolver?: () => Promise<StartupNotice | null>;
   watchRuntime?: WatchedInputRuntime;
   workspaceFileWriter?: WorkspaceFileWriter;
+  /** Runtime identity injection for reload compatibility tests. */
+  bunVersion?: string;
 }) {
   const initialBootstrap = bootstrap.reloadContext.vcsCatalog
     ? bootstrap
@@ -264,6 +268,9 @@ export function AppHost({
         cwd,
         vcsCatalog: discoveryCatalog,
       });
+      if (configured.input.options.watch) {
+        assertReliableWatchRuntime(bunVersion);
+      }
       let replacementExtensions: ExtensionLoadResult | undefined;
 
       if (options?.reloadExtensions || cwd !== extensionsCwdRef.current) {


### PR DESCRIPTION
## Summary

- Refuse initial `--watch` startup on Bun versions older than 1.3.14.
- Apply the same runtime check when a live session reload enables watch mode.
- Raise the documented source-development requirement to Bun 1.3.14.

## Why

A live `bun src/main.tsx diff main --watch --fast` session became completely unresponsive: keyboard and mouse bytes accumulated in the PTY while the process remained alive at 0% CPU.

A forced core dump showed an AB/BA lock inversion in Bun 1.3.10:

- Main thread: `PathWatcherManager.unregisterWatcher` → `Watcher.remove`, waiting for the watcher mutex.
- File Watcher thread: `processINotifyEventBatch` → `PathWatcherManager.onFileUpdate`, waiting for the manager mutex.

This matches [oven-sh/bun#31166](https://github.com/oven-sh/bun/issues/31166). The upstream reproduction hung under Bun 1.3.10 after two heartbeats and completed under Bun 1.3.14 after nineteen. Hunk already pins Bun 1.3.14 for builds, but source invocations could still use an older global runtime.

The guard runs before watcher construction and before acquiring a controlling-terminal stream. Headless and non-watch commands remain available on older runtimes. Prebuilt/npm installs continue using their embedded or bundled fixed Bun runtime.

## Verification

- `bun test src/core/watch/runtime.test.ts src/app/startup.test.ts src/ui/AppHost.reload.test.tsx`
- `bun run typecheck`
- `bun run deps:check`
- `XDG_CONFIG_HOME=$(mktemp -d) bun run test`
- `bun run test:integration`
- `bun run test:tty-smoke`
- `bun run check:docs`
- `bun run changeset:status`
- Black-box old-runtime launch: Bun 1.3.10 exits with the actionable version error before entering the TUI.
- Real Herdr pane: Hunk remained responsive to keyboard input and watch refreshes under Bun 1.3.14.

Tested on Linux x64. The runtime policy and version parser have platform-neutral unit coverage; macOS and Windows were not tested manually.

*This PR description was generated by Pi using gpt-5.6-sol*
