### PR TITLE
fix(session): bound lifecycle defects

### DIFF
--- a/.changeset/fixed-brokers-retire.md
+++ b/.changeset/fixed-brokers-retire.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Contain unexpected session broker lifecycle failures behind one fixed, redacted user-visible message.

--- a/packages/session-broker/README.md
+++ b/packages/session-broker/README.md
@@ -210,6 +210,12 @@ callbacks receive a frozen opaque generation token; after foreign work settles, 
 commits only: they do not cancel foreign promises, cryptography, probes, or other work already in
 progress.
 
+Unexpected defects in connection-owned native callbacks, scheduled work, or fire-and-forget work
+terminally retire that connection. Applications may supply `onDefect` to observe the event. The
+callback receives only `SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE`; thrown values and lifecycle data
+are never forwarded, the callback runs at most once, and callback failures are contained. This
+runtime-neutral package does not write defect reports to process output.
+
 The helper owns:
 
 - initial `register`

--- a/packages/session-broker/src/connection.test.ts
+++ b/packages/session-broker/src/connection.test.ts
@@ -10,7 +10,11 @@ import {
   SESSION_BROKER_SIGNATURE_ALGORITHM,
 } from "@hunk/session-broker-core";
 import { SessionBrokerAuthenticator } from "./authentication";
-import { createSessionBrokerConnection, type SessionBrokerConnection } from "./connection";
+import {
+  SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE,
+  createSessionBrokerConnection,
+  type SessionBrokerConnection,
+} from "./connection";
 import { webSessionBrokerCrypto } from "./crypto";
 import { createSessionBrokerProtocolParsers } from "./protocolParsers";
 import type { SessionBrokerSocketLike } from "./types";
