### PR TITLE
fix(session): fence late lifecycle settlements

### DIFF
--- a/.changeset/fence-session-lifecycle-settlements.md
+++ b/.changeset/fence-session-lifecycle-settlements.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Fence late session lifecycle commits so stopped or replaced generations cannot authenticate, reconnect, publish daemon launch metadata, or mutate broker client state.

--- a/packages/session-broker/README.md
+++ b/packages/session-broker/README.md
@@ -203,6 +203,13 @@ fixed-rate interval scheduling, and awaitable delay. Scheduled callbacks return 
 disposers. `createNativeSessionBrokerLifecycleClock()` uses unref'd native timers so pending
 handshake, heartbeat, reconnect, and polling work does not retain the process.
 
+`createSocket` must return a fresh socket object for every generation because the helper installs
+property callbacks that cannot distinguish queued events after object reuse. Reconnect and close
+callbacks receive a frozen opaque generation token; after foreign work settles, use
+`connection.isGenerationCurrent(token)` before committing app-owned state. These checks fence
+commits only: they do not cancel foreign promises, cryptography, probes, or other work already in
+progress.
+
 The helper owns:
 
 - initial `register`

--- a/packages/session-broker/src/connection.test.ts
+++ b/packages/session-broker/src/connection.test.ts
@@ -10,7 +10,8 @@ import {
   SESSION_BROKER_SIGNATURE_ALGORITHM,
 } from "@hunk/session-broker-core";
 import { SessionBrokerAuthenticator } from "./authentication";
-import { createSessionBrokerConnection } from "./connection";
+import { createSessionBrokerConnection, type SessionBrokerConnection } from "./connection";
+import { webSessionBrokerCrypto } from "./crypto";
 import { createSessionBrokerProtocolParsers } from "./protocolParsers";
 import type { SessionBrokerSocketLike } from "./types";
 import { DeterministicLifecycleClockTest } from "../../../test/helpers/lifecycleClockTest";
@@ -24,6 +25,13 @@ interface TestSessionState {
 }
 
 type TestServerMessage = SessionServerMessage<"annotate", { summary: string }>;
+type TestConnection = SessionBrokerConnection<
+  TestSessionInfo,
+  TestSessionState,
+  TestSocket,
+  TestServerMessage,
+  { ok: true }
+>;
 
 class TestSocket implements SessionBrokerSocketLike {
   readyState = 0;
@@ -57,6 +65,26 @@ class TestSocket implements SessionBrokerSocketLike {
   emitClose(code = 1000, reason = "") {
     this.readyState = 3;
     this.onclose?.({ code, reason });
+  }
+}
+
+/** Keep close pending so tests can settle foreign authentication before the close callback. */
+class DeferredCloseSocketTest extends TestSocket {
+  override close(code?: number, reason?: string) {
+    this.lastClose = { code, reason };
+  }
+}
+
+/** Fail selected close attempts without emitting close so terminal authority can be inspected. */
+class ThrowingCloseSocketTest extends TestSocket {
+  closeAttempts = 0;
+  failClose = true;
+
+  override close(code?: number, reason?: string) {
+    this.closeAttempts += 1;
+    this.lastClose = { code, reason };
+    if (this.failClose) throw new Error("socket close exploded");
+    this.emitClose(code, reason);
   }
 }
 
@@ -324,6 +352,41 @@ describe("session broker connection", () => {
     expect(sockets).toHaveLength(2);
   });
 
+  test("replaces a stale generation retry timer with the current generation deadline", async () => {
+    const clock = new DeterministicLifecycleClockTest();
+    const sockets: TestSocket[] = [];
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      reconnectDelayMs: 30,
+      lifecycleClock: clock,
+    });
+
+    connection.start();
+    sockets[0]!.emitClose();
+    expect(clock.pendingCountTest()).toBe(1);
+
+    connection.start();
+    expect(sockets).toHaveLength(2);
+    expect(clock.pendingCountTest()).toBe(0);
+    sockets[1]!.emitClose();
+    expect(clock.pendingCountTest()).toBe(1);
+
+    clock.advanceByTest(29);
+    expect(sockets).toHaveLength(2);
+    clock.advanceByTest(1);
+    await clock.flushMicrotasksTest();
+    expect(sockets).toHaveLength(3);
+    connection.stop();
+  });
+
   test("registers on open and sends later snapshot updates", () => {
     const sockets: TestSocket[] = [];
     const connection = createSessionBrokerConnection<
@@ -406,7 +469,248 @@ describe("session broker connection", () => {
     sockets[0]!.emitOpen();
     expect(attempts).toBe(2);
     expect(sockets).toHaveLength(1);
-    expect(JSON.parse(sockets[0]!.sent[0]!)).toMatchObject({ type: "register" });
+    expect(JSON.parse(sockets[0]!.sent[0]!)).toMatchObject({
+      type: "register",
+    });
+    connection.stop();
+  });
+
+  test("publishes socket construction ownership before a reentrant start", () => {
+    const socket = new TestSocket();
+    let attempts = 0;
+    let connection!: TestConnection;
+    connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        attempts += 1;
+        connection.start();
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+    });
+
+    connection.start();
+    socket.emitOpen();
+    expect(attempts).toBe(1);
+    expect(JSON.parse(socket.sent[0]!)).toMatchObject({ type: "register" });
+    connection.stop();
+  });
+
+  test("does not adopt a socket returned after reentrant terminal stop", () => {
+    const socket = new TestSocket();
+    let attempts = 0;
+    let connection!: TestConnection;
+    connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        attempts += 1;
+        connection.stop();
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+    });
+
+    connection.start();
+    socket.emitOpen();
+    connection.start();
+    expect(attempts).toBe(1);
+    expect(socket.lastClose).toEqual({ code: undefined, reason: undefined });
+    expect(socket.sent).toEqual([]);
+  });
+
+  test("rejects a socket object reused across generations", () => {
+    const socket = new TestSocket();
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      resolveClose: () => ({ reconnect: false }),
+    });
+
+    connection.start();
+    socket.emitOpen();
+    socket.emitClose();
+    expect(() => connection.start()).toThrow(
+      "Session broker socket factory must return a fresh socket.",
+    );
+    connection.stop();
+  });
+
+  test("retries close after an adapter throw while terminal stop remains authoritative", () => {
+    const socket = new TestSocket();
+    let closeAttempts = 0;
+    socket.close = () => {
+      closeAttempts += 1;
+      if (closeAttempts === 1) throw new Error("socket close exploded");
+      socket.emitClose();
+    };
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+    });
+
+    connection.start();
+    socket.emitOpen();
+    expect(() => connection.stop()).toThrow("socket close exploded");
+    expect(() => connection.stop()).not.toThrow();
+    expect(closeAttempts).toBe(2);
+  });
+
+  test("keeps malformed-input close failures terminal before a later close retry", () => {
+    const socket = new ThrowingCloseSocketTest();
+    let dispatches = 0;
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      bridge: {
+        dispatchCommand: async () => {
+          dispatches += 1;
+          return { ok: true } as const;
+        },
+      },
+      resolveClose: () => ({ reconnect: false }),
+    });
+
+    connection.start();
+    socket.emitOpen();
+    expect(() => socket.emitMessage("{")).toThrow("socket close exploded");
+    expect(socket.closeAttempts).toBe(1);
+    const sentBeforeLateCommand = socket.sent.length;
+
+    socket.emitMessage(
+      JSON.stringify({
+        type: "command",
+        requestId: "request-late",
+        command: "annotate",
+        input: { summary: "must stay retired" },
+      }),
+    );
+    expect(dispatches).toBe(0);
+    expect(socket.sent).toHaveLength(sentBeforeLateCommand);
+    expect(socket.closeAttempts).toBe(1);
+
+    socket.failClose = false;
+    socket.onerror?.();
+    expect(socket.closeAttempts).toBe(2);
+    connection.stop();
+  });
+
+  test("keeps a failed handshake-timeout close terminal before late authentication", async () => {
+    const clock = new DeterministicLifecycleClockTest();
+    const socket = new ThrowingCloseSocketTest();
+    const pair = (await crypto.subtle.generateKey("Ed25519", false, [
+      "sign",
+      "verify",
+    ])) as CryptoKeyPair;
+    const grant: ProducerGrant = {
+      kind: "producer",
+      appId: "dev.example",
+      principalId: "producer-1",
+      keyId: "producer-key-1",
+      grantId: "producer-grant-1",
+      algorithm: SESSION_BROKER_SIGNATURE_ALGORITHM,
+      issuedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+      revocationId: "producer-revocation-1",
+      mayDelegate: false,
+      operations: ["register"],
+    };
+    const authenticator = new SessionBrokerAuthenticator({
+      appId: "dev.example",
+      appRevision: 1,
+      generation: "generation-1",
+      daemonIdentity: { keyId: "daemon-key-1", privateKey: pair.privateKey },
+      credentials: [{ grant, publicKey: pair.publicKey }],
+    });
+    let connected = 0;
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      producerAuthentication: {
+        appId: "dev.example",
+        appRevision: 1,
+        credential: { grant, privateKey: pair.privateKey },
+        daemon: { keyId: "daemon-key-1", publicKey: pair.publicKey },
+      },
+      lifecycleClock: clock,
+      onConnected: () => {
+        connected += 1;
+      },
+      resolveClose: () => ({ reconnect: false }),
+    });
+
+    connection.start();
+    socket.emitOpen();
+    const helloInit = JSON.parse(socket.sent[0]!) as { hello: unknown };
+    const challenge = await authenticator.issueChallenge(
+      helloInit.hello,
+      "ws://broker.test/session",
+    );
+    expect(() => clock.advanceByTest(connection.limits.maxHandshakeDurationMs)).toThrow(
+      "socket close exploded",
+    );
+    expect(socket.closeAttempts).toBe(1);
+
+    socket.emitMessage(JSON.stringify({ type: "hello-challenge", challenge }));
+    await clock.flushMicrotasksTest();
+    expect(socket.sent).toHaveLength(1);
+    expect(connected).toBe(0);
+
+    socket.failClose = false;
+    socket.onerror?.();
+    expect(socket.closeAttempts).toBe(2);
+    connection.stop();
+  });
+
+  test("passes callbacks an immutable opaque generation token", () => {
+    const sockets: TestSocket[] = [];
+    const callbackTokens: unknown[] = [];
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      resolveClose: (_event, generation) => {
+        callbackTokens.push(generation);
+        return { reconnect: false };
+      },
+      onConnected: (generation) => callbackTokens.push(generation),
+    });
+
+    connection.start();
+    sockets[0]!.emitOpen();
+    const token = callbackTokens[0] as { id: number };
+    expect(Object.keys(token)).toEqual(["id"]);
+    expect(Object.isFrozen(token)).toBe(true);
+    expect(connection.isGenerationCurrent(token)).toBe(true);
+    expect(connection.isGenerationCurrent({ id: token.id })).toBe(false);
+    expect(() => Object.assign(token, { status: "closed" })).toThrow();
+
+    sockets[0]!.emitClose();
+    expect(callbackTokens[1]).toBe(token);
+    connection.start();
+    sockets[1]!.emitOpen();
+    expect(connection.isGenerationCurrent(token)).toBe(false);
     connection.stop();
   });
 
