### PR TITLE
fix(session): accept native terminal identifiers

### DIFF
--- a/.changeset/friendly-terminals-register.md
+++ b/.changeset/friendly-terminals-register.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep iTerm2 sessions connected to the local session daemon when their terminal identifiers contain native punctuation.

--- a/packages/session-broker-core/src/brokerWire.test.ts
+++ b/packages/session-broker-core/src/brokerWire.test.ts
@@ -53,6 +53,27 @@ describe("session broker wire parsing", () => {
     ).toBeNull();
   });
 
+  test("accepts terminal-native session identifiers without treating them as broker ids", () => {
+    const registration = parseSessionRegistrationEnvelope(
+      {
+        registrationVersion: SESSION_BROKER_REGISTRATION_VERSION,
+        sessionId: "session-1",
+        pid: 123,
+        cwd: "/repo",
+        launchedAt: "2026-03-22T00:00:00.000Z",
+        terminal: {
+          locations: [{ source: "iterm2", sessionId: "w1t2p3:ABCDEF" }],
+        },
+        info: { ok: true },
+      },
+      (value) => (value && typeof value === "object" ? value : null),
+    );
+
+    expect(registration?.terminal?.locations).toEqual([
+      { source: "iterm2", sessionId: "w1t2p3:ABCDEF" },
+    ]);
+  });
+
   test("rejects prototype-shaped registration and terminal metadata extras", () => {
     const parseInfo = (value: unknown) => (value && typeof value === "object" ? value : null);
     const registration = {

--- a/packages/session-broker-core/src/brokerWire.ts
+++ b/packages/session-broker-core/src/brokerWire.ts
@@ -74,9 +74,7 @@ function parseSessionTerminalLocation(value: unknown): SessionTerminalLocation {
     ...(record.terminalId === undefined
       ? {}
       : { terminalId: parseBrokerString(record.terminalId) }),
-    ...(record.sessionId === undefined
-      ? {}
-      : { sessionId: parseBrokerIdentifier(record.sessionId) }),
+    ...(record.sessionId === undefined ? {} : { sessionId: parseBrokerString(record.sessionId) }),
   };
 }
 


### PR DESCRIPTION
## Summary

- treat terminal-native session identifiers as bounded opaque metadata rather than broker authority identifiers
- preserve strict validation for the actual broker session ID
- cover iTerm2's colon-containing `ITERM_SESSION_ID` format

## Why

Strict broker registration parsing rejected valid iTerm2 identifiers such as `w1t2p3:ABCDEF`, preventing those Hunk windows from registering with the local session daemon.

## Validation

- `bun test packages/session-broker-core/src/brokerWire.test.ts packages/session-broker-core/src/sessionTerminalMetadata.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bun run changeset:status`
- scoped `oxfmt --check`
- `git diff --check`

*This PR description was generated by Pi using gpt-5.6-sol*