@@ -37,6 +41,7 @@ class TestSocket implements SessionBrokerSocketLike {
   readyState = 0;
   sent: string[] = [];
   throwOnSend = false;
+  throwOnNextSend: unknown = null;
   lastClose: { code?: number; reason?: string } | null = null;
   onopen: (() => void) | null = null;
   onmessage: ((event: { data: unknown }) => void) | null = null;
@@ -45,6 +50,11 @@ class TestSocket implements SessionBrokerSocketLike {
 
   send(data: string) {
     if (this.throwOnSend) throw new Error("socket exploded");
+    if (this.throwOnNextSend !== null) {
+      const error = this.throwOnNextSend;
+      this.throwOnNextSend = null;
+      throw error;
+    }
     this.sent.push(data);
   }
 
@@ -72,6 +82,24 @@ class TestSocket implements SessionBrokerSocketLike {
 class DeferredCloseSocketTest extends TestSocket {
   override close(code?: number, reason?: string) {
     this.lastClose = { code, reason };
+  }
+}
+
+/** Throw from selected one-shot schedules while retaining deterministic retry time. */
+class ThrowingScheduleClockTest extends DeterministicLifecycleClockTest {
+  scheduleCalls = 0;
+
+  constructor(
+    private readonly throwOnScheduleCall: number,
+    private readonly thrownValue: unknown,
+  ) {
+    super();
+  }
+
+  override schedule(callback: () => void, delayMs: number) {
+    this.scheduleCalls += 1;
+    if (this.scheduleCalls === this.throwOnScheduleCall) throw this.thrownValue;
+    return super.schedule(callback, delayMs);
   }
 }
 
@@ -103,6 +131,33 @@ function createSnapshot(): SessionSnapshot<TestSessionState> {
   return {
     updatedAt: "2026-04-15T00:00:00.000Z",
     state: { selectedIndex: 0 },
+  };
+}
+
+/** Create one valid producer authentication setup for lifecycle-only connection tests. */
+async function createProducerAuthenticationTest() {
+  const pair = (await crypto.subtle.generateKey("Ed25519", false, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const grant: ProducerGrant = {
+    kind: "producer",
+    appId: "dev.example",
+    principalId: "producer-1",
+    keyId: "producer-key-1",
+    grantId: "producer-grant-1",
+    algorithm: SESSION_BROKER_SIGNATURE_ALGORITHM,
+    issuedAt: Date.now() - 1_000,
+    expiresAt: Date.now() + 60_000,
+    revocationId: "producer-revocation-1",
+    mayDelegate: false,
+    operations: ["register"],
+  };
+  return {
+    appId: "dev.example",
+    appRevision: 1,
+    credential: { grant, privateKey: pair.privateKey },
+    daemon: { keyId: "daemon-key-1", publicKey: pair.publicKey },
   };
 }
 
@@ -283,6 +338,405 @@ describe("session broker connection", () => {
     expect(clock.pendingCountTest()).toBe(0);
   });
 
+  test("contains a heartbeat defect once and terminally retires its timer", () => {
+    const clock = new DeterministicLifecycleClockTest();
+    const socket = new TestSocket();
+    const defectMessages: string[] = [];
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      heartbeatIntervalMs: 10,
+      lifecycleClock: clock,
+      onDefect: (message) => defectMessages.push(message),
+    });
+
+    connection.start();
+    socket.emitOpen();
+    socket.throwOnSend = true;
+
+    expect(() => clock.advanceByTest(10)).not.toThrow();
+    expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    expect(clock.pendingCountTest()).toBe(0);
+    expect(() => clock.advanceByTest(100)).not.toThrow();
+    expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    connection.start();
+    expect(clock.pendingCountTest()).toBe(0);
+  });
+
+  test("observes async lifecycle callbacks and contains an async defect sink", async () => {
+    const callbackMarker = `connected-${crypto.randomUUID()}`;
+    const sinkMarker = `sink-${crypto.randomUUID()}`;
+    const socket = new TestSocket();
+    const defectMessages: string[] = [];
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      const connection = createSessionBrokerConnection({
+        url: "ws://broker.test/session",
+        createSocket: () => socket,
+        registration: createRegistration(),
+        snapshot: createSnapshot(),
+        protocolParsers,
+        onConnected: async () => {
+          throw new Error(callbackMarker);
+        },
+        onDefect: async (message) => {
+          defectMessages.push(message);
+          throw new Error(sinkMarker);
+        },
+      });
+
+      connection.start();
+      socket.emitOpen();
+      await Bun.sleep(10);
+      connection.start();
+
+      expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+      expect(unhandledRejections).toEqual([]);
+      expect(JSON.stringify({ defectMessages, sent: socket.sent })).not.toContain(callbackMarker);
+      expect(JSON.stringify({ defectMessages, sent: socket.sent })).not.toContain(sinkMarker);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  test("contains a successful command-result transport defect without exposing it", async () => {
+    const marker = `result-send-${crypto.randomUUID()}`;
+    const socket = new TestSocket();
+    const defectMessages: string[] = [];
+    const capturedConsole: unknown[][] = [];
+    const capturedStdout: unknown[][] = [];
+    const capturedStderr: unknown[][] = [];
+    const originalConsoleError = console.error;
+    const originalStdoutWrite = process.stdout.write;
+    const originalStderrWrite = process.stderr.write;
+    let factoryCalls = 0;
+    let dispatches = 0;
+    const connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        factoryCalls += 1;
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      bridge: {
+        dispatchCommand: async () => {
+          dispatches += 1;
+          return { ok: true };
+        },
+      },
+      onDefect: (message) => defectMessages.push(message),
+    });
+
+    console.error = (...args: unknown[]) => capturedConsole.push(args);
+    process.stdout.write = ((...args: unknown[]) => {
+      capturedStdout.push(args);
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((...args: unknown[]) => {
+      capturedStderr.push(args);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      connection.start();
+      socket.emitOpen();
+      socket.throwOnNextSend = new Error(marker);
+      socket.emitMessage(
+        JSON.stringify({
+          type: "command",
+          requestId: "request-sensitive-send",
+          command: "annotate",
+          input: { summary: "review" },
+        }),
+      );
+      socket.emitMessage(
+        JSON.stringify({
+          type: "command",
+          requestId: "request-queued-before-defect",
+          command: "annotate",
+          input: { summary: "must not dispatch" },
+        }),
+      );
+      await Bun.sleep(0);
+
+      socket.emitMessage(
+        JSON.stringify({
+          type: "command",
+          requestId: "request-after-defect",
+          command: "annotate",
+          input: { summary: "ignored" },
+        }),
+      );
+      connection.start();
+      await Bun.sleep(0);
+    } finally {
+      console.error = originalConsoleError;
+      process.stdout.write = originalStdoutWrite;
+      process.stderr.write = originalStderrWrite;
+    }
+
+    expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    expect({ dispatches, factoryCalls }).toEqual({ dispatches: 1, factoryCalls: 1 });
+    expect(socket.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
+    expect(capturedConsole).toEqual([]);
+    expect(capturedStdout).toEqual([]);
+    expect(capturedStderr).toEqual([]);
+    expect(
+      JSON.stringify({
+        defectMessages,
+        sent: socket.sent,
+        close: socket.lastClose,
+        registration: connection.getRegistration(),
+        capturedConsole,
+        capturedStdout,
+        capturedStderr,
+      }),
+    ).not.toContain(marker);
+  });
+
+  test("contains an error command-result transport defect outside bridge rejection handling", async () => {
+    const bridgeMarker = `bridge-error-${crypto.randomUUID()}`;
+    const transportMarker = `error-send-${crypto.randomUUID()}`;
+    const socket = new TestSocket();
+    const defectMessages: string[] = [];
+    let dispatches = 0;
+    const connection = createSessionBrokerConnection<
+      TestSessionInfo,
+      TestSessionState,
+      TestSocket,
+      TestServerMessage,
+      { ok: true }
+    >({
+      url: "ws://broker.test/session",
+      createSocket: () => socket,
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      bridge: {
+        dispatchCommand: async () => {
+          dispatches += 1;
+          throw new Error(bridgeMarker);
+        },
+      },
+      onDefect: (message) => defectMessages.push(message),
+    });
+
+    connection.start();
+    socket.emitOpen();
+    socket.throwOnNextSend = new Error(transportMarker);
+    socket.emitMessage(
+      JSON.stringify({
+        type: "command",
+        requestId: "request-error-send",
+        command: "annotate",
+        input: { summary: "review" },
+      }),
+    );
+    await Bun.sleep(0);
+
+    expect(dispatches).toBe(1);
+    expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    expect(socket.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
+    const observable = JSON.stringify({
+      defectMessages,
+      sent: socket.sent,
+      close: socket.lastClose,
+      registration: connection.getRegistration(),
+    });
+    expect(observable).not.toContain(bridgeMarker);
+    expect(observable).not.toContain(transportMarker);
+  });
+
+  test("contains direct authenticated handshake scheduling failure after socket commit", async () => {
+    const marker = `direct-handshake-clock-${crypto.randomUUID()}`;
+    const clock = new ThrowingScheduleClockTest(1, new Error(marker));
+    const sockets: TestSocket[] = [];
+    const defectMessages: string[] = [];
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      producerAuthentication: await createProducerAuthenticationTest(),
+      lifecycleClock: clock,
+      onDefect: (message) => defectMessages.push(message),
+    });
+
+    expect(() => connection.start()).not.toThrow();
+    expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]).toMatchObject({
+      onopen: null,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      lastClose: { code: undefined, reason: undefined },
+    });
+    expect(clock.pendingCountTest()).toBe(0);
+    connection.start();
+    expect(sockets).toHaveLength(1);
+    expect(JSON.stringify({ defectMessages, socket: sockets[0] })).not.toContain(marker);
+  });
+
+  test("contains authenticated handshake scheduling failure during natural reconnect", async () => {
+    const marker = `reconnect-handshake-clock-${crypto.randomUUID()}`;
+    const clock = new ThrowingScheduleClockTest(3, new Error(marker));
+    const sockets: TestSocket[] = [];
+    const defectMessages: string[] = [];
+    const connection = createSessionBrokerConnection({
+      url: "ws://broker.test/session",
+      createSocket: () => {
+        const socket = new TestSocket();
+        sockets.push(socket);
+        return socket;
+      },
+      registration: createRegistration(),
+      snapshot: createSnapshot(),
+      protocolParsers,
+      producerAuthentication: await createProducerAuthenticationTest(),
+      reconnectDelayMs: 10,
+      lifecycleClock: clock,
+      onDefect: (message) => defectMessages.push(message),
+    });
+
+    connection.start();
+    sockets[0]!.emitClose();
+    expect(clock.pendingCountTest()).toBe(1);
+    await clock.advanceByTestAsync(10);
+
+    expect(clock.scheduleCalls).toBe(3);
+    expect(clock.pendingCountTest()).toBe(0);
+    expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    expect(sockets).toHaveLength(2);
+    expect(sockets[1]).toMatchObject({
+      onopen: null,
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      lastClose: { code: undefined, reason: undefined },
+    });
+    connection.start();
+    expect(sockets).toHaveLength(2);
+    expect(JSON.stringify({ defectMessages, sockets })).not.toContain(marker);
+  });
+
+  test("redacts callback defects, contains its sink, and performs no package output", () => {
+    const sinkMarker = `sink-${crypto.randomUUID()}`;
+    const markers = Array.from({ length: 4 }, () => crypto.randomUUID());
+    let getterReads = 0;
+    let stringifications = 0;
+    const thrownValues: unknown[] = [
+      new Error(markers[0]),
+      markers[1],
+      { marker: markers[2] },
+      {
+        get marker() {
+          getterReads += 1;
+          return markers[3];
+        },
+        toString() {
+          stringifications += 1;
+          return markers[3];
+        },
+      },
+    ];
+    const hookArguments: unknown[][] = [];
+    const capturedConsole: unknown[][] = [];
+    const capturedStdout: unknown[][] = [];
+    const capturedStderr: unknown[][] = [];
+    const escaped: unknown[] = [];
+    const registrations: string[] = [];
+    const originalConsoleError = console.error;
+    const originalStdoutWrite = process.stdout.write;
+    const originalStderrWrite = process.stderr.write;
+
+    console.error = (...args: unknown[]) => capturedConsole.push(args);
+    process.stdout.write = ((...args: unknown[]) => {
+      capturedStdout.push(args);
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((...args: unknown[]) => {
+      capturedStderr.push(args);
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      for (const thrownValue of thrownValues) {
+        const clock = new DeterministicLifecycleClockTest();
+        const socket = new TestSocket();
+        const connection = createSessionBrokerConnection({
+          url: "ws://broker.test/session",
+          createSocket: () => socket,
+          registration: createRegistration(),
+          snapshot: createSnapshot(),
+          protocolParsers,
+          reconnectDelayMs: 10,
+          lifecycleClock: clock,
+          resolveClose: () => {
+            throw thrownValue;
+          },
+          onDefect: (...args) => {
+            hookArguments.push(args);
+            throw new Error(sinkMarker);
+          },
+        });
+
+        connection.start();
+        socket.emitOpen();
+        try {
+          socket.emitClose(1008, "close-policy");
+        } catch (error) {
+          escaped.push(error);
+        }
+        registrations.push(JSON.stringify(connection.getRegistration()));
+        clock.advanceByTest(100);
+        socket.emitClose(1008, "late-close");
+        connection.start();
+
+        expect(clock.pendingCountTest()).toBe(0);
+      }
+    } finally {
+      console.error = originalConsoleError;
+      process.stdout.write = originalStdoutWrite;
+      process.stderr.write = originalStderrWrite;
+    }
+
+    expect(hookArguments).toEqual(
+      thrownValues.map(() => [SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]),
+    );
+    expect(capturedConsole).toEqual([]);
+    expect(capturedStdout).toEqual([]);
+    expect(capturedStderr).toEqual([]);
+    expect(escaped).toEqual([]);
+    expect(getterReads).toBe(0);
+    expect(stringifications).toBe(0);
+    const observableText = JSON.stringify({
+      hookArguments,
+      capturedConsole,
+      capturedStdout,
+      capturedStderr,
+      escaped,
+      registrations,
+    });
+    for (const marker of [...markers, sinkMarker]) expect(observableText).not.toContain(marker);
+  });
+
   test("uses a delayed fixed-rate heartbeat and disposes it on stop", () => {
     const clock = new DeterministicLifecycleClockTest();
     const socket = new TestSocket();
@@ -434,6 +888,7 @@ describe("session broker connection", () => {
   test("preserves a synchronous socket factory throw and permits a later direct start", () => {
     const sockets: TestSocket[] = [];
     const startupFailure = { source: "socket factory" };
+    const defectMessages: string[] = [];
     let attempts = 0;
     const connection = createSessionBrokerConnection<
       TestSessionInfo,
@@ -453,6 +908,7 @@ describe("session broker connection", () => {
       registration: createRegistration(),
       snapshot: createSnapshot(),
       protocolParsers,
+      onDefect: (message) => defectMessages.push(message),
     });
 
     let thrown: unknown;
@@ -464,6 +920,7 @@ describe("session broker connection", () => {
     expect(thrown).toBe(startupFailure);
     expect(attempts).toBe(1);
     expect(sockets).toHaveLength(0);
+    expect(defectMessages).toEqual([]);
 
     connection.start();
     sockets[0]!.emitOpen();
@@ -585,8 +1042,8 @@ describe("session broker connection", () => {
 
     connection.start();
     socket.emitOpen();
-    expect(() => socket.emitMessage("{")).toThrow("socket close exploded");
-    expect(socket.closeAttempts).toBe(1);
+    expect(() => socket.emitMessage("{")).not.toThrow();
+    expect(socket.closeAttempts).toBe(2);
     const sentBeforeLateCommand = socket.sent.length;
 
     socket.emitMessage(
@@ -599,7 +1056,7 @@ describe("session broker connection", () => {
     );
     expect(dispatches).toBe(0);
     expect(socket.sent).toHaveLength(sentBeforeLateCommand);
-    expect(socket.closeAttempts).toBe(1);
+    expect(socket.closeAttempts).toBe(2);
 
     socket.failClose = false;
     socket.onerror?.();
@@ -661,10 +1118,8 @@ describe("session broker connection", () => {
       helloInit.hello,
       "ws://broker.test/session",
     );
-    expect(() => clock.advanceByTest(connection.limits.maxHandshakeDurationMs)).toThrow(
-      "socket close exploded",
-    );
-    expect(socket.closeAttempts).toBe(1);
+    expect(() => clock.advanceByTest(connection.limits.maxHandshakeDurationMs)).not.toThrow();
+    expect(socket.closeAttempts).toBe(2);
 
     socket.emitMessage(JSON.stringify({ type: "hello-challenge", challenge }));
     await clock.flushMicrotasksTest();
@@ -1170,30 +1625,8 @@ describe("session broker connection", () => {
   });
 
   test("closes malformed and mismatched commands without invoking the bridge", async () => {
-    const socket = new TestSocket();
     let dispatched = 0;
-    const connection = createSessionBrokerConnection<
-      TestSessionInfo,
-      TestSessionState,
-      TestSocket,
-      TestServerMessage,
-      { ok: true }
-    >({
-      url: "ws://broker.test/session",
-      createSocket: () => socket,
-      registration: createRegistration(),
-      snapshot: createSnapshot(),
-      protocolParsers,
-      bridge: {
-        dispatchCommand: async () => {
-          dispatched += 1;
-          return { ok: true };
-        },
-      },
-      reconnectDelayMs: 1_000,
-    });
-    connection.start();
-    socket.emitOpen();
+    const defectMessages: string[] = [];
 
     for (const message of [
       null,
@@ -1211,16 +1644,41 @@ describe("session broker connection", () => {
         input: { summary: "note", extra: true },
       },
     ]) {
-      socket.readyState = 1;
+      const socket = new TestSocket();
+      const connection = createSessionBrokerConnection<
+        TestSessionInfo,
+        TestSessionState,
+        TestSocket,
+        TestServerMessage,
+        { ok: true }
+      >({
+        url: "ws://broker.test/session",
+        createSocket: () => socket,
+        registration: createRegistration(),
+        snapshot: createSnapshot(),
+        protocolParsers,
+        bridge: {
+          dispatchCommand: async () => {
+            dispatched += 1;
+            return { ok: true };
+          },
+        },
+        reconnectDelayMs: 1_000,
+        onDefect: (defect) => defectMessages.push(defect),
+      });
+      connection.start();
+      socket.emitOpen();
       socket.emitMessage(JSON.stringify(message));
       expect(socket.lastClose).toEqual({
         code: 1008,
         reason: "Malformed session broker command.",
       });
+      expect(defectMessages).toEqual([]);
+      connection.stop();
     }
     await Bun.sleep(0);
     expect(dispatched).toBe(0);
-    connection.stop();
+    expect(defectMessages).toEqual([]);
   });
 
   test("enforces text framing and the exact websocket message ceiling before app parsing", async () => {
@@ -1463,6 +1921,97 @@ describe("session broker connection", () => {
     expect(sockets[0]!.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
     expect(sockets[1]!.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
     connection.stop();
+  });
+
+  test("closes post-dispatch result failures without defect reporting or sensitive output", async () => {
+    type AdversarialResult = { ok: true; toJSON?: () => { ok: true } };
+
+    for (const failure of ["measurement", "parser", "serialization"] as const) {
+      const marker = `${failure}-${crypto.randomUUID()}`;
+      let parsedSerializationCalls = 0;
+      const bridgeResult: AdversarialResult =
+        failure === "measurement"
+          ? {
+              ok: true,
+              toJSON: () => {
+                throw new Error(marker);
+              },
+            }
+          : { ok: true };
+      const parsedResult: AdversarialResult =
+        failure === "serialization"
+          ? {
+              ok: true,
+              toJSON: () => {
+                parsedSerializationCalls += 1;
+                if (parsedSerializationCalls === 2) throw new Error(marker);
+                return { ok: true };
+              },
+            }
+          : { ok: true };
+      const adversarialParsers = createSessionBrokerProtocolParsers<
+        TestSessionInfo,
+        TestSessionState,
+        TestServerMessage,
+        AdversarialResult
+      >({
+        appRevision: 1,
+        features: [],
+        parseRegistration: (value) => value as SessionRegistration<TestSessionInfo>,
+        parseSnapshot: (value) => value as SessionSnapshot<TestSessionState>,
+        commands: [
+          {
+            command: "annotate",
+            version: 1,
+            parseInput: (value) => value as { summary: string },
+            parseResult: () => {
+              if (failure === "parser") throw new Error(marker);
+              return parsedResult;
+            },
+          },
+        ],
+      });
+      const socket = new TestSocket();
+      const defectMessages: string[] = [];
+      const connection = createSessionBrokerConnection<
+        TestSessionInfo,
+        TestSessionState,
+        TestSocket,
+        TestServerMessage,
+        AdversarialResult
+      >({
+        url: "ws://broker.test/session",
+        createSocket: () => socket,
+        registration: createRegistration(),
+        snapshot: createSnapshot(),
+        protocolParsers: adversarialParsers,
+        bridge: { dispatchCommand: async () => bridgeResult },
+        onDefect: (message) => defectMessages.push(message),
+      });
+
+      connection.start();
+      socket.emitOpen();
+      socket.emitMessage(
+        JSON.stringify({
+          type: "command",
+          requestId: `request-${failure}`,
+          command: "annotate",
+          input: { summary: "review" },
+        }),
+      );
+      await Bun.sleep(0);
+
+      expect(socket.lastClose).toEqual({
+        code: 1008,
+        reason: "Malformed session broker command result.",
+      });
+      expect(defectMessages).toEqual([]);
+      expect(socket.sent.map((message) => JSON.parse(message).type)).toEqual(["register"]);
+      expect(
+        JSON.stringify({ defectMessages, sent: socket.sent, close: socket.lastClose }),
+      ).not.toContain(marker);
+      connection.stop();
+    }
   });
 
   test("does not send a command result when envelope serialization retires its generation", async () => {
@@ -1959,53 +2508,37 @@ describe("session broker connection", () => {
   });
 
   test("rejects producer hello wrappers with unknown or dangerous keys", async () => {
-    const socket = new TestSocket();
-    const pair = (await crypto.subtle.generateKey("Ed25519", false, [
-      "sign",
-      "verify",
-    ])) as CryptoKeyPair;
-    const grant: ProducerGrant = {
-      kind: "producer",
-      appId: "dev.example",
-      principalId: "producer-1",
-      keyId: "producer-key-1",
-      grantId: "producer-grant-1",
-      algorithm: SESSION_BROKER_SIGNATURE_ALGORITHM,
-      issuedAt: Date.now() - 1_000,
-      expiresAt: Date.now() + 60_000,
-      revocationId: "producer-revocation-1",
-      mayDelegate: false,
-      operations: ["register"],
-    };
-    const connection = createSessionBrokerConnection({
-      url: "ws://broker.test/session",
-      createSocket: () => socket,
-      registration: createRegistration(),
-      snapshot: createSnapshot(),
-      protocolParsers,
-      producerAuthentication: {
-        appId: "dev.example",
-        appRevision: 1,
-        credential: { grant, privateKey: pair.privateKey },
-        daemon: { keyId: "daemon-key-1", publicKey: pair.publicKey },
-      },
-      reconnectDelayMs: 10_000,
-    });
-    connection.start();
-    socket.emitOpen();
+    const producerAuthentication = await createProducerAuthenticationTest();
+    const defectMessages: string[] = [];
 
     for (const message of [
       '{"type":"hello-challenge","challenge":{},"extra":true}',
       '{"type":"hello-challenge","challenge":{},"__proto__":{}}',
     ]) {
-      socket.readyState = 1;
+      const socket = new TestSocket();
+      const connection = createSessionBrokerConnection({
+        url: "ws://broker.test/session",
+        createSocket: () => socket,
+        registration: createRegistration(),
+        snapshot: createSnapshot(),
+        protocolParsers,
+        producerAuthentication,
+        reconnectDelayMs: 10_000,
+        onDefect: (defect) => defectMessages.push(defect),
+      });
+      connection.start();
+      socket.emitOpen();
       socket.emitMessage(message);
+      await Bun.sleep(0);
+
       expect(socket.lastClose).toEqual({
         code: 1008,
         reason: "Session broker authentication failed.",
       });
+      expect(defectMessages).toEqual([]);
+      connection.stop();
     }
-    connection.stop();
+    expect(defectMessages).toEqual([]);
   });
 
   test("retries a transient synchronous socket factory failure during reconnect", async () => {

--- a/packages/session-broker/src/connection.ts
+++ b/packages/session-broker/src/connection.ts
@@ -46,6 +46,9 @@ const DEFAULT_HEARTBEAT_INTERVAL_MS = 10_000;
 const DEFAULT_SOCKET_OPEN_STATE = 1;
 const PRODUCER_COMMAND_OVERHEAD_BYTES = 128;
 
+export const SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE =
+  "Session broker lifecycle failed unexpectedly.";
+
 /** Identifies the exact socket generation that owns one connection callback. */
 export interface SessionBrokerConnectionGeneration {
   readonly id: number;
@@ -130,6 +133,8 @@ export interface SessionBrokerConnectionOptions<
   prepareReconnect?: (generation: SessionBrokerConnectionGeneration) => Promise<void>;
   onConnected?: (generation: SessionBrokerConnectionGeneration) => void;
   onWarning?: (message: string, generation: SessionBrokerConnectionGeneration) => void;
+  /** Observe one terminal lifecycle defect through a fixed, redacted message. */
+  onDefect?: (message: string) => void;
   limits?: SessionBrokerLimitOptions["limits"];
   unsafeLimits?: SessionBrokerLimitOptions["unsafeLimits"];
 }
@@ -161,6 +166,7 @@ export class SessionBrokerConnection<
   private reconnectTimer: ScheduledReconnect<Socket> | null = null;
   private heartbeatTimer: (() => void) | null = null;
   private stopped = false;
+  private lifecycleDefectReported = false;
   private registration: SessionRegistration<Info>;
   private snapshot: SessionSnapshot<State>;
   private pendingSessionReplacement: PendingSessionReplacement<Info, State> | null = null;
@@ -239,7 +245,7 @@ export class SessionBrokerConnection<
 
   setBridge(bridge: SessionBrokerConnectionBridge<ServerMessage, Result> | null) {
     this.bridge = bridge;
-    void this.flushQueuedMessages();
+    this.observeLifecycleWork(this.flushQueuedMessages());
   }
 
   replaceSession(registration: SessionRegistration<Info>, snapshot: SessionSnapshot<State>) {
@@ -332,106 +338,134 @@ export class SessionBrokerConnection<
     this.currentGeneration = generation;
     this.socket = socket;
     if (this.options.producerAuthentication) {
-      const disposeHandshake = this.lifecycleClock.schedule(() => {
-        this.closeGeneration(generation, 1008, "Session broker authentication timed out.");
-      }, this.limits.maxHandshakeDurationMs);
+      let disposeHandshake: () => void;
+      try {
+        disposeHandshake = this.lifecycleClock.schedule(() => {
+          this.runLifecycleCallback(() => {
+            this.closeGeneration(generation, 1008, "Session broker authentication timed out.");
+          });
+        }, this.limits.maxHandshakeDurationMs);
+      } catch {
+        // Construction has already committed this socket generation. A scheduling failure is no
+        // longer a caller-owned factory failure, so retire it through the bounded defect boundary.
+        this.reportLifecycleDefect();
+        return;
+      }
+      if (this.stopped || this.currentGeneration !== generation) {
+        try {
+          disposeHandshake();
+        } catch {
+          this.reportLifecycleDefect();
+        }
+        return;
+      }
       this.handshakeTimers.set(generation, disposeHandshake);
     }
 
     socket.onopen = () => {
-      if (!this.canAuthenticate(generation)) return;
-      if (this.options.producerAuthentication) {
-        const authentication = this.options.producerAuthentication;
-        const request = createSessionBrokerHelloRequest({
-          ...authentication,
-          endpoint: this.options.url,
-        });
-        this.producerHellos.set(generation, { request });
-        socket.send(JSON.stringify({ type: "hello-init", hello: request }));
-        return;
-      }
-      this.activateGeneration(generation);
+      this.runLifecycleCallback(() => {
+        if (!this.canAuthenticate(generation)) return;
+        if (this.options.producerAuthentication) {
+          const authentication = this.options.producerAuthentication;
+          const request = createSessionBrokerHelloRequest({
+            ...authentication,
+            endpoint: this.options.url,
+          });
+          this.producerHellos.set(generation, { request });
+          socket.send(JSON.stringify({ type: "hello-init", hello: request }));
+          return;
+        }
+        this.activateGeneration(generation);
+      });
     };
 
     socket.onmessage = (event) => {
-      if (!this.canReceive(generation)) return;
-      if (typeof event.data !== "string") {
-        this.closeGeneration(generation, 1003, "Session broker accepts text messages only.");
-        return;
-      }
-      if (utf8ByteLength(event.data) > this.limits.maxWsMessageBytes) {
-        this.closeGeneration(generation, 1009, "Message exceeds the session broker size limit.");
-        return;
-      }
-      if (this.options.producerAuthentication && generation.status !== "active") {
-        void this.handleProducerHello(generation, event.data);
-        return;
-      }
-      let parsed: ServerMessage;
-      try {
-        const raw = parseSessionBrokerJsonText(event.data) as {
-          input?: unknown;
-        };
-        if (commandValueBytes(raw?.input) > this.limits.maxCommandInputBytes) {
-          throw new BrokerCapacityError("capacity-exceeded", "maxCommandInputBytes");
+      this.runLifecycleCallback(() => {
+        if (!this.canReceive(generation)) return;
+        if (typeof event.data !== "string") {
+          this.closeGeneration(generation, 1003, "Session broker accepts text messages only.");
+          return;
         }
-        parsed = this.options.protocolParsers.parseServerMessage(raw);
-        if (commandValueBytes(parsed.input) > this.limits.maxCommandInputBytes) {
-          throw new BrokerCapacityError("capacity-exceeded", "maxCommandInputBytes");
+        if (utf8ByteLength(event.data) > this.limits.maxWsMessageBytes) {
+          this.closeGeneration(generation, 1009, "Message exceeds the session broker size limit.");
+          return;
         }
-      } catch {
-        // Never invoke the app bridge after a malformed or mismatched command contract. Closing
-        // prevents this producer from retaining daemon assumptions that were not actually parsed.
-        this.closeGeneration(generation, 1008, "Malformed session broker command.");
-        return;
-      }
+        if (this.options.producerAuthentication && generation.status !== "active") {
+          this.observeLifecycleWork(this.handleProducerHello(generation, event.data));
+          return;
+        }
+        let parsed: ServerMessage;
+        try {
+          const raw = parseSessionBrokerJsonText(event.data) as {
+            input?: unknown;
+          };
+          if (commandValueBytes(raw?.input) > this.limits.maxCommandInputBytes) {
+            throw new BrokerCapacityError("capacity-exceeded", "maxCommandInputBytes");
+          }
+          parsed = this.options.protocolParsers.parseServerMessage(raw);
+          if (commandValueBytes(parsed.input) > this.limits.maxCommandInputBytes) {
+            throw new BrokerCapacityError("capacity-exceeded", "maxCommandInputBytes");
+          }
+        } catch {
+          // Never invoke the app bridge after a malformed or mismatched command contract. Closing
+          // prevents this producer from retaining daemon assumptions that were not actually parsed.
+          this.closeGeneration(generation, 1008, "Malformed session broker command.");
+          return;
+        }
 
-      // App-owned parsers may synchronously stop or replace the connection. Refuse admission after
-      // that authority change so the stale input retains no budget or queue ownership.
-      if (!this.isGenerationActive(generation)) return;
-      void this.handleServerMessage(generation, parsed);
+        // App-owned parsers may synchronously stop or replace the connection. Refuse admission after
+        // that authority change so the stale input retains no budget or queue ownership.
+        if (!this.isGenerationActive(generation)) return;
+        this.observeLifecycleWork(this.handleServerMessage(generation, parsed));
+      });
     };
 
     socket.onclose = (event) => {
-      const wasAuthenticated = generation.authenticated;
-      this.disposeHandshake(generation);
-      const ownsConnection = this.currentGeneration === generation;
-      generation.status = "closed";
-      if (ownsConnection) {
-        this.socket = null;
-        this.stopHeartbeat();
-      }
+      this.runLifecycleCallback(() => {
+        const wasAuthenticated = generation.authenticated;
+        this.disposeHandshake(generation);
+        const ownsConnection = this.currentGeneration === generation;
+        generation.status = "closed";
+        if (ownsConnection) {
+          this.socket = null;
+          this.stopHeartbeat();
+        }
 
-      this.queuedMessages = this.queuedMessages.filter((queued) => {
-        if (queued.generation !== generation) return true;
-        queued.reservation.release();
-        return false;
+        this.queuedMessages = this.queuedMessages.filter((queued) => {
+          if (queued.generation !== generation) return true;
+          queued.reservation.release();
+          return false;
+        });
+        // Executing bridge work retains its reservation until its promise settles. A disconnect
+        // prevents its response from migrating but does not make the retained input or work vanish.
+        if (this.stopped || !ownsConnection || this.currentGeneration !== generation) return;
+
+        const directive = this.options.resolveClose?.(
+          {
+            code: event.code,
+            reason: event.reason,
+            authenticated: wasAuthenticated,
+          },
+          generation.token,
+        ) ?? { reconnect: true };
+        if (directive.warning && this.isGenerationCurrent(generation.token)) {
+          this.observeLifecycleCallbackResult(
+            this.options.onWarning?.(directive.warning, generation.token),
+          );
+        }
+
+        if (directive.reconnect !== false && this.isGenerationCurrent(generation.token)) {
+          this.scheduleReconnect(generation);
+        }
       });
-      // Executing bridge work retains its reservation until its promise settles. A disconnect
-      // prevents its response from migrating but does not make the retained input or work vanish.
-      if (this.stopped || !ownsConnection || this.currentGeneration !== generation) return;
-
-      const directive = this.options.resolveClose?.(
-        {
-          code: event.code,
-          reason: event.reason,
-          authenticated: wasAuthenticated,
-        },
-        generation.token,
-      ) ?? { reconnect: true };
-      if (directive.warning && this.isGenerationCurrent(generation.token)) {
-        this.options.onWarning?.(directive.warning, generation.token);
-      }
-
-      if (directive.reconnect !== false && this.isGenerationCurrent(generation.token)) {
-        this.scheduleReconnect(generation);
-      }
     };
 
     socket.onerror = () => {
-      // Normalize raw socket errors through onclose so reconnect and warning policy stays in one
-      // place instead of splitting behavior across runtime-specific error events.
-      this.closeGeneration(generation);
+      this.runLifecycleCallback(() => {
+        // Normalize raw socket errors through onclose so reconnect and warning policy stays in one
+        // place instead of splitting behavior across runtime-specific error events.
+        this.closeGeneration(generation);
+      });
     };
   }
 
@@ -503,7 +537,7 @@ export class SessionBrokerConnection<
     generation.authenticated = true;
     this.disposeHandshake(generation);
     this.startHeartbeat(generation);
-    this.options.onConnected?.(generation.token);
+    this.observeLifecycleCallbackResult(this.options.onConnected?.(generation.token));
     const replacement = this.pendingSessionReplacement;
     const registration = replacement?.registration ?? this.registration;
     const snapshot = replacement?.snapshot ?? this.snapshot;
@@ -518,12 +552,13 @@ export class SessionBrokerConnection<
     ) {
       replacement.published = true;
     }
-    void this.flushQueuedMessages(generation);
+    this.observeLifecycleWork(this.flushQueuedMessages(generation));
   }
 
   /** Verify the daemon challenge and acknowledgement before registration leaves this process. */
   private async handleProducerHello(generation: ConnectionGeneration<Socket>, message: unknown) {
     const socket = generation.socket;
+    let sendingProof = false;
     let activating = false;
     try {
       if (typeof message === "string" && utf8ByteLength(message) > this.limits.maxWsMessageBytes) {
@@ -548,7 +583,9 @@ export class SessionBrokerConnection<
         );
         if (!this.canAuthenticate(generation)) return;
         hello.pending = pending;
+        sendingProof = true;
         socket.send(JSON.stringify({ type: "hello-proof", proof: pending.proof }));
+        sendingProof = false;
         return;
       }
       if (!hello.pending) throw new Error();
@@ -558,12 +595,11 @@ export class SessionBrokerConnection<
       activating = true;
       this.activateGeneration(generation);
     } catch {
-      if (
-        !this.canAuthenticate(generation) &&
-        !(activating && this.isGenerationActive(generation))
-      ) {
+      if (sendingProof || activating) {
+        this.reportLifecycleDefect();
         return;
       }
+      if (!this.canAuthenticate(generation)) return;
       this.closeGeneration(generation, 1008, "Session broker authentication failed.");
     }
   }
@@ -581,7 +617,7 @@ export class SessionBrokerConnection<
       if (this.reconnectTimer !== scheduled) return;
       this.reconnectTimer = null;
       if (!this.isGenerationCurrent(generation.token)) return;
-      void this.prepareAndReconnect(generation);
+      this.observeLifecycleWork(this.prepareAndReconnect(generation));
     }, delayMs);
     scheduled = { generation, dispose };
     this.reconnectTimer = scheduled;
@@ -614,9 +650,11 @@ export class SessionBrokerConnection<
   /** Warn and retry only while one failed reconnect generation still owns commit authority. */
   private handleReconnectFailure(generation: ConnectionGeneration<Socket>, error: unknown) {
     if (!this.isGenerationCurrent(generation.token)) return;
-    this.options.onWarning?.(
-      error instanceof Error ? error.message : "Session broker reconnect preparation failed.",
-      generation.token,
+    this.observeLifecycleCallbackResult(
+      this.options.onWarning?.(
+        error instanceof Error ? error.message : "Session broker reconnect preparation failed.",
+        generation.token,
+      ),
     );
     if (!this.isGenerationCurrent(generation.token)) return;
     this.scheduleReconnect(generation);
@@ -628,10 +666,12 @@ export class SessionBrokerConnection<
     }
 
     this.heartbeatTimer = this.lifecycleClock.scheduleInterval(() => {
-      if (!this.isGenerationActive(generation)) return;
-      this.send({
-        type: "heartbeat",
-        sessionId: this.registration.sessionId,
+      this.runLifecycleCallback(() => {
+        if (!this.isGenerationActive(generation)) return;
+        this.send({
+          type: "heartbeat",
+          sessionId: this.registration.sessionId,
+        });
       });
     }, this.options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS);
   }
@@ -643,6 +683,87 @@ export class SessionBrokerConnection<
 
     this.heartbeatTimer();
     this.heartbeatTimer = null;
+  }
+
+  /** Contain one native or timer callback failure at the lifecycle owner. */
+  private runLifecycleCallback(callback: () => void) {
+    try {
+      callback();
+    } catch {
+      this.reportLifecycleDefect();
+    }
+  }
+
+  /** Observe fire-and-forget lifecycle work without exposing its rejection. */
+  private observeLifecycleWork(work: Promise<unknown>) {
+    void work.catch(() => this.reportLifecycleDefect());
+  }
+
+  /** Treat a promise returned from a nominally synchronous lifecycle callback as observed work. */
+  private observeLifecycleCallbackResult(result: unknown) {
+    void Promise.resolve(result).catch(() => this.reportLifecycleDefect());
+  }
+
+  /** Retire all lifecycle authority and emit at most one fixed defect notification. */
+  private reportLifecycleDefect() {
+    if (this.stopped || this.lifecycleDefectReported) return;
+    this.lifecycleDefectReported = true;
+    this.stopped = true;
+
+    const reconnectTimer = this.reconnectTimer;
+    this.reconnectTimer = null;
+    try {
+      reconnectTimer?.dispose();
+    } catch {
+      // Defect cleanup is terminal and best effort; observer failures cannot recurse.
+    }
+
+    const heartbeatTimer = this.heartbeatTimer;
+    this.heartbeatTimer = null;
+    try {
+      heartbeatTimer?.();
+    } catch {
+      // Continue retiring the remaining socket and scheduling authority.
+    }
+
+    const handshakeTimers = [...this.handshakeTimers.values()];
+    this.handshakeTimers.clear();
+    for (const dispose of handshakeTimers) {
+      try {
+        dispose();
+      } catch {
+        // Continue retiring every handshake timer after one disposer fails.
+      }
+    }
+
+    for (const entry of this.queuedMessages.splice(0)) {
+      try {
+        entry.reservation.release();
+      } catch {
+        // Internal reservation cleanup cannot weaken terminal lifecycle retirement.
+      }
+    }
+
+    const generation = this.currentGeneration;
+    this.currentGeneration = null;
+    this.socket = null;
+    if (generation) {
+      generation.status = "closed";
+      try {
+        generation.socket.close();
+      } catch {
+        // Socket cleanup cannot escape or trigger a second defect notification.
+      }
+    }
+
+    try {
+      const observerResult = this.options.onDefect?.(SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE);
+      // TypeScript permits async functions where a void callback is expected. Observe that promise
+      // without recursively reporting a defect in the best-effort defect observer itself.
+      void Promise.resolve(observerResult).catch(() => undefined);
+    } catch {
+      // The optional observer is best effort and cannot recursively report its own failure.
+    }
   }
 
   private send(message: SessionClientMessage<Info, State, Result>) {
@@ -721,6 +842,7 @@ export class SessionBrokerConnection<
   private async flushQueuedMessages(generation = this.currentGeneration) {
     if (!this.bridge || !generation || this.draining) return;
     this.draining = true;
+    let failed = false;
     try {
       // Take one command at a time so newly received work joins the same FIFO and a disconnect can
       // prevent every command that has not started from executing on a replacement transport.
@@ -742,14 +864,18 @@ export class SessionBrokerConnection<
           entry.reservation.release();
         }
       }
+    } catch (error) {
+      failed = true;
+      throw error;
     } finally {
       this.draining = false;
       if (
+        !failed &&
         this.bridge &&
         this.currentGeneration &&
         this.queuedMessages.some((entry) => entry.generation === this.currentGeneration)
       ) {
-        void this.flushQueuedMessages(this.currentGeneration);
+        this.observeLifecycleWork(this.flushQueuedMessages(this.currentGeneration));
       }
     }
   }
@@ -761,13 +887,30 @@ export class SessionBrokerConnection<
   ) {
     const bridge = this.bridge;
     if (!bridge) return;
+
+    let result: Result;
     try {
-      const result = await bridge.dispatchCommand(message);
+      result = await bridge.dispatchCommand(message);
+    } catch (error) {
       if (!this.isGenerationActive(generation)) return;
+      // A bridge rejection is an expected command outcome. Serialization and transport remain
+      // outside this catch so their defects cannot be mislabeled or expose the thrown value.
+      this.sendToGeneration(generation, {
+        type: "command-result",
+        requestId: message.requestId,
+        ok: false,
+        error: error instanceof Error ? error.message : "Unknown broker connection error.",
+      });
+      return;
+    }
+
+    if (!this.isGenerationActive(generation)) return;
+    let parsedResult: Result;
+    try {
       if (commandValueBytes(result) > this.limits.maxCommandResultBytes) {
         throw new BrokerProtocolError("invalid-app-payload");
       }
-      const parsedResult = this.options.protocolParsers.parseCommandResult(
+      parsedResult = this.options.protocolParsers.parseCommandResult(
         message.command,
         message.commandVersion ?? 1,
         result,
@@ -775,25 +918,29 @@ export class SessionBrokerConnection<
       if (commandValueBytes(parsedResult) > this.limits.maxCommandResultBytes) {
         throw new BrokerProtocolError("invalid-app-payload");
       }
-      this.sendToGeneration(generation, {
+    } catch {
+      if (!this.isGenerationActive(generation)) return;
+      this.closeGeneration(generation, 1008, "Malformed session broker command result.");
+      return;
+    }
+
+    let serialized: string;
+    try {
+      serialized = JSON.stringify({
         type: "command-result",
         requestId: message.requestId,
         ok: true,
         result: parsedResult,
-      });
-    } catch (error) {
+      } satisfies SessionClientMessage<Info, State, Result>);
+    } catch {
       if (!this.isGenerationActive(generation)) return;
-      if (error instanceof BrokerProtocolError) {
-        this.closeGeneration(generation, 1008, "Malformed session broker command result.");
-        return;
-      }
-      this.sendToGeneration(generation, {
-        type: "command-result",
-        requestId: message.requestId,
-        ok: false,
-        error: error instanceof Error ? error.message : "Unknown broker connection error.",
-      });
+      this.closeGeneration(generation, 1008, "Malformed session broker command result.");
+      return;
     }
+    // App-owned serialization can retire this generation. The transport write itself remains
+    // outside every expected-error catch and therefore rejects to the lifecycle defect observer.
+    if (!this.isGenerationActive(generation)) return;
+    generation.socket.send(serialized);
   }
 }
 

--- a/src/session/broker/brokerClient.test.ts
+++ b/src/session/broker/brokerClient.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../test/helpers/session-daemon-fixtures";
 import { HUNK_SESSION_API_VERSION, HUNK_SESSION_DAEMON_VERSION } from "../protocol";
 import {
+  SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE,
   SessionBroker,
   createSessionBrokerDaemon,
   type SessionBrokerSocketLike,
@@ -41,6 +42,9 @@ let restoreWebSocketObserverTest: (() => void) | null = null;
 type DeepPartialTest<T> = T extends object ? { [Key in keyof T]?: DeepPartialTest<T[Key]> } : T;
 
 interface SessionBrokerConnectionTestDouble {
+  options: {
+    resolveClose?: (...args: unknown[]) => { reconnect?: boolean };
+  };
   start(): void;
   stop(): void;
   updateSnapshot(snapshot: ReturnType<typeof createSnapshot>): void;
@@ -672,6 +676,29 @@ describe("Hunk session daemon client", () => {
       rmSync(runtimeDir, { recursive: true, force: true });
     }
   }, 10_000);
+
+  test("threads only the fixed lifecycle defect message through the generic connection", () => {
+    const webSockets = installWebSocketObserverTest();
+    const defectMessages: string[] = [];
+    const client = new SessionBrokerClient(createRegistration(), createSnapshot(), {
+      onDefect: (message) => defectMessages.push(message),
+    });
+    const config = prepareDirectConnectTest(client);
+
+    try {
+      clientTestAccess(client).connect(config);
+      const connection = clientTestAccess(client).connection;
+      if (!connection?.options) throw new Error("Expected a live connection test owner.");
+      connection.options.resolveClose = () => {
+        throw new Error(`credential-${crypto.randomUUID()}`);
+      };
+      expect(() => webSockets.sockets[0]!.emitClose()).not.toThrow();
+      expect(defectMessages).toEqual([SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]);
+    } finally {
+      client.stop();
+      webSockets.restoreTest();
+    }
+  });
 
   test("threads its lifecycle clock into the generic connection", () => {
     const clock = new DeterministicLifecycleClockTest();

--- a/src/session/broker/brokerClient.ts
+++ b/src/session/broker/brokerClient.ts
@@ -46,10 +46,12 @@ type SessionAppBridge = SessionBrokerConnectionBridge<
   HunkSessionCommandResult
 >;
 
-interface SessionBrokerClientTiming {
+export interface SessionBrokerClientOptions {
   daemonStartupTimeoutMs?: number;
   reconnectDelayMs?: number;
   lifecycleClock?: SessionBrokerLifecycleClock;
+  /** Observe a terminal connection lifecycle defect through the broker's fixed message. */
+  onDefect?: (message: string) => void;
 }
 
 interface ScheduledStartupRetry {
@@ -117,7 +119,7 @@ export class SessionBrokerClient {
   constructor(
     private registration: SessionRegistration<HunkSessionInfo>,
     private snapshot: SessionSnapshot<HunkSessionState>,
-    private timing: SessionBrokerClientTiming = {},
+    private timing: SessionBrokerClientOptions = {},
   ) {
     this.lifecycleClock = timing.lifecycleClock ?? createNativeSessionBrokerLifecycleClock();
   }
@@ -332,6 +334,7 @@ export class SessionBrokerClient {
       onWarning: (message, brokerGeneration) => {
         if (isConnectionCurrent(brokerGeneration)) this.warnUnavailable(message);
       },
+      onDefect: this.timing.onDefect,
     });
 
     this.connectionGeneration = clientGeneration;

--- a/src/session/broker/lifecycleDefect.test.ts
+++ b/src/session/broker/lifecycleDefect.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE } from "@hunk/session-broker";
+import { reportHunkSessionBrokerLifecycleDefect } from "./lifecycleDefect";
+
+describe("Hunk session broker lifecycle defect composition", () => {
+  test("writes only the fixed message even when called with sensitive input", () => {
+    const originalConsoleError = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => calls.push(args);
+    try {
+      reportHunkSessionBrokerLifecycleDefect(`credential-${crypto.randomUUID()}`);
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(calls).toEqual([[SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE]]);
+  });
+});

--- a/src/session/broker/lifecycleDefect.ts
+++ b/src/session/broker/lifecycleDefect.ts
@@ -1,0 +1,6 @@
+import { SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE } from "@hunk/session-broker";
+
+/** Show only the fixed lifecycle-defect message in Hunk's user-visible error console. */
+export function reportHunkSessionBrokerLifecycleDefect(_message: string) {
+  console.error(SESSION_BROKER_LIFECYCLE_DEFECT_MESSAGE);
+}

--- a/src/ui/runInteractiveApp.tsx
+++ b/src/ui/runInteractiveApp.tsx
@@ -22,6 +22,7 @@ import {
   createSessionRegistration,
 } from "../app/session/registration";
 import { SessionBrokerClient } from "../session/broker/brokerClient";
+import { reportHunkSessionBrokerLifecycleDefect } from "../session/broker/lifecycleDefect";
 import { AppHost } from "./AppHost";
 import { disposeHighlightWorker } from "./diff/worker";
 import { retireExtensionLoadResult } from "../extensions/events";
@@ -55,7 +56,7 @@ export async function runInteractiveApp({
   const hostClient = new SessionBrokerClient(
     createSessionRegistration(bootstrap, publication),
     createInitialSessionSnapshot(bootstrap, publication),
-    { lifecycleClock },
+    { lifecycleClock, onDefect: reportHunkSessionBrokerLifecycleDefect },
   );
   hostClient.start();
 


### PR DESCRIPTION
## Summary

- add one terminal lifecycle-defect boundary to the runtime-neutral session connection owner
- expose only `Session broker lifecycle failed unexpectedly.` through an optional bounded `onDefect` callback
- retire socket, handshake, heartbeat, reconnect, and queued-command authority before best-effort cleanup
- observe native callbacks, scheduled callbacks, fire-and-forget work, and promises/thenables returned from nominally synchronous lifecycle callbacks
- contain synchronous and asynchronous defect-sink failures without recursion or unhandled rejection
- keep expected authentication, malformed-wire, bridge-command, reconnect warning, and synchronous public API behavior separate
- compose Hunk's user-visible sink defensively so it ignores callback input and prints only the fixed constant

## Stack

1. #949 — lifecycle characterization
2. #950 — synchronous socket-start rollback
3. #952 — explicit startup lifecycle states
4. #953 — plain TypeScript lifecycle clock
5. #955 — late-settlement and generation fences
6. #956 — real Node/Bun lifecycle exit fixtures
7. **This PR:** bounded lifecycle-defect reporting

Base branch: `test/session-lifecycle-exit-fixtures`. Review only the seventh commit for this PR.

## Security and lifecycle properties

- thrown values, socket events, credentials, URLs, payloads, snapshots, causes, and diagnostics never cross the defect callback
- the runtime-neutral package writes no defect output itself
- callback cardinality is at most once per terminal connection
- throwing cleanup, socket, timer, and sink callbacks cannot weaken terminal retirement
- command-result transport failures are defects, not bridge errors; transport diagnostics cannot be reflected over the protocol
- malformed post-dispatch results close with a fixed protocol reason without defect reporting
- authenticated handshake scheduling failures after socket commit retire the partial generation
- direct socket-factory failures and explicit replacement sends retain their existing synchronous contracts
- already-running foreign bridge promises are not falsely cancelled; their reservations remain owned until settlement and delivery stays generation-fenced

## Validation

- focused connection/client/composition tests — 83 pass
- `bun run test` — 1,791 pass, 2 skip, 0 fail across both official shards
- Bun runtime exit fixture — pass
- real Node suite — 4 pass
- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- source boundaries — 11 pass
- `bun run check:pack`
- scoped formatting and diff checks
- three independent review rounds plus a final async-callback review; fixed command-result transport leakage, partial-generation handshake scheduling failure, ineffective malformed corpora, and async callback/sink unhandled rejections

## Residual classification

Existing actionable reconnect warnings and expected bridge-command error results retain their established details by design. Native Windows was not executed for this patch; subprocess structure remains shell-free and path-portable through the parent fixture PR.

*This PR description was generated by Pi using gpt-5.6-sol*
