### PR TITLE
feat(cli): compare two revisions explicitly

### DIFF
--- a/.changeset/two-revision-diff.md
+++ b/.changeset/two-revision-diff.md
@@ -1,5 +1,5 @@
 ---
-"hunkdiff": minor
+"hunkdiff": major
 ---
 
-Support `hunk diff <from> <to>` as a two-revision review across Git, Jujutsu, and Sapling. Two-revision reviews use backend-native comparison syntax, keep source expansion pinned to both revisions, and exclude working-copy untracked files. Concrete file comparisons now use the explicit `hunk diff --files <left> <right>` form; two positional arguments always mean revisions.
+Support backend-native `hunk diff <from> <to>` reviews across Git, Jujutsu, and Sapling, with pinned source expansion, working-copy isolation, explicit `hunk diff --files <left> <right>` file comparison, and structured `rangeEndpoints` in extension API generation 14.

--- a/.changeset/two-revision-diff.md
+++ b/.changeset/two-revision-diff.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Support `hunk diff <from> <to>` as a two-revision review across Git, Jujutsu, and Sapling. Two-revision reviews use backend-native comparison syntax, keep source expansion pinned to both revisions, and exclude working-copy untracked files. Concrete file comparisons now use the explicit `hunk diff --files <left> <right>` form; two positional arguments always mean revisions.

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Hunk auto-detects Jujutsu and Sapling checkouts, so `hunk diff [revset]` and `hu
 ### Working with raw files and patches
 
 ```bash
-hunk diff before.ts after.ts                # compare two files directly
-hunk diff before.ts after.ts --watch        # auto-reload when either file changes
+hunk diff --files before.ts after.ts        # compare two files directly
+hunk diff --files before.ts after.ts --watch # auto-reload when either file changes
 git diff --no-color | hunk patch -          # review a patch from stdin
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -280,7 +280,8 @@ new instances and run that shutdown/startup pair around the replacement.
 
 ### `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `13`). Branch on it if you want
+The API generation this Hunk speaks (currently `14`). Generation 14 adds structured `rangeEndpoints`
+to two-revision VCS diff requests. Branch on it if you want
 one file to support several Hunk versions. Version 13 adds saved-note parent identities and
 committed note-edit events; version 12 adds responsive fractional pane sizing; version 11 added
 the `"dim"` line-highlight tone; version 10 added generic top-level CLI commands; version 9

--- a/examples/1-hello-diff/README.md
+++ b/examples/1-hello-diff/README.md
@@ -5,7 +5,7 @@ A tiny first-run demo with one clean TypeScript diff.
 ## Run
 
 ```bash
-hunk diff examples/1-hello-diff/before.ts examples/1-hello-diff/after.ts
+hunk diff --files examples/1-hello-diff/before.ts examples/1-hello-diff/after.ts
 ```
 
 ## What to look for

--- a/examples/4-ui-polish/README.md
+++ b/examples/4-ui-polish/README.md
@@ -5,7 +5,7 @@ A screenshot-friendly TSX diff with copy edits, prop renames, and a small layout
 ## Run
 
 ```bash
-hunk diff examples/4-ui-polish/before.tsx examples/4-ui-polish/after.tsx
+hunk diff --files examples/4-ui-polish/before.tsx examples/4-ui-polish/after.tsx
 ```
 
 ## What to look for

--- a/examples/5-pager-tour/README.md
+++ b/examples/5-pager-tour/README.md
@@ -5,7 +5,7 @@ A tall single-file diff made to show line scrolling, paging, and hunk jumps.
 ## Run
 
 ```bash
-hunk diff --pager examples/5-pager-tour/before.ts examples/5-pager-tour/after.ts
+hunk diff --files examples/5-pager-tour/before.ts examples/5-pager-tour/after.ts --pager
 ```
 
 ## What to look for

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,11 +8,11 @@ Each folder tells a small review story and includes the exact command to run fro
 
 | Example                | Best for                               | Command                                                                                                                                              |
 | ---------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `1-hello-diff`         | fastest first run                      | `hunk diff examples/1-hello-diff/before.ts examples/1-hello-diff/after.ts`                                                                           |
+| `1-hello-diff`         | fastest first run                      | `hunk diff --files examples/1-hello-diff/before.ts examples/1-hello-diff/after.ts`                                                                   |
 | `2-mini-app-refactor`  | realistic multi-file review            | `hunk patch examples/2-mini-app-refactor/change.patch`                                                                                               |
 | `3-agent-review-demo`  | inline agent rationale                 | `hunk patch examples/3-agent-review-demo/change.patch --agent-context examples/3-agent-review-demo/agent-context.json`                               |
-| `4-ui-polish`          | screenshot-friendly TSX diff           | `hunk diff examples/4-ui-polish/before.tsx examples/4-ui-polish/after.tsx`                                                                           |
-| `5-pager-tour`         | line scrolling, paging, and hunk jumps | `hunk diff --pager examples/5-pager-tour/before.ts examples/5-pager-tour/after.ts`                                                                   |
+| `4-ui-polish`          | screenshot-friendly TSX diff           | `hunk diff --files examples/4-ui-polish/before.tsx examples/4-ui-polish/after.tsx`                                                                   |
+| `5-pager-tour`         | line scrolling, paging, and hunk jumps | `hunk diff --files examples/5-pager-tour/before.ts examples/5-pager-tour/after.ts --pager`                                                           |
 | `6-readme-screenshot`  | README screenshot with agent notes     | `hunk patch examples/6-readme-screenshot/change.patch --agent-context examples/6-readme-screenshot/agent-context.json --mode split --theme midnight` |
 | `7-opentui-component`  | embedding `HunkDiffView` in OpenTUI    | `bun run examples/7-opentui-component/from-files.tsx`                                                                                                |
 | `8-opentui-primitives` | composing Hunk's OpenTUI primitives    | `bun run examples/8-opentui-primitives/primitives-demo.tsx`                                                                                          |

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -130,6 +130,12 @@ export function renderCliReference() {
         renderUsage(command.synopsis),
       ];
 
