### PR TITLE
fix(keys): reject key chords with empty segments around +

### DIFF
--- a/.changeset/reject-empty-keychord-segments.md
+++ b/.changeset/reject-empty-keychord-segments.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reject malformed configured and extension key chords instead of silently rebinding them after empty `+` segments.

--- a/src/extension-api/keys.test.ts
+++ b/src/extension-api/keys.test.ts
@@ -87,6 +87,31 @@ describe("parseKeyChord", () => {
     expect(parseKeyChord("")).toHaveProperty("error");
   });
 
+  test("rejects chords with an empty segment around a plus", () => {
+    // A missing component around "+" must be refused, not silently
+    // normalized into a different, real shortcut.
+    expect(parseKeyChord("s+")).toHaveProperty("error");
+    expect(parseKeyChord("+s")).toHaveProperty("error");
+    expect(parseKeyChord("ctrl++s")).toHaveProperty("error");
+    expect(parseKeyChord("ctrl+s+")).toHaveProperty("error");
+  });
+
+  test("keeps the literal plus-key chord valid", () => {
+    const literalPlus = {
+      base: "+",
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+    };
+    expect(parsed("+")).toEqual(literalPlus);
+    expect(parsed(" + ")).toEqual(literalPlus);
+  });
+
+  test("tolerates whitespace around valid components", () => {
+    expect(parsed("ctrl + s")).toEqual(parsed("ctrl+s"));
+  });
+
   test("refuses shift on symbols and digits, keeps it for letters and named keys", () => {
     // Shifted symbols have no layout-independent identity; the binding must
     // name the character shift produces instead.

--- a/src/extension-api/keys.ts
+++ b/src/extension-api/keys.ts
@@ -70,15 +70,15 @@ const MODIFIER_TOKENS: Record<string, keyof Omit<ParsedKeyChord, "base">> = {
  * registration instead of silently never firing.
  */
 export function parseKeyChord(chord: string): ParsedKeyChord | { error: string } {
-  const tokens = chord
-    .split("+")
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0);
-  // A literal "+" binding arrives as empty tokens; treat the lone "+" specially.
-  if (tokens.length === 0) {
-    return chord.trim() === "+"
-      ? { base: "+", ctrl: false, meta: false, option: false, shift: false }
-      : { error: `Empty key chord "${chord}"` };
+  // A literal "+" binding splits into empty segments below; recognize it before
+  // segments are validated, so the intentional plus-key chord stays valid.
+  if (chord.trim() === "+") {
+    return { base: "+", ctrl: false, meta: false, option: false, shift: false };
+  }
+
+  const tokens = chord.split("+").map((token) => token.trim());
+  if (tokens.some((token) => token.length === 0)) {
+    return { error: `Key chord "${chord}" has an empty component around "+"` };
   }
 
   const parsed: ParsedKeyChord = {

--- a/src/ui/lib/keymap.test.ts
+++ b/src/ui/lib/keymap.test.ts
@@ -106,6 +106,14 @@ describe("resolveCommandKeys", () => {
     expect(issues[0]?.message).toContain("not a usable key chord");
   });
 
+  test("a chord with an empty segment is rejected without claiming the real shortcut", () => {
+    const { keys, issues } = resolve({ "hunk.app.quit": ["s+", "ctrl+q"] });
+
+    expect(keys.get("hunk.app.quit")).toEqual(["ctrl+q"]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.message).toContain("not a usable key chord");
+  });
+
   test("unknown ids are reported, softly when they look like extension commands", () => {
     const { keys, issues } = resolve({ "hunk.app.quti": "x", "ghost.command": "z" });
 


### PR DESCRIPTION
## Problem

`parseKeyChord` filtered out empty segments after splitting a chord on `+`, so malformed bindings were silently reinterpreted as different, real shortcuts:

```
s+       → s
+s       → s
ctrl++s  → ctrl+s
ctrl+s+  → ctrl+s
```

## Fix

- Recognize the literal `+`/` + ` chord before segment validation (since splitting it produces two empty segments that must stay valid).
- For every other chord, reject any empty segment around `+` instead of filtering it out.
- Whitespace-padded valid chords (`ctrl + s`) continue to parse as before.

## Testing

Ran locally (not just written blind):
- `bun test src/extension-api/keys.test.ts src/ui/lib/keymap.test.ts` — 36/36 passing, including new coverage for all four malformed cases, the literal-plus compatibility cases, and the keymap-level "malformed chord doesn't claim the real shortcut" case.
- `bun run typecheck` — clean.
- `bun run lint` — 0 warnings/errors.
- `bun run format:check` on the changed files — clean (the repo-wide `format:check` currently reports ~1000 pre-existing unrelated files; scoped to my 4 changed files only).

Added a patch Changeset per the contribution convention.

Fixes #906