### PR TITLE
fix(extension-api): reject key chords with empty + segments

### DIFF
--- a/.changeset/reject-empty-keychord-segments.md
+++ b/.changeset/reject-empty-keychord-segments.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reject malformed configured and extension key chords instead of silently rebinding them after empty `+` segments.

--- a/src/extension-api/keys.test.ts
+++ b/src/extension-api/keys.test.ts
@@ -87,6 +87,28 @@ describe("parseKeyChord", () => {
     expect(parseKeyChord("")).toHaveProperty("error");
   });
 
+  test("refuses chords with an empty segment around +", () => {
+    expect(parseKeyChord("s+")).toHaveProperty("error");
+    expect(parseKeyChord("+s")).toHaveProperty("error");
+    expect(parseKeyChord("ctrl++s")).toHaveProperty("error");
+    expect(parseKeyChord("ctrl+s+")).toHaveProperty("error");
+  });
+
+  test("keeps the literal plus key valid, with or without surrounding whitespace", () => {
+    expect(parsed("+")).toEqual({
+      base: "+",
+      ctrl: false,
+      meta: false,
+      option: false,
+      shift: false,
+    });
+    expect(parsed(" + ")).toEqual(parsed("+"));
+  });
+
+  test("tolerates whitespace around otherwise valid chord components", () => {
+    expect(parsed("ctrl + s")).toEqual(parsed("ctrl+s"));
+  });
+
   test("refuses shift on symbols and digits, keeps it for letters and named keys", () => {
     // Shifted symbols have no layout-independent identity; the binding must
     // name the character shift produces instead.

--- a/src/extension-api/keys.ts
+++ b/src/extension-api/keys.ts
@@ -70,15 +70,19 @@ const MODIFIER_TOKENS: Record<string, keyof Omit<ParsedKeyChord, "base">> = {
  * registration instead of silently never firing.
  */
 export function parseKeyChord(chord: string): ParsedKeyChord | { error: string } {
-  const tokens = chord
-    .split("+")
-    .map((token) => token.trim())
-    .filter((token) => token.length > 0);
-  // A literal "+" binding arrives as empty tokens; treat the lone "+" specially.
-  if (tokens.length === 0) {
-    return chord.trim() === "+"
-      ? { base: "+", ctrl: false, meta: false, option: false, shift: false }
-      : { error: `Empty key chord "${chord}"` };
+  // The literal "+" binding (optionally whitespace-padded) splits into two
+  // empty segments; recognize it before empty segments are rejected below.
+  if (chord.trim() === "+") {
+    return { base: "+", ctrl: false, meta: false, option: false, shift: false };
+  }
+
+  if (chord.trim().length === 0) {
+    return { error: `Empty key chord "${chord}"` };
+  }
+
+  const tokens = chord.split("+").map((token) => token.trim());
+  if (tokens.some((token) => token.length === 0)) {
+    return { error: `Key chord "${chord}" has an empty segment around "+"` };
   }
 
   const parsed: ParsedKeyChord = {

--- a/src/ui/lib/keymap.test.ts
+++ b/src/ui/lib/keymap.test.ts
@@ -106,6 +106,16 @@ describe("resolveCommandKeys", () => {
     expect(issues[0]?.message).toContain("not a usable key chord");
   });
 
+  test("a malformed chord with an empty + segment does not claim another command's shortcut", () => {
+    const { keys, issues } = resolve({ "hunk.app.quit": ["s+", "ctrl+q"] });
+
+    expect(keys.get("hunk.app.quit")).toEqual(["ctrl+q"]);
+    // "s+" must not be normalized into "s" and steal it from its default owner.
+    expect(keys.get("hunk.view.toggleFilesPane")).toEqual(["s"]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.message).toContain("not a usable key chord");
+  });
+
   test("unknown ids are reported, softly when they look like extension commands", () => {
     const { keys, issues } = resolve({ "hunk.app.quti": "x", "ghost.command": "z" });
 


### PR DESCRIPTION
## Problem

The shared key-chord parser (`parseKeyChord` in `src/extension-api/keys.ts`) split a chord on `+` and filtered out any empty tokens before validating modifier/base-key structure. That let malformed bindings silently resolve to a different, valid shortcut:

```
s+       → s
+s       → s
ctrl++s  → ctrl+s
ctrl+s+  → ctrl+s
```

`parseKeyChord("s+")` returned the same parsed chord as `parseKeyChord("s")`, so a typo in a user `[keybindings]` entry, an extension `registerCommand` binding, or the public `matchesKey` helper could claim and fire a real shortcut instead of being rejected. This was inconsistent with the parser's existing behavior for other malformed chords like `ctlr+s`, `f13`, and `ctrl+`, which are already rejected.

## Fix

Recognize the literal `+` chord (optionally whitespace-padded, e.g. `" + "`) before empty-segment rejection, since splitting it on `+` produces two empty segments that are intentional. For every other chord, split on `+`, trim each segment, and return a parse error if any segment is empty instead of silently dropping it. Whitespace-padded valid chords such as `ctrl + s` continue to parse.

The fix lives entirely in the shared grammar in `src/extension-api/keys.ts`, so built-in commands, user keybindings, extension `registerCommand` bindings, and the public `matchesKey` helper all inherit the stricter validation from one place.

## Tests

- `src/extension-api/keys.test.ts`: added table-driven coverage asserting `s+`, `+s`, `ctrl++s`, and `ctrl+s+` are rejected, and that `+`, `" + "`, and `ctrl + s` still parse correctly.
- `src/ui/lib/keymap.test.ts`: added a case confirming a malformed chord with an empty `+` segment (`s+`) does not claim another command's real shortcut (`s`) and is reported as one keybinding issue while its valid sibling chord survives.

## Validation

```
bun test src/extension-api/keys.test.ts src/ui/lib/keymap.test.ts   # 36 pass
bun run typecheck                                                    # pass
bun run lint                                                         # 0 warnings, 0 errors
bun run format:check                                                 # pass
bun run deps:check                                                   # no violations
bun run test                                                         # 3364 pass, 35 skip, 2 fail (pre-existing, unrelated: a jujutsu test that requires the `jj` binary on PATH, and a React-internal error in an unrelated component test — both reproduce identically on main without this change)
```

A patch Changeset for `hunkdiff` is included.

Fixes #906