### PR TITLE
fix(extensions): prioritize focused pane editors

### DIFF
--- a/.changeset/focused-extension-editor.md
+++ b/.changeset/focused-extension-editor.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Let focused editors inside extension panes receive keys before Hunk's global shortcuts.

--- a/src/ui/AppHost.key-routing.test.tsx
+++ b/src/ui/AppHost.key-routing.test.tsx
@@ -278,4 +278,68 @@ describe("UI key routing with a focused scroll box", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test("an extension pane editor receives typing before app and extension commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hunk-key-routing-pane-input-"));
+    const extension = join(root, "prompt-pane");
+    mkdirSync(extension, { recursive: true });
+    writeFileSync(
+      join(extension, "package.json"),
+      JSON.stringify({
+        name: "prompt-pane",
+        private: true,
+        hunk: { extensions: ["./index.tsx"] },
+      }),
+    );
+    writeFileSync(
+      join(extension, "index.tsx"),
+      `import { createElement, useState } from "react";
+export default function (hunk) {
+  hunk.registerPane({
+    id: "prompt",
+    placement: "bottom",
+    defaultOpen: true,
+    height: { preferred: 3, min: 3, max: 3 },
+    component: () => {
+      const [value, setValue] = useState("");
+      return createElement("input", { value, focused: true, onInput: setValue });
+    },
+  });
+  hunk.registerCommand({ id: "letter", title: "Letter command", key: "j" }, (ctx) => {
+    ctx.notify("COMMAND FIRED");
+  });
+}
+`,
+    );
+    const extensions = await loadStartupExtensions({
+      cliExtensionPaths: [extension],
+      cwd: root,
+      env: { XDG_CONFIG_HOME: root } as NodeJS.ProcessEnv,
+      extensions: { enabled: true, extensionConfigs: {}, paths: [], repoPaths: [] },
+    });
+    const bootstrap = createScrollableBootstrap();
+    bootstrap.extensions = extensions;
+    const setup = await testRender(<AppHost bootstrap={bootstrap} onQuit={() => {}} />, {
+      width: 120,
+      height: 24,
+    });
+
+    try {
+      await waitForFrame(setup, () => setup.renderer.currentFocusedEditor !== null, 12);
+      expect(setup.renderer.currentFocusedEditor).not.toBeNull();
+
+      await act(async () => setup.mockInput.typeText("j?"));
+      await flush(setup);
+
+      const frame = setup.captureCharFrame();
+      expect(frame).toContain("j?");
+      expect(frame).not.toContain("COMMAND FIRED");
+      expect(frame).not.toContain("Controls help");
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -1,5 +1,5 @@
 import type { KeyEvent } from "@opentui/core";
-import { useKeyboard } from "@opentui/react";
+import { useKeyboard, useRenderer } from "@opentui/react";
 import { useRef } from "react";
 import type {
   ExtensionFileViewModeKeyResult,
@@ -135,6 +135,7 @@ export function useAppKeyboardShortcuts({
   toggleFocusArea,
   themeSelectorOpen,
 }: UseAppKeyboardShortcutsOptions) {
+  const renderer = useRenderer();
   const activeMenuIdRef = useRef(activeMenuId);
   const commandsRef = useRef(commands);
   const focusAreaRef = useRef(focusArea);
@@ -491,7 +492,10 @@ export function useAppKeyboardShortcuts({
     }
 
     if (focusAreaRef.current !== "note") {
-      return "notMine";
+      // Extension panes can mount the same OpenTUI editors Hunk uses. The
+      // renderer is the live focus authority for those inputs, which do not
+      // participate in App's host-only focus-area state.
+      return renderer.currentFocusedEditor ? "focused" : "notMine";
     }
 
     if (isEscapeKey(key)) {


### PR DESCRIPTION
## Summary

- let focused OpenTUI editors inside extension panes receive keys before Hunk app shortcuts
- preserve existing note-editor routing
- cover extension command and global shortcut conflicts with a host-level regression test

## Verification

- `bun test ./src/ui/AppHost.key-routing.test.tsx`
- `bunx oxfmt --check src/ui/AppHost.key-routing.test.tsx src/ui/hooks/useAppKeyboardShortcuts.ts .changeset/focused-extension-editor.md`
- `bunx oxlint src/ui/AppHost.key-routing.test.tsx src/ui/hooks/useAppKeyboardShortcuts.ts --deny-warnings`

## Context

This enables prompt-style extension panes, including `modem-dev/hunk-opencode`, to type keys that also have Hunk or extension command bindings without firing those commands.