### PR TITLE
fix(session): accept dim highlight commands

### DIFF
--- a/.changeset/fuzzy-highlights-dim.md
+++ b/.changeset/fuzzy-highlights-dim.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Accept the documented `dim` tone when routing line-highlight commands through the session daemon.

--- a/src/session/broker/protocolParsers.test.ts
+++ b/src/session/broker/protocolParsers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { HUNK_REVIEW_PROTOCOL_VERSION } from "../reviewProtocol";
+import { hunkSessionProtocolParsers } from "./protocolParsers";
+
+describe("Hunk session protocol parsers", () => {
+  test("accepts the dim line-highlight tone", () => {
+    const input = {
+      filePath: "src/App.tsx",
+      side: "new" as const,
+      line: 42,
+      start: 6,
+      end: 19,
+      tone: "dim" as const,
+      reveal: true,
+    };
+
+    expect(
+      hunkSessionProtocolParsers.parseCommandInput(
+        "highlight",
+        HUNK_REVIEW_PROTOCOL_VERSION,
+        input,
+      ),
+    ).toEqual(input);
+
+    const result = {
+      fileId: "file-1",
+      filePath: input.filePath,
+      hunkIndex: 0,
+      side: input.side,
+      line: input.line,
+      start: input.start,
+      end: input.end,
+      tone: input.tone,
+      fileMarkCount: 1,
+      revealed: "line" as const,
+    };
+    expect(
+      hunkSessionProtocolParsers.parseCommandResult(
+        "highlight",
+        HUNK_REVIEW_PROTOCOL_VERSION,
+        result,
+      ),
+    ).toEqual(result);
+  });
+});

--- a/src/session/broker/protocolParsers.ts
+++ b/src/session/broker/protocolParsers.ts
@@ -113,7 +113,7 @@ const commandInputs = {
     line: positive,
     start: nonnegative,
     end: positive,
-    tone: z.enum(["match", "current", "info", "warning", "error"]).optional(),
+    tone: z.enum(["match", "current", "info", "warning", "error", "dim"]).optional(),
     reveal: z.boolean().optional(),
   }),
   clear_highlights: z.strictObject({

--- a/src/session/protocolSchemas.ts
+++ b/src/session/protocolSchemas.ts
@@ -394,7 +394,7 @@ export const hunkCommandResultSchemas = {
     line: positive,
     start: nonnegative,
     end: positive,
-    tone: z.enum(["match", "current", "info", "warning", "error"]),
+    tone: z.enum(["match", "current", "info", "warning", "error", "dim"]),
     fileMarkCount: nonnegative,
     revealed: z.enum(["line", "hunk"]).optional(),
   }),


### PR DESCRIPTION
## Summary

- accept the documented `dim` tone in broker highlight command inputs
- accept `dim` in producer and HTTP highlight results
- cover both command directions through the real Hunk parser registry

## Why

The public CLI and session protocol accepted `dim`, but the internal broker parser omitted it. Requests therefore failed before delivery, and a returned `dim` result could close the producer connection as an invalid payload.

## Validation

- `bun test src/session/broker/protocolParsers.test.ts src/session/protocolSchemas.test.ts src/session/agent/surface.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bun run changeset:status`
- scoped `oxfmt --check`
- `git diff --check`

*This PR description was generated by Pi using gpt-5.6-sol*
