### PR TITLE
feat(ui): add adaptive file tree sidebar

### DIFF
--- a/.changeset/wide-trees-expand.md
+++ b/.changeset/wide-trees-expand.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Show a fully expanded file tree when the file sidebar has more than 30 content columns.

--- a/.changeset/wide-trees-expand.md
+++ b/.changeset/wide-trees-expand.md
@@ -2,4 +2,4 @@
 "hunkdiff": minor
 ---
 
-Show a fully expanded file tree when the file sidebar reaches its preferred 34-column width.
+Show a fully expanded file tree when the file sidebar reaches its preferred 34-column width, and keep resize drags active while its layout changes.

--- a/.changeset/wide-trees-expand.md
+++ b/.changeset/wide-trees-expand.md
@@ -2,4 +2,4 @@
 "hunkdiff": minor
 ---
 
-Show a fully expanded file tree when the file sidebar has more than 30 content columns.
+Show a fully expanded file tree when the file sidebar reaches its preferred 34-column width.

--- a/src/extensions/default/ui/sidebar/FileSidebars.tsx
+++ b/src/extensions/default/ui/sidebar/FileSidebars.tsx
@@ -1,0 +1,235 @@
+import type { ScrollBoxRenderable } from "@opentui/core";
+import { useTerminalDimensions } from "@opentui/react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import type { ExtensionPaneProps } from "../../../../extension-api/types";
+import {
+  buildFlatSidebarEntries,
+  buildTreeSidebarEntries,
+  resolveFileSidebarMode,
+  sidebarEntryStatsWidth,
+  type SidebarEntry,
+} from "../../../../ui/lib/files";
+import { fileRowId } from "../../../../ui/lib/ids";
+import { buildSidebarRenderWindow } from "../../../../ui/lib/sidebarRenderWindow";
+import {
+  FileDirectoryRow,
+  FileGroupHeader,
+  FileListItem,
+} from "../../../../ui/components/panes/FileListItem";
+
+export type BuiltInSidebarProps = Omit<ExtensionPaneProps, "placement" | "height" | "currentLine"> &
+  Partial<Pick<ExtensionPaneProps, "placement" | "height" | "currentLine">>;
+
+type FileSidebarVariantProps = Pick<
+  BuiltInSidebarProps,
+  "actions" | "files" | "selectedFileId" | "theme"
+> & {
+  estimatedViewportRows: number;
+  scrollTop: number;
+  textWidth: number;
+  viewportHeight: number;
+};
+
+interface VirtualizedFileSidebarRowsProps extends Omit<FileSidebarVariantProps, "files"> {
+  entries: SidebarEntry[];
+}
+
+/** Render one windowed sidebar projection with shared file selection and stats lanes. */
+export function VirtualizedFileSidebarRows({
+  actions,
+  entries,
+  estimatedViewportRows,
+  scrollTop,
+  selectedFileId,
+  textWidth,
+  theme,
+  viewportHeight,
+}: VirtualizedFileSidebarRowsProps): ReactNode {
+  const fileEntries = entries.filter((entry) => entry.kind === "file");
+  const statsWidth = Math.max(0, ...fileEntries.map((entry) => sidebarEntryStatsWidth(entry)));
+  const renderWindow = useMemo(
+    () =>
+      buildSidebarRenderWindow({
+        entries,
+        estimatedViewportRows,
+        overscanRows: 4,
+        scrollTop,
+        selectedFileId: selectedFileId ?? undefined,
+        viewportHeight,
+      }),
+    [entries, estimatedViewportRows, scrollTop, selectedFileId, viewportHeight],
+  );
+
+  return (
+    <box style={{ width: "100%", flexDirection: "column" }}>
+      {renderWindow.items.map((item) => {
+        if (item.kind === "spacer") {
+          return (
+            <box
+              key={item.key}
+              style={{ width: "100%", height: item.height, backgroundColor: theme.panel }}
+            />
+          );
+        }
+
+        const { entry } = item;
+        if (entry.kind === "group") {
+          return (
+            <FileGroupHeader key={entry.id} entry={entry} textWidth={textWidth} theme={theme} />
+          );
+        }
+        if (entry.kind === "directory") {
+          return (
+            <FileDirectoryRow
+              key={entry.id}
+              entry={entry}
+              statsWidth={statsWidth}
+              textWidth={textWidth}
+              theme={theme}
+            />
+          );
+        }
+
+        return (
+          <FileListItem
+            key={entry.id}
+            entry={entry}
+            selected={entry.id === selectedFileId}
+            statsWidth={statsWidth}
+            textWidth={textWidth}
+            theme={theme}
+            onSelectFile={actions.selectFile}
+          />
+        );
+      })}
+    </box>
+  );
+}
+
+/** Render the compact directory-group projection for a narrow file sidebar. */
+export function FlatFileSidebar({ files, ...props }: FileSidebarVariantProps): ReactNode {
+  const entries = useMemo(() => buildFlatSidebarEntries(files), [files]);
+  return <VirtualizedFileSidebarRows {...props} entries={entries} />;
+}
+
+/** Render the fully expanded ordered hierarchy for a wide file sidebar. */
+export function TreeFileSidebar({ files, ...props }: FileSidebarVariantProps): ReactNode {
+  const entries = useMemo(() => buildTreeSidebarEntries(files), [files]);
+  return <VirtualizedFileSidebarRows {...props} entries={entries} />;
+}
+
+/**
+ * Adapt the built-in file sidebar between compact and hierarchical projections.
+ *
+ * Resizing only replaces the rows inside one stable scrollbox. The sidebar keeps
+ * file navigation and selected-row reveal shared so both projections preserve
+ * the same review-stream behavior.
+ */
+export function FlexFileSidebar({
+  files,
+  selectedFileId,
+  theme,
+  width,
+  actions,
+}: BuiltInSidebarProps): ReactNode {
+  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const [scrollViewport, setScrollViewport] = useState({ top: 0, height: 0 });
+  const terminal = useTerminalDimensions();
+  // Mirrors the host layout: one column of row highlight plus row padding.
+  const textWidth = Math.max(8, width - 2);
+  const mode = resolveFileSidebarMode(textWidth);
+  const variantProps: FileSidebarVariantProps = {
+    actions,
+    estimatedViewportRows: terminal.height,
+    files,
+    scrollTop: scrollViewport.top,
+    selectedFileId,
+    textWidth,
+    theme,
+    viewportHeight: scrollViewport.height,
+  };
+
+  useEffect(() => {
+    const scrollBox = scrollRef.current;
+    if (!scrollBox) {
+      return;
+    }
+
+    let cancelled = false;
+    let scheduled = false;
+
+    const readViewport = () => {
+      const nextTop = scrollBox.scrollTop ?? 0;
+      const nextHeight = scrollBox.viewport.height ?? 0;
+      setScrollViewport((current) =>
+        current.top === nextTop && current.height === nextHeight
+          ? current
+          : { top: nextTop, height: nextHeight },
+      );
+    };
+
+    const handleViewportChange = () => {
+      if (scheduled) {
+        return;
+      }
+      scheduled = true;
+      queueMicrotask(() => {
+        if (cancelled) {
+          scheduled = false;
+          return;
+        }
+
+        try {
+          readViewport();
+        } finally {
+          scheduled = false;
+        }
+      });
+    };
+
+    readViewport();
+    scrollBox.verticalScrollBar.on("change", handleViewportChange);
+    scrollBox.viewport.on("layout-changed", handleViewportChange);
+    scrollBox.viewport.on("resized", handleViewportChange);
+
+    return () => {
+      cancelled = true;
+      scrollBox.verticalScrollBar.off("change", handleViewportChange);
+      scrollBox.viewport.off("layout-changed", handleViewportChange);
+      scrollBox.viewport.off("resized", handleViewportChange);
+    };
+  }, [files, mode]);
+
+  // Selection and projection changes can both move the target row, so follow
+  // the stable file id after either event instead of only after navigation.
+  useEffect(() => {
+    if (!selectedFileId) {
+      return;
+    }
+
+    scrollRef.current?.scrollChildIntoView(fileRowId(selectedFileId));
+  }, [files, mode, selectedFileId]);
+
+  return (
+    <scrollbox
+      ref={scrollRef}
+      width="100%"
+      height="100%"
+      focused={false}
+      scrollY={true}
+      viewportCulling={true}
+      rootOptions={{ backgroundColor: theme.panel }}
+      wrapperOptions={{ backgroundColor: theme.panel }}
+      viewportOptions={{ backgroundColor: theme.panel }}
+      contentOptions={{ backgroundColor: theme.panel }}
+      verticalScrollbarOptions={{ visible: false }}
+      horizontalScrollbarOptions={{ visible: false }}
+    >
+      {mode === "tree" ? (
+        <TreeFileSidebar {...variantProps} />
+      ) : (
+        <FlatFileSidebar {...variantProps} />
+      )}
+    </scrollbox>
+  );
+}

