### PR TITLE
fix(ui): restore review stream responsiveness

### DIFF
--- a/.changeset/restore-review-interaction-latency.md
+++ b/.changeset/restore-review-interaction-latency.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Restore first-frame and scroll responsiveness for large review streams.

--- a/src/ui/components/panes/DiffPane.tsx
+++ b/src/ui/components/panes/DiffPane.tsx
@@ -51,9 +51,9 @@ import { inlineNoteStableKey } from "../../diff/reviewRenderPlan";
 import {
   buildLineCursors,
   clampLineCursorToViewport,
+  createLineCursorStabilizer,
   EMPTY_LINE_CURSORS,
   firstLineCursorInHunk,
-  reuseEquivalentLineCursors,
   type LineCursor,
   type LineCursorBoundsLookup,
 } from "../../lib/lineCursors";
@@ -962,6 +962,27 @@ export function DiffPane({
 
     // OpenTUI emits viewport events from its own layout and slider work. Keep React state updates
     // timer-deferred so wheel/key bursts collapse into bounded review-stream renders.
+    /** Schedule at most one deferred read for the current viewport event burst. */
+    const scheduleViewportRead = (delay: number) => {
+      if (scheduled) {
+        return;
+      }
+      scheduled = true;
+      scheduledViewportRead = setTimeout(() => {
+        scheduledViewportRead = null;
+        if (cancelled) {
+          scheduled = false;
+          return;
+        }
+
+        try {
+          readViewport();
+        } finally {
+          scheduled = false;
+        }
+      }, delay);
+    };
+
     const handleViewportChange = () => {
       if (
         (scrollBox.scrollTop ?? 0) === lastReadTop &&
@@ -969,24 +990,7 @@ export function DiffPane({
       ) {
         return;
       }
-      if (scheduled) {
-        return;
-      }
-      scheduled = true;
-      scheduledViewportRead = setTimeout(
-        () => {
-          scheduledViewportRead = null;
-          if (cancelled) {
-            scheduled = false;
-            return;
-          }
-
-          try {
-            readViewport();
-          } finally {
-            scheduled = false;
-          }
-        },
+      scheduleViewportRead(
         wrapLines ? Math.floor(VIEWPORT_READ_COALESCE_MS / 2) : VIEWPORT_READ_COALESCE_MS,
       );
     };
@@ -999,11 +1003,17 @@ export function DiffPane({
         return;
       }
       scrollBox.viewport.off("resize", handleViewportResize);
-      queueMicrotask(() => {
-        if (!cancelled) {
-          readViewport();
-        }
-      });
+      if (wrapLines) {
+        queueMicrotask(() => {
+          if (!cancelled) {
+            readViewport();
+          }
+        });
+        return;
+      }
+      // The exact nowrap estimate already fills the first paint. Publish Yoga's measured height on
+      // the next frame so later input shares the authoritative window without rendering twice.
+      scheduleViewportRead(VIEWPORT_READ_COALESCE_MS);
     };
 
     readViewport();
@@ -1194,12 +1204,11 @@ export function DiffPane({
     () => (cursorLine === "off" ? EMPTY_LINE_CURSORS : buildLineCursors(files, sectionGeometry)),
     [cursorLine, files, sectionGeometry],
   );
-  const previousLineCursorsRef = useRef<LineCursor[]>(EMPTY_LINE_CURSORS);
-  const lineCursors = reuseEquivalentLineCursors(
-    previousLineCursorsRef.current,
-    measuredLineCursors,
+  const lineCursorStabilizerRef = useRef<ReturnType<typeof createLineCursorStabilizer> | null>(
+    null,
   );
-  previousLineCursorsRef.current = lineCursors;
+  lineCursorStabilizerRef.current ??= createLineCursorStabilizer();
+  const lineCursors = lineCursorStabilizerRef.current(measuredLineCursors);
   /** Locate one measured row in whole-stream rows, addressed by its file and plan anchor. */
   const rowBoundsInStream = useCallback(
     (fileId: string, stableKey: string) => {

--- a/src/ui/lib/lineCursors.test.ts
+++ b/src/ui/lib/lineCursors.test.ts
@@ -12,6 +12,7 @@ import { resolveTheme } from "../themes";
 import {
   buildLineCursors,
   clampLineCursorToViewport,
+  createLineCursorStabilizer,
   findLineCursorAt,
   findNextLineCursor,
   firstLineCursorInHunk,
@@ -214,6 +215,25 @@ describe("reuseEquivalentLineCursors", () => {
     );
 
     expect(reuseEquivalentLineCursors(previous, next)).toBe(next);
+  });
+});
+
+describe("createLineCursorStabilizer", () => {
+  test("does not rescan an unchanged measurement during unrelated renders", () => {
+    const stabilize = createLineCursorStabilizer();
+    const measured = cursorsFor([createContextWrappedFile("alpha", "alpha.ts")], "stack");
+
+    expect(stabilize(measured)).toBe(measured);
+    expect(stabilize(measured)).toBe(measured);
+  });
+
+  test("preserves stable cursor identity across equivalent remeasurement", () => {
+    const stabilize = createLineCursorStabilizer();
+    const stable = cursorsFor([createContextWrappedFile("alpha", "alpha.ts")], "stack");
+    const measured = stable.map((cursor) => ({ ...cursor, target: { ...cursor.target } }));
+
+    expect(stabilize(stable)).toBe(stable);
+    expect(stabilize(measured)).toBe(stable);
   });
 });
 

--- a/src/ui/lib/lineCursors.ts
+++ b/src/ui/lib/lineCursors.ts
@@ -127,6 +127,20 @@ export function reuseEquivalentLineCursors(previous: LineCursor[], next: LineCur
   return next;
 }
 
+/** Create a cursor stabilizer that only compares newly measured lists. */
+export function createLineCursorStabilizer() {
+  let measured = EMPTY_LINE_CURSORS;
+  let stable = EMPTY_LINE_CURSORS;
+
+  return (next: LineCursor[]) => {
+    if (measured !== next) {
+      measured = next;
+      stable = reuseEquivalentLineCursors(stable, next);
+    }
+    return stable;
+  };
+}
+
 /** Find the first cursor in one hunk, then anywhere in its file. */
 function nearestCursorInFile(cursors: LineCursor[], fileId: string, hunkIndex: number) {
   return (


### PR DESCRIPTION
## Summary

- avoid rescanning the full measured line-cursor list during unrelated review-stream renders
- defer the redundant exact-height update for nowrap first paint while preserving the estimated viewport fill
- retain the immediate exact-height path for wrapped layouts

## Background

A balanced A/B investigation identified `dfa9aa4c` (`fix(ui): fill the review stream on first paint`) as the regression boundary. The commit correctly fixed a blank first-frame region in tall terminals, but introduced two independent costs:

1. every render compared the complete line-cursor list even when the measured list retained object identity;
2. nowrap startup published Yoga's exact viewport height in the same frame after the estimated height had already populated the viewport, causing a duplicate whole-stream render.

This change preserves the original first-paint fix and removes those redundant operations. It does not change review behavior or the immediate measured-height handling required by wrapped layouts.

## Performance

Current main versus this branch, 10 order-balanced alternating pairs on Bun 1.3.14:

| Metric | Main median | Fixed median | Paired median delta | Fixed slower |
|---|---:|---:|---:|---:|
| First frame | 30.50ms | 21.73ms | -8.70ms / -28.84% | 0/10 |
| Scroll median | 4.42ms | 1.25ms | -3.05ms / -66.53% | 0/10 |
| Scroll p95 | 10.61ms | 7.87ms | -2.81ms / -27.77% | 3/10 |
| Non-ASCII first frame | 25.84ms | 17.97ms | -7.96ms / -31.04% | 0/10 |
| Non-ASCII scroll median | 5.61ms | 1.75ms | -3.26ms / -60.85% | 0/10 |
| Non-ASCII scroll p95 | 11.77ms | 10.93ms | -0.96ms / -8.14% | 2/10 |

At the culprit boundary, the patched child returned to its parent's performance. Wrapped-CJK comparisons stayed within approximately 1% with mixed directions.

Dependency controls found no consistent regression from the OpenTUI or tuistory upgrades; the culprit commit itself contains no dependency changes.

## Validation

- `bun run test` — 2,134 passed, 3 skipped
- `bun test test/pty/layout.test.ts` — 23 passed
- focused cursor, AppHost, and viewport tests — 118 passed
- `bun run typecheck`
- `bun run deps:check`
- `bun run lint`
- `bun run format:check`
- `git diff --check`

Existing PTY coverage confirms that the first frame still fills tall nowrap viewports beyond the first-file overscan neighbor.

Tested on Linux with Bun 1.3.14. Absolute host timings remained scheduler-sensitive, so conclusions use balanced paired comparisons rather than unpaired aggregate timing.

*This PR description was generated by Pi using gpt-5.6-sol*
