### PR TITLE
fix(session): recover from socket startup failures

### DIFF
--- a/.changeset/fresh-sockets-retry.md
+++ b/.changeset/fresh-sockets-retry.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Retry session broker connections after synchronous WebSocket startup failures.

--- a/packages/session-broker/src/connection.test.ts
+++ b/packages/session-broker/src/connection.test.ts
@@ -185,6 +185,7 @@ describe("session broker connection", () => {
 
   test("preserves a synchronous socket factory throw and permits a later direct start", () => {
     const sockets: TestSocket[] = [];
+    const startupFailure = { source: "socket factory" };
     let attempts = 0;
     const connection = createSessionBrokerConnection<
       TestSessionInfo,
@@ -196,7 +197,7 @@ describe("session broker connection", () => {
       url: "ws://broker.test/session",
       createSocket: () => {
         attempts += 1;
-        if (attempts === 1) throw new Error("socket factory exploded");
+        if (attempts === 1) throw startupFailure;
         const socket = new TestSocket();
         sockets.push(socket);
         return socket;
@@ -206,7 +207,13 @@ describe("session broker connection", () => {
       protocolParsers,
     });
 
-    expect(() => connection.start()).toThrow("socket factory exploded");
+    let thrown: unknown;
+    try {
+      connection.start();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBe(startupFailure);
     expect(attempts).toBe(1);
     expect(sockets).toHaveLength(0);
 

--- a/src/session/broker/brokerClient.test.ts
+++ b/src/session/broker/brokerClient.test.ts
@@ -206,7 +206,10 @@ function installDeterministicClockTest() {
 }
 
 /** Observe WebSocket construction without opening a network connection. */
-function installWebSocketObserverTest(throwOnAttempt?: number) {
+function installWebSocketObserverTest(
+  throwOnAttempt?: number,
+  onConstruct?: (attempt: number) => void,
+) {
   if (restoreWebSocketObserverTest) {
     throw new Error("A WebSocket observer is already installed.");
   }
@@ -224,6 +227,7 @@ function installWebSocketObserverTest(throwOnAttempt?: number) {
 
     constructor(_url: string) {
       constructionAttempts += 1;
+      onConstruct?.(constructionAttempts);
       if (constructionAttempts === throwOnAttempt) throw new Error("socket factory exploded");
       sockets.push(this);
     }
@@ -816,7 +820,7 @@ describe("Hunk session daemon client", () => {
     }
   });
 
-  test.todo("known regression: client retained after synchronous socket factory failure prevents a later fresh start", async () => {
+  test("creates a fresh socket after synchronous socket construction fails", async () => {
     delete process.env.HUNK_MCP_DISABLE;
     const webSockets = installWebSocketObserverTest(1);
     const client = new SessionBrokerClient(createRegistration(), createSnapshot(), {
@@ -832,6 +836,54 @@ describe("Hunk session daemon client", () => {
       await settleWithinTestTimeout(client.start());
       expect(webSockets.constructionAttemptsTest()).toBe(2);
       expect(webSockets.sockets).toHaveLength(1);
+    } finally {
+      client.stop();
+      webSockets.restoreTest();
+    }
+  });
+
+  test("preserves a reentrant replacement and the original synchronous construction failure", () => {
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    const config = prepareDirectConnectTest(client);
+    const startupFailure = { source: "socket construction" };
+    const cleanupFailure = new Error("connection cleanup exploded");
+    const snapshots: ReturnType<typeof createSnapshot>[] = [];
+    let failedConnectionStops = 0;
+    let replacementStops = 0;
+    const replacement = {
+      updateSnapshot(snapshot: ReturnType<typeof createSnapshot>) {
+        snapshots.push(snapshot);
+      },
+      stop() {
+        replacementStops += 1;
+      },
+    };
+    const webSockets = installWebSocketObserverTest(undefined, () => {
+      const failedConnection = clientTestAccess(client).connection;
+      if (!failedConnection) throw new Error("Expected the failed connection to be published.");
+      failedConnection.stop = () => {
+        failedConnectionStops += 1;
+        throw cleanupFailure;
+      };
+      clientTestAccess(client).connection = replacement;
+      throw startupFailure;
+    });
+
+    let thrown: unknown;
+    try {
+      clientTestAccess(client).connect(config);
+    } catch (error) {
+      thrown = error;
+    }
+
+    try {
+      expect(thrown).toBe(startupFailure);
+      expect(failedConnectionStops).toBe(1);
+      const nextSnapshot = createSnapshot();
+      client.updateSnapshot(nextSnapshot);
+      expect(snapshots).toEqual([nextSnapshot]);
+      client.stop();
+      expect(replacementStops).toBe(1);
     } finally {
       client.stop();
       webSockets.restoreTest();

--- a/src/session/broker/brokerClient.ts
+++ b/src/session/broker/brokerClient.ts
@@ -236,7 +236,19 @@ export class SessionBrokerClient {
     });
 
     this.connection = connection;
-    connection.start();
+    try {
+      connection.start();
+    } catch (error) {
+      try {
+        connection.stop();
+      } catch {
+        // Preserve the synchronous startup failure even when best-effort cleanup also fails.
+      }
+      if (this.connection === connection) {
+        this.connection = null;
+      }
+      throw error;
+    }
   }
 
   private scheduleReconnect(delayMs = this.timing.reconnectDelayMs ?? RECONNECT_DELAY_MS) {


### PR DESCRIPTION
## Summary

- roll back the exact stored connection when synchronous WebSocket startup fails
- preserve a reentrant replacement connection instead of clearing it accidentally
- preserve the original synchronous failure even when best-effort cleanup also throws
- turn the parent PR's known-regression marker into passing recovery coverage

## Stack

1. #949 — lifecycle characterization
2. **This PR:** synchronous socket-start rollback
3. Next: explicit startup states
4. Then: lifecycle clock, generation fences, runtime exit fixtures, and bounded defect reporting

Base branch: `test/session-lifecycle-characterization`. Review only the second commit for this PR.

## Validation

- `bun test packages/session-broker/src/connection.test.ts src/session/broker/brokerClient.test.ts` — 40 pass
- changed-file `oxfmt --check`
- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- independent correctness review approved with no blocker/high/medium findings

## Non-goals

- no startup state refactor
- no Effect or general lifecycle runtime
- no change to protocol, authentication, or stored state

*This PR description was generated by Pi using gpt-5.6-sol*