+      if (command.details && command.details.length > 0) {
+        pieces.push(
+          "",
+          ...command.details.flatMap((detail, index) => (index > 0 ? ["", detail] : [detail])),
+        );
+      }
       if (command.aliases && command.aliases.length > 0) {
         pieces.push(
           "",

--- a/src/app/cli.test.ts
+++ b/src/app/cli.test.ts
@@ -223,7 +223,7 @@ describe("parseCli", () => {
     writeFileSync(left, "export const answer = 1;\n");
     writeFileSync(right, "export const answer = 2;\n");
 
-    expect(await parseCli(["bun", "hunk", "--fast", left, right])).toMatchObject({
+    expect(await parseCli(["bun", "hunk", "--fast", "--files", left, right])).toMatchObject({
       kind: "diff",
       left,
       right,
@@ -369,22 +369,92 @@ describe("parseCli", () => {
     });
   });
 
-  test("keeps two concrete file paths as file-pair diff mode", async () => {
+  test("parses the explicit two-file comparison form", async () => {
     const dir = createTempDir("hunk-cli-files-");
     const left = join(dir, "before.ts");
     const right = join(dir, "after.ts");
     writeFileSync(left, "before\n");
     writeFileSync(right, "after\n");
 
-    const parsed = await parseCli(["bun", "hunk", "diff", left, right, "--mode", "stack"]);
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "diff",
+      "--files",
+      left,
+      right,
+      "--mode",
+      "stack",
+    ]);
 
     expect(parsed).toMatchObject({
       kind: "diff",
       left,
       right,
-      options: {
-        mode: "stack",
-      },
+      options: { mode: "stack" },
+    });
+  });
+
+  test("treats two existing file paths as revisions unless --files is present", async () => {
+    const dir = createTempDir("hunk-cli-file-shaped-revisions-");
+    const left = join(dir, "before.ts");
+    const right = join(dir, "after.ts");
+    writeFileSync(left, "before\n");
+    writeFileSync(right, "after\n");
+
+    expect(await parseCli(["bun", "hunk", "diff", left, right])).toMatchObject({
+      kind: "vcs",
+      rangeEndpoints: { from: left, to: right },
+    });
+  });
+
+  test("rejects malformed or mixed --files forms", async () => {
+    for (const args of [
+      ["--files", "one"],
+      ["--files", "one", "two", "three"],
+      ["--files", "one", "two", "--staged"],
+      ["target", "--files", "one", "two"],
+    ]) {
+      await expect(parseCli(["bun", "hunk", "diff", ...args])).rejects.toThrow(
+        "exactly two file paths",
+      );
+    }
+  });
+
+  test("parses two revision positionals as structured range endpoints", async () => {
+    const parsed = await parseCli(["bun", "hunk", "diff", "main", "feature"]);
+
+    expect(parsed).toMatchObject({
+      kind: "vcs",
+      rangeEndpoints: { from: "main", to: "feature" },
+      staged: false,
+    });
+    expect(parsed).not.toHaveProperty("range", "main..feature");
+  });
+
+  test("keeps two revisions structured when pathspecs follow the separator", async () => {
+    expect(
+      await parseCli(["bun", "hunk", "diff", "main", "feature", "--", "src/app.ts"]),
+    ).toMatchObject({
+      kind: "vcs",
+      rangeEndpoints: { from: "main", to: "feature" },
+      pathspecs: ["src/app.ts"],
+    });
+  });
+
+  test("does not use filesystem existence to distinguish a revision from a pathspec", async () => {
+    const dir = createTempDir("hunk-cli-revision-path-");
+    const existing = join(dir, "branch-name");
+    mkdirSync(existing);
+
+    expect(await parseCli(["bun", "hunk", "diff", "HEAD", existing])).toMatchObject({
+      kind: "vcs",
+      rangeEndpoints: { from: "HEAD", to: existing },
+    });
+    expect(await parseCli(["bun", "hunk", "diff", "HEAD", "--", existing])).toMatchObject({
+      kind: "vcs",
+      range: "HEAD",
+      pathspecs: [existing],
     });
   });
 
@@ -406,10 +476,12 @@ describe("parseCli", () => {
     });
   });
 
-  test("parses target followed by pathspecs without a separator", async () => {
-    const parsed = await parseCli(["bun", "hunk", "diff", "trunk()..@", ".github"]);
-
-    expect(parsed).toMatchObject({
+  test("treats a range-shaped target plus one positional as two revision endpoints", async () => {
+    expect(await parseCli(["bun", "hunk", "diff", "trunk()..@", ".github"])).toMatchObject({
+      kind: "vcs",
+      rangeEndpoints: { from: "trunk()..@", to: ".github" },
+    });
+    expect(await parseCli(["bun", "hunk", "diff", "trunk()..@", "--", ".github"])).toMatchObject({
       kind: "vcs",
       range: "trunk()..@",
       pathspecs: [".github"],
@@ -671,6 +743,33 @@ describe("parseCli", () => {
         pathspecs: ["README.md"],
       },
       output: "json",
+    });
+  });
+
+  test("keeps structured endpoints through nested session reload parsing", async () => {
+    const parsed = await parseCli([
+      "bun",
+      "hunk",
+      "session",
+      "reload",
+      "session-1",
+      "--",
+      "diff",
+      "main",
+      "feature",
+      "--",
+      "src/app.ts",
+    ]);
+
+    expect(parsed).toMatchObject({
+      kind: "session",
+      action: "reload",
+      selector: { sessionId: "session-1" },
+      nextInput: {
+        kind: "vcs",
+        rangeEndpoints: { from: "main", to: "feature" },
+        pathspecs: ["src/app.ts"],
+      },
     });
   });
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { Command, Option } from "commander";
 import type {
@@ -80,6 +80,8 @@ export interface CliReferenceCommand {
   readonly summary: string;
   readonly synopsis: readonly string[];
   readonly aliases?: readonly string[];
+  /** Additional prose rendered after this command's generated usage block. */
+  readonly details?: readonly string[];
   readonly options?: readonly CliReferenceOption[];
   readonly commonReviewOptions?: boolean;
   readonly watch?: boolean;
@@ -146,6 +148,10 @@ export const WATCH_OPTION = {
 } as const satisfies CliReferenceOption;
 
 const DIFF_OPTIONS = [
+  {
+    flag: "--files <paths...>",
+    description: "compare exactly two concrete files: --files <left> <right>",
+  },
   { flag: "--staged", description: "show staged changes instead of the working tree" },
   { flag: "--cached", description: "alias for --staged" },
   AUXILIARY_AGENT_OPTIONS.excludeUntracked,
@@ -163,8 +169,13 @@ export const CLI_REFERENCE_COMMANDS = {
     summary: "review diffs or compare two concrete files",
     synopsis: [
       "hunk diff [target] [-- <pathspec...>]",
+      "hunk diff <from> <to> [-- <pathspec...>]",
       "hunk diff --staged [-- <pathspec...>]",
-      "hunk diff <left> <right>",
+      "hunk diff --files <left> <right>",
+    ],
+    details: [
+      "Two positional arguments always name revision endpoints, even when matching files exist on disk.",
+      "Use `--files <left> <right>` for concrete-file comparison; this replaces the former filesystem-existence disambiguation.",
     ],
     options: DIFF_OPTIONS,
     commonReviewOptions: true,
@@ -497,8 +508,9 @@ function renderCliHelp() {
     "",
     "Commands:",
     "  hunk diff [target] [-- <pathspec...>]   review working tree changes or compare against a target",
+    "  hunk diff <from> <to>                   compare two revisions",
     "  hunk diff --staged [-- <pathspec...>]   review staged changes",
-    "  hunk diff <left> <right>                compare two concrete files",
+    "  hunk diff --files <left> <right>        compare two concrete files",
     "  hunk show [target] [-- <pathspec...>]   review the last commit or a given target",
     "  hunk stash show [ref]                   review a stash entry (git only)",
     "  hunk patch [file]                       review a patch file or stdin",
@@ -558,11 +570,6 @@ function splitPathspecArgs(tokens: string[]) {
     commandTokens: tokens.slice(0, separatorIndex),
     pathspecs: tokens.slice(separatorIndex + 1),
   };
-}
-
-/** Return whether both diff operands are concrete files on disk. */
-function areExistingFiles(left: string, right: string) {
-  return [left, right].every((path) => existsSync(path) && statSync(path).isFile());
 }
 
 /** Parse one standalone command while letting us capture `--help` as plain text. */
@@ -773,6 +780,18 @@ async function parseDiffCommand(tokens: string[], argv: string[]): Promise<Parse
   const staged = Boolean(parsedOptions.staged) || Boolean(parsedOptions.cached);
   const options = buildCommonOptions(parsedOptions, argv);
   const normalizedPathspecs = pathspecs.length > 0 ? pathspecs : undefined;
+  const files = Array.isArray(parsedOptions.files)
+    ? parsedOptions.files.filter((value): value is string => typeof value === "string")
+    : undefined;
+
+  if (files) {
+    if (files.length !== 2 || parsedTargets.length > 0 || staged || normalizedPathspecs) {
+      throw new Error(
+        "Use `hunk diff --files <left> <right>` with exactly two file paths and no revision, staged, or pathspec arguments.",
+      );
+    }
+    return { kind: "diff", left: files[0]!, right: files[1]!, options };
+  }
 
   if (parsedTargets.length === 0) {
     return {
@@ -793,16 +812,22 @@ async function parseDiffCommand(tokens: string[], argv: string[]): Promise<Parse
     };
   }
 
-  if (!staged && !normalizedPathspecs) {
-    if (parsedTargets.length === 2 && areExistingFiles(parsedTargets[0]!, parsedTargets[1]!)) {
-      return {
-        kind: "diff",
-        left: parsedTargets[0]!,
-        right: parsedTargets[1]!,
-        options,
-      };
-    }
+  if (!staged && parsedTargets.length === 2) {
+    const left = parsedTargets[0]!;
+    const right = parsedTargets[1]!;
 
+    // Two positionals always name revisions. Paths use `--`, while concrete file comparison uses
+    // `--files`, so parsing never depends on the current filesystem or backend syntax.
+    return {
+      kind: "vcs",
+      rangeEndpoints: { from: left, to: right },
+      staged,
+      pathspecs: normalizedPathspecs,
+      options,
+    };
+  }
+
+  if (!staged && !normalizedPathspecs) {
     return {
       kind: "vcs",
       range: parsedTargets[0]!,
@@ -813,7 +838,7 @@ async function parseDiffCommand(tokens: string[], argv: string[]): Promise<Parse
   }
 
   throw new Error(
-    "Use `hunk diff [target] [-- pathspec...]`, `hunk diff <left> <right>` for file comparison.",
+    "Use `hunk diff [target] [-- pathspec...]`, `hunk diff <from> <to>`, or `hunk diff --files <left> <right>` for file comparison.",
   );
 }
 

--- a/src/app/session/reloadBounds.test.ts
+++ b/src/app/session/reloadBounds.test.ts
@@ -80,6 +80,22 @@ describe("session reload filesystem bounds", () => {
       ).toThrow("diff range that looks like a VCS option");
       expect(() =>
         validateSessionReloadWithinBounds(bounds, {
+          kind: "vcs",
+          rangeEndpoints: { from: "main", to: "--output=/tmp/hunk-poc" },
+          staged: false,
+          options: {},
+        }),
+      ).toThrow("diff to revision that looks like a VCS option");
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "vcs",
+          rangeEndpoints: { from: "-R", to: "feature" },
+          staged: false,
+          options: {},
+        }),
+      ).toThrow("diff from revision that looks like a VCS option");
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
           kind: "show",
           ref: "--output=/tmp/hunk-poc",
           options: {},
@@ -101,6 +117,14 @@ describe("session reload filesystem bounds", () => {
           range: "main..feature",
           staged: false,
           pathspecs: ["--help"],
+          options: {},
+        }),
+      ).not.toThrow();
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "vcs",
+          rangeEndpoints: { from: "main", to: "feature" },
+          staged: false,
           options: {},
         }),
       ).not.toThrow();

--- a/src/app/session/reloadBounds.ts
+++ b/src/app/session/reloadBounds.ts
@@ -11,9 +11,9 @@ import type { VcsCatalog } from "../../core/vcs/types";
  * | Initial session | Reload roots | Rejected reload filesystem reads |
  * | --- | --- | --- |
  * | `hunk diff` / `hunk show` / `hunk stash show` | Initial repo root | Anything outside that repo root. |
- * | `hunk diff fileA fileB` inside a repo, both files in repo | The repo root | Anything outside that repo root. |
+ * | `hunk diff --files fileA fileB` inside a repo, both files in repo | The repo root | Anything outside that repo root. |
  * | `hunk difftool fileA fileB` inside a repo, both files in repo | The repo root | Anything outside that repo root. |
- * | `hunk diff fileA fileB` outside a repo | None | All session reloads. |
+ * | `hunk diff --files fileA fileB` outside a repo | None | All session reloads. |
  * | `hunk difftool fileA fileB` outside a repo | None | All session reloads. |
  * | `hunk patch patchfile` inside a repo | The repo root | Anything outside that repo root. |
  * | `hunk patch patchfile` outside a repo | Exact initial patch file | Other files and every repository-backed reload. |
@@ -23,8 +23,8 @@ import type { VcsCatalog } from "../../core/vcs/types";
  * All candidate paths are realpath-normalized through existing ancestors so symlinks cannot escape
  * the roots, including paths whose final file does not exist yet.
  *
- * Revision-shaped fields (`vcs` `range`, `show`/`stash-show` `ref`) must name revisions, not
- * command options: a value beginning with `-` would let a daemon caller inject flags such as
+ * Revision-shaped fields (`vcs` `range`/`rangeEndpoints`, `show`/`stash-show` `ref`) must name
+ * revisions, not command options: a value beginning with `-` would let a daemon caller inject flags such as
  * `--output=<path>` into the VCS backend's spawned command. Pathspecs are exempt because every
  * bundled backend appends them after `--`, where the VCS treats them as paths.
  */
@@ -227,6 +227,10 @@ export function validateSessionReloadWithinBounds(
       }
       if (nextInput.range) {
         assertReloadRevisionNotOptionLike("diff range", nextInput.range);
+      }
+      if (nextInput.rangeEndpoints) {
+        assertReloadRevisionNotOptionLike("diff from revision", nextInput.rangeEndpoints.from);
+        assertReloadRevisionNotOptionLike("diff to revision", nextInput.rangeEndpoints.to);
       }
       break;
     case "show":

--- a/src/core/run/commandInputs.ts
+++ b/src/core/run/commandInputs.ts
@@ -60,9 +60,9 @@ export interface CommonOptions {
  * Hunk's commands produce. `options` is the internal half: resolved CLI and
  * config state that no adapter — bundled or third-party — needs to see.
  */
-export interface VcsDiffCommandInput extends ExtensionVcsDiffInput {
+export type VcsDiffCommandInput = ExtensionVcsDiffInput & {
   options: CommonOptions;
-}
+};
 
 export interface VcsShowCommandInput extends ExtensionVcsShowInput {
   options: CommonOptions;

--- a/src/core/run/config.ts
+++ b/src/core/run/config.ts
@@ -468,7 +468,7 @@ export const CONFIG_COMMAND_SECTIONS = {
   vcs: "working-tree and target reviews (`hunk diff`)",
   show: "commit and target display reviews (`hunk show`)",
   "stash-show": "stash reviews (`hunk stash show`)",
-  diff: "two-file comparisons (`hunk diff <left> <right>`)",
+  diff: "two-file comparisons (`hunk diff --files <left> <right>`)",
   patch: "patch-file reviews (`hunk patch`)",
   difftool: "Git difftool pair reviews (`hunk difftool`)",
 } as const satisfies Record<CliInput["kind"], string>;

--- a/src/core/watch/signature.test.ts
+++ b/src/core/watch/signature.test.ts
@@ -72,7 +72,7 @@ function createGitInput({
       mode: "auto",
       ...options,
     },
-  } satisfies Extract<CliInput, { kind: "vcs" }>;
+  } as Extract<CliInput, { kind: "vcs" }>;
 }
 
 afterEach(() => {

--- a/src/extension-api/index.ts
+++ b/src/extension-api/index.ts
@@ -144,6 +144,7 @@ export type {
   ExtensionVcsOperation,
   ExtensionVcsOperations,
   ExtensionVcsPatchResult,
+  ExtensionVcsRangeEndpoints,
   ExtensionVcsReviewOptions,
   ExtensionVcsShowInput,
   ExtensionVcsSkippedFile,

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -21,7 +21,7 @@
  * Extensions can branch on `hunk.apiVersion` so a newer Hunk can keep loading
  * older extensions without guessing at their expectations.
  */
-export const HUNK_EXTENSION_API_VERSION = 13;
+export const HUNK_EXTENSION_API_VERSION = 14;
 export type HunkExtensionApiVersion = typeof HUNK_EXTENSION_API_VERSION;
 
 export type ExtensionNotifyType = "info" | "warning" | "error";

--- a/src/extension-api/types.ts
+++ b/src/extension-api/types.ts
@@ -690,14 +690,34 @@ export interface ExtensionVcsReviewOptions {
   colorMoved?: boolean;
 }
 
-/** Working-tree review request, as extension adapters receive it. */
-export interface ExtensionVcsDiffInput {
-  kind: "vcs";
-  range?: string;
-  staged: boolean;
-  pathspecs?: string[];
-  options: ExtensionVcsReviewOptions;
+/** The two revisions named by `hunk diff <from> <to>`, kept backend-neutral. */
+export interface ExtensionVcsRangeEndpoints {
+  /** Revision supplying the old side of the comparison. */
+  from: string;
+  /** Revision supplying the new side of the comparison. */
+  to: string;
 }
+
+/** Working-tree review request, as extension adapters receive it. */
+export type ExtensionVcsDiffInput =
+  | {
+      kind: "vcs";
+      /** One revision or range expression in the selected backend's language. */
+      range?: string;
+      rangeEndpoints?: never;
+      staged: boolean;
+      pathspecs?: string[];
+      options: ExtensionVcsReviewOptions;
+    }
+  | {
+      kind: "vcs";
+      range?: never;
+      /** Two explicit revisions, kept separate so each backend can spell the comparison correctly. */
+      rangeEndpoints: ExtensionVcsRangeEndpoints;
+      staged: boolean;
+      pathspecs?: string[];
+      options: ExtensionVcsReviewOptions;
+    };
 
 /** Single-revision review request, as extension adapters receive it. */
 export interface ExtensionVcsShowInput {

--- a/src/extensions/default/vcs/diffRange.ts
+++ b/src/extensions/default/vcs/diffRange.ts
@@ -1,0 +1,24 @@
+import type { ExtensionVcsDiffInput } from "hunkdiff/extension";
+
+/**
+ * Describe a diff's comparison in compact range form for titles and Git arguments.
+ *
+ * This is display text for non-Git backends: Jujutsu and Sapling interpret `..` as a
+ * revset rather than Git's direct two-tree comparison, so they must build process
+ * arguments from `rangeEndpoints` instead.
+ */
+export function describeDiffRange(input: ExtensionVcsDiffInput) {
+  const endpoints = input.rangeEndpoints;
+  return endpoints ? `${endpoints.from}..${endpoints.to}` : input.range;
+}
+
+/** Describe the targets using the positional spelling the user supplied. */
+export function describeDiffTargets(input: ExtensionVcsDiffInput) {
+  const endpoints = input.rangeEndpoints;
+  return endpoints ? `${endpoints.from} ${endpoints.to}` : input.range;
+}
+
+/** Return whether a VCS diff has any explicit revision or range target. */
+export function hasExplicitDiffTarget(input: ExtensionVcsDiffInput) {
+  return describeDiffRange(input) !== undefined;
+}

--- a/src/extensions/default/vcs/git/commands.test.ts
+++ b/src/extensions/default/vcs/git/commands.test.ts
@@ -104,6 +104,63 @@ describe("git command helpers", () => {
     expect(buildGitDiffArgs(makeGitInput())).toContain("core.quotePath=true");
   });
 
+  test("spells two named revisions as exact Git A..B command arguments", () => {
+    const input = makeGitInput({ rangeEndpoints: { from: "main", to: "feature" } });
+    const prefix = [
+      "-c",
+      "core.quotePath=true",
+      "-c",
+      "diff.noprefix=false",
+      "-c",
+      "diff.mnemonicPrefix=false",
+      "-c",
+      "diff.srcPrefix=a/",
+      "-c",
+      "diff.dstPrefix=b/",
+    ];
+
+    expect(buildGitDiffArgs(input)).toEqual([
+      ...prefix,
+      "diff",
+      "--no-ext-diff",
+      "--find-renames",
+      "--no-color",
+      "main..feature",
+    ]);
+    expect(buildGitDiffNumstatArgs(input)).toEqual([
+      ...prefix,
+      "diff",
+      "--no-ext-diff",
+      "--find-renames",
+      "--no-color",
+      "--numstat",
+      "-z",
+      "main..feature",
+    ]);
+  });
+
+  test("rejects each option-like Git endpoint before commands, probes, or source resolution", () => {
+    for (const rangeEndpoints of [
+      { from: "--output=/tmp/from", to: "feature" },
+      { from: "main", to: "--output=/tmp/to" },
+    ]) {
+      const input = makeGitInput({ rangeEndpoints });
+      expect(() => buildGitDiffArgs(input)).toThrow("looks like a Git option");
+      expect(() => listGitUntrackedFiles(input)).toThrow("looks like a Git option");
+      expect(() => resolveGitDiffEndpoints(input)).toThrow("looks like a Git option");
+    }
+
+    for (const rangeEndpoints of [
+      { from: "", to: "feature" },
+      { from: "main", to: "" },
+    ]) {
+      const input = makeGitInput({ rangeEndpoints });
+      expect(() => buildGitDiffArgs(input)).toThrow("empty revision");
+      expect(() => listGitUntrackedFiles(input)).toThrow("empty revision");
+      expect(() => resolveGitDiffEndpoints(input)).toThrow("empty revision");
+    }
+  });
+
   test("refuses option-like revision values before spawning Git", () => {
     expect(() => buildGitDiffArgs(makeGitInput({ range: "--output=/tmp/hunk-poc" }))).toThrow(
       "looks like a Git option",
@@ -293,6 +350,28 @@ describe("resolveGitMetadata", () => {
 });
 
 describe("resolveGitDiffEndpoints", () => {
+  test("resolves two named revisions for exact source expansion", () => {
+    const repoRoot = createTempRepo("hunk-endpoints-two-revisions-");
+    writeFileSync(join(repoRoot, "x.txt"), "first\n");
+    git(repoRoot, "add", "x.txt");
+    git(repoRoot, "commit", "-m", "first");
+    const from = git(repoRoot, "rev-parse", "HEAD").trim();
+    writeFileSync(join(repoRoot, "x.txt"), "second\n");
+    git(repoRoot, "add", "x.txt");
+    git(repoRoot, "commit", "-m", "second");
+    const to = git(repoRoot, "rev-parse", "HEAD").trim();
+
+    expect(
+      resolveGitDiffEndpoints(makeGitInput({ rangeEndpoints: { from, to } }), {
+        cwd: repoRoot,
+        repoRoot,
+      }),
+    ).toEqual({
+      old: { kind: "git-ref", ref: from },
+      new: { kind: "git-ref", ref: to },
+    });
+  });
+
   test("staged diffs compare HEAD against the index", () => {
     const repoRoot = createTempRepo("hunk-endpoints-staged-");
     writeFileSync(join(repoRoot, "x.txt"), "x\n");

--- a/src/extensions/default/vcs/git/commands.ts
+++ b/src/extensions/default/vcs/git/commands.ts
@@ -8,6 +8,7 @@ import {
 } from "hunkdiff/extension";
 import { LARGE_DIFF_FILE_MAX_BYTES, LARGE_DIFF_FILE_MAX_LINES } from "../../../../lib/largeFile";
 import { normalizePathForOS } from "../../../../lib/osPath";
+import { describeDiffRange, describeDiffTargets } from "../diffRange";
 
 /**
  * Every Git command Hunk runs, and the failures they translate into.
@@ -63,6 +64,14 @@ export function appendGitPathspecs(args: string[], pathspecs?: string[]) {
  * of reaching the spawned command.
  */
 export function requireGitRevisionArg(input: GitBackedInput, value: string) {
+  if (value.length === 0) {
+    throw new HunkExtensionUserError(
+      `\`${formatGitCommandLabel(input)}\` refused an empty revision.`,
+      {
+        suggestions: ["Pass a non-empty revision or range and try again."],
+      },
+    );
+  }
   if (value.startsWith("-")) {
     throw new HunkExtensionUserError(
       `\`${formatGitCommandLabel(input)}\` refused revision \`${value}\` because it looks like a Git option.`,
@@ -71,6 +80,17 @@ export function requireGitRevisionArg(input: GitBackedInput, value: string) {
   }
 
   return value;
+}
+
+/** Validate each explicit Git endpoint before joining them into Git's A..B spelling. */
+function requireGitDiffRangeArg(input: ExtensionVcsDiffInput) {
+  if (input.rangeEndpoints) {
+    const from = requireGitRevisionArg(input, input.rangeEndpoints.from);
+    const to = requireGitRevisionArg(input, input.rangeEndpoints.to);
+    return `${from}..${to}`;
+  }
+
+  return input.range ? requireGitRevisionArg(input, input.range) : undefined;
 }
 
 // @pierre/diffs currently assumes git-style a/ and b/ prefixes when parsing patch headers.
@@ -146,8 +166,9 @@ export function buildGitDiffArgs(
     args.push("--staged");
   }
 
-  if (input.range) {
-    args.push(requireGitRevisionArg(input, input.range));
+  const range = requireGitDiffRangeArg(input);
+  if (range) {
+    args.push(range);
   }
 
   if (excludedPathspecs.length > 0) {
@@ -171,8 +192,9 @@ export function buildGitDiffNumstatArgs(input: ExtensionVcsDiffInput) {
     args.push("--staged");
   }
 
-  if (input.range) {
-    args.push(requireGitRevisionArg(input, input.range));
+  const range = requireGitDiffRangeArg(input);
+  if (range) {
+    args.push(range);
   }
 
   appendGitPathspecs(args, input.pathspecs);
@@ -284,12 +306,14 @@ export function buildGitStashShowArgs(
 
 export function formatGitCommandLabel(input: GitBackedInput) {
   switch (input.kind) {
-    case "vcs":
+    case "vcs": {
       if (input.staged) {
         return "hunk diff --staged";
       }
 
-      return input.range ? `hunk diff ${input.range}` : "hunk diff";
+      const targets = describeDiffTargets(input);
+      return targets ? `hunk diff ${targets}` : "hunk diff";
+    }
     case "show":
       return input.ref ? `hunk show ${input.ref}` : "hunk show";
     case "stash-show":
@@ -301,7 +325,7 @@ function getMissingRepoHelp(input: GitBackedInput) {
   if (input.kind === "vcs") {
     return [
       "Run the command from a Git checkout, or compare files directly instead:",
-      "  hunk diff <before-file> <after-file>",
+      "  hunk diff --files <before-file> <after-file>",
       "  hunk patch <file.patch>",
     ];
   }
@@ -357,9 +381,19 @@ function createMissingRepoError(input: GitBackedInput) {
 
 function createInvalidRevisionError(input: ExtensionVcsDiffInput | ExtensionVcsShowInput) {
   if (input.kind === "vcs") {
+    const endpoints = input.rangeEndpoints;
     return new HunkExtensionUserError(
-      `\`${formatGitCommandLabel(input)}\` could not resolve Git revision or range \`${input.range}\`.`,
-      { suggestions: ["Check the revision or range and try again."] },
+      `\`${formatGitCommandLabel(input)}\` could not resolve Git revision or range \`${describeDiffRange(input)}\`.`,
+      {
+        suggestions: [
+          "Check the revision or range and try again.",
+          ...(endpoints
+            ? [
+                `To limit the review to a path, separate it: \`hunk diff ${endpoints.from} -- ${endpoints.to}\`.`,
+              ]
+            : []),
+        ],
+      },
     );
   }
 
@@ -419,7 +453,7 @@ function translateGitExitFailure(input: GitBackedInput, stderr: string) {
     return createMissingStashError(input);
   }
 
-  if (input.kind === "vcs" && input.range && isUnknownRevisionMessage(stderr)) {
+  if (input.kind === "vcs" && describeDiffRange(input) && isUnknownRevisionMessage(stderr)) {
     return createInvalidRevisionError(input);
   }
 
@@ -569,11 +603,12 @@ function isWorkingTreeGitDiffInput(
     return false;
   }
 
-  if (!input.range) {
+  const range = requireGitDiffRangeArg(input);
+  if (!range) {
     return true;
   }
 
-  const cacheKey = `${gitExecutable}\0${repoRoot ?? cwd}\0${input.range}`;
+  const cacheKey = `${gitExecutable}\0${repoRoot ?? cwd}\0${range}`;
   const cached = workingTreeGitDiffInputCache.get(cacheKey);
   if (cached !== undefined) {
     return cached;
@@ -581,7 +616,7 @@ function isWorkingTreeGitDiffInput(
 
   const revs = runGitText({
     input,
-    args: ["rev-parse", "--revs-only", requireGitRevisionArg(input, input.range)],
+    args: ["rev-parse", "--revs-only", requireGitRevisionArg(input, range)],
     cwd,
     gitExecutable,
     preventOptionalLocks,
@@ -871,8 +906,10 @@ export function resolveGitDiffEndpoints(
     repoRoot,
   }: Omit<RunGitTextOptions, "input" | "args"> & { repoRoot?: string } = {},
 ): GitDiffEndpoints | null {
+  const range = requireGitDiffRangeArg(input);
+
   if (input.staged) {
-    if (!input.range) {
+    if (!range) {
       const headRef = tryResolveGitCommitRef(input, "HEAD", {
         cwd: repoRoot ?? cwd,
         gitExecutable,
@@ -884,7 +921,7 @@ export function resolveGitDiffEndpoints(
       };
     }
 
-    const { positives, negatives } = resolveRangeRevisions(input, input.range, {
+    const { positives, negatives } = resolveRangeRevisions(input, range, {
       cwd,
       gitExecutable,
       repoRoot,
@@ -897,14 +934,14 @@ export function resolveGitDiffEndpoints(
     return null;
   }
 
-  if (!input.range) {
+  if (!range) {
     return { old: { kind: "index" }, new: { kind: "worktree" } };
   }
 
   // `git diff A...B` compares merge-base(A, B) against B, not HEAD or the
   // working tree. Resolve the merge base explicitly so expanded source rows
   // read from the same revisions the diff was computed from.
-  const symmetric = parseSymmetricDiffRange(input.range);
+  const symmetric = parseSymmetricDiffRange(range);
   if (symmetric) {
     const mergeBase = runGitText({
       input,
@@ -931,7 +968,7 @@ export function resolveGitDiffEndpoints(
 
   // Real rev-parse failures (bogus refs, missing repo) propagate to the caller
   // so the user sees a clear error instead of a silent working-tree fallback.
-  const { positives, negatives } = resolveRangeRevisions(input, input.range, {
+  const { positives, negatives } = resolveRangeRevisions(input, range, {
     cwd,
     gitExecutable,
     repoRoot,

--- a/src/extensions/default/vcs/git/index.test.ts
+++ b/src/extensions/default/vcs/git/index.test.ts
@@ -86,6 +86,20 @@ describe("GitVcsAdapter", () => {
     expect(GitVcsAdapter.detect(nested)).toEqual({ id: "git", repoRoot: repo });
   });
 
+  test("rejects option-like endpoints from direct adapter callers", async () => {
+    const repo = createTempRepo("hunk-git-adapter-endpoint-trust-");
+    const input = {
+      kind: "vcs",
+      rangeEndpoints: { from: "main", to: "--output=unsafe" },
+      staged: false,
+      options: {},
+    } satisfies ExtensionVcsDiffInput;
+
+    await expect(
+      GitVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: repo }),
+    ).rejects.toThrow("looks like a Git option");
+  });
+
   test("loads working-tree diffs with untracked files through the neutral operation", async () => {
     const repo = createTempRepo("hunk-git-adapter-diff-");
     writeFileSync(join(repo, "tracked.txt"), "old\n");
@@ -129,6 +143,32 @@ describe("GitVcsAdapter", () => {
     // one `git status` covers all of them instead of one `git diff --no-index`
     // subprocess per file, which made review scale with the untracked count.
     expect(result.extraFiles ?? []).toHaveLength(0);
+  });
+
+  test("loads two-revision diffs with exact sources and no working-tree untracked files", async () => {
+    const repo = createTempRepo("hunk-git-adapter-two-revisions-");
+    writeFileSync(join(repo, "tracked.txt"), "old\ncontext\n");
+    git(repo, "add", "tracked.txt");
+    git(repo, "commit", "-m", "old");
+    const from = git(repo, "rev-parse", "HEAD").trim();
+    writeFileSync(join(repo, "tracked.txt"), "new\ncontext\n");
+    git(repo, "commit", "-am", "new");
+    const to = git(repo, "rev-parse", "HEAD").trim();
+    writeFileSync(join(repo, "untracked.txt"), "not part of either revision\n");
+
+    const input = {
+      kind: "vcs",
+      staged: false,
+      rangeEndpoints: { from, to },
+      options: {},
+    } satisfies ExtensionVcsDiffInput;
+    const result = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: repo });
+    const file = { path: "tracked.txt", changeType: "change", isUntracked: false } as const;
+
+    expect(result.title).toContain(`${from}..${to}`);
+    expect(result.untrackedPaths).toEqual([]);
+    expect(await result.readFileSource?.({ ...file, side: "old" })).toBe("old\ncontext\n");
+    expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("new\ncontext\n");
   });
 
   test("loads revision and stash patches through adapter operations", async () => {

--- a/src/extensions/default/vcs/git/index.ts
+++ b/src/extensions/default/vcs/git/index.ts
@@ -20,6 +20,7 @@ import {
   type GitDiffEndpoints,
 } from "./commands";
 import { gitEndpointSourceSpec, readGitFileSource } from "./source";
+import { describeDiffRange } from "../diffRange";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -283,10 +284,11 @@ export function createGitVcsAdapter({
         async load(input, { cwd }) {
           const repoRoot = resolveGitRepoRoot(input, { cwd, gitExecutable });
           const repoName = basename(repoRoot);
+          const range = describeDiffRange(input);
           const title = input.staged
             ? `${repoName} staged changes`
-            : input.range
-              ? `${repoName} ${input.range}`
+            : range
+              ? `${repoName} ${range}`
               : `${repoName} working tree`;
           // Ask for stats before the patch so files too large to render can be
           // excluded from the diff instead of generating output nobody reads.

--- a/src/extensions/default/vcs/jujutsu/commands.test.ts
+++ b/src/extensions/default/vcs/jujutsu/commands.test.ts
@@ -2,7 +2,13 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildJjDiffArgs, buildJjShowArgs, resolveJjDiffEndpoints, runJjText } from "./commands";
+import {
+  buildJjDiffArgs,
+  buildJjShowArgs,
+  resolveJjDiffEndpoints,
+  resolveJjRangeEndpoints,
+  runJjText,
+} from "./commands";
 import type { ExtensionVcsDiffInput as VcsDiffCommandInput } from "hunkdiff/extension";
 
 const tempDirs: string[] = [];
@@ -92,6 +98,43 @@ afterEach(() => {
 const jjTest = Bun.which("jj") ? test : test.skip;
 
 describe("jj command helpers", () => {
+  test("compares named revisions with --from/--to rather than a range revset", () => {
+    expect(buildJjDiffArgs(diffInput({ rangeEndpoints: { from: "main", to: "feature" } }))).toEqual(
+      ["diff", "--git", "--ignore-working-copy", "--from", "main", "--to", "feature"],
+    );
+  });
+
+  test("rejects each option-like Jujutsu endpoint before commands or revision probes", () => {
+    for (const rangeEndpoints of [
+      { from: "--from-file", to: "feature" },
+      { from: "main", to: "--to-file" },
+    ]) {
+      const input = diffInput({ rangeEndpoints });
+      expect(() => buildJjDiffArgs(input)).toThrow("looks like a Jujutsu option");
+      expect(() => resolveJjRangeEndpoints(input, rangeEndpoints)).toThrow(
+        "looks like a Jujutsu option",
+      );
+    }
+
+    for (const rangeEndpoints of [
+      { from: "", to: "feature" },
+      { from: "main", to: "" },
+    ]) {
+      const input = diffInput({ rangeEndpoints });
+      expect(() => buildJjDiffArgs(input)).toThrow("empty revision");
+      expect(() => resolveJjRangeEndpoints(input, rangeEndpoints)).toThrow("empty revision");
+    }
+  });
+
+  test("passes an explicitly written revset through to -r", () => {
+    expect(buildJjDiffArgs(diffInput({ range: "trunk()..@" }))).toEqual([
+      "diff",
+      "--git",
+      "-r",
+      "trunk()..@",
+    ]);
+  });
+
   test("uses an immutable revision override without changing fileset arguments", () => {
     expect(buildJjDiffArgs(diffInput({ pathspecs: ["src/a b.ts"] }), "abc123")).toEqual([
       "diff",
@@ -156,7 +199,7 @@ describe("jj command helpers", () => {
 
     expect(resolveJjDiffEndpoints(diffInput(), "@", { cwd: dir })).toEqual({
       newCommitId: secondCommitId,
-      parentCommitIds: [firstCommitId],
+      oldCommitIds: [firstCommitId],
     });
   });
 
@@ -176,7 +219,22 @@ describe("jj command helpers", () => {
 
     expect(resolveJjDiffEndpoints(diffInput(), "@", { cwd: dir })).toEqual({
       newCommitId: thirdCommitId,
-      parentCommitIds: [secondCommitId],
+      oldCommitIds: [secondCommitId],
+    });
+  });
+
+  jjTest("resolves two revisions to immutable source-expansion endpoints", () => {
+    const dir = createTempJjRepo("hunk-jj-two-endpoints-");
+    writeFileSync(join(dir, "file.txt"), "one\n");
+    jj(dir, "commit", "-m", "first");
+    const from = jj(dir, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+    writeFileSync(join(dir, "file.txt"), "two\n");
+    const to = jj(dir, "log", "--no-graph", "-r", "@", "-T", "commit_id");
+    const input = diffInput({ rangeEndpoints: { from: "@-", to: "@" } });
+
+    expect(resolveJjRangeEndpoints(input, input.rangeEndpoints!, { cwd: dir })).toEqual({
+      newCommitId: to,
+      oldCommitIds: [from],
     });
   });
 
@@ -212,7 +270,7 @@ describe("jj command helpers", () => {
 
     expect(endpoints).toEqual({
       newCommitId: mergeCommitId,
-      parentCommitIds: [leftCommitId, rightCommitId].sort(),
+      oldCommitIds: [leftCommitId, rightCommitId].sort(),
     });
   });
 

--- a/src/extensions/default/vcs/jujutsu/commands.test.ts
+++ b/src/extensions/default/vcs/jujutsu/commands.test.ts
@@ -99,9 +99,24 @@ const jjTest = Bun.which("jj") ? test : test.skip;
 
 describe("jj command helpers", () => {
   test("compares named revisions with --from/--to rather than a range revset", () => {
-    expect(buildJjDiffArgs(diffInput({ rangeEndpoints: { from: "main", to: "feature" } }))).toEqual(
-      ["diff", "--git", "--ignore-working-copy", "--from", "main", "--to", "feature"],
-    );
+    const input = diffInput({ rangeEndpoints: { from: "main", to: "feature" } });
+    expect(buildJjDiffArgs(input)).toEqual([
+      "diff",
+      "--git",
+      "--ignore-working-copy",
+      "--from",
+      "main",
+      "--to",
+      "feature",
+    ]);
+    expect(buildJjDiffArgs(input, undefined, true)).toEqual([
+      "diff",
+      "--git",
+      "--from",
+      "main",
+      "--to",
+      "feature",
+    ]);
   });
 
   test("rejects each option-like Jujutsu endpoint before commands or revision probes", () => {

--- a/src/extensions/default/vcs/jujutsu/commands.ts
+++ b/src/extensions/default/vcs/jujutsu/commands.ts
@@ -1,9 +1,11 @@
 import {
   HunkExtensionUserError,
   type ExtensionVcsDiffInput,
+  type ExtensionVcsRangeEndpoints,
   type ExtensionVcsShowInput,
 } from "hunkdiff/extension";
 import { normalizePathForOS } from "../../../../lib/osPath";
+import { describeDiffTargets } from "../diffRange";
 
 export type JjBackedInput = ExtensionVcsDiffInput | ExtensionVcsShowInput;
 
@@ -14,10 +16,10 @@ export interface RunJjTextOptions {
   jjExecutable?: string;
 }
 
-/** Identifies the reviewed commit and every parent JJ used to build the old side. */
+/** Identifies the reviewed new commit and every commit JJ used to build the old side. */
 export interface JjDiffEndpoints {
   newCommitId: string;
-  parentCommitIds: string[];
+  oldCommitIds: string[];
 }
 
 /** Bypass user template aliases while rendering full commit IDs. */
@@ -31,6 +33,25 @@ function parseJjCommitIds(output: string) {
     .filter((line) => /^[0-9a-f]+$/i.test(line));
 }
 
+/** Reject a Jujutsu revision that could be interpreted as a command option. */
+export function requireJjRevisionArg(input: JjBackedInput, value: string) {
+  if (value.length === 0) {
+    throw new HunkExtensionUserError(
+      `\`${formatJjCommandLabel(input)}\` refused an empty revision.`,
+      {
+        suggestions: ["Pass a non-empty revision or revset and try again."],
+      },
+    );
+  }
+  if (value.startsWith("-")) {
+    throw new HunkExtensionUserError(
+      `\`${formatJjCommandLabel(input)}\` refused revision \`${value}\` because it looks like a Jujutsu option.`,
+      { suggestions: ["Pass a plain revision or revset and try again."] },
+    );
+  }
+  return value;
+}
+
 /** Append Jujutsu filesets only when the caller requested path filtering. */
 function appendJjFilesets(args: string[], pathspecs?: string[]) {
   if (!pathspecs || pathspecs.length === 0) {
@@ -40,12 +61,22 @@ function appendJjFilesets(args: string[], pathspecs?: string[]) {
   args.push("--", ...pathspecs);
 }
 
-/** Build the `jj diff --git` arguments for working-copy and revset reviews. */
-export function buildJjDiffArgs(input: ExtensionVcsDiffInput, pinnedRevision?: string) {
+/** Build the `jj diff --git` arguments for working-copy, revset, and two-revision reviews. */
+export function buildJjDiffArgs(
+  input: ExtensionVcsDiffInput,
+  pinned?: string | ExtensionVcsRangeEndpoints,
+) {
   const args = ["diff", "--git"];
+  const endpoints = typeof pinned === "object" ? pinned : input.rangeEndpoints;
 
-  if (pinnedRevision || input.range) {
-    args.push("-r", pinnedRevision ?? input.range!);
+  if (endpoints) {
+    // A `from..to` revset selects commits between two points; it does not compare their trees.
+    // Pinning resolved endpoints also lets the second command avoid another workspace snapshot.
+    const from = requireJjRevisionArg(input, endpoints.from);
+    const to = requireJjRevisionArg(input, endpoints.to);
+    args.push("--ignore-working-copy", "--from", from, "--to", to);
+  } else if (typeof pinned === "string" || input.range) {
+    args.push("-r", typeof pinned === "string" ? pinned : input.range!);
   }
 
   appendJjFilesets(args, input.pathspecs);
@@ -66,7 +97,8 @@ export function formatJjCommandLabel(input: JjBackedInput) {
       return "hunk diff --staged";
     }
 
-    return input.range ? `hunk diff ${input.range}` : "hunk diff";
+    const targets = describeDiffTargets(input);
+    return targets ? `hunk diff ${targets}` : "hunk diff";
   }
 
   return input.ref ? `hunk show ${input.ref}` : "hunk show";
@@ -128,6 +160,14 @@ export function createJjStagedError(input: ExtensionVcsDiffInput) {
 }
 
 function createInvalidRevsetError(input: JjBackedInput) {
+  if (input.kind === "vcs" && input.rangeEndpoints) {
+    const { from, to } = input.rangeEndpoints;
+    return new HunkExtensionUserError(
+      `\`${formatJjCommandLabel(input)}\` could not resolve Jujutsu revisions \`${from}\` and \`${to}\`.`,
+      { suggestions: ["Check both revisions and try again."] },
+    );
+  }
+
   const revset = input.kind === "vcs" ? input.range : (input.ref ?? "@");
   return new HunkExtensionUserError(
     `\`${formatJjCommandLabel(input)}\` could not resolve Jujutsu revset \`${revset}\`.`,
@@ -256,8 +296,33 @@ export function resolveJjDiffEndpoints(
 
   return {
     newCommitId: commitId,
-    parentCommitIds: parentCommitIds.sort(),
+    oldCommitIds: parentCommitIds.sort(),
   };
+}
+
+/** Resolve two named JJ revisions to the immutable trees used by diff and source expansion. */
+export function resolveJjRangeEndpoints(
+  input: ExtensionVcsDiffInput,
+  endpoints: ExtensionVcsRangeEndpoints,
+  options: Omit<RunJjTextOptions, "input" | "args"> = {},
+): JjDiffEndpoints | undefined {
+  const from = requireJjRevisionArg(input, endpoints.from);
+  const to = requireJjRevisionArg(input, endpoints.to);
+  const resolveOne = (revset: string) =>
+    parseJjCommitIds(
+      runJjText({
+        input,
+        args: ["log", "--no-graph", "-r", revset, "-T", JjCommitIdTemplate],
+        ...options,
+      }),
+    );
+  const fromCommitIds = resolveOne(from);
+  const toCommitIds = resolveOne(to);
+  if (fromCommitIds.length !== 1 || toCommitIds.length !== 1) {
+    return undefined;
+  }
+
+  return { newCommitId: toCommitIds[0]!, oldCommitIds: [fromCommitIds[0]!] };
 }
 
 export function resolveJjRepoRoot(

--- a/src/extensions/default/vcs/jujutsu/commands.ts
+++ b/src/extensions/default/vcs/jujutsu/commands.ts
@@ -65,6 +65,7 @@ function appendJjFilesets(args: string[], pathspecs?: string[]) {
 export function buildJjDiffArgs(
   input: ExtensionVcsDiffInput,
   pinned?: string | ExtensionVcsRangeEndpoints,
+  snapshotWorkingCopy = false,
 ) {
   const args = ["diff", "--git"];
   const endpoints = typeof pinned === "object" ? pinned : input.rangeEndpoints;
@@ -74,7 +75,13 @@ export function buildJjDiffArgs(
     // Pinning resolved endpoints also lets the second command avoid another workspace snapshot.
     const from = requireJjRevisionArg(input, endpoints.from);
     const to = requireJjRevisionArg(input, endpoints.to);
-    args.push("--ignore-working-copy", "--from", from, "--to", to);
+    args.push(
+      ...(snapshotWorkingCopy ? [] : ["--ignore-working-copy"]),
+      "--from",
+      from,
+      "--to",
+      to,
+    );
   } else if (typeof pinned === "string" || input.range) {
     args.push("-r", typeof pinned === "string" ? pinned : input.range!);
   }

--- a/src/extensions/default/vcs/jujutsu/index.test.ts
+++ b/src/extensions/default/vcs/jujutsu/index.test.ts
@@ -87,6 +87,20 @@ describe("JjVcsAdapter", () => {
     JjAdapterIntegrationTestTimeoutMs,
   );
 
+  jjTest("rejects option-like endpoints from direct adapter callers", async () => {
+    const repo = createTempJjRepo("hunk-jj-adapter-endpoint-trust-");
+    const input = {
+      kind: "vcs",
+      rangeEndpoints: { from: "main", to: "--at-operation" },
+      staged: false,
+      options: {},
+    } satisfies ExtensionVcsDiffInput;
+
+    await expect(
+      JjVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: repo }),
+    ).rejects.toThrow("looks like a Jujutsu option");
+  });
+
   jjTest(
     "loads working-copy and revision patches through neutral operations",
     async () => {
@@ -156,6 +170,31 @@ describe("JjVcsAdapter", () => {
       expect(
         JjVcsAdapter.operations["revision-show"]!.watchSignature!(showInput, { cwd: repo }),
       ).toContain("diff --git");
+    },
+    JjAdapterIntegrationTestTimeoutMs,
+  );
+
+  jjTest(
+    "expands source from both explicit revision endpoints",
+    async () => {
+      const repo = createTempJjRepo("hunk-jj-adapter-two-revisions-");
+      writeFileSync(join(repo, "file.txt"), "one\ncontext\n");
+      jj(repo, "commit", "-m", "first");
+      const from = jj(repo, "log", "--no-graph", "-r", "@-", "-T", "commit_id");
+      writeFileSync(join(repo, "file.txt"), "two\ncontext\n");
+      const input = {
+        kind: "vcs",
+        staged: false,
+        rangeEndpoints: { from, to: "@" },
+        options: {},
+      } satisfies ExtensionVcsDiffInput;
+
+      const result = await JjVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: repo });
+      const file = { path: "file.txt", changeType: "change", isUntracked: false } as const;
+      expect(result.title).toContain(`${from}..@`);
+      expect(result.patchText).toContain("+two");
+      expect(await result.readFileSource?.({ ...file, side: "old" })).toBe("one\ncontext\n");
+      expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("two\ncontext\n");
     },
     JjAdapterIntegrationTestTimeoutMs,
   );

--- a/src/extensions/default/vcs/jujutsu/index.test.ts
+++ b/src/extensions/default/vcs/jujutsu/index.test.ts
@@ -195,6 +195,11 @@ describe("JjVcsAdapter", () => {
       expect(result.patchText).toContain("+two");
       expect(await result.readFileSource?.({ ...file, side: "old" })).toBe("one\ncontext\n");
       expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("two\ncontext\n");
+
+      writeFileSync(join(repo, "file.txt"), "three\ncontext\n");
+      expect(
+        JjVcsAdapter.operations["working-tree-diff"]!.watchSignature!(input, { cwd: repo }),
+      ).toContain("+three");
     },
     JjAdapterIntegrationTestTimeoutMs,
   );

--- a/src/extensions/default/vcs/jujutsu/index.ts
+++ b/src/extensions/default/vcs/jujutsu/index.ts
@@ -168,7 +168,12 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
           };
         },
         watchSignature(input, { cwd }) {
-          return runJjText({ input, args: buildJjDiffArgs(input), cwd, jjExecutable });
+          return runJjText({
+            input,
+            args: buildJjDiffArgs(input, undefined, true),
+            cwd,
+            jjExecutable,
+          });
         },
       },
       "revision-show": {

--- a/src/extensions/default/vcs/jujutsu/index.ts
+++ b/src/extensions/default/vcs/jujutsu/index.ts
@@ -5,11 +5,13 @@ import {
   buildJjShowArgs,
   createJjStagedError,
   resolveJjDiffEndpoints,
+  resolveJjRangeEndpoints,
   resolveJjRepoRoot,
   runJjText,
   type JjDiffEndpoints,
 } from "./commands";
 import { readJjFileSource } from "./source";
+import { describeDiffRange } from "../diffRange";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -56,11 +58,11 @@ interface JjSourceCapability {
   sourceCacheKey: string;
 }
 
-/** Include every resolved parent in the identity Hunk uses to retain cached source text. */
-function jjParentCacheKey(parentCommitIds: string[]) {
-  return parentCommitIds.length === 1
-    ? `commit:${parentCommitIds[0]}`
-    : `merged-parents:${parentCommitIds.join(",")}`;
+/** Include every resolved old-side commit in retained source identity. */
+function jjOldSideCacheKey(oldCommitIds: string[]) {
+  return oldCommitIds.length === 1
+    ? `commit:${oldCommitIds[0]}`
+    : `merged-parents:${oldCommitIds.join(",")}`;
 }
 
 /**
@@ -86,13 +88,12 @@ function createJjSourceCapability(
   endpoints: JjDiffEndpoints,
   jjExecutable: string,
 ): JjSourceCapability {
-  const oldCommitId =
-    endpoints.parentCommitIds.length === 1 ? endpoints.parentCommitIds[0] : undefined;
+  const oldCommitId = endpoints.oldCommitIds.length === 1 ? endpoints.oldCommitIds[0] : undefined;
 
   return {
     sourceCacheKey: [
       "jj-source-v1",
-      jjParentCacheKey(endpoints.parentCommitIds),
+      jjOldSideCacheKey(endpoints.oldCommitIds),
       `commit:${endpoints.newCommitId}`,
     ].join(":"),
     readFileSource: ({ path, previousPath, changeType, side }) => {
@@ -138,20 +139,28 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
           }
           const repoRoot = resolveJjRepoRoot(input, { cwd, jjExecutable });
           const repoName = basename(repoRoot);
-          const sourceEndpoints = resolveJjDiffEndpoints(input, input.range ?? "@", {
-            cwd,
-            jjExecutable,
-          });
+          const sourceEndpoints = input.rangeEndpoints
+            ? resolveJjRangeEndpoints(input, input.rangeEndpoints, { cwd, jjExecutable })
+            : resolveJjDiffEndpoints(input, input.range ?? "@", { cwd, jjExecutable });
           const sourceCapability = sourceEndpoints
             ? createJjSourceCapability(repoRoot, sourceEndpoints, jjExecutable)
             : undefined;
+          const pinnedInput = input.rangeEndpoints
+            ? sourceEndpoints?.oldCommitIds.length === 1
+              ? {
+                  from: sourceEndpoints.oldCommitIds[0]!,
+                  to: sourceEndpoints.newCommitId,
+                }
+              : undefined
+            : sourceEndpoints?.newCommitId;
+          const range = describeDiffRange(input);
           return {
             repoRoot,
             sourceLabel: repoRoot,
-            title: input.range ? `${repoName} ${input.range}` : `${repoName} working copy`,
+            title: range ? `${repoName} ${range}` : `${repoName} working copy`,
             patchText: runJjText({
               input,
-              args: buildJjDiffArgs(input, sourceEndpoints?.newCommitId),
+              args: buildJjDiffArgs(input, pinnedInput),
               cwd,
               jjExecutable,
             }),

--- a/src/extensions/default/vcs/sapling/commands.test.ts
+++ b/src/extensions/default/vcs/sapling/commands.test.ts
@@ -104,17 +104,17 @@ describe("sl command helpers", () => {
     ]);
   });
 
-  test("does not discover working-copy unknown files for revision comparisons", () => {
+  test("discovers unknown files for single-target reviews but not two-revision comparisons", () => {
     expect(
       listSlUntrackedFiles(diffInput({ rangeEndpoints: { from: "main", to: "feature" } }), {
         slExecutable: "definitely-not-a-real-sl-binary",
       }),
     ).toEqual([]);
-    expect(
-      listSlUntrackedFiles(diffInput({ range: ".^::." }), {
+    expect(() =>
+      listSlUntrackedFiles(diffInput({ range: "." }), {
         slExecutable: "definitely-not-a-real-sl-binary",
       }),
-    ).toEqual([]);
+    ).toThrow("was not found in PATH");
   });
 
   test("reports a friendly error when sl is not installed or not on PATH", () => {

--- a/src/extensions/default/vcs/sapling/commands.test.ts
+++ b/src/extensions/default/vcs/sapling/commands.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildSlDiffArgs, runSlText } from "./commands";
+import { buildSlDiffArgs, listSlUntrackedFiles, runSlText } from "./commands";
 import type { ExtensionVcsDiffInput as VcsDiffCommandInput } from "hunkdiff/extension";
 
 const slAvailable = (() => {
@@ -65,6 +65,58 @@ afterEach(() => {
 });
 
 describe("sl command helpers", () => {
+  test("compares named revisions with one -r argument per endpoint", () => {
+    expect(buildSlDiffArgs(diffInput({ rangeEndpoints: { from: "main", to: "feature" } }))).toEqual(
+      ["diff", "--git", "-r", "main", "-r", "feature"],
+    );
+  });
+
+  test("rejects each option-like Sapling endpoint before commands or untracked probes", () => {
+    for (const rangeEndpoints of [
+      { from: "--from-file", to: "feature" },
+      { from: "main", to: "--to-file" },
+    ]) {
+      const input = diffInput({ rangeEndpoints });
+      expect(() => buildSlDiffArgs(input)).toThrow("looks like a Sapling option");
+      expect(() =>
+        listSlUntrackedFiles(input, { slExecutable: "definitely-not-a-real-sl-binary" }),
+      ).toThrow("looks like a Sapling option");
+    }
+
+    for (const rangeEndpoints of [
+      { from: "", to: "feature" },
+      { from: "main", to: "" },
+    ]) {
+      const input = diffInput({ rangeEndpoints });
+      expect(() => buildSlDiffArgs(input)).toThrow("empty revision");
+      expect(() =>
+        listSlUntrackedFiles(input, { slExecutable: "definitely-not-a-real-sl-binary" }),
+      ).toThrow("empty revision");
+    }
+  });
+
+  test("passes an explicitly written revset through to -r", () => {
+    expect(buildSlDiffArgs(diffInput({ range: ".^::." }))).toEqual([
+      "diff",
+      "--git",
+      "-r",
+      ".^::.",
+    ]);
+  });
+
+  test("does not discover working-copy unknown files for revision comparisons", () => {
+    expect(
+      listSlUntrackedFiles(diffInput({ rangeEndpoints: { from: "main", to: "feature" } }), {
+        slExecutable: "definitely-not-a-real-sl-binary",
+      }),
+    ).toEqual([]);
+    expect(
+      listSlUntrackedFiles(diffInput({ range: ".^::." }), {
+        slExecutable: "definitely-not-a-real-sl-binary",
+      }),
+    ).toEqual([]);
+  });
+
   test("reports a friendly error when sl is not installed or not on PATH", () => {
     expect(() =>
       runSlText({

--- a/src/extensions/default/vcs/sapling/commands.ts
+++ b/src/extensions/default/vcs/sapling/commands.ts
@@ -6,7 +6,7 @@ import {
   type ExtensionVcsShowInput,
 } from "hunkdiff/extension";
 import { normalizePathForOS } from "../../../../lib/osPath";
-import { describeDiffTargets, hasExplicitDiffTarget } from "../diffRange";
+import { describeDiffTargets } from "../diffRange";
 
 export type SlBackedInput = ExtensionVcsDiffInput | ExtensionVcsShowInput;
 
@@ -240,7 +240,7 @@ export function runSlText(options: RunSlTextOptions) {
 
 /** Return whether working-copy review should synthesize unknown Sapling files into the patch stream. */
 function shouldIncludeUntrackedFiles(input: ExtensionVcsDiffInput) {
-  return !input.staged && !hasExplicitDiffTarget(input) && input.options.excludeUntracked !== true;
+  return !input.staged && !input.rangeEndpoints && input.options.excludeUntracked !== true;
 }
 
 /** Parse `sl status --unknown --print0` output down to repo-root-relative file paths. */

--- a/src/extensions/default/vcs/sapling/commands.ts
+++ b/src/extensions/default/vcs/sapling/commands.ts
@@ -6,6 +6,7 @@ import {
   type ExtensionVcsShowInput,
 } from "hunkdiff/extension";
 import { normalizePathForOS } from "../../../../lib/osPath";
+import { describeDiffTargets, hasExplicitDiffTarget } from "../diffRange";
 
 export type SlBackedInput = ExtensionVcsDiffInput | ExtensionVcsShowInput;
 
@@ -14,6 +15,32 @@ export interface RunSlTextOptions {
   args: string[];
   cwd?: string;
   slExecutable?: string;
+}
+
+/** Reject a Sapling revision that could be interpreted as a command option. */
+export function requireSlRevisionArg(input: SlBackedInput, value: string) {
+  if (value.length === 0) {
+    throw new HunkExtensionUserError(
+      `\`${formatSlCommandLabel(input)}\` refused an empty revision.`,
+      {
+        suggestions: ["Pass a non-empty revision or revset and try again."],
+      },
+    );
+  }
+  if (value.startsWith("-")) {
+    throw new HunkExtensionUserError(
+      `\`${formatSlCommandLabel(input)}\` refused revision \`${value}\` because it looks like a Sapling option.`,
+      { suggestions: ["Pass a plain revision or revset and try again."] },
+    );
+  }
+  return value;
+}
+
+/** Validate both structured endpoints before any Sapling probe or diff command handles them. */
+function validateSlDiffEndpoints(input: ExtensionVcsDiffInput) {
+  if (!input.rangeEndpoints) return;
+  requireSlRevisionArg(input, input.rangeEndpoints.from);
+  requireSlRevisionArg(input, input.rangeEndpoints.to);
 }
 
 /** Append Sapling pathspec arguments only when the caller requested path filtering. */
@@ -27,9 +54,13 @@ function appendSlPathspecs(args: string[], pathspecs?: string[]) {
 
 /** Build the `sl diff --git` arguments for working-copy and revset reviews. */
 export function buildSlDiffArgs(input: ExtensionVcsDiffInput) {
+  validateSlDiffEndpoints(input);
   const args = ["diff", "--git"];
 
-  if (input.range) {
+  if (input.rangeEndpoints) {
+    // Sapling's `..` is a revset range, while a `-r` per side compares the two trees.
+    args.push("-r", input.rangeEndpoints.from, "-r", input.rangeEndpoints.to);
+  } else if (input.range) {
     args.push("-r", input.range);
   }
 
@@ -60,7 +91,8 @@ export function formatSlCommandLabel(input: SlBackedInput) {
       return "hunk diff --staged";
     }
 
-    return input.range ? `hunk diff ${input.range}` : "hunk diff";
+    const targets = describeDiffTargets(input);
+    return targets ? `hunk diff ${targets}` : "hunk diff";
   }
 
   return input.ref ? `hunk show ${input.ref}` : "hunk show";
@@ -123,6 +155,14 @@ export function createSlStagedError(input: ExtensionVcsDiffInput) {
 }
 
 function createInvalidRevsetError(input: SlBackedInput) {
+  if (input.kind === "vcs" && input.rangeEndpoints) {
+    const { from, to } = input.rangeEndpoints;
+    return new HunkExtensionUserError(
+      `\`${formatSlCommandLabel(input)}\` could not resolve Sapling revisions \`${from}\` and \`${to}\`.`,
+      { suggestions: ["Check both revisions and try again."] },
+    );
+  }
+
   const revset = input.kind === "vcs" ? input.range : (input.ref ?? ".");
   return new HunkExtensionUserError(
     `\`${formatSlCommandLabel(input)}\` could not resolve Sapling revset \`${revset}\`.`,
@@ -200,7 +240,7 @@ export function runSlText(options: RunSlTextOptions) {
 
 /** Return whether working-copy review should synthesize unknown Sapling files into the patch stream. */
 function shouldIncludeUntrackedFiles(input: ExtensionVcsDiffInput) {
-  return !input.staged && input.options.excludeUntracked !== true;
+  return !input.staged && !hasExplicitDiffTarget(input) && input.options.excludeUntracked !== true;
 }
 
 /** Parse `sl status --unknown --print0` output down to repo-root-relative file paths. */
@@ -246,6 +286,7 @@ export function listSlUntrackedFiles(
     slExecutable = "sl",
   }: Omit<RunSlTextOptions, "input" | "args"> & { repoRoot?: string } = {},
 ) {
+  validateSlDiffEndpoints(input);
   if (!shouldIncludeUntrackedFiles(input)) {
     return [];
   }

--- a/src/extensions/default/vcs/sapling/index.test.ts
+++ b/src/extensions/default/vcs/sapling/index.test.ts
@@ -162,6 +162,39 @@ describe("SaplingVcsAdapter", () => {
 
 // These branches run before any `sl` invocation, so they need no external binary.
 describe("SaplingVcsAdapter without the sl binary", () => {
+  test("adapter range loads do not probe working-copy unknown files", async () => {
+    const repo = createTempDir("hunk-sl-adapter-range-untracked-");
+    const commands: string[][] = [];
+    const mutableBun = Bun as unknown as { spawnSync: typeof Bun.spawnSync };
+    const originalSpawnSync = mutableBun.spawnSync;
+    mutableBun.spawnSync = ((command: string[]) => {
+      commands.push(command);
+      const operation = command.slice(4);
+      const stdout = operation[0] === "root" ? `${repo}\n` : "";
+      return { exitCode: 0, stdout: Buffer.from(stdout), stderr: Buffer.from("") };
+    }) as typeof Bun.spawnSync;
+
+    try {
+      const input = {
+        kind: "vcs",
+        rangeEndpoints: { from: "main", to: "feature" },
+        staged: false,
+        options: {},
+      } satisfies ExtensionVcsDiffInput;
+      const result = await SaplingVcsAdapter.operations["working-tree-diff"]!.load(input, {
+        cwd: repo,
+      });
+
+      expect(result.untrackedPaths).toEqual([]);
+      expect(commands.some((command) => command.includes("status"))).toBe(false);
+      expect(
+        commands.some((command) => command.includes("main") && command.includes("feature")),
+      ).toBe(true);
+    } finally {
+      mutableBun.spawnSync = originalSpawnSync;
+    }
+  });
+
   test("treats a .hg directory with no requires file as non-Sapling", () => {
     const repo = createTempDir("hunk-sl-hg-no-requires-");
     mkdirSync(join(repo, ".hg"));
@@ -171,6 +204,18 @@ describe("SaplingVcsAdapter without the sl binary", () => {
 
   test("returns null when no Sapling marker exists up to the filesystem root", () => {
     expect(SaplingVcsAdapter.detect(createTempDir("hunk-sl-detect-none-"))).toBeNull();
+  });
+
+  test("rejects option-like endpoints from direct adapter callers before spawning sl", async () => {
+    const input = {
+      kind: "vcs",
+      rangeEndpoints: { from: "main", to: "--config=unsafe" },
+      staged: false,
+      options: {},
+    } satisfies ExtensionVcsDiffInput;
+    await expect(
+      SaplingVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: tmpdir() }),
+    ).rejects.toThrow("looks like a Sapling option");
   });
 
   test("rejects staged working-tree diffs before spawning sl", async () => {

--- a/src/extensions/default/vcs/sapling/index.ts
+++ b/src/extensions/default/vcs/sapling/index.ts
@@ -8,6 +8,7 @@ import {
   resolveSlRepoRoot,
   runSlText,
 } from "./commands";
+import { describeDiffRange } from "../diffRange";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -79,13 +80,15 @@ export const SaplingVcsAdapter = {
         if (input.staged) {
           throw createSlStagedError(input);
         }
+        const diffArgs = buildSlDiffArgs(input);
         const repoRoot = resolveSlRepoRoot(input, { cwd });
         const repoName = basename(repoRoot);
+        const range = describeDiffRange(input);
         return {
           repoRoot,
           sourceLabel: repoRoot,
-          title: input.range ? `${repoName} ${input.range}` : `${repoName} working copy`,
-          patchText: runSlText({ input, args: buildSlDiffArgs(input), cwd }),
+          title: range ? `${repoName} ${range}` : `${repoName} working copy`,
+          patchText: runSlText({ input, args: diffArgs, cwd }),
           untrackedPaths: listSlUntrackedFiles(input, { cwd, repoRoot }),
         };
       },

--- a/src/session/agent/commands.test.ts
+++ b/src/session/agent/commands.test.ts
@@ -611,7 +611,7 @@ describe("session command compatibility checks", () => {
     });
   });
 
-  test("passes a separate source path through reload commands", async () => {
+  test("forwards structured endpoints and a separate source path through reload commands", async () => {
     setSessionCommandTestHooks({
       createClient: () =>
         createClient({
@@ -623,6 +623,7 @@ describe("session command compatibility checks", () => {
             expect(input.sourcePath).toBe("/source-repo");
             expect(input.nextInput).toEqual({
               kind: "vcs",
+              rangeEndpoints: { from: "main", to: "feature" },
               staged: false,
               options: {},
             });
@@ -648,6 +649,7 @@ describe("session command compatibility checks", () => {
       sourcePath: "/source-repo",
       nextInput: {
         kind: "vcs",
+        rangeEndpoints: { from: "main", to: "feature" },
         staged: false,
         options: {},
       },

--- a/src/session/broker/brokerServer.test.ts
+++ b/src/session/broker/brokerServer.test.ts
@@ -818,7 +818,7 @@ describe("Hunk session daemon server", () => {
     }
   });
 
-  test("forwards reload sourcePath through the session API", async () => {
+  test("forwards reload sourcePath and structured endpoints through the session API", async () => {
     const port = await reserveLoopbackPort();
     process.env.HUNK_MCP_HOST = "127.0.0.1";
     process.env.HUNK_MCP_PORT = String(port);
@@ -831,6 +831,7 @@ describe("Hunk session daemon server", () => {
         sourcePath: "/tmp/source-repo",
         nextInput: {
           kind: "vcs",
+          rangeEndpoints: { from: "main", to: "feature" },
           staged: false,
           options: {},
         },
@@ -860,6 +861,7 @@ describe("Hunk session daemon server", () => {
           sourcePath: "/tmp/source-repo",
           nextInput: {
             kind: "vcs",
+            rangeEndpoints: { from: "main", to: "feature" },
             staged: false,
             options: {},
           },

--- a/src/session/protocol.ts
+++ b/src/session/protocol.ts
@@ -36,7 +36,7 @@ export const HUNK_SESSION_API_VERSION = 1;
  * builds can refresh an older daemon even when it still exposes the same API endpoints. Bump this
  * when daemon-forwarded payloads change, even if the supported action names stay stable.
  */
-export const HUNK_SESSION_DAEMON_VERSION = 11;
+export const HUNK_SESSION_DAEMON_VERSION = 12;
 
 export type SessionDaemonAction =
   | "list"

--- a/src/session/protocolSchemas.test.ts
+++ b/src/session/protocolSchemas.test.ts
@@ -27,8 +27,21 @@ const _schemaMatchesProtocol: Equal<
 void _schemaMatchesProtocol;
 const _cliInputSchemaMatchesProtocol: Equal<z.infer<typeof cliInputSchema>, CliInput> = true;
 void _cliInputSchemaMatchesProtocol;
+const _dualSelectorIsNotCliInput: CliInput = {
+  kind: "vcs",
+  range: "main..feature",
+  // @ts-expect-error A VCS input cannot carry both selector forms.
+  rangeEndpoints: { from: "main", to: "feature" },
+  staged: false,
+  options: {},
+};
+void _dualSelectorIsNotCliInput;
 
 describe("session daemon request validation", () => {
+  test("uses the daemon revision for structured two-endpoint reload payloads", () => {
+    expect(HUNK_SESSION_DAEMON_VERSION).toBe(12);
+  });
+
   test("strictly parses cross-process capabilities", () => {
     expect(
       parseSessionDaemonCapabilities({
@@ -96,6 +109,16 @@ describe("session daemon request validation", () => {
         action: "reload",
         selector: { sessionId: "s-1" },
         nextInput: { kind: "show", ref: "HEAD~1", options: {} },
+      },
+      {
+        action: "reload",
+        selector: { sessionId: "s-1" },
+        nextInput: {
+          kind: "vcs",
+          rangeEndpoints: { from: "main", to: "feature" },
+          staged: false,
+          options: {},
+        },
       },
       {
         action: "comment-add",
@@ -277,6 +300,47 @@ describe("session daemon request validation", () => {
         action: "reload",
         selector: { sessionId: "s-1" },
         nextInput: { kind: "patch", options: {}, unknown: true },
+      },
+      {
+        action: "reload",
+        selector: { sessionId: "s-1" },
+        nextInput: {
+          kind: "vcs",
+          rangeEndpoints: { from: "main" },
+          staged: false,
+          options: {},
+        },
+      },
+      {
+        action: "reload",
+        selector: { sessionId: "s-1" },
+        nextInput: {
+          kind: "vcs",
+          rangeEndpoints: { from: "", to: "feature" },
+          staged: false,
+          options: {},
+        },
+      },
+      {
+        action: "reload",
+        selector: { sessionId: "s-1" },
+        nextInput: {
+          kind: "vcs",
+          rangeEndpoints: { from: "main", to: "feature", injected: true },
+          staged: false,
+          options: {},
+        },
+      },
+      {
+        action: "reload",
+        selector: { sessionId: "s-1" },
+        nextInput: {
+          kind: "vcs",
+          range: "main..feature",
+          rangeEndpoints: { from: "main", to: "feature" },
+          staged: false,
+          options: {},
+        },
       },
       {
         action: "comment-apply",

--- a/src/session/protocolSchemas.ts
+++ b/src/session/protocolSchemas.ts
@@ -50,6 +50,11 @@ const sessionDaemonCapabilitiesSchema = z.strictObject({
   actions: z.array(sessionDaemonActionSchema),
 });
 
+const rangeEndpointsSchema = z.strictObject({
+  from: z.string().min(1),
+  to: z.string().min(1),
+});
+
 const commonOptionsSchema = z.strictObject({
   mode: z.enum(["auto", "split", "stack"]).optional(),
   cursorLine: z.enum(["row", "number", "off"]).optional(),
@@ -79,10 +84,19 @@ const commonOptionsSchema = z.strictObject({
 });
 
 /** Parses the complete reloadable CLI input tree carried inside a command. */
-export const cliInputSchema = z.discriminatedUnion("kind", [
+export const cliInputSchema: z.ZodType<CliInput> = z.union([
   z.strictObject({
     kind: z.literal("vcs"),
     range: z.string().optional(),
+    rangeEndpoints: z.never().optional(),
+    staged: z.boolean(),
+    pathspecs: z.array(z.string()).optional(),
+    options: commonOptionsSchema,
+  }),
+  z.strictObject({
+    kind: z.literal("vcs"),
+    range: z.never().optional(),
+    rangeEndpoints: rangeEndpointsSchema,
     staged: z.boolean(),
     pathspecs: z.array(z.string()).optional(),
     options: commonOptionsSchema,

--- a/src/ui/lib/extensionWorkspace.test.ts
+++ b/src/ui/lib/extensionWorkspace.test.ts
@@ -47,6 +47,15 @@ describe("extension workspace write policy", () => {
   test("refuses every review that is not the plain working tree", () => {
     const inputs: Array<[string, CliInput]> = [
       ["vcs range", { kind: "vcs", staged: false, range: "main..HEAD", options: NO_OPTIONS }],
+      [
+        "vcs endpoints",
+        {
+          kind: "vcs",
+          staged: false,
+          rangeEndpoints: { from: "main", to: "feature" },
+          options: NO_OPTIONS,
+        },
+      ],
       ["vcs staged", { kind: "vcs", staged: true, options: NO_OPTIONS }],
       ["show", { kind: "show", ref: "HEAD", options: NO_OPTIONS }],
       ["stash show", { kind: "stash-show", options: NO_OPTIONS }],

--- a/src/ui/lib/extensionWorkspace.ts
+++ b/src/ui/lib/extensionWorkspace.ts
@@ -77,7 +77,7 @@ export interface WorkspaceWriteRequestFields {
 function nonWorkingTreeReview(input: CliInput): string | null {
   switch (input.kind) {
     case "vcs":
-      if (input.range) {
+      if (input.range || input.rangeEndpoints) {
         return "a revision range";
       }
 

--- a/test/cli/entrypoint.test.ts
+++ b/test/cli/entrypoint.test.ts
@@ -316,7 +316,7 @@ describe("CLI entrypoint contracts", () => {
       expect(proc.exitCode).toBe(1);
       expect(stdout).toBe("");
       expect(stderr).toContain("hunk: `hunk diff` must be run inside a Git repository.");
-      expect(stderr).toContain("hunk diff <before-file> <after-file>");
+      expect(stderr).toContain("hunk diff --files <before-file> <after-file>");
       expect(stderr).not.toContain("at runGitText");
       expect(stderr).not.toContain("loadGitChangeset");
       expect(stderr).not.toContain("Bun v");

--- a/test/cli/non-interactive-stdin.test.ts
+++ b/test/cli/non-interactive-stdin.test.ts
@@ -40,7 +40,7 @@ describe("non-interactive stdin contracts", () => {
     writeFileSync(before, "export const value = 1;\n");
     writeFileSync(after, "export const value = 2;\n");
 
-    const proc = Bun.spawn(["bun", "run", "src/main.tsx", "--", "diff", before, after], {
+    const proc = Bun.spawn(["bun", "run", "src/main.tsx", "--", "diff", "--files", before, after], {
       cwd: process.cwd(),
       stdin: "ignore",
       stdout: "pipe",

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -20,6 +20,7 @@ describe("PTY chrome", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -123,7 +124,7 @@ describe("PTY chrome", () => {
     const configHome = mkdtempSync(join(tmpdir(), "hunk-tuistory-save-view-"));
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after],
+      args: ["diff", "--files", fixture.before, fixture.after],
       cwd: fixture.dir,
       cols: 120,
       rows: 24,

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -61,6 +61,7 @@ describe("PTY current line", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -109,7 +110,7 @@ describe("PTY current line", () => {
   test("multi-row copy drag keeps extending after highlighted rows repaint", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 20,
     });
@@ -149,6 +150,7 @@ describe("PTY current line", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -184,6 +186,7 @@ describe("PTY current line", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -252,7 +255,7 @@ describe("PTY current line", () => {
   test("stepping reaches the lines an expanded gap reveals", async () => {
     const fixture = harness.createExpandableContextFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
       cols: 140,
       rows: 16,
     });
@@ -278,7 +281,7 @@ describe("PTY current line", () => {
   test("expanding a gap moves the current line into it and collapsing puts it back", async () => {
     const fixture = harness.createExpandableContextFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
       cols: 140,
       rows: 16,
     });

--- a/test/pty/file-views-integration.test.ts
+++ b/test/pty/file-views-integration.test.ts
@@ -114,7 +114,7 @@ describe("PTY file views", () => {
   test("does not load the Markdown example unless the user installs it", async () => {
     const pair = createMarkdownPairTest();
     const session = await harness.launchHunk({
-      args: ["diff", "--mode", "stack", pair.before, pair.after],
+      args: ["diff", "--mode", "stack", "--files", pair.before, pair.after],
       cwd: pair.directory,
       cols: 140,
       rows: 24,
@@ -140,6 +140,7 @@ describe("PTY file views", () => {
         RENDERED_MARKDOWN_EXTENSION,
         "--mode",
         "stack",
+        "--files",
         pair.before,
         pair.after,
       ],
@@ -211,6 +212,7 @@ describe("PTY file views", () => {
           JSX_FILE_VIEW_GALLERY,
           "--mode",
           "stack",
+          "--files",
           demo.before,
           demo.after,
         ],
@@ -291,7 +293,16 @@ describe("PTY file views", () => {
     const extension = join(pair.dir, "jsx-runtime-proof");
     cpSync(JSX_FILE_VIEW_EXTENSION, extension, { recursive: true });
     const session = await harness.launchHunk({
-      args: ["diff", "--extension", extension, "--mode", "stack", pair.before, pair.after],
+      args: [
+        "diff",
+        "--extension",
+        extension,
+        "--mode",
+        "stack",
+        "--files",
+        pair.before,
+        pair.after,
+      ],
       cwd: pair.dir,
       cols: 140,
       rows: 24,
@@ -335,7 +346,16 @@ describe("PTY file views", () => {
     const pair = harness.createMultiHunkFilePair();
     const extension = createInteractiveViewExtension(pair.dir);
     const session = await harness.launchHunk({
-      args: ["diff", "--extension", extension, "--mode", "stack", pair.before, pair.after],
+      args: [
+        "diff",
+        "--extension",
+        extension,
+        "--mode",
+        "stack",
+        "--files",
+        pair.before,
+        pair.after,
+      ],
       cwd: pair.dir,
       cols: 140,
       rows: 24,
@@ -542,6 +562,7 @@ describe("PTY file views", () => {
         "--agent-context",
         pair.agentContext,
         "--agent-notes",
+        "--files",
         pair.before,
         pair.after,
       ],
@@ -578,6 +599,7 @@ describe("PTY file views", () => {
         "--agent-context",
         pair.agentContext,
         "--agent-notes",
+        "--files",
         pair.before,
         pair.after,
       ],

--- a/test/pty/highlighting.test.ts
+++ b/test/pty/highlighting.test.ts
@@ -36,7 +36,7 @@ describe("PTY syntax highlighting", () => {
   test("keeps key input responsive while a large added file highlights", async () => {
     const fixture = createLargeHighlightTestFiles();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--fast", "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--fast", "--mode", "stack"],
       cwd: fixture.dir,
       cols: 120,
       rows: 24,

--- a/test/pty/key-routing.test.ts
+++ b/test/pty/key-routing.test.ts
@@ -127,7 +127,7 @@ describe("PTY key routing", () => {
   test("F10 does not open the menu bar while a note draft is focused", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 24,
     });

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -127,6 +127,7 @@ describe("PTY layout", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -162,7 +163,7 @@ describe("PTY layout", () => {
   test("split rows keep the center separator aligned after wide characters", async () => {
     const fixture = harness.createWideCharacterFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 140,
       rows: 16,
     });
@@ -225,7 +226,7 @@ describe("PTY layout", () => {
   test("the CLI tab width reaches interactive app rendering", async () => {
     const fixture = harness.createTabbedFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack", "-x8"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack", "-x8"],
       cols: 100,
       rows: 12,
     });
@@ -250,7 +251,7 @@ describe("PTY layout", () => {
   test("real PTY sessions can toggle wrapped lines on and off", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 102,
       rows: 20,
     });
@@ -290,7 +291,7 @@ describe("PTY layout", () => {
   test("real PTY sessions can expand and collapse unchanged context", async () => {
     const fixture = harness.createExpandableContextFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 140,
       rows: 16,
     });
@@ -701,7 +702,7 @@ describe("PTY layout", () => {
   test("layout hotkeys preserve the current review position in a real PTY", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 220,
       rows: 12,
     });
@@ -755,7 +756,7 @@ describe("PTY layout", () => {
   test("arrow-key horizontal scrolling reveals hidden code columns in a real PTY", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 102,
       rows: 20,
     });
@@ -801,7 +802,7 @@ describe("PTY layout", () => {
   test("shifted mouse-wheel input scrolls code horizontally in a real PTY", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 102,
       rows: 20,
     });
@@ -835,7 +836,7 @@ describe("PTY layout", () => {
   test("wrap toggles reset horizontal code scrolling in a real PTY", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 102,
       rows: 20,
     });

--- a/test/pty/lifecycle.test.ts
+++ b/test/pty/lifecycle.test.ts
@@ -214,7 +214,12 @@ describe("PTY lifecycle", () => {
     test.skipIf(process.platform === "win32")(`exits cleanly on ${signal}`, async () => {
       const fixture = harness.createLongWrapFilePair();
       const runtimeDir = harness.createIsolatedConfigHome();
-      const hunkCommand = harness.buildHunkCommand(["diff", fixture.before, fixture.after]);
+      const hunkCommand = harness.buildHunkCommand([
+        "diff",
+        "--files",
+        fixture.before,
+        fixture.after,
+      ]);
       const child = spawn("/bin/sh", ["-c", `exec ${hunkCommand}`], {
         cwd: fixture.dir,
         stdio: ["pipe", "pipe", "pipe"],
@@ -248,7 +253,12 @@ describe("PTY lifecycle", () => {
     async () => {
       const fixture = harness.createLongWrapFilePair();
       const { master, slave } = openPtyPair();
-      const hunkCommand = harness.buildHunkCommand(["diff", fixture.before, fixture.after]);
+      const hunkCommand = harness.buildHunkCommand([
+        "diff",
+        "--files",
+        fixture.before,
+        fixture.after,
+      ]);
       // `exec` to keep the pid pointing at Hunk
       const child = spawn("/bin/sh", ["-c", `exec ${hunkCommand}`], {
         cwd: fixture.dir,
@@ -296,7 +306,12 @@ describe("PTY lifecycle", () => {
       const pidFile = join(fixture.dir, "hunk.pid");
       const exitFile = join(fixture.dir, "hunk.exit");
       const ttyFile = join(fixture.dir, "hunk.tty");
-      const hunkCommand = harness.buildHunkCommand(["diff", fixture.before, fixture.after]);
+      const hunkCommand = harness.buildHunkCommand([
+        "diff",
+        "--files",
+        fixture.before,
+        fixture.after,
+      ]);
       const session = await harness.launchShellCommand({
         command: `trap '' HUP; tty_path="$(tty)"; printf '%s' "$tty_path" > ${harness.shellQuote(ttyFile)}; ${hunkCommand} < "$tty_path" & hunk_pid=$!; printf '%s' "$hunk_pid" > ${harness.shellQuote(pidFile)}; wait "$hunk_pid"; printf '%s' "$?" > ${harness.shellQuote(exitFile)}`,
         cwd: fixture.dir,

--- a/test/pty/nav.test.ts
+++ b/test/pty/nav.test.ts
@@ -56,7 +56,7 @@ describe("PTY navigation", () => {
   test("real hunk navigation jumps to later hunks in the review stream", async () => {
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 104,
       rows: 12,
     });
@@ -134,7 +134,7 @@ describe("PTY navigation", () => {
   test("PTY sessions can navigate forward and backward between distant hunks in one large file", async () => {
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 104,
       rows: 12,
     });

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -24,6 +24,7 @@ describe("PTY notes", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -66,6 +67,7 @@ describe("PTY notes", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -97,6 +99,7 @@ describe("PTY notes", () => {
     const session = await harness.launchHunk({
       args: [
         "diff",
+        "--files",
         fixture.before,
         fixture.after,
         "--mode",
@@ -123,7 +126,7 @@ describe("PTY notes", () => {
   test("opening a draft keeps the active line fixed while pushing following code down", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
       cols: 120,
       rows: 26,
     });
@@ -178,7 +181,16 @@ describe("PTY notes", () => {
   test("cursor-line-off drafts still reveal their default target and full composer", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack", "--cursor-line", "off"],
+      args: [
+        "diff",
+        "--files",
+        fixture.before,
+        fixture.after,
+        "--mode",
+        "stack",
+        "--cursor-line",
+        "off",
+      ],
       cols: 120,
       rows: 12,
     });
@@ -209,7 +221,7 @@ describe("PTY notes", () => {
   test("user notes can be drafted and saved inline in a real PTY", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 20,
     });
@@ -270,7 +282,7 @@ describe("PTY notes", () => {
   test("saved notes can be edited and replied to through clickable threaded actions", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
       cols: 100,
       rows: 30,
     });
@@ -381,7 +393,7 @@ describe("PTY notes", () => {
   test("CJK draft notes wrap instead of scrolling out of view in a real PTY", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 24,
     });
@@ -417,7 +429,7 @@ describe("PTY notes", () => {
   test("rapid Ctrl+S presses save a draft note exactly once", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 24,
     });
@@ -451,7 +463,7 @@ describe("PTY notes", () => {
   test("add-note affordance appears only after mouse movement in a real PTY", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 12,
     });
@@ -498,7 +510,7 @@ describe("PTY notes", () => {
   test("a single Escape cancels a freshly opened empty draft note", async () => {
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 20,
     });
@@ -530,7 +542,7 @@ describe("PTY notes", () => {
   test("clicked add-note drafts can cancel and save with keyboard shortcuts", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 20,
     });
@@ -569,7 +581,7 @@ describe("PTY notes", () => {
   test("clicking stack-mode add-note affordances can save draft notes", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
       cols: 100,
       rows: 20,
     });
@@ -597,7 +609,7 @@ describe("PTY notes", () => {
   test("clicking deletion-only add-note affordances can save draft notes", async () => {
     const fixture = harness.createDeletionOnlyFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 16,
     });
@@ -625,7 +637,7 @@ describe("PTY notes", () => {
   test("clicking context-row add-note affordances can save draft notes", async () => {
     const fixture = harness.createDeletionOnlyFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 16,
     });
@@ -663,7 +675,7 @@ describe("PTY notes", () => {
   test("draft note focus blocks app shortcuts until cancelled", async () => {
     const fixture = harness.createMultiHunkFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 104,
       rows: 12,
     });
@@ -748,7 +760,7 @@ describe("PTY notes", () => {
   test("multiple add-note drafts can be saved on one hunk", async () => {
     const fixture = harness.createDeletionOnlyFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 20,
     });
@@ -789,7 +801,7 @@ describe("PTY notes", () => {
   test("clicking diff add-note affordances can cancel and save draft notes", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 20,
     });

--- a/test/pty/scroll.test.ts
+++ b/test/pty/scroll.test.ts
@@ -106,7 +106,7 @@ describe("PTY scrolling", () => {
   test("clicking and dragging the live scrollbar scrolls the review pane", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 120,
       rows: 10,
     });
@@ -240,7 +240,7 @@ describe("PTY scrolling", () => {
   test("mouse wheel scrolling moves the review pane", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 220,
       rows: 12,
     });
@@ -283,7 +283,7 @@ describe("PTY scrolling", () => {
   test("repeated mouse-wheel input remains stable at the end of the review stream", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "split"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
       cols: 220,
       rows: 12,
     });

--- a/test/pty/session-attention-integration.test.ts
+++ b/test/pty/session-attention-integration.test.ts
@@ -128,7 +128,7 @@ describe("PTY session attention marks", () => {
     const fixture = createTallFilePair();
     const port = await reserveLoopbackPort();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
       cwd: fixture.dir,
       cols: 140,
       rows: 24,

--- a/test/pty/watch.test.ts
+++ b/test/pty/watch.test.ts
@@ -16,7 +16,7 @@ describe("PTY watch mode", () => {
   test("passively refreshes direct files after an atomic save", async () => {
     const fixture = harness.createWatchFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", fixture.before, fixture.after, "--watch", "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--watch", "--mode", "stack"],
       cwd: fixture.dir,
       cols: 120,
       rows: 16,

--- a/test/session/broker-e2e.test.ts
+++ b/test/session/broker-e2e.test.ts
@@ -114,7 +114,7 @@ async function reserveLoopbackPort() {
 
 /** Start one real terminal session whose input the test can control directly. */
 function spawnHunkSession(fixture: FixtureFiles, port: number) {
-  const innerCommand = `bun run ${shellQuote(sourceEntrypoint)} diff ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`;
+  const innerCommand = `bun run ${shellQuote(sourceEntrypoint)} diff --files ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`;
 
   return Bun.spawn(["script", "-q", "-f", "-e", "-c", innerCommand, fixture.transcript], {
     cwd: fixture.dir,

--- a/test/session/cli.test.ts
+++ b/test/session/cli.test.ts
@@ -110,7 +110,7 @@ function createFixtureFiles(name: string, beforeLines: string[], afterLines: str
 }
 
 function spawnHunkSession(fixture: ReturnType<typeof createFixtureFiles>, port: number) {
-  const innerCommand = `bun run ${shellQuote(sourceEntrypoint)} diff ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`;
+  const innerCommand = `bun run ${shellQuote(sourceEntrypoint)} diff --files ${shellQuote(fixture.before)} ${shellQuote(fixture.after)}`;
 
   return Bun.spawn(["script", "-q", "-f", "-e", "-c", innerCommand, fixture.transcript], {
     cwd: fixture.dir,
@@ -396,7 +396,7 @@ sessionDescribe("session CLI integration", () => {
       writeFileSync(fixture.after, "export const after = 20;\nexport const extra = 'yes';\n");
 
       const reload = runSessionCli(
-        ["reload", sessionId, "--json", "--", "diff", fixture.before, fixture.after],
+        ["reload", sessionId, "--json", "--", "diff", "--files", fixture.before, fixture.after],
         port,
       );
       expect(reload.proc.exitCode).toBe(0);
@@ -465,6 +465,7 @@ sessionDescribe("session CLI integration", () => {
           outside.dir,
           "--",
           "diff",
+          "--files",
           outside.before,
           outside.after,
         ],

--- a/test/smoke/tty.test.ts
+++ b/test/smoke/tty.test.ts
@@ -429,7 +429,7 @@ async function runTtySmoke(options: {
 }) {
   const fixture = options.longWrapFixture ? createLongWrapFixtureFiles() : createFixtureFiles();
   const transcript = join(fixture.dir, "transcript.txt");
-  const args = ["diff", fixture.before, fixture.after];
+  const args = ["diff", "--files", fixture.before, fixture.after];
 
   if (options.mode) {
     args.push("--mode", options.mode);

--- a/website/src/content/docs/docs/configure/configuration.md
+++ b/website/src/content/docs/docs/configure/configuration.md
@@ -47,14 +47,14 @@ wrap_lines = true
 
 Command sections are named after the input Hunk parses, which is not always the command you type. In particular, `hunk diff` on a repository reads `[vcs]`, not `[diff]`:
 
-| Section        | Applies to                                        |
-| -------------- | ------------------------------------------------- |
-| `[vcs]`        | `hunk diff` working-tree and target reviews       |
-| `[show]`       | `hunk show` commit reviews                        |
-| `[stash-show]` | `hunk stash show` reviews                         |
-| `[diff]`       | two-file comparisons (`hunk diff <left> <right>`) |
-| `[patch]`      | `hunk patch` reviews                              |
-| `[difftool]`   | `hunk difftool` pair reviews                      |
+| Section        | Applies to                                                |
+| -------------- | --------------------------------------------------------- |
+| `[vcs]`        | `hunk diff` working-tree and target reviews               |
+| `[show]`       | `hunk show` commit reviews                                |
+| `[stash-show]` | `hunk stash show` reviews                                 |
+| `[diff]`       | two-file comparisons (`hunk diff --files <left> <right>`) |
+| `[patch]`      | `hunk patch` reviews                                      |
+| `[difftool]`   | `hunk difftool` pair reviews                              |
 
 `[pager]` is an overlay applied after the matching command section whenever the invocation uses pager-style behavior.
 

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -7,9 +7,9 @@ The extension factory receives one API object. Registration calls are only valid
 
 ## `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `12`). Branch on it if you want
-one file to support several Hunk versions. Version 12 adds responsive fractional
-pane sizing; version 11 added the `dim` line-highlight tone; version 10 added
+The API generation this Hunk speaks (currently `14`). Branch on it if you want
+one file to support several Hunk versions. Version 14 adds structured two-revision
+VCS diff endpoints; version 12 added responsive fractional pane sizing; version 11 added the `dim` line-highlight tone; version 10 added
 generic top-level CLI commands; version 9
 added exact-filename and glob selectors to `registerFileLanguage`; version 8
 added authoritative review snapshots to command handlers; version 7 added the

--- a/website/src/content/docs/docs/reference/cli.md
+++ b/website/src/content/docs/docs/reference/cli.md
@@ -53,14 +53,20 @@ review diffs or compare two concrete files
 
 ```bash
 hunk diff [target] [-- <pathspec...>]
+hunk diff <from> <to> [-- <pathspec...>]
 hunk diff --staged [-- <pathspec...>]
-hunk diff <left> <right>
+hunk diff --files <left> <right>
 ```
+
+Two positional arguments always name revision endpoints, even when matching files exist on disk.
+
+Use `--files <left> <right>` for concrete-file comparison; this replaces the former filesystem-existence disambiguation.
 
 ### Command-specific options
 
 | Option                   | Description                                                                                   |
 | ------------------------ | --------------------------------------------------------------------------------------------- |
+| `--files <paths...>`     | compare exactly two concrete files: --files &lt;left&gt; &lt;right&gt;                        |
 | `--staged`               | show staged changes instead of the working tree                                               |
 | `--cached`               | alias for --staged                                                                            |
 | `--exclude-untracked`    | exclude untracked files from working tree reviews                                             |

--- a/website/src/content/docs/docs/reference/config.md
+++ b/website/src/content/docs/docs/reference/config.md
@@ -211,14 +211,14 @@ Enable moved-line coloring when the renderer supports it.
 
 ## Command tables
 
-| Table          | Applies to                                        |
-| -------------- | ------------------------------------------------- |
-| `[vcs]`        | working-tree and target reviews (`hunk diff`)     |
-| `[show]`       | commit and target display reviews (`hunk show`)   |
-| `[stash-show]` | stash reviews (`hunk stash show`)                 |
-| `[diff]`       | two-file comparisons (`hunk diff <left> <right>`) |
-| `[patch]`      | patch-file reviews (`hunk patch`)                 |
-| `[difftool]`   | Git difftool pair reviews (`hunk difftool`)       |
+| Table          | Applies to                                                |
+| -------------- | --------------------------------------------------------- |
+| `[vcs]`        | working-tree and target reviews (`hunk diff`)             |
+| `[show]`       | commit and target display reviews (`hunk show`)           |
+| `[stash-show]` | stash reviews (`hunk stash show`)                         |
+| `[diff]`       | two-file comparisons (`hunk diff --files <left> <right>`) |
+| `[patch]`      | patch-file reviews (`hunk patch`)                         |
+| `[difftool]`   | Git difftool pair reviews (`hunk difftool`)               |
 
 `[pager]` is an additional overlay for any review opened with pager-style chrome. It is applied after the matching command table in the same file.
 

--- a/website/src/content/docs/docs/workflows/files-and-patches.md
+++ b/website/src/content/docs/docs/workflows/files-and-patches.md
@@ -8,13 +8,13 @@ Use file comparison when you already have before and after content, and patch mo
 ## Compare files
 
 ```bash
-hunk diff before.ts after.ts
+hunk diff --files before.ts after.ts
 ```
 
-When both operands are existing concrete files, Hunk treats them as a direct comparison instead of VCS targets. Add `--watch` to reload when either file changes:
+The explicit `--files` option keeps file comparison distinct from `hunk diff <from> <to>`, which compares two VCS revisions. Add `--watch` to reload when either file changes:
 
 ```bash
-hunk diff before.ts after.ts --watch
+hunk diff --files before.ts after.ts --watch
 ```
 
 ## Open a patch file

--- a/website/src/content/docs/docs/workflows/watch-mode.md
+++ b/website/src/content/docs/docs/workflows/watch-mode.md
@@ -17,7 +17,7 @@ Other reopenable inputs also work:
 
 ```bash
 hunk show HEAD~1 --watch
-hunk diff before.ts after.ts --watch
+hunk diff --files before.ts after.ts --watch
 hunk patch changes.patch --watch
 ```
 


### PR DESCRIPTION
## Summary

- make `hunk diff <from> <to>` compare two revisions deterministically
- keep revision endpoints structured until Git, Jujutsu, or Sapling formats its native command
- move concrete file comparison to the explicit `hunk diff --files <left> <right>` form
- preserve pinned source expansion, read-only historical review policy, session reloads, watch mode, and working-copy isolation
- expose structured `rangeEndpoints` through extension API generation 14

This rebuilds and supersedes #678 on current `main`, retaining the original contribution's intent and credit to @HackAttack while integrating with the current VCS extension, session protocol, and workspace safety boundaries.

## Behavior

| Command | Meaning |
| --- | --- |
| `hunk diff` | working-tree review, including untracked files by default |
| `hunk diff A` | backend-native target/range review |
| `hunk diff A B` | historical comparison from revision A to revision B |
| `hunk diff A B -- path` | historical comparison restricted to a pathspec |
| `hunk diff --files before.ts after.ts` | concrete two-file comparison |

Two-revision comparisons exclude unrelated working-copy and untracked files. Git uses `A..B`, Jujutsu uses `--from A --to B`, and Sapling uses two `-r` arguments. Each endpoint is validated independently before backend probes or commands.

## Before and after by VCS

### Git

| Intent | Before | After |
| --- | --- | --- |
| Working tree | `hunk diff` | `hunk diff` |
| Working tree vs target | `hunk diff main` → `git diff main` | unchanged |
| Git range expression | `hunk diff main..feature` | unchanged |
| Two separate revisions | `hunk diff main feature` treated `feature` as a pathspec | `hunk diff main feature` → `git diff main..feature` |
| Two revisions with a path filter | no direct two-endpoint form | `hunk diff main feature -- src/` |
| Two concrete files | `hunk diff before.ts after.ts`, guessed from filesystem state | `hunk diff --files before.ts after.ts`, deterministic |

### Jujutsu

| Intent | Before | After |
| --- | --- | --- |
| Working copy | `hunk diff` | unchanged |
| One revset | `hunk diff '@-'` → `jj diff -r @-` | unchanged |
| Two separate revisions | `hunk diff A B` treated `B` as a fileset | `hunk diff A B` → `jj diff --from A --to B` |
| Two-tree comparison | no structured form; `A..B` is a revset rather than two tree endpoints | backend-native `--from A --to B` |
| Two revisions with a fileset | no direct two-endpoint form | `hunk diff A B -- src/` |
| Watched `@` endpoint | not representable as two endpoints | `hunk diff A @ --watch` snapshots and refreshes working-copy changes |

### Sapling

| Intent | Before | After |
| --- | --- | --- |
| Working copy | `hunk diff` | unchanged |
| Working copy vs target | `hunk diff main` → `sl diff -r main` | unchanged, including unknown-file behavior |
| Backend revset expression | `hunk diff REVSET` | unchanged |
| Two separate revisions | `hunk diff A B` treated `B` as a path | `hunk diff A B` → `sl diff -r A -r B` |
| Two revisions with a path filter | no direct two-endpoint form | `hunk diff A B -- src/` |
| Historical working-copy isolation | no direct two-endpoint form | endpoint comparisons exclude current unknown files |

## Verification

Automated:

- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bun run check:docs`
- `bun run test` — 2,127 passed, 3 Sapling-dependent tests skipped
- `bun run test:integration` — 139 passed, 1 macOS-only test skipped

Real TTY testing in tmux at 120×36 on Linux:

- Git historical comparison rendered changes from exactly A to B
- Git historical comparison excluded current tracked edits and untracked files
- bare Git working-tree review continued to include tracked and untracked changes
- endpoint pathspecs excluded unrelated historical files
- `--files` rendered a concrete file pair
- existing filesystem names used positionally were treated as revisions, not guessed as files
- option-shaped input failed closed without creating the requested output path
- Jujutsu historical comparison excluded later working-copy changes
- Jujutsu `@` endpoint watch mode refreshed after an ordinary filesystem edit

Sapling is not installed on this machine, so executable-backed Sapling tests remain skipped; exact command construction, validation, untracked policy, and adapter-spawn behavior are covered by unit tests.

No visual styling changed, so screenshots are not included.

*This PR description was generated by Pi using OpenAI Codex gpt-5.6-sol*