@@ -469,7 +773,10 @@ describe("session broker connection", () => {
     connection.replaceSession(createRegistration(), createSnapshot());
 
     expect(socket.sent).toHaveLength(1);
-    const helloInit = JSON.parse(socket.sent[0]!) as { type: string; hello: unknown };
+    const helloInit = JSON.parse(socket.sent[0]!) as {
+      type: string;
+      hello: unknown;
+    };
     expect(helloInit.type).toBe("hello-init");
     const challenge = await authenticator.issueChallenge(
       helloInit.hello,
@@ -477,7 +784,10 @@ describe("session broker connection", () => {
     );
     socket.emitMessage(JSON.stringify({ type: "hello-challenge", challenge }));
     await waitForSentMessagesTest(socket, 2);
-    const helloProof = JSON.parse(socket.sent[1]!) as { type: string; proof: unknown };
+    const helloProof = JSON.parse(socket.sent[1]!) as {
+      type: string;
+      proof: unknown;
+    };
     expect(helloProof.type).toBe("hello-proof");
     const authenticated = await authenticator.completeProducerHello(
       helloProof.proof,
@@ -496,8 +806,100 @@ describe("session broker connection", () => {
     expect(clock.pendingCountTest()).toBe(0);
   });
 
-  test("keeps the previous registration when replacement send throws", () => {
-    const socket = new TestSocket();
+  for (const outcome of ["resolve", "reject"] as const) {
+    test(`does not activate a late acknowledgement ${outcome} after the handshake deadline`, async () => {
+      const clock = new DeterministicLifecycleClockTest();
+      const socket = new DeferredCloseSocketTest();
+      const pair = (await crypto.subtle.generateKey("Ed25519", false, [
+        "sign",
+        "verify",
+      ])) as CryptoKeyPair;
+      const grant: ProducerGrant = {
+        kind: "producer",
+        appId: "dev.example",
+        principalId: "producer-1",
+        keyId: "producer-key-1",
+        grantId: "producer-grant-1",
+        algorithm: SESSION_BROKER_SIGNATURE_ALGORITHM,
+        issuedAt: Date.now() - 1_000,
+        expiresAt: Date.now() + 60_000,
+        revocationId: "producer-revocation-1",
+        mayDelegate: false,
+        operations: ["register"],
+      };
+      const authenticator = new SessionBrokerAuthenticator({
+        appId: "dev.example",
+        appRevision: 1,
+        generation: "generation-1",
+        daemonIdentity: { keyId: "daemon-key-1", privateKey: pair.privateKey },
+        credentials: [{ grant, publicKey: pair.publicKey }],
+      });
+      const ackVerification = createDeferredTest<boolean>();
+      const ackVerificationStarted = createDeferredTest();
+      let verifyCalls = 0;
+      const connection = createSessionBrokerConnection({
+        url: "ws://broker.test/session",
+        createSocket: () => socket,
+        registration: createRegistration(),
+        snapshot: createSnapshot(),
+        protocolParsers,
+        producerAuthentication: {
+          appId: "dev.example",
+          appRevision: 1,
+          credential: { grant, privateKey: pair.privateKey },
+          daemon: { keyId: "daemon-key-1", publicKey: pair.publicKey },
+          crypto: {
+            ...webSessionBrokerCrypto,
+            verify: async (...args) => {
+              verifyCalls += 1;
+              if (verifyCalls === 2) {
+                ackVerificationStarted.resolve();
+                return ackVerification.promise;
+              }
+              return webSessionBrokerCrypto.verify(...args);
+            },
+          },
+        },
+        heartbeatIntervalMs: 10,
+        lifecycleClock: clock,
+      });
+
+      connection.start();
+      socket.emitOpen();
+      const helloInit = JSON.parse(socket.sent[0]!) as { hello: unknown };
+      const challenge = await authenticator.issueChallenge(
+        helloInit.hello,
+        "ws://broker.test/session",
+      );
+      socket.emitMessage(JSON.stringify({ type: "hello-challenge", challenge }));
+      await waitForSentMessagesTest(socket, 2);
+      const helloProof = JSON.parse(socket.sent[1]!) as { proof: unknown };
+      const authenticated = await authenticator.completeProducerHello(
+        helloProof.proof,
+        "connection-1",
+      );
+      socket.emitMessage(JSON.stringify({ type: "hello-ack", ack: authenticated.ack }));
+      await settleWithinTestTimeout(ackVerificationStarted.promise);
+
+      clock.advanceByTest(connection.limits.maxHandshakeDurationMs);
+      expect(socket.lastClose).toEqual({
+        code: 1008,
+        reason: "Session broker authentication timed out.",
+      });
+      if (outcome === "resolve") ackVerification.resolve(true);
+      else ackVerification.reject(new Error("late acknowledgement verification failure"));
+      await clock.flushMicrotasksTest();
+      clock.advanceByTest(20);
+      expect(socket.sent).toHaveLength(2);
+      expect(clock.pendingCountTest()).toBe(0);
+
+      socket.emitClose(1008, "Session broker authentication timed out.");
+      connection.stop();
+    });
+  }
+
+  test("publishes a pending replacement through a generation rotated during serialization", () => {
+    const sockets: TestSocket[] = [];
     const registration = createRegistration();
     const connection = createSessionBrokerConnection<
       TestSessionInfo,
@@ -507,22 +909,153 @@ describe("session broker connection", () => {
       { ok: true }
     >({
       url: "ws://broker.test/session",
-      createSocket: () => socket,
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
       registration,
       snapshot: createSnapshot(),
       protocolParsers,
+      reconnectDelayMs: 10_000,
     });
     connection.start();
-    socket.emitOpen();
-    socket.throwOnSend = true;
+    sockets[0]!.emitOpen();
+
+    let rotated = false;
+    const replacement = {
+      ...registration,
+      sessionId: "session-2",
+      info: {
+        title: "replacement",
+        toJSON() {
+          if (!rotated) {
+            rotated = true;
+            sockets[0]!.emitClose();
+            connection.start();
+            sockets[1]!.emitOpen();
+          }
+          return { title: "replacement" };
+        },
+      },
+    };
+    const replacementSnapshot = {
+      ...createSnapshot(),
+      state: { selectedIndex: 2 },
+    };
+
+    connection.replaceSession(replacement, replacementSnapshot);
+
+    expect(connection.getRegistration()).toBe(replacement);
+    expect(sockets).toHaveLength(2);
+    expect(sockets[0]!.sent).toHaveLength(1);
+    expect(JSON.parse(sockets[1]!.sent[0]!)).toEqual({
+      type: "register",
+      registration: {
+        ...replacement,
+        info: { title: "replacement" },
+      },
+      snapshot: replacementSnapshot,
+    });
+    connection.stop();
+  });
+
+  test("commits a candidate published by a replacement before the stale source send throws", () => {
+    const sockets: TestSocket[] = [];
+    const registration = createRegistration();
+    const connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration,
+      snapshot: createSnapshot(),
+      protocolParsers,
+      reconnectDelayMs: 10_000,
+    });
+    connection.start();
+    sockets[0]!.emitOpen();
+
+    const firstSend = sockets[0]!.send.bind(sockets[0]);
+    sockets[0]!.send = (data) => {
+      const message = JSON.parse(data) as { registration?: { sessionId?: string } };
+      if (message.registration?.sessionId === "session-2") {
+        sockets[0]!.emitClose();
+        connection.start();
+        sockets[1]!.emitOpen();
+        throw new Error("stale source exploded");
+      }
+      firstSend(data);
+    };
+    const replacement = { ...registration, sessionId: "session-2" };
+    const replacementSnapshot = {
+      ...createSnapshot(),
+      state: { selectedIndex: 2 },
+    };
+
+    connection.replaceSession(replacement, replacementSnapshot);
+
+    expect(connection.getRegistration()).toBe(replacement);
+    expect(sockets[0]!.sent).toHaveLength(1);
+    expect(JSON.parse(sockets[1]!.sent[0]!)).toEqual({
+      type: "register",
+      registration: replacement,
+      snapshot: replacementSnapshot,
+    });
+    connection.stop();
+  });
+
+  test("keeps the previous registration and snapshot when the current generation send throws", () => {
+    const sockets: TestSocket[] = [];
+    const registration = createRegistration();
+    const snapshot = createSnapshot();
+    const connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration,
+      snapshot,
+      protocolParsers,
+      reconnectDelayMs: 10_000,
+    });
+    connection.start();
+    sockets[0]!.emitOpen();
+    sockets[0]!.throwOnSend = true;
 
     expect(() =>
       connection.replaceSession(
         { ...registration, sessionId: "session-2" },
-        { ...createSnapshot(), state: { selectedIndex: 2 } },
+        { ...snapshot, state: { selectedIndex: 2 } },
       ),
     ).toThrow("socket exploded");
     expect(connection.getRegistration()).toBe(registration);
+
+    sockets[0]!.throwOnSend = false;
+    sockets[0]!.emitClose();
+    connection.start();
+    sockets[1]!.emitOpen();
+    expect(JSON.parse(sockets[1]!.sent[0]!)).toEqual({
+      type: "register",
+      registration,
+      snapshot,
+    });
     connection.stop();
   });
 
@@ -757,7 +1290,10 @@ describe("session broker connection", () => {
     expect(new TextEncoder().encode(exact).byteLength).toBe(maxBytes);
     socket.emitMessage(exact);
     await Bun.sleep(0);
-    expect({ inputCalls, bridgeCalls }).toEqual({ inputCalls: 1, bridgeCalls: 1 });
+    expect({ inputCalls, bridgeCalls }).toEqual({
+      inputCalls: 1,
+      bridgeCalls: 1,
+    });
 
     connection.stop();
 
@@ -793,7 +1329,9 @@ describe("session broker connection", () => {
     };
 
     expect(emitRejected(`${exact} `)).toMatchObject({ code: 1009 });
-    expect(emitRejected("{".repeat(maxBytes + 1))).toMatchObject({ code: 1009 });
+    expect(emitRejected("{".repeat(maxBytes + 1))).toMatchObject({
+      code: 1009,
+    });
     expect(
       emitRejected(
         JSON.stringify({
@@ -805,8 +1343,13 @@ describe("session broker connection", () => {
         }),
       ),
     ).toMatchObject({ code: 1008 });
-    expect(emitRejected(new Uint8Array([123, 125]))).toMatchObject({ code: 1003 });
-    expect({ inputCalls, bridgeCalls }).toEqual({ inputCalls: 1, bridgeCalls: 1 });
+    expect(emitRejected(new Uint8Array([123, 125]))).toMatchObject({
+      code: 1003,
+    });
+    expect({ inputCalls, bridgeCalls }).toEqual({
+      inputCalls: 1,
+      bridgeCalls: 1,
+    });
   });
 
   test("ignores a late socket callback after stop before parsing or reserving", async () => {
@@ -868,7 +1411,10 @@ describe("session broker connection", () => {
     );
     await Bun.sleep(0);
 
-    expect({ inputCalls, bridgeCalls }).toEqual({ inputCalls: 0, bridgeCalls: 0 });
+    expect({ inputCalls, bridgeCalls }).toEqual({
+      inputCalls: 0,
+      bridgeCalls: 0,
+    });
   });
 
   test("does not migrate a late command result onto a replacement socket", async () => {
@@ -916,6 +1462,70 @@ describe("session broker connection", () => {
 
     expect(sockets[0]!.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
     expect(sockets[1]!.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
+    connection.stop();
+  });
+
+  test("does not send a command result when envelope serialization retires its generation", async () => {
+    type ReentrantResult = { ok: true; toJSON: () => { ok: true } };
+    const socket = new TestSocket();
+    let serializationCount = 0;
+    const result: ReentrantResult = {
+      ok: true,
+      toJSON: () => {
+        serializationCount += 1;
+        if (serializationCount === 3) socket.emitClose(1000, "serialization retired");
+        return { ok: true };
+      },
+    };
+    const reentrantParsers = createSessionBrokerProtocolParsers<
+      TestSessionInfo,
+      TestSessionState,
+      TestServerMessage,
+      ReentrantResult
+    >({
+      appRevision: 1,
+      features: [],
+      parseRegistration: (value) => value as SessionRegistration<TestSessionInfo>,
+      parseSnapshot: (value) => value as SessionSnapshot<TestSessionState>,
+      commands: [
+        {
+          command: "annotate",
+          version: 1,
+          parseInput: (value) => value as { summary: string },
+          parseResult: (value) => value as ReentrantResult,
+        },
+      ],
+    });
+    const connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      ReentrantResult
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers: reentrantParsers,
+      bridge: { dispatchCommand: async () => result },
+      reconnectDelayMs: 10_000,
+    });
+
+    connection.start();
+    socket.emitOpen();
+    socket.emitMessage(
+      JSON.stringify({
+        type: "command",
+        requestId: "request-serialization",
+        command: "annotate",
+        input: { summary: "Retire during result serialization" },
+      }),
+    );
+    await Bun.sleep(0);
+
+    expect(serializationCount).toBe(3);
+    expect(socket.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
     connection.stop();
   });
 
@@ -1020,6 +1630,148 @@ describe("session broker connection", () => {
     connection.stop();
   });
 
+  test("refuses queue admission when an app parser replaces the active generation", () => {
+    const sockets: TestSocket[] = [];
+    let replaceDuringParse = true;
+    let connection!: TestConnection;
+    const reentrantParsers = Object.assign(Object.create(protocolParsers), {
+      parseServerMessage(value: unknown) {
+        const parsed = protocolParsers.parseServerMessage(value);
+        if (replaceDuringParse) {
+          replaceDuringParse = false;
+          sockets[0]!.emitClose();
+          connection.start();
+          sockets[1]!.emitOpen();
+        }
+        return parsed;
+      },
+    }) as typeof protocolParsers;
+    connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers: reentrantParsers,
+      limits: { maxPreBridgeCommands: 1 },
+    });
+    const command = (requestId: string) =>
+      JSON.stringify({
+        type: "command",
+        requestId,
+        command: "annotate",
+        input: { summary: requestId },
+      });
+
+    connection.start();
+    sockets[0]!.emitOpen();
+    sockets[0]!.emitMessage(command("request-stale"));
+    sockets[1]!.emitMessage(command("request-current"));
+    expect(
+      sockets[1]!.sent.filter((message) => JSON.parse(message).type === "command-result"),
+    ).toEqual([]);
+
+    sockets[1]!.emitMessage(command("request-over-capacity"));
+    expect(JSON.parse(sockets[1]!.sent.at(-1)!)).toMatchObject({
+      requestId: "request-over-capacity",
+      error: "queue-full",
+    });
+    connection.stop();
+  });
+
+  test("refuses stale admission when command serialization replaces the generation", async () => {
+    const sockets: TestSocket[] = [];
+    const dispatched: string[] = [];
+    let parserCalls = 0;
+    let serializationCalls = 0;
+    let replaceDuringSerialization = true;
+    let connection!: TestConnection;
+    const reentrantParsers = Object.assign(Object.create(protocolParsers), {
+      parseServerMessage(value: unknown) {
+        parserCalls += 1;
+        const parsed = protocolParsers.parseServerMessage(value);
+        const type = parsed.type;
+        Object.defineProperty(parsed, "type", {
+          configurable: true,
+          enumerable: true,
+          get: () => {
+            serializationCalls += 1;
+            if (replaceDuringSerialization) {
+              replaceDuringSerialization = false;
+              sockets[0]!.emitClose();
+              connection.start();
+              sockets[1]!.emitOpen();
+            }
+            return type;
+          },
+        });
+        return parsed;
+      },
+    }) as typeof protocolParsers;
+    connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers: reentrantParsers,
+      limits: { maxPreBridgeCommands: 1 },
+    });
+    const command = (requestId: string) =>
+      JSON.stringify({
+        type: "command",
+        requestId,
+        command: "annotate",
+        input: { summary: requestId },
+      });
+
+    connection.start();
+    sockets[0]!.emitOpen();
+    sockets[0]!.emitMessage(command("request-stale"));
+    await Bun.sleep(0);
+    expect(parserCalls).toBe(1);
+    expect(serializationCalls).toBe(1);
+    expect(sockets).toHaveLength(2);
+
+    sockets[1]!.emitMessage(command("request-current"));
+    expect(
+      sockets[1]!.sent.filter((message) => JSON.parse(message).type === "command-result"),
+    ).toEqual([]);
+
+    connection.setBridge({
+      dispatchCommand: async (message) => {
+        dispatched.push(message.requestId);
+        return { ok: true };
+      },
+    });
+    await waitForSentMessagesTest(sockets[1]!, 2);
+    expect(dispatched).toEqual(["request-current"]);
+    expect(JSON.parse(sockets[1]!.sent.at(-1)!)).toMatchObject({
+      type: "command-result",
+      requestId: "request-current",
+      ok: true,
+    });
+    connection.stop();
+  });
+
   test("keeps 32 missing-bridge commands FIFO and explicitly rejects the 33rd", async () => {
     const socket = new TestSocket();
     const dispatched: string[] = [];
@@ -1048,8 +1800,14 @@ describe("session broker connection", () => {
         }),
       );
     }
-    const overflow = JSON.parse(socket.sent.at(-1)!) as { requestId: string; error: string };
-    expect(overflow).toMatchObject({ requestId: "request-33", error: "queue-full" });
+    const overflow = JSON.parse(socket.sent.at(-1)!) as {
+      requestId: string;
+      error: string;
+    };
+    expect(overflow).toMatchObject({
+      requestId: "request-33",
+      error: "queue-full",
+    });
 
     connection.setBridge({
       dispatchCommand: async (message) => {
@@ -1250,6 +2008,47 @@ describe("session broker connection", () => {
     connection.stop();
   });
 
+  test("retries a transient synchronous socket factory failure during reconnect", async () => {
+    const clock = new DeterministicLifecycleClockTest();
+    const sockets: TestSocket[] = [];
+    const warnings: string[] = [];
+    let constructionAttempts = 0;
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        constructionAttempts += 1;
+        if (constructionAttempts === 2) throw new Error("transient socket factory failure");
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      reconnectDelayMs: 10,
+      lifecycleClock: clock,
+      onWarning: (message) => warnings.push(message),
+    });
+
+    connection.start();
+    sockets[0]!.emitOpen();
+    sockets[0]!.emitClose();
+    await clock.advanceByTestAsync(10);
+    expect({ constructionAttempts, warnings, sockets: sockets.length }).toEqual({
+      constructionAttempts: 2,
+      warnings: ["transient socket factory failure"],
+      sockets: 1,
+    });
+    expect(clock.pendingCountTest()).toBe(1);
+
+    await clock.advanceByTestAsync(10);
+    expect(constructionAttempts).toBe(3);
+    expect(sockets).toHaveLength(2);
+    sockets[1]!.emitOpen();
+    expect(JSON.parse(sockets[1]!.sent[0]!)).toMatchObject({ type: "register" });
+    connection.stop();
+  });
+
   test("prepares reconnect once per attempt and stops after awaited preparation", async () => {
     const sockets: TestSocket[] = [];
     const warnings: string[] = [];
@@ -1384,6 +2183,63 @@ describe("session broker connection", () => {
 
       expect(warnings).toEqual([]);
       expect(sockets).toHaveLength(1);
+    });
+  }
+
+  for (const outcome of ["resolve", "reject"] as const) {
+    test(`replacement generation fences stale reconnect preparation ${outcome}`, async () => {
+      const clock = new DeterministicLifecycleClockTest();
+      const sockets: TestSocket[] = [];
+      const warnings: string[] = [];
+      const preparationStarted = createDeferredTest();
+      const preparationGate = createDeferredTest();
+      const callbackGenerations: number[] = [];
+      const connection = createSessionBrokerConnection<
+        TestSessionInfo,
+        TestSessionState,
+        TestSocket,
+        TestServerMessage,
+        { ok: true }
+      >({
+        url: "ws://broker.test/session",
+        createSocket: () => {
+          const socket = new TestSocket();
+          sockets.push(socket);
+          return socket;
+        },
+        registration: createRegistration(),
+        snapshot: createSnapshot(),
+        protocolParsers,
+        reconnectDelayMs: 10,
+        lifecycleClock: clock,
+        prepareReconnect: async (generation) => {
+          callbackGenerations.push(generation.id);
+          preparationStarted.resolve();
+          await preparationGate.promise;
+          if (outcome === "reject") throw new Error("stale preparation failure");
+        },
+        onWarning: (message) => warnings.push(message),
+      });
+
+      connection.start();
+      sockets[0]!.emitOpen();
+      sockets[0]!.emitClose();
+      clock.advanceByTest(10);
+      await settleWithinTestTimeout(preparationStarted.promise);
+
+      connection.start();
+      sockets[1]!.emitOpen();
+      preparationGate.resolve();
+      await clock.flushMicrotasksTest();
+      clock.advanceByTest(20);
+
+      expect(callbackGenerations).toHaveLength(1);
+      expect(warnings).toEqual([]);
+      expect(sockets).toHaveLength(2);
+      expect(JSON.parse(sockets[1]!.sent[0]!)).toMatchObject({
+        type: "register",
+      });
+      connection.stop();
     });
   }
 

--- a/packages/session-broker/src/connection.ts
+++ b/packages/session-broker/src/connection.ts
@@ -28,6 +28,7 @@ import {
   type SessionBrokerClientCredential,
   type SessionBrokerDaemonVerifier,
 } from "./clientAuthentication";
+import type { SessionBrokerCrypto } from "./crypto";
 import type {
   SessionBrokerProducerHelloAck,
   SessionBrokerHelloChallenge,
@@ -45,8 +46,31 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 10_000;
 const DEFAULT_SOCKET_OPEN_STATE = 1;
 const PRODUCER_COMMAND_OVERHEAD_BYTES = 128;
 
+/** Identifies the exact socket generation that owns one connection callback. */
+export interface SessionBrokerConnectionGeneration {
+  readonly id: number;
+}
+
+interface ConnectionGeneration<Socket> {
+  readonly token: SessionBrokerConnectionGeneration;
+  readonly socket: Socket;
+  status: "connecting" | "active" | "closing" | "close-failed" | "closed";
+  authenticated: boolean;
+}
+
+interface ScheduledReconnect<Socket> {
+  readonly generation: ConnectionGeneration<Socket>;
+  readonly dispose: () => void;
+}
+
+interface PendingSessionReplacement<Info, State> {
+  readonly registration: SessionRegistration<Info>;
+  readonly snapshot: SessionSnapshot<State>;
+  published: boolean;
+}
+
 interface QueuedProducerCommand<Socket, Message> {
-  socket: Socket;
+  generation: ConnectionGeneration<Socket>;
   message: Message;
   reservation: BudgetReservation;
 }
@@ -80,6 +104,7 @@ export interface SessionBrokerConnectionOptions<
   Result = unknown,
 > {
   url: string;
+  /** Create a fresh socket object for each generation; property handlers cannot safely be reused. */
   createSocket: (url: string) => Socket;
   registration: SessionRegistration<Info>;
   snapshot: SessionSnapshot<State>;
@@ -90,17 +115,21 @@ export interface SessionBrokerConnectionOptions<
     readonly appRevision: number;
     readonly credential: SessionBrokerClientCredential<ProducerGrant>;
     readonly daemon: SessionBrokerDaemonVerifier;
+    readonly crypto?: SessionBrokerCrypto;
   };
   heartbeatIntervalMs?: number;
   reconnectDelayMs?: number;
   /** Supply lifecycle timing for authentication, heartbeats, and reconnect attempts. */
   lifecycleClock?: SessionBrokerLifecycleClock;
   openState?: number;
-  resolveClose?: (event: SessionBrokerSocketCloseEvent) => SessionBrokerConnectionCloseDirective;
+  resolveClose?: (
+    event: SessionBrokerSocketCloseEvent,
+    generation: SessionBrokerConnectionGeneration,
+  ) => SessionBrokerConnectionCloseDirective;
   /** Prepare application-owned discovery before one reconnect attempt opens a new socket. */
-  prepareReconnect?: () => Promise<void>;
-  onConnected?: () => void;
-  onWarning?: (message: string) => void;
+  prepareReconnect?: (generation: SessionBrokerConnectionGeneration) => Promise<void>;
+  onConnected?: (generation: SessionBrokerConnectionGeneration) => void;
+  onWarning?: (message: string, generation: SessionBrokerConnectionGeneration) => void;
   limits?: SessionBrokerLimitOptions["limits"];
   unsafeLimits?: SessionBrokerLimitOptions["unsafeLimits"];
 }
@@ -117,7 +146,10 @@ export class SessionBrokerConnection<
   Result = unknown,
 > {
   private socket: Socket | null = null;
-  private activeSocket: Socket | null = null;
+  private currentGeneration: ConnectionGeneration<Socket> | null = null;
+  private nextGenerationId = 1;
+  private constructingSocket = false;
+  private readonly adoptedSockets = new WeakSet<Socket>();
   private bridge: SessionBrokerConnectionBridge<ServerMessage, Result> | null;
   readonly limits: Readonly<SessionBrokerLimits>;
 
@@ -126,15 +158,16 @@ export class SessionBrokerConnection<
   private readonly queuedCommandCountBudget: ResourceBudget;
   private readonly queuedCommandByteBudget: ResourceBudget;
   private draining = false;
-  private reconnectTimer: (() => void) | null = null;
+  private reconnectTimer: ScheduledReconnect<Socket> | null = null;
   private heartbeatTimer: (() => void) | null = null;
   private stopped = false;
   private registration: SessionRegistration<Info>;
   private snapshot: SessionSnapshot<State>;
+  private pendingSessionReplacement: PendingSessionReplacement<Info, State> | null = null;
   private readonly lifecycleClock: SessionBrokerLifecycleClock;
-  private readonly handshakeTimers = new WeakMap<Socket, () => void>();
+  private readonly handshakeTimers = new Map<ConnectionGeneration<Socket>, () => void>();
   private readonly producerHellos = new WeakMap<
-    Socket,
+    ConnectionGeneration<Socket>,
     {
       request: SessionBrokerHelloChallengeRequest;
       pending?: PendingSessionBrokerHello<ProducerGrant> | null;
@@ -171,32 +204,35 @@ export class SessionBrokerConnection<
   }
 
   start() {
-    if (this.stopped || this.socket) {
-      return;
-    }
-
+    if (this.stopped || this.socket || this.constructingSocket) return;
     this.connect();
   }
 
   stop() {
     this.stopped = true;
     for (const entry of this.queuedMessages.splice(0)) entry.reservation.release();
-    for (const entry of this.executingMessages) entry.reservation.release();
-    this.executingMessages.clear();
-    if (this.reconnectTimer) {
-      this.reconnectTimer();
-      this.reconnectTimer = null;
-    }
+    // Executing foreign bridge work is not cancellable. Its reservation remains owned until the
+    // promise settles; generation-fenced delivery prevents its response from migrating.
+    this.clearReconnectTimer();
 
     this.stopHeartbeat();
-    if (this.socket) {
-      const disposeHandshake = this.handshakeTimers.get(this.socket);
+    const generation = this.currentGeneration;
+    if (generation) {
+      const disposeHandshake = this.handshakeTimers.get(generation);
       disposeHandshake?.();
-      this.handshakeTimers.delete(this.socket);
-      this.socket.close();
+      this.handshakeTimers.delete(generation);
+      if (generation.status !== "closed") {
+        this.closeGeneration(generation);
+        if (generation.status === "closing") generation.status = "closed";
+      }
     }
     this.socket = null;
-    this.activeSocket = null;
+    this.currentGeneration = null;
+  }
+
+  /** Report whether a callback still belongs to this connection's exact commit generation. */
+  isGenerationCurrent(generation: SessionBrokerConnectionGeneration) {
+    return !this.stopped && this.currentGeneration?.token === generation;
   }
 
   getRegistration() {
@@ -215,16 +251,43 @@ export class SessionBrokerConnection<
     ) {
       throw new BrokerProtocolError("invalid-app-payload");
     }
-    // Re-register instead of sending only a snapshot because selectors like cwd, repoRoot, and the
-    // session id itself live in the registration envelope. Send before committing local state so
-    // a throwing socket keeps the previous registration and snapshot coherent.
-    this.send({
-      type: "register",
+    if (this.pendingSessionReplacement) {
+      throw new BrokerProtocolError("invalid-app-payload");
+    }
+
+    const replacement: PendingSessionReplacement<Info, State> = {
       registration,
       snapshot,
-    });
-    this.registration = registration;
-    this.snapshot = snapshot;
+      published: false,
+    };
+    this.pendingSessionReplacement = replacement;
+    try {
+      // Re-register instead of sending only a snapshot because selectors like cwd, repoRoot, and
+      // the session id itself live in the registration envelope. A generation activated
+      // reentrantly during serialization also reads this pending pair, keeping broker and local
+      // state coherent before the synchronous transaction commits.
+      if (
+        this.send({
+          type: "register",
+          registration,
+          snapshot,
+        })
+      ) {
+        replacement.published = true;
+      }
+      this.registration = registration;
+      this.snapshot = snapshot;
+    } catch (error) {
+      if (!replacement.published) throw error;
+      // A replacement generation already published this exact candidate. Treat a stale source
+      // generation's later send failure as retired work rather than claiming rollback succeeded.
+      this.registration = registration;
+      this.snapshot = snapshot;
+    } finally {
+      if (this.pendingSessionReplacement === replacement) {
+        this.pendingSessionReplacement = null;
+      }
+    }
   }
 
   updateSnapshot(snapshot: SessionSnapshot<State>) {
@@ -237,50 +300,80 @@ export class SessionBrokerConnection<
   }
 
   private connect() {
-    if (this.stopped || this.socket) {
-      return;
+    if (this.stopped || this.socket || this.constructingSocket) return;
+
+    // Publish construction ownership before invoking the foreign factory so a reentrant start
+    // cannot construct a second socket. Synchronous factory failures remain caller-visible.
+    this.constructingSocket = true;
+    let socket: Socket;
+    try {
+      socket = this.options.createSocket(this.options.url);
+    } finally {
+      this.constructingSocket = false;
     }
 
-    const socket = this.options.createSocket(this.options.url);
+    if (this.stopped || this.socket) {
+      try {
+        socket.close();
+      } catch {
+        // Terminal/reentrant ownership already won; orphan cleanup is best effort.
+      }
+      return;
+    }
+    if (this.adoptedSockets.has(socket)) {
+      throw new Error("Session broker socket factory must return a fresh socket.");
+    }
+    this.adoptedSockets.add(socket);
+    this.clearReconnectTimer();
+    const generation: ConnectionGeneration<Socket> = {
+      token: Object.freeze({ id: this.nextGenerationId++ }),
+      socket,
+      status: "connecting",
+      authenticated: false,
+    };
+    this.currentGeneration = generation;
     this.socket = socket;
     if (this.options.producerAuthentication) {
       const disposeHandshake = this.lifecycleClock.schedule(() => {
-        socket.close(1008, "Session broker authentication timed out.");
+        this.closeGeneration(generation, 1008, "Session broker authentication timed out.");
       }, this.limits.maxHandshakeDurationMs);
-      this.handshakeTimers.set(socket, disposeHandshake);
+      this.handshakeTimers.set(generation, disposeHandshake);
     }
 
     socket.onopen = () => {
+      if (!this.canAuthenticate(generation)) return;
       if (this.options.producerAuthentication) {
         const authentication = this.options.producerAuthentication;
         const request = createSessionBrokerHelloRequest({
           ...authentication,
           endpoint: this.options.url,
         });
-        this.producerHellos.set(socket, { request });
+        this.producerHellos.set(generation, { request });
         socket.send(JSON.stringify({ type: "hello-init", hello: request }));
         return;
       }
-      this.activateSocket(socket);
+      this.activateGeneration(generation);
     };
 
     socket.onmessage = (event) => {
-      if (this.stopped || this.socket !== socket) return;
+      if (!this.canReceive(generation)) return;
       if (typeof event.data !== "string") {
-        socket.close(1003, "Session broker accepts text messages only.");
+        this.closeGeneration(generation, 1003, "Session broker accepts text messages only.");
         return;
       }
       if (utf8ByteLength(event.data) > this.limits.maxWsMessageBytes) {
-        socket.close(1009, "Message exceeds the session broker size limit.");
+        this.closeGeneration(generation, 1009, "Message exceeds the session broker size limit.");
         return;
       }
-      if (this.options.producerAuthentication && this.activeSocket !== socket) {
-        void this.handleProducerHello(socket, event.data);
+      if (this.options.producerAuthentication && generation.status !== "active") {
+        void this.handleProducerHello(generation, event.data);
         return;
       }
       let parsed: ServerMessage;
       try {
-        const raw = parseSessionBrokerJsonText(event.data) as { input?: unknown };
+        const raw = parseSessionBrokerJsonText(event.data) as {
+          input?: unknown;
+        };
         if (commandValueBytes(raw?.input) > this.limits.maxCommandInputBytes) {
           throw new BrokerCapacityError("capacity-exceeded", "maxCommandInputBytes");
         }
@@ -291,82 +384,158 @@ export class SessionBrokerConnection<
       } catch {
         // Never invoke the app bridge after a malformed or mismatched command contract. Closing
         // prevents this producer from retaining daemon assumptions that were not actually parsed.
-        socket.close(1008, "Malformed session broker command.");
+        this.closeGeneration(generation, 1008, "Malformed session broker command.");
         return;
       }
 
-      void this.handleServerMessage(socket, parsed);
+      // App-owned parsers may synchronously stop or replace the connection. Refuse admission after
+      // that authority change so the stale input retains no budget or queue ownership.
+      if (!this.isGenerationActive(generation)) return;
+      void this.handleServerMessage(generation, parsed);
     };
 
     socket.onclose = (event) => {
-      const wasAuthenticated = this.activeSocket === socket;
-      const disposeHandshake = this.handshakeTimers.get(socket);
+      const wasAuthenticated = generation.authenticated;
+      const disposeHandshake = this.handshakeTimers.get(generation);
       disposeHandshake?.();
-      this.handshakeTimers.delete(socket);
-      if (this.socket === socket) {
+      this.handshakeTimers.delete(generation);
+      const ownsConnection = this.currentGeneration === generation;
+      generation.status = "closed";
+      if (ownsConnection) {
         this.socket = null;
-        this.activeSocket = null;
         this.stopHeartbeat();
       }
 
       this.queuedMessages = this.queuedMessages.filter((queued) => {
-        if (queued.socket !== socket) return true;
+        if (queued.generation !== generation) return true;
         queued.reservation.release();
         return false;
       });
       // Executing bridge work retains its reservation until its promise settles. A disconnect
       // prevents its response from migrating but does not make the retained input or work vanish.
-      if (this.stopped) {
-        return;
+      if (this.stopped || !ownsConnection || this.currentGeneration !== generation) return;
+
+      const directive = this.options.resolveClose?.(
+        {
+          code: event.code,
+          reason: event.reason,
+          authenticated: wasAuthenticated,
+        },
+        generation.token,
+      ) ?? { reconnect: true };
+      if (directive.warning && this.isGenerationCurrent(generation.token)) {
+        this.options.onWarning?.(directive.warning, generation.token);
       }
 
-      const directive = this.options.resolveClose?.({
-        code: event.code,
-        reason: event.reason,
-        authenticated: wasAuthenticated,
-      }) ?? { reconnect: true };
-      if (directive.warning) {
-        this.options.onWarning?.(directive.warning);
-      }
-
-      if (directive.reconnect !== false) {
-        this.scheduleReconnect();
+      if (directive.reconnect !== false && this.isGenerationCurrent(generation.token)) {
+        this.scheduleReconnect(generation);
       }
     };
 
     socket.onerror = () => {
       // Normalize raw socket errors through onclose so reconnect and warning policy stays in one
       // place instead of splitting behavior across runtime-specific error events.
-      socket.close();
+      this.closeGeneration(generation);
     };
   }
 
-  private activateSocket(socket: Socket) {
-    if (this.socket !== socket || this.activeSocket === socket) return;
-    this.activeSocket = socket;
-    const disposeHandshake = this.handshakeTimers.get(socket);
+  /** Return whether this exact generation can still commit authentication work. */
+  private canAuthenticate(generation: ConnectionGeneration<Socket>) {
+    return (
+      this.currentGeneration === generation &&
+      generation.status === "connecting" &&
+      generation.socket.readyState === (this.options.openState ?? DEFAULT_SOCKET_OPEN_STATE) &&
+      !this.stopped
+    );
+  }
+
+  /** Return whether this exact generation can still receive protocol input. */
+  private canReceive(generation: ConnectionGeneration<Socket>) {
+    return (
+      this.currentGeneration === generation &&
+      (generation.status === "connecting" || generation.status === "active") &&
+      !this.stopped
+    );
+  }
+
+  /** Close only the exact current generation and retire its commit authority before close settles. */
+  private closeGeneration(
+    generation: ConnectionGeneration<Socket>,
+    code?: number,
+    reason?: string,
+  ) {
+    if (
+      this.currentGeneration !== generation ||
+      generation.status === "closing" ||
+      generation.status === "closed"
+    ) {
+      return;
+    }
+    generation.status = "closing";
+    try {
+      generation.socket.close(code, reason);
+    } catch (error) {
+      // A terminal close decision permanently retires protocol authority even when the adapter
+      // throws before emitting close. The explicit state still permits a later close attempt.
+      if (this.currentGeneration === generation && generation.status === "closing") {
+        generation.status = "close-failed";
+      }
+      throw error;
+    }
+  }
+
+  /** Return whether one exact generation remains the active send authority. */
+  private isGenerationActive(generation: ConnectionGeneration<Socket>) {
+    return (
+      this.currentGeneration === generation &&
+      generation.status === "active" &&
+      generation.socket.readyState === (this.options.openState ?? DEFAULT_SOCKET_OPEN_STATE) &&
+      !this.stopped
+    );
+  }
+
+  private activateGeneration(generation: ConnectionGeneration<Socket>) {
+    if (!this.canAuthenticate(generation)) return;
+    generation.status = "active";
+    generation.authenticated = true;
+    const disposeHandshake = this.handshakeTimers.get(generation);
     disposeHandshake?.();
-    this.handshakeTimers.delete(socket);
-    this.startHeartbeat();
-    this.options.onConnected?.();
-    this.sendToSocket(socket, {
-      type: "register",
-      registration: this.registration,
-      snapshot: this.snapshot,
-    });
-    void this.flushQueuedMessages(socket);
+    this.handshakeTimers.delete(generation);
+    this.startHeartbeat(generation);
+    this.options.onConnected?.(generation.token);
+    const replacement = this.pendingSessionReplacement;
+    const registration = replacement?.registration ?? this.registration;
+    const snapshot = replacement?.snapshot ?? this.snapshot;
+    if (
+      this.sendToGeneration(generation, {
+        type: "register",
+        registration,
+        snapshot,
+      }) &&
+      replacement &&
+      this.pendingSessionReplacement === replacement
+    ) {
+      replacement.published = true;
+    }
+    void this.flushQueuedMessages(generation);
   }
 
   /** Verify the daemon challenge and acknowledgement before registration leaves this process. */
-  private async handleProducerHello(socket: Socket, message: unknown) {
+  private async handleProducerHello(generation: ConnectionGeneration<Socket>, message: unknown) {
+    const socket = generation.socket;
+    let activating = false;
     try {
       if (typeof message === "string" && utf8ByteLength(message) > this.limits.maxWsMessageBytes) {
-        socket.close(1009, "Session broker authentication message exceeded its limit.");
+        this.closeGeneration(
+          generation,
+          1009,
+          "Session broker authentication message exceeded its limit.",
+        );
         return;
       }
       const value = parseSessionBrokerJsonText(message);
       const authentication = this.options.producerAuthentication!;
-      const hello = this.producerHellos.get(socket);
+      const hello = this.producerHellos.get(generation);
       if (!hello) throw new Error();
       if (hello.pending === undefined) {
         const envelope = exactHelloEnvelope(value, "hello-challenge", "challenge");
@@ -376,12 +545,7 @@ export class SessionBrokerConnection<
           hello.request,
           envelope.challenge as SessionBrokerHelloChallenge,
         );
-        if (
-          this.socket !== socket ||
-          socket.readyState !== (this.options.openState ?? DEFAULT_SOCKET_OPEN_STATE)
-        ) {
-          return;
-        }
+        if (!this.canAuthenticate(generation)) return;
         hello.pending = pending;
         socket.send(JSON.stringify({ type: "hello-proof", proof: pending.proof }));
         return;
@@ -389,42 +553,81 @@ export class SessionBrokerConnection<
       if (!hello.pending) throw new Error();
       const envelope = exactHelloEnvelope(value, "hello-ack", "ack");
       await verifyProducerHelloAck(hello.pending, envelope.ack as SessionBrokerProducerHelloAck);
-      this.activateSocket(socket);
+      if (!this.canAuthenticate(generation)) return;
+      activating = true;
+      this.activateGeneration(generation);
     } catch {
-      socket.close(1008, "Session broker authentication failed.");
+      if (
+        !this.canAuthenticate(generation) &&
+        !(activating && this.isGenerationActive(generation))
+      ) {
+        return;
+      }
+      this.closeGeneration(generation, 1008, "Session broker authentication failed.");
     }
   }
 
-  private scheduleReconnect(delayMs = this.options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS) {
-    if (this.reconnectTimer || this.stopped) return;
+  private scheduleReconnect(
+    generation: ConnectionGeneration<Socket>,
+    delayMs = this.options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS,
+  ) {
+    if (!this.isGenerationCurrent(generation.token)) return;
+    if (this.reconnectTimer?.generation === generation) return;
+    this.clearReconnectTimer();
 
-    this.reconnectTimer = this.lifecycleClock.schedule(() => {
+    let scheduled!: ScheduledReconnect<Socket>;
+    const dispose = this.lifecycleClock.schedule(() => {
+      if (this.reconnectTimer !== scheduled) return;
       this.reconnectTimer = null;
-      void this.prepareAndReconnect();
+      if (!this.isGenerationCurrent(generation.token)) return;
+      void this.prepareAndReconnect(generation);
     }, delayMs);
+    scheduled = { generation, dispose };
+    this.reconnectTimer = scheduled;
+  }
+
+  /** Dispose only the reconnect timer that currently owns scheduling authority. */
+  private clearReconnectTimer() {
+    this.reconnectTimer?.dispose();
+    this.reconnectTimer = null;
   }
 
   /** Run app discovery once per retry while retaining this connection's aggregate budgets. */
-  private async prepareAndReconnect() {
+  private async prepareAndReconnect(generation: ConnectionGeneration<Socket>) {
     try {
-      await this.options.prepareReconnect?.();
+      await this.options.prepareReconnect?.(generation.token);
     } catch (error) {
-      if (this.stopped) return;
-      this.options.onWarning?.(
-        error instanceof Error ? error.message : "Session broker reconnect preparation failed.",
-      );
-      this.scheduleReconnect();
+      this.handleReconnectFailure(generation, error);
       return;
     }
-    if (!this.stopped) this.connect();
+    if (!this.isGenerationCurrent(generation.token)) return;
+    try {
+      this.connect();
+    } catch (error) {
+      // Explicit public start keeps synchronous factory failures. Once reconnect owns the attempt,
+      // a transient factory failure follows the existing warning and retry policy instead.
+      this.handleReconnectFailure(generation, error);
+    }
   }
 
-  private startHeartbeat() {
+  /** Warn and retry only while one failed reconnect generation still owns commit authority. */
+  private handleReconnectFailure(generation: ConnectionGeneration<Socket>, error: unknown) {
+    if (!this.isGenerationCurrent(generation.token)) return;
+    this.options.onWarning?.(
+      error instanceof Error ? error.message : "Session broker reconnect preparation failed.",
+      generation.token,
+    );
+    if (!this.isGenerationCurrent(generation.token)) return;
+    this.scheduleReconnect(generation);
+  }
+
+  private startHeartbeat(generation: ConnectionGeneration<Socket>) {
     if (this.heartbeatTimer) {
       return;
     }
 
     this.heartbeatTimer = this.lifecycleClock.scheduleInterval(() => {
+      if (!this.isGenerationActive(generation)) return;
       this.send({
         type: "heartbeat",
         sessionId: this.registration.sessionId,
@@ -442,77 +645,102 @@ export class SessionBrokerConnection<
   }
 
   private send(message: SessionClientMessage<Info, State, Result>) {
-    if (!this.activeSocket) {
-      return;
-    }
-
-    this.sendToSocket(this.activeSocket, message);
+    const generation = this.currentGeneration;
+    if (!generation) return false;
+    return this.sendToGeneration(generation, message);
   }
 
-  /** Send a response only through the still-active socket that received its command. */
-  private sendToSocket(socket: Socket, message: SessionClientMessage<Info, State, Result>) {
-    if (
-      this.socket !== socket ||
-      this.activeSocket !== socket ||
-      socket.readyState !== (this.options.openState ?? DEFAULT_SOCKET_OPEN_STATE)
-    ) {
-      return;
-    }
-
-    socket.send(JSON.stringify(message));
+  /** Send a response only through the still-active generation that received its command. */
+  private sendToGeneration(
+    generation: ConnectionGeneration<Socket>,
+    message: SessionClientMessage<Info, State, Result>,
+  ) {
+    if (!this.isGenerationActive(generation)) return false;
+    const serialized = JSON.stringify(message);
+    // App-owned values can run `toJSON` while the envelope is serialized. Refuse delivery when that
+    // callback retires or replaces the exact generation before the transport write begins.
+    if (!this.isGenerationActive(generation)) return false;
+    generation.socket.send(serialized);
+    return true;
   }
 
-  private async handleServerMessage(socket: Socket, message: ServerMessage) {
-    const reservations = new ReservationGroup();
+  private async handleServerMessage(
+    generation: ConnectionGeneration<Socket>,
+    message: ServerMessage,
+  ) {
+    let messageBytes: number;
     try {
-      reservations.add(this.queuedCommandCountBudget.reserve());
-      reservations.add(
-        this.queuedCommandByteBudget.reserve(
-          commandValueBytes(message) + PRODUCER_COMMAND_OVERHEAD_BYTES,
-        ),
-      );
+      messageBytes = commandValueBytes(message) + PRODUCER_COMMAND_OVERHEAD_BYTES;
     } catch {
-      reservations.release();
+      if (!this.isGenerationActive(generation)) return;
       try {
-        this.sendToSocket(socket, {
+        this.sendToGeneration(generation, {
           type: "command-result",
           requestId: message.requestId,
           ok: false,
           error: "queue-full",
         });
       } catch {
-        socket.close(1013, "Session broker queue pressure exceeded.");
+        this.closeGeneration(generation, 1013, "Session broker queue pressure exceeded.");
       }
       return;
     }
 
+    // JSON serialization is app-influenced and can synchronously retire this generation. Recheck
+    // authority before reserving so stale work cannot consume capacity from its replacement.
+    if (!this.isGenerationActive(generation)) return;
+    const reservations = new ReservationGroup();
+    try {
+      reservations.add(this.queuedCommandCountBudget.reserve());
+      reservations.add(this.queuedCommandByteBudget.reserve(messageBytes));
+    } catch {
+      reservations.release();
+      if (!this.isGenerationActive(generation)) return;
+      try {
+        this.sendToGeneration(generation, {
+          type: "command-result",
+          requestId: message.requestId,
+          ok: false,
+          error: "queue-full",
+        });
+      } catch {
+        this.closeGeneration(generation, 1013, "Session broker queue pressure exceeded.");
+      }
+      return;
+    }
+
+    if (!this.isGenerationActive(generation)) {
+      reservations.release();
+      return;
+    }
     // Every admitted command, including one executing in a hung bridge, retains its reservation.
-    this.queuedMessages.push({ socket, message, reservation: reservations });
-    if (this.bridge) await this.flushQueuedMessages(socket);
+    this.queuedMessages.push({
+      generation,
+      message,
+      reservation: reservations,
+    });
+    if (this.bridge) await this.flushQueuedMessages(generation);
   }
 
-  private async flushQueuedMessages(socket = this.socket) {
-    if (!this.bridge || !socket || this.draining) return;
+  private async flushQueuedMessages(generation = this.currentGeneration) {
+    if (!this.bridge || !generation || this.draining) return;
     this.draining = true;
     try {
       // Take one command at a time so newly received work joins the same FIFO and a disconnect can
       // prevent every command that has not started from executing on a replacement transport.
       for (;;) {
         if (!this.bridge) return;
-        const index = this.queuedMessages.findIndex((entry) => entry.socket === socket);
+        const index = this.queuedMessages.findIndex((entry) => entry.generation === generation);
         if (index < 0) return;
         const [entry] = this.queuedMessages.splice(index, 1);
         if (!entry) return;
-        if (
-          this.socket !== entry.socket ||
-          entry.socket.readyState !== (this.options.openState ?? DEFAULT_SOCKET_OPEN_STATE)
-        ) {
+        if (!this.isGenerationActive(entry.generation)) {
           entry.reservation.release();
           return;
         }
         this.executingMessages.add(entry);
         try {
-          await this.executeServerMessage(entry.socket, entry.message);
+          await this.executeServerMessage(entry.generation, entry.message);
         } finally {
           this.executingMessages.delete(entry);
           entry.reservation.release();
@@ -522,20 +750,24 @@ export class SessionBrokerConnection<
       this.draining = false;
       if (
         this.bridge &&
-        this.socket &&
-        this.queuedMessages.some((entry) => entry.socket === this.socket)
+        this.currentGeneration &&
+        this.queuedMessages.some((entry) => entry.generation === this.currentGeneration)
       ) {
-        void this.flushQueuedMessages(this.socket);
+        void this.flushQueuedMessages(this.currentGeneration);
       }
     }
   }
 
   /** Execute one already-admitted command without re-entering the producer FIFO. */
-  private async executeServerMessage(socket: Socket, message: ServerMessage) {
+  private async executeServerMessage(
+    generation: ConnectionGeneration<Socket>,
+    message: ServerMessage,
+  ) {
     const bridge = this.bridge;
     if (!bridge) return;
     try {
       const result = await bridge.dispatchCommand(message);
+      if (!this.isGenerationActive(generation)) return;
       if (commandValueBytes(result) > this.limits.maxCommandResultBytes) {
         throw new BrokerProtocolError("invalid-app-payload");
       }
@@ -547,18 +779,19 @@ export class SessionBrokerConnection<
       if (commandValueBytes(parsedResult) > this.limits.maxCommandResultBytes) {
         throw new BrokerProtocolError("invalid-app-payload");
       }
-      this.sendToSocket(socket, {
+      this.sendToGeneration(generation, {
         type: "command-result",
         requestId: message.requestId,
         ok: true,
         result: parsedResult,
       });
     } catch (error) {
+      if (!this.isGenerationActive(generation)) return;
       if (error instanceof BrokerProtocolError) {
-        socket.close(1008, "Malformed session broker command result.");
+        this.closeGeneration(generation, 1008, "Malformed session broker command result.");
         return;
       }
-      this.sendToSocket(socket, {
+      this.sendToGeneration(generation, {
         type: "command-result",
         requestId: message.requestId,
         ok: false,

--- a/packages/session-broker/src/connection.ts
+++ b/packages/session-broker/src/connection.ts
@@ -218,9 +218,7 @@ export class SessionBrokerConnection<
     this.stopHeartbeat();
     const generation = this.currentGeneration;
     if (generation) {
-      const disposeHandshake = this.handshakeTimers.get(generation);
-      disposeHandshake?.();
-      this.handshakeTimers.delete(generation);
+      this.disposeHandshake(generation);
       if (generation.status !== "closed") {
         this.closeGeneration(generation);
         if (generation.status === "closing") generation.status = "closed";
@@ -396,9 +394,7 @@ export class SessionBrokerConnection<
 
     socket.onclose = (event) => {
       const wasAuthenticated = generation.authenticated;
-      const disposeHandshake = this.handshakeTimers.get(generation);
-      disposeHandshake?.();
-      this.handshakeTimers.delete(generation);
+      this.disposeHandshake(generation);
       const ownsConnection = this.currentGeneration === generation;
       generation.status = "closed";
       if (ownsConnection) {
@@ -484,6 +480,13 @@ export class SessionBrokerConnection<
     }
   }
 
+  /** Dispose and forget only the handshake timer owned by one exact generation. */
+  private disposeHandshake(generation: ConnectionGeneration<Socket>) {
+    const dispose = this.handshakeTimers.get(generation);
+    dispose?.();
+    this.handshakeTimers.delete(generation);
+  }
+
   /** Return whether one exact generation remains the active send authority. */
   private isGenerationActive(generation: ConnectionGeneration<Socket>) {
     return (
@@ -498,9 +501,7 @@ export class SessionBrokerConnection<
     if (!this.canAuthenticate(generation)) return;
     generation.status = "active";
     generation.authenticated = true;
-    const disposeHandshake = this.handshakeTimers.get(generation);
-    disposeHandshake?.();
-    this.handshakeTimers.delete(generation);
+    this.disposeHandshake(generation);
     this.startHeartbeat(generation);
     this.options.onConnected?.(generation.token);
     const replacement = this.pendingSessionReplacement;
@@ -672,17 +673,7 @@ export class SessionBrokerConnection<
     try {
       messageBytes = commandValueBytes(message) + PRODUCER_COMMAND_OVERHEAD_BYTES;
     } catch {
-      if (!this.isGenerationActive(generation)) return;
-      try {
-        this.sendToGeneration(generation, {
-          type: "command-result",
-          requestId: message.requestId,
-          ok: false,
-          error: "queue-full",
-        });
-      } catch {
-        this.closeGeneration(generation, 1013, "Session broker queue pressure exceeded.");
-      }
+      this.rejectQueuePressure(generation, message.requestId);
       return;
     }
 
@@ -695,17 +686,7 @@ export class SessionBrokerConnection<
       reservations.add(this.queuedCommandByteBudget.reserve(messageBytes));
     } catch {
       reservations.release();
-      if (!this.isGenerationActive(generation)) return;
-      try {
-        this.sendToGeneration(generation, {
-          type: "command-result",
-          requestId: message.requestId,
-          ok: false,
-          error: "queue-full",
-        });
-      } catch {
-        this.closeGeneration(generation, 1013, "Session broker queue pressure exceeded.");
-      }
+      this.rejectQueuePressure(generation, message.requestId);
       return;
     }
 
@@ -720,6 +701,21 @@ export class SessionBrokerConnection<
       reservation: reservations,
     });
     if (this.bridge) await this.flushQueuedMessages(generation);
+  }
+
+  /** Reject one over-budget command without admitting it to the producer queue. */
+  private rejectQueuePressure(generation: ConnectionGeneration<Socket>, requestId: string) {
+    if (!this.isGenerationActive(generation)) return;
+    try {
+      this.sendToGeneration(generation, {
+        type: "command-result",
+        requestId,
+        ok: false,
+        error: "queue-full",
+      });
+    } catch {
+      this.closeGeneration(generation, 1013, "Session broker queue pressure exceeded.");
+    }
   }
 
   private async flushQueuedMessages(generation = this.currentGeneration) {

--- a/src/session/broker/brokerClient.test.ts
+++ b/src/session/broker/brokerClient.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./credentials";
 import { serveSessionBrokerDaemon as serveHunkSessionBrokerDaemon } from "./brokerServer";
 import { createHttpHunkSessionCliClient } from "../agent/cliClient";
+import { HUNK_DAEMON_UPGRADE_WAIT_MESSAGE } from "../client/capabilities";
 import { resolveSessionBrokerRuntimePaths } from "./brokerLauncher";
 import { DeterministicLifecycleClockTest } from "../../../test/helpers/lifecycleClockTest";
 
@@ -55,8 +56,9 @@ interface SessionBrokerClientTestAccess {
   waitingForIncumbentExit: boolean;
   restartIncompatibleDaemon?: unknown;
   connect(config: ResolvedSessionBrokerConfig): void;
-  ensureDaemonAndConnect(): Promise<void>;
+  ensureDaemonAndConnect(attempt?: unknown): Promise<void>;
   ensureDaemonAvailable(config: ResolvedSessionBrokerConfig): Promise<void>;
+  loadCredentials(): Promise<HunkSessionBrokerCredentials>;
   scheduleReconnect(delayMs?: number): void;
 }
 
@@ -150,7 +152,11 @@ function installWebSocketObserverTest(
     throw new Error("A WebSocket observer is already installed.");
   }
   const OriginalWebSocket = globalThis.WebSocket;
-  const sockets: Array<{ sent: string[] }> = [];
+  const sockets: Array<{
+    sent: string[];
+    emitOpen: () => void;
+    emitClose: (code?: number, reason?: string) => void;
+  }> = [];
   let constructionAttempts = 0;
 
   class ObservedWebSocketTest implements SessionBrokerSocketLike {
@@ -173,6 +179,15 @@ function installWebSocketObserverTest(
     }
 
     close(code = 1000, reason = "") {
+      this.emitClose(code, reason);
+    }
+
+    emitOpen() {
+      this.readyState = 1;
+      this.onopen?.();
+    }
+
+    emitClose(code = 1000, reason = "") {
       this.readyState = 3;
       this.onclose?.({ code, reason });
     }
@@ -988,6 +1003,66 @@ describe("Hunk session daemon client", () => {
   });
 
   for (const outcome of ["resolve", "reject"] as const) {
+    test(`stop fences late credential ${outcome} without assignment, warning, or retry`, async () => {
+      delete process.env.HUNK_MCP_DISABLE;
+      const clock = new DeterministicLifecycleClockTest();
+      const messages: string[] = [];
+      console.error = (...args: unknown[]) => {
+        messages.push(args.map((value) => String(value)).join(" "));
+      };
+      const credentials = createDeferredTest<any>();
+      const credentialLoadStarted = createDeferredTest();
+      const client = new SessionBrokerClient(createRegistration(), createSnapshot(), {
+        reconnectDelayMs: 30,
+        lifecycleClock: clock,
+      });
+      clientTestAccess(client).ensureDaemonAvailable = async () => {};
+      clientTestAccess(client).loadCredentials = async () => {
+        credentialLoadStarted.resolve();
+        return credentials.promise;
+      };
+
+      const startup = client.start();
+      await settleWithinTestTimeout(credentialLoadStarted.promise);
+      client.stop();
+      if (outcome === "resolve") {
+        credentials.resolve({ source: "late credentials" });
+      } else {
+        credentials.reject(new Error("late credential failure"));
+      }
+      await settleWithinTestTimeout(startup);
+
+      expect(clientTestAccess(client).credentials).toBeNull();
+      expect(messages).toEqual([]);
+      expect(clock.pendingCountTest()).toBe(0);
+    });
+  }
+
+  test("a reentrant stop during initial health remains terminal after settlement", async () => {
+    delete process.env.HUNK_MCP_DISABLE;
+    const nativeFetch = globalThis.fetch;
+    const webSockets = installWebSocketObserverTest();
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot());
+    let healthChecks = 0;
+    globalThis.fetch = (async () => {
+      healthChecks += 1;
+      client.stop();
+      return Response.json({ ok: true });
+    }) as unknown as typeof fetch;
+
+    try {
+      await settleWithinTestTimeout(client.start());
+      await settleWithinTestTimeout(client.start());
+      expect(healthChecks).toBe(1);
+      expect(webSockets.constructionAttemptsTest()).toBe(0);
+    } finally {
+      client.stop();
+      globalThis.fetch = nativeFetch;
+      webSockets.restoreTest();
+    }
+  });
+
+  for (const outcome of ["resolve", "reject"] as const) {
     test(`stop fences a late startup ${outcome} without warning, retry, or socket mutation`, async () => {
       delete process.env.HUNK_MCP_DISABLE;
       const clock = new DeterministicLifecycleClockTest();
@@ -1018,6 +1093,62 @@ describe("Hunk session daemon client", () => {
         webSockets.restoreTest();
       }
     });
+  }
+
+  for (const authority of ["stop", "replacement"] as const) {
+    for (const outcome of ["resolve", "reject"] as const) {
+      test(`${authority} fences late incumbent health ${outcome} before reconnect mutation`, async () => {
+        const nativeFetch = globalThis.fetch;
+        const clock = new DeterministicLifecycleClockTest();
+        const webSockets = installWebSocketObserverTest();
+        const fetchStarted = createDeferredTest();
+        const fetchGate = createDeferredTest();
+        const messages: string[] = [];
+        console.error = (...args: unknown[]) => {
+          messages.push(args.map((value) => String(value)).join(" "));
+        };
+        globalThis.fetch = (async () => {
+          fetchStarted.resolve();
+          await fetchGate.promise;
+          if (outcome === "reject") throw new Error("late health failure");
+          return new Response("unavailable", { status: 503 });
+        }) as unknown as typeof fetch;
+        const client = new SessionBrokerClient(createRegistration(), createSnapshot(), {
+          reconnectDelayMs: 10,
+          lifecycleClock: clock,
+        });
+        const config = prepareDirectConnectTest(client);
+
+        try {
+          clientTestAccess(client).connect(config);
+          webSockets.sockets[0]!.emitClose(
+            1008,
+            "Session broker authentication required; upgrade Hunk.",
+          );
+          expect(clientTestAccess(client).waitingForIncumbentExit).toBe(true);
+          clock.advanceByTest(10);
+          await settleWithinTestTimeout(fetchStarted.promise);
+
+          if (authority === "stop") {
+            client.stop();
+          } else {
+            clientTestAccess(client).connection!.start!();
+            expect(webSockets.sockets).toHaveLength(2);
+          }
+          fetchGate.resolve();
+          await clock.flushMicrotasksTest();
+          clock.advanceByTest(20);
+
+          expect(clientTestAccess(client).waitingForIncumbentExit).toBe(true);
+          expect(messages).toEqual([`[session:broker] ${HUNK_DAEMON_UPGRADE_WAIT_MESSAGE}`]);
+          expect(webSockets.sockets).toHaveLength(authority === "stop" ? 1 : 2);
+        } finally {
+          client.stop();
+          globalThis.fetch = nativeFetch;
+          webSockets.restoreTest();
+        }
+      });
+    }
   }
 
   test("retries the complete startup cycle and recovers without restarting the client", async () => {

--- a/src/session/broker/brokerClient.ts
+++ b/src/session/broker/brokerClient.ts
@@ -3,6 +3,7 @@ import {
   createSessionBrokerConnection,
   type SessionBrokerConnection as GenericSessionBrokerConnection,
   type SessionBrokerConnectionBridge,
+  type SessionBrokerConnectionGeneration,
   type SessionBrokerLifecycleClock,
   type SessionBrokerSocketLike,
 } from "@hunk/session-broker";
@@ -55,10 +56,19 @@ interface ScheduledStartupRetry {
   dispose: () => void;
 }
 
+interface StartupAttempt {
+  readonly id: symbol;
+}
+
+interface ClientConnectionGeneration {
+  readonly id: symbol;
+}
+
 type StartupLifecycleState =
   | { status: "idle" }
   | {
       status: "attempting";
+      attempt: StartupAttempt;
       promise: Promise<void>;
       retry: ScheduledStartupRetry | null;
     }
@@ -97,6 +107,7 @@ export class SessionBrokerClient {
   > | null = null;
   private bridge: SessionAppBridge | null = null;
   private startupState: StartupLifecycleState = { status: "idle" };
+  private connectionGeneration: ClientConnectionGeneration | null = null;
   private lastConnectionWarning: string | null = null;
   private credentials: HunkSessionBrokerCredentials | null = null;
   private waitingForIncumbentExit = false;
@@ -149,6 +160,7 @@ export class SessionBrokerClient {
     }
 
     this.startupState = { status: "stopped" };
+    this.connectionGeneration = null;
     this.connection?.stop();
     this.connection = null;
   }
@@ -172,19 +184,51 @@ export class SessionBrokerClient {
     return resolveSessionBrokerConfig();
   }
 
-  private async ensureDaemonAndConnect() {
+  /** Return whether one startup attempt still owns commits for this live client. */
+  private isStartupAttemptCurrent(attempt: StartupAttempt) {
+    const state = this.startupState;
+    switch (state.status) {
+      case "attempting":
+        return state.attempt === attempt;
+      case "idle":
+      case "waiting":
+      case "stopped":
+        return false;
+      default:
+        return assertNeverStartupState(state);
+    }
+  }
+
+  /** Load credentials as foreign work so tests can hold its settlement deterministically. */
+  private loadCredentials() {
+    return loadOrCreateHunkSessionBrokerCredentials();
+  }
+
+  private async ensureDaemonAndConnect(attempt: StartupAttempt) {
+    const isCommitAuthorized = () => this.isStartupAttemptCurrent(attempt);
     const config = this.resolveConfig();
-    await this.ensureDaemonAvailable(config);
-    this.credentials ??= await loadOrCreateHunkSessionBrokerCredentials();
+    await this.ensureDaemonAvailable(config, isCommitAuthorized);
+    if (!isCommitAuthorized()) return;
+    if (!this.credentials) {
+      const credentials = await this.loadCredentials();
+      if (!isCommitAuthorized()) return;
+      this.credentials = credentials;
+    }
+    if (!isCommitAuthorized()) return;
     this.connect(config);
   }
 
-  private async ensureDaemonAvailable(config: ResolvedSessionBrokerConfig) {
+  private async ensureDaemonAvailable(
+    config: ResolvedSessionBrokerConfig,
+    isCommitAuthorized: () => boolean = () => true,
+  ) {
     await ensureSessionBrokerAvailable({
       config,
       timeoutMs: this.timing.daemonStartupTimeoutMs ?? DAEMON_STARTUP_TIMEOUT_MS,
       lifecycleClock: this.lifecycleClock,
+      isCommitAuthorized,
     });
+    if (!isCommitAuthorized()) return;
 
     // Minimal health proves only liveness. Compatibility and identity are established by the
     // signed websocket hello; an unverifiable incumbent is never signalled or replaced by PID.
@@ -201,12 +245,26 @@ export class SessionBrokerClient {
   }
 
   private connect(config: ResolvedSessionBrokerConfig) {
-    if (this.startupState.status === "stopped" || this.connection) {
-      return;
-    }
-
+    if (this.startupState.status === "stopped" || this.connection) return;
     if (!this.credentials) return;
-    const connection = createSessionBrokerConnection<
+
+    const clientGeneration: ClientConnectionGeneration = {
+      id: Symbol("broker-connection"),
+    };
+    let connection!: GenericSessionBrokerConnection<
+      HunkSessionInfo,
+      HunkSessionState,
+      SessionBrokerSocketLike,
+      HunkSessionServerMessage,
+      HunkSessionCommandResult
+    >;
+    const isConnectionCurrent = (brokerGeneration?: SessionBrokerConnectionGeneration) =>
+      this.startupState.status !== "stopped" &&
+      this.connectionGeneration === clientGeneration &&
+      this.connection === connection &&
+      (!brokerGeneration || connection.isGenerationCurrent(brokerGeneration));
+
+    connection = createSessionBrokerConnection<
       HunkSessionInfo,
       HunkSessionState,
       SessionBrokerSocketLike,
@@ -231,11 +289,15 @@ export class SessionBrokerClient {
       heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
       reconnectDelayMs: this.timing.reconnectDelayMs ?? RECONNECT_DELAY_MS,
       lifecycleClock: this.lifecycleClock,
-      prepareReconnect: async () => {
+      prepareReconnect: async (brokerGeneration) => {
+        const isCommitAuthorized = () => isConnectionCurrent(brokerGeneration);
+        if (!isCommitAuthorized()) return;
         if (this.waitingForIncumbentExit) {
           const healthy = await isSessionBrokerHealthy(config);
+          if (!isCommitAuthorized()) return;
           if (healthy) {
             const currentFingerprint = readSessionBrokerLaunchFingerprint(config);
+            if (!isCommitAuthorized()) return;
             // Owner-private metadata is only a generation-change hint. The signed hello remains the
             // sole compatibility and identity authority, and unchanged/malformed metadata causes
             // health-only polling so skewed waiters cannot keep the incumbent active.
@@ -243,11 +305,14 @@ export class SessionBrokerClient {
               throw new Error(HUNK_DAEMON_UPGRADE_WAIT_MESSAGE);
             }
           }
+          if (!isCommitAuthorized()) return;
           this.waitingForIncumbentExit = false;
         }
-        await this.ensureDaemonAvailable(config);
+        await this.ensureDaemonAvailable(config, isCommitAuthorized);
+        if (!isCommitAuthorized()) return;
       },
-      resolveClose: (event) => {
+      resolveClose: (event, brokerGeneration) => {
+        if (!isConnectionCurrent(brokerGeneration)) return { reconnect: false };
         const preAuthenticationRefusal = isQuiescentUpgradeRefusal(event);
         if (preAuthenticationRefusal) {
           this.waitingForIncumbentExit = true;
@@ -258,14 +323,18 @@ export class SessionBrokerClient {
           ...(preAuthenticationRefusal ? { warning: HUNK_DAEMON_UPGRADE_WAIT_MESSAGE } : {}),
         };
       },
-      onConnected: () => {
+      onConnected: (brokerGeneration) => {
+        if (!isConnectionCurrent(brokerGeneration)) return;
         this.waitingForIncumbentExit = false;
         this.incumbentLaunchFingerprint = null;
         this.lastConnectionWarning = null;
       },
-      onWarning: (message) => this.warnUnavailable(message),
+      onWarning: (message, brokerGeneration) => {
+        if (isConnectionCurrent(brokerGeneration)) this.warnUnavailable(message);
+      },
     });
 
+    this.connectionGeneration = clientGeneration;
     this.connection = connection;
     try {
       connection.start();
@@ -275,8 +344,9 @@ export class SessionBrokerClient {
       } catch {
         // Preserve the synchronous startup failure even when best-effort cleanup also fails.
       }
-      if (this.connection === connection) {
+      if (this.connection === connection && this.connectionGeneration === clientGeneration) {
         this.connection = null;
+        this.connectionGeneration = null;
       }
       throw error;
     }
@@ -284,25 +354,39 @@ export class SessionBrokerClient {
 
   /** Begin one startup attempt while preserving any automatic retry already in flight. */
   private beginStartupAttempt(retry?: ScheduledStartupRetry) {
+    const attempt: StartupAttempt = { id: Symbol("broker-startup") };
+    let resolveWork!: () => void;
+    let rejectWork!: (error: unknown) => void;
+    const work = new Promise<void>((resolve, reject) => {
+      resolveWork = resolve;
+      rejectWork = reject;
+    });
     let promise: Promise<void>;
-    promise = this.ensureDaemonAndConnect()
-      .catch((error) => this.handleStartupFailure(promise, error))
-      .finally(() => this.handleStartupSettlement(promise));
-    this.startupState = { status: "attempting", promise, retry: retry ?? null };
+    promise = work
+      .catch((error) => this.handleStartupFailure(promise, attempt, error))
+      .finally(() => this.handleStartupSettlement(promise, attempt));
+    // Publish the complete authoritative state before foreign startup work can synchronously stop
+    // or otherwise invalidate this attempt.
+    this.startupState = { status: "attempting", attempt, promise, retry: retry ?? null };
+    try {
+      void Promise.resolve(this.ensureDaemonAndConnect(attempt)).then(resolveWork, rejectWork);
+    } catch (error) {
+      rejectWork(error);
+    }
     return promise;
   }
 
   /** Warn for the current failed attempt and retain or schedule exactly one retry. */
-  private handleStartupFailure(promise: Promise<void>, error: unknown) {
+  private handleStartupFailure(promise: Promise<void>, attempt: StartupAttempt, error: unknown) {
     const state = this.startupState;
     switch (state.status) {
       case "attempting":
-        if (state.promise !== promise) return;
+        if (state.promise !== promise || state.attempt !== attempt) return;
         if (!state.retry) {
           const retry = this.createStartupRetry();
           // Publish retry ownership before the warning side effect so a reentrant stop clears the
           // exact handle and cannot be overwritten when the callback returns.
-          this.startupState = { status: "attempting", promise, retry };
+          this.startupState = { status: "attempting", attempt, promise, retry };
         }
         this.warnUnavailable(error);
         return;
@@ -316,11 +400,11 @@ export class SessionBrokerClient {
   }
 
   /** Move the current settled attempt to idle or back to its retained retry wait. */
-  private handleStartupSettlement(promise: Promise<void>) {
+  private handleStartupSettlement(promise: Promise<void>, attempt: StartupAttempt) {
     const state = this.startupState;
     switch (state.status) {
       case "attempting":
-        if (state.promise === promise) {
+        if (state.promise === promise && state.attempt === attempt) {
           this.startupState = state.retry
             ? { status: "waiting", retry: state.retry }
             : { status: "idle" };
@@ -357,7 +441,12 @@ export class SessionBrokerClient {
         return;
       case "attempting":
         if (state.retry !== retry) return;
-        this.startupState = { status: "attempting", promise: state.promise, retry: null };
+        this.startupState = {
+          status: "attempting",
+          attempt: state.attempt,
+          promise: state.promise,
+          retry: null,
+        };
         return;
       case "idle":
       case "stopped":

--- a/src/session/broker/brokerLauncher.test.ts
+++ b/src/session/broker/brokerLauncher.test.ts
@@ -21,6 +21,37 @@ const testConfig = {
   wsOrigin: "ws://127.0.0.1:47657",
 };
 
+/** Create manually settled foreign work for launcher commit-fence tests. */
+function createDeferredTest<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Await one launcher result while turning a lost settlement into a bounded failure. */
+async function settleWithinTestTimeout<T>(promise: Promise<T>, timeoutMs = 500) {
+  return Promise.race([
+    promise,
+    Bun.sleep(timeoutMs).then(() => {
+      throw new Error(`Launcher work did not settle within ${timeoutMs}ms.`);
+    }),
+  ]);
+}
+
+/** Wait for one asynchronous test condition with an actionable bounded failure. */
+async function waitUntilTest(label: string, predicate: () => boolean, timeoutMs = 500) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await Bun.sleep(0);
+  }
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
 function createRuntimeDir() {
   const dir = mkdtempSync(join(tmpdir(), "hunk-session-daemon-launcher-test-"));
   tempDirs.push(dir);
@@ -285,6 +316,193 @@ describe("session daemon launcher", () => {
     expect(clock.now()).toBe(30);
     expect(clock.pendingCountTest()).toBe(0);
     expect(existsSync(resolveSessionBrokerRuntimePaths(testConfig, env).lockPath)).toBe(false);
+  });
+
+  for (const outcome of ["resolve", "reject"] as const) {
+    test(`lost authority fences protected health ${outcome} and still releases the launch lock`, async () => {
+      const runtimeDir = createRuntimeDir();
+      const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+      const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
+      const protectedHealth = createDeferredTest<boolean>();
+      let healthCalls = 0;
+      let authorized = true;
+      let launchCount = 0;
+      const ensuring = ensureSessionBrokerAvailable({
+        config: testConfig,
+        env,
+        timeoutMs: 100,
+        isCommitAuthorized: () => authorized,
+        isHealthy: async () => {
+          healthCalls += 1;
+          if (healthCalls === 1) return false;
+          return protectedHealth.promise;
+        },
+        isPortReachable: async () => false,
+        launchDaemon: () => {
+          launchCount += 1;
+          return { pid: process.pid } as ChildProcess;
+        },
+      });
+
+      await waitUntilTest("protected health probe", () => healthCalls >= 2);
+      expect(existsSync(paths.lockPath)).toBe(true);
+      authorized = false;
+      if (outcome === "resolve") protectedHealth.resolve(false);
+      else protectedHealth.reject(new Error("late protected health failure"));
+      await ensuring;
+
+      expect(launchCount).toBe(0);
+      expect(existsSync(paths.lockPath)).toBe(false);
+      expect(existsSync(paths.metadataPath)).toBe(false);
+    });
+
+    test(`lost authority fences final port ${outcome} without a late conflict or timeout`, async () => {
+      const runtimeDir = createRuntimeDir();
+      const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+      const portProbe = createDeferredTest<boolean>();
+      let portStarted = false;
+      let authorized = true;
+      const ensuring = ensureSessionBrokerAvailable({
+        config: testConfig,
+        env,
+        timeoutMs: 0,
+        isCommitAuthorized: () => authorized,
+        isHealthy: async () => false,
+        isPortReachable: async () => {
+          portStarted = true;
+          return portProbe.promise;
+        },
+      });
+
+      await waitUntilTest("final port probe", () => portStarted);
+      authorized = false;
+      if (outcome === "resolve") portProbe.resolve(true);
+      else portProbe.reject(new Error("late port failure"));
+      await ensuring;
+    });
+  }
+
+  test("fences a synchronous foreign throw after authority changes", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
+    let authorized = true;
+    let launchCount = 0;
+    let portCalls = 0;
+    const ensuring = ensureSessionBrokerAvailable({
+      config: testConfig,
+      env,
+      isCommitAuthorized: () => authorized,
+      isHealthy: () => {
+        mkdirSync(paths.runtimeDir, { recursive: true });
+        writeFileSync(
+          paths.metadataPath,
+          JSON.stringify({
+            pid: process.pid,
+            host: testConfig.host,
+            port: testConfig.port,
+            command: "/fixture/hunk",
+            args: ["daemon", "serve"],
+            launchedAt: new Date(0).toISOString(),
+            launchedByPid: process.pid,
+            launchCwd: "/fixture",
+          }),
+        );
+        authorized = false;
+        throw new Error("late synchronous health failure");
+      },
+      isPortReachable: async () => {
+        portCalls += 1;
+        return false;
+      },
+      launchDaemon: () => {
+        launchCount += 1;
+        return { pid: process.pid } as ChildProcess;
+      },
+    });
+
+    await settleWithinTestTimeout(ensuring);
+    expect(launchCount).toBe(0);
+    expect(portCalls).toBe(0);
+    expect(existsSync(paths.lockPath)).toBe(false);
+    expect(existsSync(paths.metadataPath)).toBe(true);
+  });
+
+  test("suppresses a synchronous launch error after the callback revokes authority", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
+    let authorized = true;
+    let healthCalls = 0;
+    const ensuring = ensureSessionBrokerAvailable({
+      config: testConfig,
+      env,
+      timeoutMs: 100,
+      isCommitAuthorized: () => authorized,
+      isHealthy: async () => {
+        healthCalls += 1;
+        return false;
+      },
+      isPortReachable: async () => false,
+      launchDaemon: () => {
+        authorized = false;
+        throw new Error("stale synchronous launch failure");
+      },
+    });
+
+    await settleWithinTestTimeout(ensuring);
+    expect(healthCalls).toBe(2);
+    expect(existsSync(paths.lockPath)).toBe(false);
+    expect(existsSync(paths.metadataPath)).toBe(false);
+  });
+
+  test("preserves a synchronous launch error while authority remains current", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
+    const launchFailure = new Error("current synchronous launch failure");
+    const ensuring = ensureSessionBrokerAvailable({
+      config: testConfig,
+      env,
+      timeoutMs: 100,
+      isCommitAuthorized: () => true,
+      isHealthy: async () => false,
+      isPortReachable: async () => false,
+      launchDaemon: () => {
+        throw launchFailure;
+      },
+    });
+
+    await expect(settleWithinTestTimeout(ensuring)).rejects.toBe(launchFailure);
+    expect(existsSync(paths.lockPath)).toBe(false);
+    expect(existsSync(paths.metadataPath)).toBe(false);
+  });
+
+  test("does not clean stale metadata after authority is already lost", async () => {
+    const runtimeDir = createRuntimeDir();
+    const env = { ...process.env, XDG_RUNTIME_DIR: runtimeDir };
+    const paths = resolveSessionBrokerRuntimePaths(testConfig, env);
+    mkdirSync(paths.runtimeDir, { recursive: true });
+    writeFileSync(
+      paths.metadataPath,
+      JSON.stringify({
+        pid: 999999,
+        host: testConfig.host,
+        port: testConfig.port,
+        command: "/fixture/hunk",
+        args: ["daemon", "serve"],
+        launchedAt: new Date(0).toISOString(),
+        launchedByPid: 999999,
+        launchCwd: "/fixture",
+      }),
+    );
+
+    await ensureSessionBrokerAvailable({
+      config: testConfig,
+      env,
+      isCommitAuthorized: () => false,
+    });
+    expect(existsSync(paths.metadataPath)).toBe(true);
   });
 
   test("recovers a stale launch lock from a dead launcher and overwrites stale metadata", async () => {

--- a/src/session/broker/brokerLauncher.ts
+++ b/src/session/broker/brokerLauncher.ts
@@ -65,6 +65,8 @@ export interface EnsureSessionBrokerAvailableOptions {
   lockStaleMs?: number;
   timeoutMessage?: string;
   lifecycleClock?: SessionBrokerLifecycleClock;
+  /** Fence commits when the caller's exact lifecycle attempt no longer owns the result. */
+  isCommitAuthorized?: () => boolean;
   isHealthy?: (config: ResolvedSessionBrokerConfig) => Promise<boolean>;
   isPortReachable?: (
     config: Pick<ResolvedSessionBrokerConfig, "host" | "port">,
@@ -231,7 +233,12 @@ function tryAcquireDaemonLaunchLock({
         const stat = statSync(paths.lockPath);
         if (lifecycleClock.now() - stat.mtimeMs > staleAfterMs) {
           removeFileIfPresent(paths.lockPath);
-          return tryAcquireDaemonLaunchLock({ config, env, staleAfterMs, lifecycleClock });
+          return tryAcquireDaemonLaunchLock({
+            config,
+            env,
+            staleAfterMs,
+            lifecycleClock,
+          });
         }
       } catch {
         // Ignore racing readers while another process still owns the lock.
@@ -245,7 +252,12 @@ function tryAcquireDaemonLaunchLock({
 
   if (!ownerAlive) {
     removeFileIfPresent(paths.lockPath);
-    return tryAcquireDaemonLaunchLock({ config, env, staleAfterMs, lifecycleClock });
+    return tryAcquireDaemonLaunchLock({
+      config,
+      env,
+      staleAfterMs,
+      lifecycleClock,
+    });
   }
 
   return null;
@@ -279,30 +291,66 @@ function daemonStartupTimeoutError(
   );
 }
 
+type ForeignSettlement<T> = { current: true; value: T } | { current: false };
+
+/** Invoke synchronous foreign work and refuse values or errors after commit authority changes. */
+function settleForeignCall<T>(
+  work: () => T,
+  isCommitAuthorized: () => boolean,
+): ForeignSettlement<T> {
+  try {
+    const value = work();
+    return isCommitAuthorized() ? { current: true, value } : { current: false };
+  } catch (error) {
+    if (!isCommitAuthorized()) return { current: false };
+    throw error;
+  }
+}
+
+/** Invoke asynchronous foreign work and refuse both late values and errors after authority changes. */
+async function settleForeignWork<T>(
+  work: () => Promise<T>,
+  isCommitAuthorized: () => boolean,
+): Promise<ForeignSettlement<T>> {
+  try {
+    const value = await work();
+    return isCommitAuthorized() ? { current: true, value } : { current: false };
+  } catch (error) {
+    if (!isCommitAuthorized()) return { current: false };
+    throw error;
+  }
+}
+
 async function waitForDaemonHealthWithCheck({
   config,
   timeoutMs,
   intervalMs,
   lifecycleClock,
   isHealthy,
+  isCommitAuthorized,
 }: {
   config: ResolvedSessionBrokerConfig;
   timeoutMs: number;
   intervalMs: number;
   lifecycleClock: SessionBrokerLifecycleClock;
   isHealthy: (config: ResolvedSessionBrokerConfig) => Promise<boolean>;
-}) {
+  isCommitAuthorized: () => boolean;
+}): Promise<"ready" | "timeout" | "stale"> {
   const deadline = lifecycleClock.now() + timeoutMs;
 
-  while (lifecycleClock.now() < deadline) {
-    if (await isHealthy(config)) {
-      return true;
-    }
+  while (isCommitAuthorized() && lifecycleClock.now() < deadline) {
+    const health = await settleForeignWork(() => isHealthy(config), isCommitAuthorized);
+    if (!health.current) return "stale";
+    if (health.value) return "ready";
 
-    await lifecycleClock.delay(intervalMs);
+    const delay = await settleForeignWork(
+      () => lifecycleClock.delay(intervalMs),
+      isCommitAuthorized,
+    );
+    if (!delay.current) return "stale";
   }
 
-  return false;
+  return isCommitAuthorized() ? "timeout" : "stale";
 }
 
 /** Resolve how the current process should launch a sibling `daemon serve` process. */
@@ -545,20 +593,21 @@ export async function ensureSessionBrokerAvailable({
   lockStaleMs = DEFAULT_DAEMON_LOCK_STALE_MS,
   timeoutMessage,
   lifecycleClock = createNativeSessionBrokerLifecycleClock(),
+  isCommitAuthorized = () => true,
   isHealthy = (resolvedConfig) => isSessionBrokerHealthy(resolvedConfig),
   isPortReachable = isLoopbackPortReachable,
   launchDaemon = launchSessionBrokerDaemon,
 }: EnsureSessionBrokerAvailableOptions = {}) {
+  if (!isCommitAuthorized()) return;
   const paths = resolveSessionBrokerRuntimePaths(config, env);
   cleanStaleDaemonMetadata(paths);
 
-  if (await isHealthy(config)) {
-    return;
-  }
+  const initialHealth = await settleForeignWork(() => isHealthy(config), isCommitAuthorized);
+  if (!initialHealth.current || initialHealth.value) return;
 
   const deadline = lifecycleClock.now() + timeoutMs;
 
-  while (lifecycleClock.now() < deadline) {
+  while (isCommitAuthorized() && lifecycleClock.now() < deadline) {
     const lock = tryAcquireDaemonLaunchLock({
       config,
       env,
@@ -568,15 +617,25 @@ export async function ensureSessionBrokerAvailable({
 
     if (lock) {
       try {
+        if (!isCommitAuthorized()) return;
         cleanStaleDaemonMetadata(paths);
-        if (await isHealthy(config)) {
-          return;
-        }
+        const protectedHealth = await settleForeignWork(
+          () => isHealthy(config),
+          isCommitAuthorized,
+        );
+        if (!protectedHealth.current || protectedHealth.value) return;
 
+        if (!isCommitAuthorized()) return;
         const launchCommand = resolveDaemonLaunchCommand(argv, execPath);
-        const child = launchDaemon({ cwd, env, argv, execPath });
+        const launched = settleForeignCall(
+          () => launchDaemon({ cwd, env, argv, execPath }),
+          isCommitAuthorized,
+        );
+        // A callback may have already spawned a detached child before revoking authority. That
+        // process cannot be recalled; fencing suppresses only metadata and later lifecycle commits.
+        if (!launched.current) return;
         writeDaemonLaunchMetadata(paths, {
-          pid: child.pid ?? 0,
+          pid: launched.value.pid ?? 0,
           host: config.host,
           port: config.port,
           command: launchCommand.command,
@@ -592,19 +651,18 @@ export async function ensureSessionBrokerAvailable({
           intervalMs,
           lifecycleClock,
           isHealthy,
+          isCommitAuthorized,
         });
-        if (ready) {
-          return;
-        }
+        if (ready === "ready" || ready === "stale") return;
       } finally {
+        // Lock ownership is synchronous and must be released even when foreign work settles stale.
         lock.release();
       }
     }
 
+    if (!isCommitAuthorized()) return;
     const remainingMs = deadline - lifecycleClock.now();
-    if (remainingMs <= 0) {
-      break;
-    }
+    if (remainingMs <= 0) break;
 
     const ready = await waitForDaemonHealthWithCheck({
       config,
@@ -612,17 +670,19 @@ export async function ensureSessionBrokerAvailable({
       intervalMs,
       lifecycleClock,
       isHealthy,
+      isCommitAuthorized,
     });
-    if (ready) {
-      return;
-    }
+    if (ready === "ready" || ready === "stale") return;
 
+    if (!isCommitAuthorized()) return;
     cleanStaleDaemonMetadata(paths);
   }
 
-  if (await isPortReachable(config)) {
-    throw daemonPortConflictError(config);
-  }
+  if (!isCommitAuthorized()) return;
+  const portReachable = await settleForeignWork(() => isPortReachable(config), isCommitAuthorized);
+  if (!portReachable.current) return;
+  if (portReachable.value) throw daemonPortConflictError(config);
 
+  if (!isCommitAuthorized()) return;
   throw daemonStartupTimeoutError(config, timeoutMessage);
 }


### PR DESCRIPTION
## Summary

- add exact opaque generation identities across socket callbacks, authentication, reconnect preparation, timers, warnings, and command delivery
- fence late startup credentials, daemon checks, incumbent probes, launcher probes, and metadata commits after stop or replacement
- publish startup attempt identity inside the explicit lifecycle union before invoking foreign work
- retire protocol authority before close settles, including close failures and handshake deadlines
- preserve foreign bridge work and reservations until settlement while fencing stale response delivery
- make registration replacement coherent when serialization synchronously rotates generations
- fence both synchronous and asynchronous injected launcher results/errors while retaining lock release
- centralize generation-owned handshake disposal and queue-pressure rejection without changing throw/order semantics

## Stack

1. #949 — lifecycle characterization
2. #950 — synchronous socket-start rollback
3. #952 — explicit startup lifecycle states
4. #953 — plain TypeScript lifecycle clock
5. **This PR:** late-settlement and generation fences
6. Next: real Node/Bun runtime exit fixtures
7. Then: bounded lifecycle defect reporting

Base branch: `refactor/session-lifecycle-clock`. Review only the fifth commit for this PR.

## Validation

- focused lifecycle suites — 94 pass
- full direct unit suite — 2,205 pass, 3 skip during the final fix sequence
- `bun run typecheck`
- changed-file formatting and diff checks
- `bun run lint`
- `bun run deps:check`
- `bun run test:session-broker-node` — 3 pass
- `bun run check:pack`
- five adversarial review/fix rounds covering construction reentrancy, stale reconnect timers, opaque tokens, close failures, parser and serialization reentrancy, startup stop reentrancy, launcher sync/async errors, outbound delivery, reconnect factory failure, and transactional replacement
- final independent acceptance review approved with no blocker/high/medium findings

## Cancellation boundary

This PR fences commits; it does not claim cancellation. Foreign credential/crypto/probe/bridge promises continue until they settle. A detached process already synchronously started by an injected launcher cannot be recalled; stale metadata and cleanup commits are suppressed and launch locks are still released.

## Compatibility

- initial socket construction and explicit public startup failures remain synchronous
- callbacks receive a frozen opaque generation token; callbacks that ignore the new trailing parameter remain source-compatible
- socket factories must return a fresh object per generation because property-handler sockets cannot safely distinguish queued events after object reuse
- no protocol, authentication transcript, stored-state, or delivery replay migration

*This PR description was generated by Pi using gpt-5.6-sol*