--- a/src/extensions/default/ui/sidebar/FileSidebars.tsx
+++ b/src/extensions/default/ui/sidebar/FileSidebars.tsx
@@ -32,6 +32,7 @@ type FileSidebarVariantProps = Pick<
 
 interface VirtualizedFileSidebarRowsProps extends Omit<FileSidebarVariantProps, "files"> {
   entries: SidebarEntry[];
+  paddingLeft?: number;
 }
 
 /** Render one windowed sidebar projection with shared file selection and stats lanes. */
@@ -39,6 +40,7 @@ export function VirtualizedFileSidebarRows({
   actions,
   entries,
   estimatedViewportRows,
+  paddingLeft = 1,
   scrollTop,
   selectedFileId,
   textWidth,
@@ -75,7 +77,13 @@ export function VirtualizedFileSidebarRows({
         const { entry } = item;
         if (entry.kind === "group") {
           return (
-            <FileGroupHeader key={entry.id} entry={entry} textWidth={textWidth} theme={theme} />
+            <FileGroupHeader
+              key={entry.id}
+              entry={entry}
+              paddingLeft={paddingLeft}
+              textWidth={textWidth}
+              theme={theme}
+            />
           );
         }
         if (entry.kind === "directory") {
@@ -83,6 +91,7 @@ export function VirtualizedFileSidebarRows({
             <FileDirectoryRow
               key={entry.id}
               entry={entry}
+              paddingLeft={paddingLeft}
               statsWidth={statsWidth}
               textWidth={textWidth}
               theme={theme}
@@ -94,6 +103,7 @@ export function VirtualizedFileSidebarRows({
           <FileListItem
             key={entry.id}
             entry={entry}
+            paddingLeft={paddingLeft}
             selected={entry.id === selectedFileId}
             statsWidth={statsWidth}
             textWidth={textWidth}
@@ -115,7 +125,7 @@ export function FlatFileSidebar({ files, ...props }: FileSidebarVariantProps): R
 /** Render the fully expanded ordered hierarchy for a wide file sidebar. */
 export function TreeFileSidebar({ files, ...props }: FileSidebarVariantProps): ReactNode {
   const entries = useMemo(() => buildTreeSidebarEntries(files), [files]);
-  return <VirtualizedFileSidebarRows {...props} entries={entries} />;
+  return <VirtualizedFileSidebarRows {...props} entries={entries} paddingLeft={0} />;
 }
 
 /**

--- a/src/extensions/default/ui/sidebar/index.test.tsx
+++ b/src/extensions/default/ui/sidebar/index.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { paneKey } from "../../../apply";
-import { BUNDLED_SIDEBAR_EXTENSION_ID, BUNDLED_SIDEBAR_VIEW_ID, BuiltInSidebarView } from ".";
+import { BUNDLED_SIDEBAR_EXTENSION_ID, BUNDLED_SIDEBAR_VIEW_ID, FlexFileSidebar } from ".";
 import { getBundledUIRegistry } from "..";
 
 const getBundledFilesPane = () => getBundledUIRegistry().panes[0]!;
@@ -13,7 +13,7 @@ describe("bundled sidebar extension", () => {
     expect(registered.pane.id).toBe(BUNDLED_SIDEBAR_VIEW_ID);
     // The registration carries the exact component the app renders and the
     // extension pipeline falls back to, so there is one built-in sidebar.
-    expect(registered.pane.component).toBe(BuiltInSidebarView);
+    expect(registered.pane.component).toBe(FlexFileSidebar);
   });
 
   test("owns the reserved vendor id, so no extension can mint its view key", () => {

--- a/src/extensions/default/ui/sidebar/index.tsx
+++ b/src/extensions/default/ui/sidebar/index.tsx
@@ -1,43 +1,14 @@
-import type { ScrollBoxRenderable } from "@opentui/core";
-import { useTerminalDimensions } from "@opentui/react";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import type { ExtensionPaneProps } from "../../../../extension-api/types";
-import {
-  buildSidebarEntries,
-  sidebarEntryStatsWidth,
-  type SidebarEntry,
-} from "../../../../ui/lib/files";
-import { fileRowId } from "../../../../ui/lib/ids";
-import { buildSidebarRenderWindow } from "../../../../ui/lib/sidebarRenderWindow";
-import { FileGroupHeader, FileListItem } from "../../../../ui/components/panes/FileListItem";
 import { HUNK_VENDOR_EXTENSION_ID } from "../../../extensionIds";
 import type { ExtensionFactory } from "../../../types";
+import { FlexFileSidebar } from "./FileSidebars";
 
 /**
- * Hunk's file-navigation sidebar, shipped as a bundled extension.
+ * Hunk's file-navigation sidebar ships as a bundled extension.
  *
- * Like the Git backend, the built-in sidebar registers through the public API —
- * `registerPane` — and its component consumes exactly the published
- * `ExtensionPaneProps`: the frozen file views for its entries, the theme
- * token slice for its colors, `actions.selectFile` for navigation, and the
- * host-served `@opentui/react` for its hooks. That is what keeps the sidebar
- * contract honest: anything this pane needs that the props cannot express is a
- * real gap in what third-party panes can build.
- *
- * Unlike the VCS tier this module is UI code, so it is deliberately *not* part
- * of `loadBundledExtensions` — that list is imported from VCS adapter
- * resolution, which must stay renderer-free. The pane instead loads through
- * `getBundledUIRegistry` at the one place the app resolves its active panes.
- * Rendering helpers (row components, the render window) are imported from Hunk
- * directly: this is host code, and the dogfooding boundary is the data,
- * actions, and theme crossing the props — not utility code.
- *
- * The scrollbox usage below is itself part of the published contract: the ref
- * reads (`scrollTop`, `viewport.height`), the scrollbar/viewport change
- * events, and `scrollChildIntoView` over child `id` props are documented in
- * docs/extensions.md as the supported way third-party panes scroll and
- * follow the selection. Changing how this component talks to its scrollbox
- * means updating that contract — same honesty mechanism as the props.
+ * The component consumes the public pane props for files, selection, theme,
+ * and navigation while host-owned rendering helpers provide the responsive
+ * terminal presentation. This keeps the extension contract honest without
+ * duplicating review semantics inside the bundled surface.
  */
 
 /**
@@ -46,153 +17,14 @@ import type { ExtensionFactory } from "../../../types";
  * View keys are `<extensionId>:<viewId>`, and extension ids are file stems a
  * user picks, so `sidebar.ts` on disk would otherwise mint `sidebar:files` and
  * collide with this view. `hunk` is reserved at load, so this key cannot be
- * taken. The `sourcePath` below still names the module, since that is what it
- * describes.
+ * taken.
  */
 export const BUNDLED_SIDEBAR_EXTENSION_ID = HUNK_VENDOR_EXTENSION_ID;
 export const BUNDLED_SIDEBAR_VIEW_ID = "files";
 
-type BuiltInSidebarProps = Omit<ExtensionPaneProps, "placement" | "height" | "currentLine"> &
-  Partial<Pick<ExtensionPaneProps, "placement" | "height" | "currentLine">>;
+export { FlatFileSidebar, FlexFileSidebar, TreeFileSidebar } from "./FileSidebars";
 
-/** Render the built-in file navigation pane from public pane props. */
-export function BuiltInSidebarView({
-  files,
-  selectedFileId,
-  theme,
-  width,
-  actions,
-}: BuiltInSidebarProps): ReactNode {
-  const scrollRef = useRef<ScrollBoxRenderable | null>(null);
-  const [scrollViewport, setScrollViewport] = useState({ top: 0, height: 0 });
-  const terminal = useTerminalDimensions();
-  // Mirrors the host layout: one column of row highlight plus row padding.
-  const textWidth = Math.max(8, width - 2);
-  const entries = useMemo<SidebarEntry[]>(() => buildSidebarEntries(files), [files]);
-  const fileEntries = entries.filter((entry) => entry.kind === "file");
-  const statsWidth = Math.max(0, ...fileEntries.map((entry) => sidebarEntryStatsWidth(entry)));
-  const renderWindow = useMemo(
-    () =>
-      buildSidebarRenderWindow({
-        entries,
-        estimatedViewportRows: terminal.height,
-        overscanRows: 4,
-        scrollTop: scrollViewport.top,
-        selectedFileId: selectedFileId ?? undefined,
-        viewportHeight: scrollViewport.height,
-      }),
-    [entries, terminal.height, scrollViewport.height, scrollViewport.top, selectedFileId],
-  );
-
-  useEffect(() => {
-    const scrollBox = scrollRef.current;
-    if (!scrollBox) {
-      return;
-    }
-
-    let cancelled = false;
-    let scheduled = false;
-
-    const readViewport = () => {
-      const nextTop = scrollBox.scrollTop ?? 0;
-      const nextHeight = scrollBox.viewport.height ?? 0;
-      setScrollViewport((current) =>
-        current.top === nextTop && current.height === nextHeight
-          ? current
-          : { top: nextTop, height: nextHeight },
-      );
-    };
-
-    const handleViewportChange = () => {
-      if (scheduled) {
-        return;
-      }
-      scheduled = true;
-      queueMicrotask(() => {
-        if (cancelled) {
-          scheduled = false;
-          return;
-        }
-
-        try {
-          readViewport();
-        } finally {
-          scheduled = false;
-        }
-      });
-    };
-
-    readViewport();
-    scrollBox.verticalScrollBar.on("change", handleViewportChange);
-    scrollBox.viewport.on("layout-changed", handleViewportChange);
-    scrollBox.viewport.on("resized", handleViewportChange);
-
-    return () => {
-      cancelled = true;
-      scrollBox.verticalScrollBar.off("change", handleViewportChange);
-      scrollBox.viewport.off("layout-changed", handleViewportChange);
-      scrollBox.viewport.off("resized", handleViewportChange);
-    };
-  }, [entries.length]);
-
-  // Keep the selected file's row visible as navigation moves the selection —
-  // behavior the sidebar owns, so every sidebar (custom ones included) decides
-  // its own follow policy instead of the host scrolling a pane it cannot see.
-  useEffect(() => {
-    if (!selectedFileId) {
-      return;
-    }
-
-    scrollRef.current?.scrollChildIntoView(fileRowId(selectedFileId));
-  }, [selectedFileId]);
-
-  return (
-    <scrollbox
-      ref={scrollRef}
-      width="100%"
-      height="100%"
-      focused={false}
-      scrollY={true}
-      viewportCulling={true}
-      rootOptions={{ backgroundColor: theme.panel }}
-      wrapperOptions={{ backgroundColor: theme.panel }}
-      viewportOptions={{ backgroundColor: theme.panel }}
-      contentOptions={{ backgroundColor: theme.panel }}
-      verticalScrollbarOptions={{ visible: false }}
-      horizontalScrollbarOptions={{ visible: false }}
-    >
-      <box style={{ width: "100%", flexDirection: "column" }}>
-        {renderWindow.items.map((item) => {
-          if (item.kind === "spacer") {
-            return (
-              <box
-                key={item.key}
-                style={{ width: "100%", height: item.height, backgroundColor: theme.panel }}
-              />
-            );
-          }
-
-          const { entry } = item;
-          return entry.kind === "group" ? (
-            <FileGroupHeader key={entry.id} entry={entry} textWidth={textWidth} theme={theme} />
-          ) : (
-            <FileListItem
-              key={entry.id}
-              entry={entry}
-              selected={entry.id === selectedFileId}
-              statsWidth={statsWidth}
-              textWidth={textWidth}
-              theme={theme}
-              onSelectFile={actions.selectFile}
-            />
-          );
-        })}
-      </box>
-    </scrollbox>
-  );
-}
-
-/** The factory the bundled sidebar registers through, same as any extension. */
+/** Register the responsive built-in file navigation pane. */
 const registerBundledSidebar: ExtensionFactory = (hunk) => {
   hunk.registerPane({
     id: BUNDLED_SIDEBAR_VIEW_ID,
@@ -200,7 +32,7 @@ const registerBundledSidebar: ExtensionFactory = (hunk) => {
     placement: "left",
     width: { preferred: 34, min: 22 },
     defaultOpen: true,
-    component: BuiltInSidebarView,
+    component: FlexFileSidebar,
   });
 };
 

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -210,6 +210,9 @@ describe("OpenTUI public components", () => {
     expect(wideFrame).not.toContain("src/ui/");
     expect(wideFrame).toContain("src/");
     expect(wideFrame).toContain("ui/");
+    const wideLines = wideFrame.split("\n");
+    expect(wideLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(1);
+    expect(wideLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(3);
     expect(wideFrame).toContain("alpha.ts");
     expect(wideFrame).toContain("beta.ts");
   });

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -197,6 +197,23 @@ describe("OpenTUI public components", () => {
     expect(frame).toContain("+2 -1");
   });
 
+  test("adapts file navigation from grouped paths to an expanded hierarchy", async () => {
+    const example = createExampleDiff();
+    const files = [
+      createHunkDiffFile({ ...example, id: "alpha", path: "src/ui/alpha.ts" }),
+      createHunkDiffFile({ ...example, id: "beta", path: "src/ui/beta.ts" }),
+    ];
+    const narrowFrame = await captureFrame(<HunkFileNav files={files} width={31} />, 36, 8);
+    const wideFrame = await captureFrame(<HunkFileNav files={files} width={32} />, 36, 8);
+
+    expect(narrowFrame).toContain("src/ui/");
+    expect(wideFrame).not.toContain("src/ui/");
+    expect(wideFrame).toContain("src/");
+    expect(wideFrame).toContain("ui/");
+    expect(wideFrame).toContain("alpha.ts");
+    expect(wideFrame).toContain("beta.ts");
+  });
+
   test("creates public file models from patch text", () => {
     const files = createHunkDiffFilesFromPatch(`diff --git a/example.ts b/example.ts
 --- a/example.ts

--- a/src/opentui/HunkDiffView.test.tsx
+++ b/src/opentui/HunkDiffView.test.tsx
@@ -197,14 +197,26 @@ describe("OpenTUI public components", () => {
     expect(frame).toContain("+2 -1");
   });
 
+  test("uses a single ellipsis when a file navigation name is truncated", async () => {
+    const example = createExampleDiff();
+    const file = createHunkDiffFile({
+      ...example,
+      id: "long-name",
+      path: "src/extraordinarily-long-component-name",
+    });
+    const frame = await captureFrame(<HunkFileNav files={[file]} width={18} />, 22, 6);
+
+    expect(frame).toContain("…");
+  });
+
   test("adapts file navigation from grouped paths to an expanded hierarchy", async () => {
     const example = createExampleDiff();
     const files = [
       createHunkDiffFile({ ...example, id: "alpha", path: "src/ui/alpha.ts" }),
       createHunkDiffFile({ ...example, id: "beta", path: "src/ui/beta.ts" }),
     ];
-    const narrowFrame = await captureFrame(<HunkFileNav files={files} width={31} />, 36, 8);
-    const wideFrame = await captureFrame(<HunkFileNav files={files} width={32} />, 36, 8);
+    const narrowFrame = await captureFrame(<HunkFileNav files={files} width={32} />, 36, 8);
+    const wideFrame = await captureFrame(<HunkFileNav files={files} width={33} />, 36, 8);
 
     expect(narrowFrame).toContain("src/ui/");
     expect(wideFrame).not.toContain("src/ui/");

--- a/src/opentui/HunkFileNav.tsx
+++ b/src/opentui/HunkFileNav.tsx
@@ -1,6 +1,15 @@
 import { useMemo } from "react";
-import { FileGroupHeader, FileListItem } from "../ui/components/panes/FileListItem";
-import { buildSidebarEntries, sidebarEntryStatsWidth } from "../ui/lib/files";
+import {
+  FileDirectoryRow,
+  FileGroupHeader,
+  FileListItem,
+} from "../ui/components/panes/FileListItem";
+import {
+  buildFlatSidebarEntries,
+  buildTreeSidebarEntries,
+  resolveFileSidebarMode,
+  sidebarEntryStatsWidth,
+} from "../ui/lib/files";
 import { resolveTheme } from "../ui/themes";
 import { toInternalDiffFiles } from "./model";
 import type { HunkFileNavProps } from "./types";
@@ -15,23 +24,46 @@ export function HunkFileNav({
 }: HunkFileNavProps) {
   const resolvedTheme = resolveTheme(theme, null);
   const internalFiles = useMemo(() => toInternalDiffFiles(files), [files]);
-  const entries = useMemo(() => buildSidebarEntries(internalFiles), [internalFiles]);
+  const textWidth = Math.max(1, width - 1);
+  const mode = resolveFileSidebarMode(textWidth);
+  const entries = useMemo(
+    () =>
+      mode === "tree"
+        ? buildTreeSidebarEntries(internalFiles)
+        : buildFlatSidebarEntries(internalFiles),
+    [internalFiles, mode],
+  );
   const fileEntries = entries.filter((entry) => entry.kind === "file");
   const statsWidth = Math.max(0, ...fileEntries.map((entry) => sidebarEntryStatsWidth(entry)));
-  const textWidth = Math.max(1, width - 1);
 
   return (
     <box style={{ width: "100%", flexDirection: "column", backgroundColor: resolvedTheme.panel }}>
-      {entries.map((entry) =>
-        entry.kind === "group" ? (
-          <FileGroupHeader
-            key={entry.id}
-            entry={entry}
-            paddingLeft={0}
-            textWidth={Math.max(1, width)}
-            theme={resolvedTheme}
-          />
-        ) : (
+      {entries.map((entry) => {
+        if (entry.kind === "group") {
+          return (
+            <FileGroupHeader
+              key={entry.id}
+              entry={entry}
+              paddingLeft={0}
+              textWidth={Math.max(1, width)}
+              theme={resolvedTheme}
+            />
+          );
+        }
+        if (entry.kind === "directory") {
+          return (
+            <FileDirectoryRow
+              key={entry.id}
+              entry={entry}
+              paddingLeft={0}
+              statsWidth={statsWidth}
+              textWidth={textWidth}
+              theme={resolvedTheme}
+            />
+          );
+        }
+
+        return (
           <FileListItem
             key={entry.id}
             entry={entry}
@@ -42,8 +74,8 @@ export function HunkFileNav({
             theme={resolvedTheme}
             onSelectFile={onSelectFile}
           />
-        ),
-      )}
+        );
+      })}
     </box>
   );
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,8 @@
-import type { ScrollBoxRenderable } from "@opentui/core";
+import type {
+  BoxRenderable,
+  MouseEvent as TuiMouseEvent,
+  ScrollBoxRenderable,
+} from "@opentui/core";
 import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import {
   Suspense,
@@ -93,6 +97,7 @@ import {
 } from "./lib/extensionPanes";
 import { HUNK_FILES_PANE_KEY } from "../extensions/extensionIds";
 import { maxFileHeaderStatsWidth } from "./lib/fileHeader";
+import { setMouseCapture } from "./lib/mouseCapture";
 import { openSelectedFileInEditor } from "./lib/openInEditor";
 import { resolveResponsiveLayout } from "./lib/responsive";
 import type { WorkspaceRefreshRequest } from "./currentReviewRefresh";
@@ -190,6 +195,7 @@ export function App({
   const renderer = useRenderer();
   const terminal = useTerminalDimensions();
   const diffScrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const paneResizeCaptureRef = useRef<BoxRenderable | null>(null);
   const wrapToggleScrollTopRef = useRef<number | null>(null);
   const layoutToggleScrollTopRef = useRef<number | null>(null);
   const cancelCopySelectionRef = useRef<(() => void) | null>(null);
@@ -457,6 +463,12 @@ export function App({
     pagerMode,
     responsiveShowsSidebar: responsiveLayout.showSidebar,
   });
+
+  useEffect(() => {
+    if (resizingPaneKey === null) {
+      setMouseCapture(renderer, undefined);
+    }
+  }, [renderer, resizingPaneKey]);
 
   const {
     accept: acceptExtensionDialog,
@@ -1173,6 +1185,16 @@ export function App({
     );
   };
 
+  // OpenTUI normally chooses a drag target only after the pointer first moves. Capture on press
+  // so a fast motion or a sidebar projection swap cannot transfer the gesture to a transient row.
+  const beginCapturedPaneResize = (planned: PlannedPane, event: TuiMouseEvent) => {
+    if (!beginPaneResize(planned, event)) return;
+    if (paneResizeCaptureRef.current) {
+      setMouseCapture(renderer, paneResizeCaptureRef.current);
+    }
+    closeMenu();
+  };
+
   const renderDivider = (planned: PlannedPane) =>
     planned.divider ? (
       <box
@@ -1191,9 +1213,7 @@ export function App({
           height={planned.divider.height}
           isResizing={resizingPaneKey === planned.pane.key}
           theme={activeTheme}
-          onMouseDown={(event) => {
-            if (beginPaneResize(planned, event)) closeMenu();
-          }}
+          onMouseDown={(event) => beginCapturedPaneResize(planned, event)}
           onMouseDrag={updatePaneResize}
           onMouseDragEnd={endPaneResize}
           onMouseUp={endPaneResize}
@@ -1227,6 +1247,7 @@ export function App({
       ) : null}
 
       <box
+        ref={paneResizeCaptureRef}
         style={{
           width: bodyWidth,
           height: bodyHeight,

--- a/src/ui/AppHost.interactions.test.tsx
+++ b/src/ui/AppHost.interactions.test.tsx
@@ -3617,9 +3617,15 @@ describe("App interactions", () => {
         await flush(setup);
       }
 
+      const secondFileY = setup
+        .captureCharFrame()
+        .split("\n")
+        .findIndex((line) => line.slice(0, 34).includes("second.ts"));
+      expect(secondFileY).toBeGreaterThan(0);
+
       await act(async () => {
-        // Click inside the second file row below the repo-root group header.
-        await setup.mockMouse.click(6, 5);
+        // Target the rendered file row so flat and tree projections share this interaction proof.
+        await setup.mockMouse.click(6, secondFileY);
       });
       await flush(setup);
 

--- a/src/ui/AppHost.sidebar-resize.test.tsx
+++ b/src/ui/AppHost.sidebar-resize.test.tsx
@@ -155,8 +155,8 @@ describe("AppHost sidebar resize", () => {
     await flush(setup);
     expect(sidebarFrame(setup)).not.toContain("src/ui/");
 
-    // Raw pane width 32 leaves 30 content columns, which selects compact mode.
-    await dragDivider(setup, INITIAL_DIVIDER_COLUMN, 33);
+    // Raw pane width 33 leaves 31 content columns, just below the preferred tree width.
+    await dragDivider(setup, INITIAL_DIVIDER_COLUMN, 34);
 
     expect(sidebarFrame(setup)).toContain("src/ui/");
   });

--- a/src/ui/AppHost.sidebar-resize.test.tsx
+++ b/src/ui/AppHost.sidebar-resize.test.tsx
@@ -27,13 +27,13 @@ function createResizeBootstrap(): AppBootstrap {
     files: [
       createTestDiffFile(
         "alpha",
-        "src/alpha.ts",
+        "src/ui/alpha.ts",
         lines("export const a = 1;", "export const b = 2;"),
         lines("export const a = 10;", "export const b = 2;"),
       ),
       createTestDiffFile(
         "beta",
-        "src/beta.ts",
+        "src/ui/beta.ts",
         lines("export const c = 3;"),
         lines("export const c = 30;"),
       ),
@@ -70,6 +70,16 @@ async function flush(setup: Awaited<ReturnType<typeof testRender>>) {
 function dividerColumn(setup: Awaited<ReturnType<typeof testRender>>) {
   const row = setup.captureCharFrame().split("\n")[PROBE_ROW] ?? "";
   return row.indexOf("│");
+}
+
+/** Return only the file-sidebar columns so diff headers cannot satisfy sidebar assertions. */
+function sidebarFrame(setup: Awaited<ReturnType<typeof testRender>>) {
+  const divider = dividerColumn(setup);
+  return setup
+    .captureCharFrame()
+    .split("\n")
+    .map((line) => line.slice(0, divider))
+    .join("\n");
 }
 
 /**
@@ -138,6 +148,17 @@ describe("AppHost sidebar resize", () => {
 
     // The divider follows the new width: startWidth + (currentX - originX).
     expect(dividerColumn(setup)).toBeGreaterThan(INITIAL_DIVIDER_COLUMN);
+  });
+
+  test("resizing across the content-width threshold switches the file projection", async () => {
+    setup = await testRender(<AppHost bootstrap={createResizeBootstrap()} />, WIDE);
+    await flush(setup);
+    expect(sidebarFrame(setup)).not.toContain("src/ui/");
+
+    // Raw pane width 32 leaves 30 content columns, which selects compact mode.
+    await dragDivider(setup, INITIAL_DIVIDER_COLUMN, 33);
+
+    expect(sidebarFrame(setup)).toContain("src/ui/");
   });
 
   test("dragging the divider far left clamps the sidebar at its minimum width", async () => {

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -1,6 +1,5 @@
 import {
   MouseButton,
-  type CliRenderer,
   type MouseEvent as TuiMouseEvent,
   type ScrollBoxRenderable,
 } from "@opentui/core";
@@ -30,6 +29,7 @@ import type { FileSourceStatus } from "../../diff/expandCollapsedRows";
 import type { ActiveAddNoteAffordance } from "../../diff/DiffSectionBody";
 import type { CursorHighlight } from "../../diff/cursorHighlight";
 import { isNestedRowMouseAction } from "../../diff/rowMouseActions";
+import { setMouseCapture } from "../../lib/mouseCapture";
 import type { DraftReviewNote } from "../../lib/reviewNoteMapping";
 import {
   createVisibleAgentNote,
@@ -246,18 +246,6 @@ const EMPTY_FILE_VIEWS: ReadonlyMap<string, ResolvedFileViewLayout> = new Map();
 const EMPTY_LINE_HIGHLIGHTS: ReadonlyMap<string, readonly ValidatedLineHighlight[]> = new Map();
 const EMPTY_SOURCE_STATUS_BY_FILE_ID: Record<string, FileSourceStatus> = {};
 const NOOP_TOGGLE_GAP = () => {};
-
-/** Keep OpenTUI's drag capture on the persistent scrollbox instead of a repainting text row. */
-function retainCopySelectionCapture(renderer: CliRenderer, scrollBox: ScrollBoxRenderable) {
-  // OpenTUI exposes capture internally but has no public pointer-capture API yet. Its dispatcher
-  // otherwise captures the first dragged text node, which selection highlighting immediately
-  // replaces and leaves unable to receive the rest of the gesture.
-  (
-    renderer as unknown as {
-      setCapturedRenderable: (renderable: ScrollBoxRenderable) => void;
-    }
-  ).setCapturedRenderable(scrollBox);
-}
 
 /** Render the main multi-file review stream. */
 export function DiffPane({
@@ -1339,7 +1327,7 @@ export function DiffPane({
       if (copySelectionDragRef.current) {
         const scrollBox = scrollRef.current;
         if (scrollBox) {
-          retainCopySelectionCapture(renderer, scrollBox);
+          setMouseCapture(renderer, scrollBox);
         }
         suppressNativeSelection();
         event.preventDefault();

--- a/src/ui/components/panes/ExtensionPane.tsx
+++ b/src/ui/components/panes/ExtensionPane.tsx
@@ -9,7 +9,7 @@ import type {
 } from "../../../extension-api/types";
 import type { DiffFile } from "../../../core/changeset/model";
 import { paneKey } from "../../../extensions/apply";
-import { BuiltInSidebarView } from "../../../extensions/default/ui/sidebar";
+import { FlexFileSidebar } from "../../../extensions/default/ui/sidebar";
 import { HUNK_FILES_PANE_KEY } from "../../../extensions/extensionIds";
 import type { ExtensionNotifySink, RegisteredPane } from "../../../extensions/types";
 import { createGuardedReviewNavigation } from "../../lib/extensionNavigation";
@@ -155,7 +155,7 @@ function ExtensionPaneHostView({
     ? null
     : filesChrome
       ? box(<text fg={publicTheme.muted}>Files pane unavailable</text>)
-      : box(<BuiltInSidebarView {...viewProps} />);
+      : box(<FlexFileSidebar {...viewProps} />);
   return (
     <ExtensionPaneErrorBoundary
       registered={registered}

--- a/src/ui/components/panes/FileListItem.tsx
+++ b/src/ui/components/panes/FileListItem.tsx
@@ -172,7 +172,7 @@ export const FileListItem = memo(function FileListItem({
         }}
       >
         {icon && <text fg={color}>{icon} </text>}
-        <text fg={theme.text}>{padText(fitText(entry.name, nameWidth), nameWidth)}</text>
+        <text fg={theme.text}>{padText(fitText(entry.name, nameWidth, "…"), nameWidth)}</text>
         {statsSectionWidth > 0 && (
           <box
             style={{

--- a/src/ui/components/panes/FileListItem.tsx
+++ b/src/ui/components/panes/FileListItem.tsx
@@ -85,14 +85,9 @@ export function FileDirectoryRow({
   textWidth: number;
   theme: ExtensionSidebarTheme;
 }) {
-  const statusLaneWidth = 2;
   const statsSectionWidth = statsWidth > 0 ? statsWidth + 1 : 0;
-  const indentWidth = fileSidebarIndentWidth(
-    entry.depth,
-    textWidth,
-    statusLaneWidth + statsSectionWidth + 1,
-  );
-  const labelWidth = Math.max(1, textWidth - 1 - statusLaneWidth - statsSectionWidth - indentWidth);
+  const indentWidth = fileSidebarIndentWidth(entry.depth, textWidth, statsSectionWidth + 1);
+  const labelWidth = Math.max(1, textWidth - 1 - statsSectionWidth - indentWidth);
 
   return (
     <box
@@ -113,10 +108,7 @@ export function FileDirectoryRow({
           backgroundColor: theme.panel,
         }}
       >
-        <text fg={theme.muted}>
-          {"  "}
-          {fitText(entry.label, labelWidth)}
-        </text>
+        <text fg={theme.muted}>{fitText(entry.label, labelWidth)}</text>
       </box>
     </box>
   );

--- a/src/ui/components/panes/FileListItem.tsx
+++ b/src/ui/components/panes/FileListItem.tsx
@@ -1,7 +1,12 @@
 import { memo } from "react";
 import type { ExtensionSidebarTheme } from "../../../extension-api/types";
 import { fileRowId } from "../../lib/ids";
-import { sidebarEntryStats, type FileGroupEntry, type FileListEntry } from "../../lib/files";
+import {
+  sidebarEntryStats,
+  type FileDirectoryEntry,
+  type FileGroupEntry,
+  type FileListEntry,
+} from "../../lib/files";
 import { fitText, padText } from "../../lib/text";
 
 /**
@@ -61,6 +66,62 @@ export function FileGroupHeader({
   );
 }
 
+/** Clamp hierarchy indentation so a row always retains space for its visible label. */
+export function fileSidebarIndentWidth(depth: number, textWidth: number, reservedWidth: number) {
+  return Math.min(Math.max(0, depth) * 2, Math.max(0, textWidth - reservedWidth - 1));
+}
+
+/** Render one always-expanded directory row in the navigation sidebar. */
+export function FileDirectoryRow({
+  entry,
+  paddingLeft = 1,
+  statsWidth = 0,
+  textWidth,
+  theme,
+}: {
+  entry: FileDirectoryEntry;
+  paddingLeft?: number;
+  statsWidth?: number;
+  textWidth: number;
+  theme: ExtensionSidebarTheme;
+}) {
+  const statusLaneWidth = 2;
+  const statsSectionWidth = statsWidth > 0 ? statsWidth + 1 : 0;
+  const indentWidth = fileSidebarIndentWidth(
+    entry.depth,
+    textWidth,
+    statusLaneWidth + statsSectionWidth + 1,
+  );
+  const labelWidth = Math.max(1, textWidth - 1 - statusLaneWidth - statsSectionWidth - indentWidth);
+
+  return (
+    <box
+      style={{
+        width: "100%",
+        height: 1,
+        flexDirection: "row",
+        backgroundColor: theme.panel,
+      }}
+    >
+      <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
+      <box
+        style={{
+          flexGrow: 1,
+          height: 1,
+          paddingLeft: paddingLeft + indentWidth,
+          flexDirection: "row",
+          backgroundColor: theme.panel,
+        }}
+      >
+        <text fg={theme.muted}>
+          {"  "}
+          {fitText(entry.label, labelWidth)}
+        </text>
+      </box>
+    </box>
+  );
+}
+
 /** Render one file row in the navigation sidebar. */
 export const FileListItem = memo(function FileListItem({
   entry,
@@ -84,7 +145,12 @@ export const FileListItem = memo(function FileListItem({
   const { icon, color } = getFileStateIcon(entry, theme);
   const iconWidth = icon ? 2 : 0; // icon + space
   const statsSectionWidth = statsWidth > 0 ? statsWidth + 1 : 0;
-  const nameWidth = Math.max(1, textWidth - 1 - iconWidth - statsSectionWidth);
+  const indentWidth = fileSidebarIndentWidth(
+    entry.depth,
+    textWidth,
+    iconWidth + statsSectionWidth + 1,
+  );
+  const nameWidth = Math.max(1, textWidth - 1 - iconWidth - statsSectionWidth - indentWidth);
 
   return (
     <box
@@ -108,7 +174,7 @@ export const FileListItem = memo(function FileListItem({
         style={{
           flexGrow: 1,
           height: 1,
-          paddingLeft,
+          paddingLeft: paddingLeft + indentWidth,
           flexDirection: "row",
           backgroundColor: rowBackground,
         }}

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -517,12 +517,18 @@ describe("UI components", () => {
     const treeFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={33} />, 36, 8);
 
     expect(flatFrame).toContain("src/ui/");
+    expect(
+      flatFrame
+        .split("\n")
+        .find((line) => line.includes("src/ui/"))
+        ?.indexOf("src/ui/"),
+    ).toBe(1);
     expect(treeFrame).not.toContain("src/ui/");
     expect(treeFrame).toContain("src/");
     expect(treeFrame).toContain("ui/");
     const treeLines = treeFrame.split("\n");
-    expect(treeLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(2);
-    expect(treeLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(4);
+    expect(treeLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(1);
+    expect(treeLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(3);
     expect(treeFrame).toContain("alpha.ts");
     expect(treeFrame).toContain("beta.ts");
   });

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -25,7 +25,7 @@ import type { LineCursor } from "../lib/lineCursors";
 
 const { AppHost } = await import("../AppHost");
 const { toReadOnlyFileViews } = await import("../../extensions/events");
-const { BuiltInSidebarView } = await import("../../extensions/default/ui/sidebar");
+const { FlexFileSidebar } = await import("../../extensions/default/ui/sidebar");
 const { HelpDialog } = await import("./chrome/HelpDialog");
 const { AgentCard } = await import("./panes/AgentCard");
 const { AgentInlineNote, measureAgentInlineNoteHeight } = await import("./panes/AgentInlineNote");
@@ -459,7 +459,7 @@ describe("UI components", () => {
       ),
     ];
     const frame = await captureFrame(
-      <BuiltInSidebarView
+      <FlexFileSidebar
         // The exact frozen file views the extension pipeline hands any sidebar.
         files={toReadOnlyFileViews(files)}
         selectedFileId="app"
@@ -492,6 +492,36 @@ describe("UI components", () => {
     expect(frame).not.toContain("+0");
     expect(frame).not.toContain("-0");
     expect(frame).not.toContain("M +2 -1 AI");
+  });
+
+  test("the bundled sidebar switches to its expanded tree at 31 content columns", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const files = toReadOnlyFileViews([
+      createTestDiffFile("alpha", "src/ui/alpha.ts", "a\n", "aa\n"),
+      createTestDiffFile("beta", "src/ui/beta.ts", "b\n", "bb\n"),
+    ]);
+    const sharedProps = {
+      actions: {
+        selectFile: () => {},
+        selectHunk: () => {},
+        revealLine: () => {},
+        notify: () => {},
+      },
+      files,
+      keybindings: { matches: () => false, getKeys: () => [] },
+      selectedFileId: "alpha",
+      selectedHunkIndex: 0,
+      theme,
+    };
+    const flatFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={32} />, 36, 8);
+    const treeFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={33} />, 36, 8);
+
+    expect(flatFrame).toContain("src/ui/");
+    expect(treeFrame).not.toContain("src/ui/");
+    expect(treeFrame).toContain("src/");
+    expect(treeFrame).toContain("ui/");
+    expect(treeFrame).toContain("alpha.ts");
+    expect(treeFrame).toContain("beta.ts");
   });
 
   test("DiffPane renders all diff sections in file order", async () => {

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -494,7 +494,7 @@ describe("UI components", () => {
     expect(frame).not.toContain("M +2 -1 AI");
   });
 
-  test("the bundled sidebar switches to its expanded tree at 31 content columns", async () => {
+  test("the bundled sidebar switches to its expanded tree at 32 content columns", async () => {
     const theme = resolveTheme("github-dark-default", null);
     const files = toReadOnlyFileViews([
       createTestDiffFile("alpha", "src/ui/alpha.ts", "a\n", "aa\n"),
@@ -513,8 +513,8 @@ describe("UI components", () => {
       selectedHunkIndex: 0,
       theme,
     };
-    const flatFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={32} />, 36, 8);
-    const treeFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={33} />, 36, 8);
+    const flatFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={33} />, 36, 8);
+    const treeFrame = await captureFrame(<FlexFileSidebar {...sharedProps} width={34} />, 36, 8);
 
     expect(flatFrame).toContain("src/ui/");
     expect(

--- a/src/ui/components/ui-components.test.tsx
+++ b/src/ui/components/ui-components.test.tsx
@@ -520,6 +520,9 @@ describe("UI components", () => {
     expect(treeFrame).not.toContain("src/ui/");
     expect(treeFrame).toContain("src/");
     expect(treeFrame).toContain("ui/");
+    const treeLines = treeFrame.split("\n");
+    expect(treeLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(2);
+    expect(treeLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(4);
     expect(treeFrame).toContain("alpha.ts");
     expect(treeFrame).toContain("beta.ts");
   });

--- a/src/ui/lib/files.test.ts
+++ b/src/ui/lib/files.test.ts
@@ -150,9 +150,9 @@ describe("files helpers", () => {
     ]);
   });
 
-  test("resolveFileSidebarMode switches only above 30 content columns", () => {
-    expect(resolveFileSidebarMode(30)).toBe("flat");
-    expect(resolveFileSidebarMode(31)).toBe("tree");
+  test("resolveFileSidebarMode switches at the preferred sidebar width", () => {
+    expect(resolveFileSidebarMode(31)).toBe("flat");
+    expect(resolveFileSidebarMode(32)).toBe("tree");
   });
 
   test("buildTreeSidebarEntries expands paths without changing file order", () => {

--- a/src/ui/lib/files.test.ts
+++ b/src/ui/lib/files.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { createTestDiffFile, lines } from "../../../test/helpers/diff-helpers";
-import { buildSidebarEntries, fileLabelParts } from "./files";
+import {
+  buildFlatSidebarEntries,
+  buildTreeSidebarEntries,
+  fileLabelParts,
+  resolveFileSidebarMode,
+} from "./files";
 
 describe("files helpers", () => {
-  test("buildSidebarEntries hides zero-value sidebar stats", () => {
+  test("buildFlatSidebarEntries hides zero-value sidebar stats", () => {
     const onlyAdd = createTestDiffFile({
       id: "only-add",
       path: "src/ui/only-add.ts",
@@ -39,9 +44,11 @@ describe("files helpers", () => {
       stats: { additions: 0, deletions: 0 },
     };
 
-    const entries = buildSidebarEntries([onlyAdd, onlyRemove, renamedWithoutContentChanges]).filter(
-      (entry) => entry.kind === "file",
-    );
+    const entries = buildFlatSidebarEntries([
+      onlyAdd,
+      onlyRemove,
+      renamedWithoutContentChanges,
+    ]).filter((entry) => entry.kind === "file");
 
     expect(entries).toHaveLength(3);
     expect(entries[0]).toMatchObject({
@@ -64,7 +71,7 @@ describe("files helpers", () => {
     });
   });
 
-  test("buildSidebarEntries includes compact per-file comment counts before diff stats", () => {
+  test("buildFlatSidebarEntries includes compact per-file comment counts before diff stats", () => {
     const withComments = createTestDiffFile({
       id: "with-comments",
       path: "src/ui/commented.ts",
@@ -80,7 +87,7 @@ describe("files helpers", () => {
       },
     });
 
-    const [entry] = buildSidebarEntries([withComments]).filter((item) => item.kind === "file");
+    const [entry] = buildFlatSidebarEntries([withComments]).filter((item) => item.kind === "file");
 
     expect(entry).toMatchObject({
       name: "commented.ts",
@@ -90,7 +97,7 @@ describe("files helpers", () => {
     });
   });
 
-  test("buildSidebarEntries counts all comments attached to a file, even off-range ones", () => {
+  test("buildFlatSidebarEntries counts all comments attached to a file, even off-range ones", () => {
     const withComments = createTestDiffFile({
       id: "all-comments",
       path: "src/ui/all-comments.ts",
@@ -107,7 +114,7 @@ describe("files helpers", () => {
       },
     });
 
-    const [entry] = buildSidebarEntries([withComments]).filter((item) => item.kind === "file");
+    const [entry] = buildFlatSidebarEntries([withComments]).filter((item) => item.kind === "file");
 
     expect(entry).toMatchObject({
       name: "all-comments.ts",
@@ -117,7 +124,7 @@ describe("files helpers", () => {
     });
   });
 
-  test("buildSidebarEntries marks each root-file run with an in-place ./ group", () => {
+  test("buildFlatSidebarEntries marks each root-file run with an in-place ./ group", () => {
     const files = [
       createTestDiffFile({ id: "nested-a", path: "src/a.ts" }),
       createTestDiffFile({ id: "root-a", path: "README.md" }),
@@ -126,8 +133,8 @@ describe("files helpers", () => {
       createTestDiffFile({ id: "root-c", path: "LICENSE" }),
     ];
 
-    const labels = buildSidebarEntries(files).map((entry) =>
-      entry.kind === "group" ? entry.label : entry.name,
+    const labels = buildFlatSidebarEntries(files).map((entry) =>
+      entry.kind === "file" ? entry.name : entry.label,
     );
 
     expect(labels).toEqual([
@@ -143,6 +150,97 @@ describe("files helpers", () => {
     ]);
   });
 
+  test("resolveFileSidebarMode switches only above 30 content columns", () => {
+    expect(resolveFileSidebarMode(30)).toBe("flat");
+    expect(resolveFileSidebarMode(31)).toBe("tree");
+  });
+
+  test("buildTreeSidebarEntries expands paths without changing file order", () => {
+    const files = [
+      createTestDiffFile({ id: "ui-a", path: "src/ui/a.ts" }),
+      createTestDiffFile({ id: "ui-b", path: "src/ui/b.ts" }),
+      createTestDiffFile({ id: "root", path: "README.md" }),
+      createTestDiffFile({ id: "core", path: "src/core/c.ts" }),
+      createTestDiffFile({ id: "test", path: "test/d.ts" }),
+      createTestDiffFile({ id: "src-root", path: "src/e.ts" }),
+    ];
+
+    const entries = buildTreeSidebarEntries(files);
+    const labels = entries.map((entry) =>
+      entry.kind === "file" ? `${"  ".repeat(entry.depth)}${entry.name}` : entry.label,
+    );
+
+    expect(labels).toEqual([
+      "src/",
+      "ui/",
+      "    a.ts",
+      "    b.ts",
+      "README.md",
+      "src/",
+      "core/",
+      "    c.ts",
+      "test/",
+      "  d.ts",
+      "src/",
+      "  e.ts",
+    ]);
+    expect(entries.filter((entry) => entry.kind === "file").map((entry) => entry.id)).toEqual(
+      files.map((file) => file.id),
+    );
+  });
+
+  test("buildTreeSidebarEntries gives repeated directory branches unique row ids", () => {
+    const directories = buildTreeSidebarEntries([
+      createTestDiffFile({ id: "src-a", path: "src/a.ts" }),
+      createTestDiffFile({ id: "root", path: "README.md" }),
+      createTestDiffFile({ id: "src-b", path: "src/b.ts" }),
+    ]).filter((entry) => entry.kind === "directory");
+
+    expect(directories.map((entry) => entry.label)).toEqual(["src/", "src/"]);
+    expect(new Set(directories.map((entry) => entry.id)).size).toBe(directories.length);
+  });
+
+  test("buildTreeSidebarEntries uses the current rename path and keeps the rename filename", () => {
+    const renamed = createTestDiffFile({
+      id: "renamed",
+      path: "src/new/name.ts",
+      previousPath: "legacy/old.ts",
+    });
+
+    expect(buildTreeSidebarEntries([renamed])).toEqual([
+      expect.objectContaining({ kind: "directory", label: "src/", depth: 0 }),
+      expect.objectContaining({ kind: "directory", label: "new/", depth: 1 }),
+      expect.objectContaining({
+        kind: "file",
+        id: "renamed",
+        name: "old.ts -> name.ts",
+        depth: 2,
+      }),
+    ]);
+  });
+
+  test("buildTreeSidebarEntries preserves absolute and UNC-style path roots", () => {
+    const entries = buildTreeSidebarEntries([
+      createTestDiffFile({ id: "absolute", path: "/tmp/project/a.ts" }),
+      createTestDiffFile({ id: "unc", path: "//server/share/b.ts" }),
+    ]);
+
+    expect(
+      entries.map((entry) =>
+        entry.kind === "file" ? { kind: entry.kind, name: entry.name } : entry.label,
+      ),
+    ).toEqual([
+      "/",
+      "tmp/",
+      "project/",
+      { kind: "file", name: "a.ts" },
+      "//",
+      "server/",
+      "share/",
+      { kind: "file", name: "b.ts" },
+    ]);
+  });
+
   test("file labels and sidebar entries render path tabs as fixed-width escapes", () => {
     const file = createTestDiffFile({ id: "tabbed-path", path: "src/tab\tname.ts" });
 
@@ -150,7 +248,7 @@ describe("files helpers", () => {
       filename: "src/tab\\tname.ts",
       stateLabel: null,
     });
-    expect(buildSidebarEntries([file])).toEqual([
+    expect(buildFlatSidebarEntries([file])).toEqual([
       { kind: "group", id: "group:src:0", label: "src/" },
       expect.objectContaining({ kind: "file", name: "tab\\tname.ts" }),
     ]);

--- a/src/ui/lib/files.ts
+++ b/src/ui/lib/files.ts
@@ -55,7 +55,7 @@ export interface FileDirectoryEntry {
 export type FileSidebarMode = "flat" | "tree";
 export type SidebarEntry = FileListEntry | FileGroupEntry | FileDirectoryEntry;
 
-export const TREE_FILE_SIDEBAR_MIN_CONTENT_WIDTH = 31;
+export const TREE_FILE_SIDEBAR_MIN_CONTENT_WIDTH = 32;
 
 /** Choose the compact or hierarchical sidebar projection for an available content width. */
 export function resolveFileSidebarMode(contentWidth: number): FileSidebarMode {

--- a/src/ui/lib/files.ts
+++ b/src/ui/lib/files.ts
@@ -10,6 +10,7 @@ export interface FileListEntry {
   kind: "file";
   id: string;
   name: string;
+  depth: number;
   agentCommentsText: string | null;
   additionsText: string | null;
   deletionsText: string | null;
@@ -44,7 +45,22 @@ export interface FileGroupEntry {
   label: string;
 }
 
-export type SidebarEntry = FileListEntry | FileGroupEntry;
+export interface FileDirectoryEntry {
+  kind: "directory";
+  id: string;
+  label: string;
+  depth: number;
+}
+
+export type FileSidebarMode = "flat" | "tree";
+export type SidebarEntry = FileListEntry | FileGroupEntry | FileDirectoryEntry;
+
+export const TREE_FILE_SIDEBAR_MIN_CONTENT_WIDTH = 31;
+
+/** Choose the compact or hierarchical sidebar projection for an available content width. */
+export function resolveFileSidebarMode(contentWidth: number): FileSidebarMode {
+  return contentWidth >= TREE_FILE_SIDEBAR_MIN_CONTENT_WIDTH ? "tree" : "flat";
+}
 
 /** Build the filename-first label shown inside one sidebar row. */
 function sidebarFileName(file: SidebarFileSource) {
@@ -122,8 +138,25 @@ export function mergeFileAnnotationsByFileId<T extends AgentAnnotation>(
   });
 }
 
-/** Build the grouped sidebar entries while preserving the review stream order. */
-export function buildSidebarEntries(files: readonly SidebarFileSource[]): SidebarEntry[] {
+/** Build the shared file-row metadata used by both sidebar projections. */
+function buildSidebarFileEntry(file: SidebarFileSource, depth: number): FileListEntry {
+  const agentCommentCount = file.agent?.annotations.length ?? 0;
+
+  return {
+    kind: "file",
+    id: file.id,
+    name: sidebarFileName(file),
+    depth,
+    agentCommentsText: agentCommentCount > 0 ? `*${agentCommentCount}` : null,
+    additionsText: formatSidebarStat("+", file.stats.additions, file.statsTruncated),
+    deletionsText: formatSidebarStat("-", file.stats.deletions),
+    changeType: file.changeType ?? readMetadataChangeType(file.metadata) ?? "change",
+    isUntracked: file.isUntracked ?? false,
+  };
+}
+
+/** Build compact grouped sidebar entries while preserving the review stream order. */
+export function buildFlatSidebarEntries(files: readonly SidebarFileSource[]): SidebarEntry[] {
   const entries: SidebarEntry[] = [];
   let activeGroup: string | undefined;
 
@@ -140,18 +173,70 @@ export function buildSidebarEntries(files: readonly SidebarFileSource[]): Sideba
       });
     }
 
-    const agentCommentCount = file.agent?.annotations.length ?? 0;
+    entries.push(buildSidebarFileEntry(file, 0));
+  });
 
-    entries.push({
-      kind: "file",
-      id: file.id,
-      name: sidebarFileName(file),
-      agentCommentsText: agentCommentCount > 0 ? `*${agentCommentCount}` : null,
-      additionsText: formatSidebarStat("+", file.stats.additions, file.statsTruncated),
-      deletionsText: formatSidebarStat("-", file.stats.deletions),
-      changeType: file.changeType ?? readMetadataChangeType(file.metadata) ?? "change",
-      isUntracked: file.isUntracked ?? false,
-    });
+  return entries;
+}
+
+/** Split a POSIX review path while retaining its absolute or UNC-style root marker. */
+function sidebarDirectorySegments(parent: string) {
+  if (parent === ".") {
+    return [];
+  }
+
+  const root = parent.match(/^\/+/u)?.[0];
+  const segments = parent.split("/").filter(Boolean);
+  return root ? [root, ...segments] : segments;
+}
+
+/** Format one directory segment without doubling a retained root marker. */
+function sidebarDirectoryLabel(segment: string) {
+  return segment.startsWith("/") ? segment : `${segment}/`;
+}
+
+/** Join directory segments into the stable path represented by one row. */
+function sidebarDirectoryPath(segments: readonly string[]) {
+  const [root, ...rest] = segments;
+  return root?.startsWith("/") ? `${root}${rest.join("/")}` : segments.join("/");
+}
+
+/** Return the number of leading directory segments shared by two active branches. */
+function sharedDirectoryDepth(previous: readonly string[], next: readonly string[]) {
+  const maxDepth = Math.min(previous.length, next.length);
+  let depth = 0;
+
+  while (depth < maxDepth && previous[depth] === next[depth]) {
+    depth += 1;
+  }
+
+  return depth;
+}
+
+/** Build an expanded hierarchy without regrouping files away from review order. */
+export function buildTreeSidebarEntries(files: readonly SidebarFileSource[]): SidebarEntry[] {
+  const entries: SidebarEntry[] = [];
+  let activeDirectories: string[] = [];
+
+  files.forEach((file, fileIndex) => {
+    const path = formatTerminalPath(normalizeDiffPath(file.path) ?? file.path);
+    const parent = dirname(path);
+    const directories = sidebarDirectorySegments(parent);
+    const sharedDepth = sharedDirectoryDepth(activeDirectories, directories);
+
+    for (let depth = sharedDepth; depth < directories.length; depth += 1) {
+      const segment = directories[depth]!;
+      const directoryPath = sidebarDirectoryPath(directories.slice(0, depth + 1));
+      entries.push({
+        kind: "directory",
+        id: `directory:${fileIndex}:${depth}:${directoryPath}`,
+        label: sidebarDirectoryLabel(segment),
+        depth,
+      });
+    }
+
+    entries.push(buildSidebarFileEntry(file, directories.length));
+    activeDirectories = directories;
   });
 
   return entries;

--- a/src/ui/lib/mouseCapture.ts
+++ b/src/ui/lib/mouseCapture.ts
@@ -1,0 +1,12 @@
+import type { CliRenderer, Renderable } from "@opentui/core";
+
+type MouseCaptureRenderer = {
+  setCapturedRenderable: (renderable: Renderable | undefined) => void;
+};
+
+/** Keep a mouse gesture on a persistent renderable, or release that capture. */
+export function setMouseCapture(renderer: CliRenderer, renderable: Renderable | undefined) {
+  // OpenTUI has no public pointer-capture API yet. Without this internal seam it captures the
+  // renderable under the first drag event, which may be replaced while the gesture is active.
+  (renderer as unknown as MouseCaptureRenderer).setCapturedRenderable(renderable);
+}

--- a/src/ui/lib/sidebarRenderWindow.test.ts
+++ b/src/ui/lib/sidebarRenderWindow.test.ts
@@ -11,6 +11,7 @@ function createEntries(ids: string[]): SidebarEntry[] {
           kind: "file",
           id,
           name: `${id}.ts`,
+          depth: 0,
           agentCommentsText: null,
           additionsText: null,
           deletionsText: null,

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -726,6 +726,22 @@ end
     ]);
   }
 
+  /** Build nested changed files whose sidebar labels distinguish flat and tree projections. */
+  function createNestedSidebarRepoFixture() {
+    return createGitRepoFixture([
+      {
+        path: "src/ui/alpha.ts",
+        before: "export const alpha = 1;\n",
+        after: "export const alpha = 2;\nexport const add = true;\n",
+      },
+      {
+        path: "src/ui/beta.ts",
+        before: "export const beta = 1;\n",
+        after: "export const betaValue = 1;\n",
+      },
+    ]);
+  }
+
   function createPinnedHeaderRepoFixture() {
     return createGitRepoFixture([
       {
@@ -1090,6 +1106,7 @@ end
     createLongWrapFilePair,
     createMovedLinesRepoFixture,
     createMultiFilePagerPatchFixture,
+    createNestedSidebarRepoFixture,
     createMultiHunkFilePair,
     createNarrowHeaderTestRepoFixture,
     createPagerPatchFixture,

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -411,7 +411,7 @@ describe("PTY layout", () => {
     }
   });
 
-  test("dragging the sidebar through 30 content columns switches to compact paths", async () => {
+  test("dragging the sidebar through 31 content columns switches to compact paths", async () => {
     const fixture = harness.createNestedSidebarRepoFixture();
     const session = await harness.launchHunk({
       args: ["diff", "--mode", "split"],
@@ -439,20 +439,20 @@ describe("PTY layout", () => {
           ?.indexOf("src/"),
       ).toBe(2);
 
-      await dragMouse(session, 34, 6, 32, 6);
+      await dragMouse(session, 34, 6, 33, 6);
       const resized = await harness.waitForSnapshot(
         session,
         (text) =>
           text
             .split("\n")
-            .map((line) => line.slice(0, 32))
+            .map((line) => line.slice(0, 33))
             .join("\n")
             .includes("src/ui/"),
         5_000,
       );
       const resizedSidebar = resized
         .split("\n")
-        .map((line) => line.slice(0, 32))
+        .map((line) => line.slice(0, 33))
         .join("\n");
 
       expect(resizedSidebar).toContain("src/ui/");

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import stringWidth from "string-width";
-import { createPtyHarness, dragMouse, rightmostColumnOf } from "./harness";
+import { createPtyHarness, dragMouse, rightmostColumnOf, sleep } from "./harness";
 
 const harness = createPtyHarness();
 
@@ -406,6 +406,52 @@ describe("PTY layout", () => {
 
       expect(rightmostColumnOf(resized, "alpha.ts")).toBeGreaterThan(initialMainColumn);
       expect(resized).toContain("beta.ts");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("retains a sidebar drag when its first cell switches the file projection", async () => {
+    const fixture = harness.createNestedSidebarRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 220,
+      rows: 18,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      const initialMainColumn = rightmostColumnOf(initial, "alpha.ts");
+
+      // Press the left edge of the five-cell hit target. The first motion lands on a tree row
+      // and switches that row out for the compact projection before the second motion arrives.
+      session.writeRaw("\x1b[<0;34;7M");
+      await sleep(20);
+      session.writeRaw("\x1b[<32;33;7M");
+      await harness.waitForSnapshot(
+        session,
+        (text) =>
+          text
+            .split("\n")
+            .map((line) => line.slice(0, 33))
+            .join("\n")
+            .includes("src/ui/"),
+        5_000,
+      );
+      session.writeRaw("\x1b[<32;21;7M");
+      await sleep(20);
+      session.writeRaw("\x1b[<0;21;7m");
+      await session.waitIdle();
+
+      const resized = await harness.waitForSnapshot(
+        session,
+        (text) => rightmostColumnOf(text, "alpha.ts") <= initialMainColumn - 8,
+        5_000,
+      );
+      expect(rightmostColumnOf(resized, "alpha.ts")).toBeLessThanOrEqual(initialMainColumn - 8);
     } finally {
       session.close();
     }

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -432,6 +432,12 @@ describe("PTY layout", () => {
       expect(initialSidebar).not.toContain("src/ui/");
       expect(initialSidebar).toContain("src/");
       expect(initialSidebar).toContain("ui/");
+      expect(
+        initialSidebar
+          .split("\n")
+          .find((line) => line.includes("src/"))
+          ?.indexOf("src/"),
+      ).toBe(2);
 
       await dragMouse(session, 34, 6, 32, 6);
       const resized = await harness.waitForSnapshot(
@@ -450,6 +456,12 @@ describe("PTY layout", () => {
         .join("\n");
 
       expect(resizedSidebar).toContain("src/ui/");
+      expect(
+        resizedSidebar
+          .split("\n")
+          .find((line) => line.includes("src/ui/"))
+          ?.indexOf("src/ui/"),
+      ).toBe(2);
       expect(resizedSidebar).toContain("alpha.ts");
       expect(resizedSidebar).toContain("beta.ts");
     } finally {

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -411,6 +411,52 @@ describe("PTY layout", () => {
     }
   });
 
+  test("dragging the sidebar through 30 content columns switches to compact paths", async () => {
+    const fixture = harness.createNestedSidebarRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 220,
+      rows: 18,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      const initialSidebar = initial
+        .split("\n")
+        .map((line) => line.slice(0, 34))
+        .join("\n");
+
+      expect(initialSidebar).not.toContain("src/ui/");
+      expect(initialSidebar).toContain("src/");
+      expect(initialSidebar).toContain("ui/");
+
+      await dragMouse(session, 34, 6, 32, 6);
+      const resized = await harness.waitForSnapshot(
+        session,
+        (text) =>
+          text
+            .split("\n")
+            .map((line) => line.slice(0, 32))
+            .join("\n")
+            .includes("src/ui/"),
+        5_000,
+      );
+      const resizedSidebar = resized
+        .split("\n")
+        .map((line) => line.slice(0, 32))
+        .join("\n");
+
+      expect(resizedSidebar).toContain("src/ui/");
+      expect(resizedSidebar).toContain("alpha.ts");
+      expect(resizedSidebar).toContain("beta.ts");
+    } finally {
+      session.close();
+    }
+  });
+
   test("explicit split mode stays split after a live resize", async () => {
     const fixture = harness.createTwoFileRepoFixture();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Summary

- adapt the built-in file sidebar between compact grouped paths and a fully expanded hierarchy at the preferred 34-column pane width
- split the bundled renderer into `FlexFileSidebar`, `FlatFileSidebar`, and `TreeFileSidebar` while retaining one shared scrollbox and virtualized row renderer
- preserve review-stream order, file identities, selection follow, fixed stats lanes, and `HunkFileNav` parity

## Why

The compact grouped sidebar works in narrow panes, but the default wider sidebar has enough room to expose path structure one directory at a time. This makes nested changesets easier to scan without changing review navigation.

I evaluated Pierre Computer Company's `@pierre/trees`. Its renderer is browser/Preact/shadow-DOM specific and its headless path store is private, so this PR does not add either dependency. It independently adapts the useful conventions: path-first hierarchy, one-row directory entries, indentation, and fixed metadata lanes.

## Approach

`FlexFileSidebar` derives the available content width and selects:

- `FlatFileSidebar` at 31 content columns or fewer
- `TreeFileSidebar` at 32 content columns or more (the default 34-column pane width)

The tree projection walks files in authoritative review order and emits directory rows from the longest shared path prefix. It intentionally repeats a branch when interleaved review order returns to it instead of regrouping or sorting files.

Directories are static and always expanded. Collapse state, directory focus, sticky ancestors, and language-specific icons are intentionally out of scope.

## Visual evidence

Real Hunk TUI, split mode, GitHub dark default, Linux, 220×24:

```text
Wide (>30 content columns)       Narrow (≤30 content columns)
  src/                           src/extensions/default/ui/sidebar/
    extensions/                    M index.test.tsx
      default/                     M index.tsx
        ui/
          sidebar/
            M index.test.tsx
            M index.tsx
```

Dragging the divider through the threshold is covered by real PTY integration tests, including a regression where the first motion replaces the row OpenTUI would otherwise capture.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- changed-file `oxfmt --check`
- `bun run test` — 2,055 passed, 10 skipped
- `bun run test:integration` — 136 passed, 1 platform skip
- `bun run test:tty-smoke` — 9 passed
- `bun run install:bin`
- manual real-TTY smoke: source-built binary, actual working-tree diff, split mode at 220×24

Platform tested: Linux. macOS and Windows were not manually tested; the pure path projection includes absolute and UNC-style root coverage.

*This PR description was generated by Pi using gpt-5.6-sol*


