### PR TITLE
feat(website): add comparison pages for other diff tools

### DIFF
--- a/.changeset/compare-pages.md
+++ b/.changeset/compare-pages.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Add a `/compare/` section to hunk.dev with head-to-head pages for delta, difftastic, diff-so-fancy, `git diff`, and Plannotator, each also served as Markdown for coding agents.

--- a/scripts/check-comparison-catalog.test.ts
+++ b/scripts/check-comparison-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { BUNDLED_SHIKI_THEME_IDS } from "../src/core/theme/catalog";
-import { COMPARISONS, comparisonUrl } from "../website/src/data/comparisons";
+import { COMPARISONS, COMPARISONS_REVIEWED_ON } from "../website/src/data/comparisons";
 
 /**
  * The hunk.dev comparison catalog, held to the standard the pages claim.
@@ -25,6 +25,7 @@ describe("comparison catalog", () => {
       // and say enough to be useful when lifted away from the page.
       expect(comparison.answer.length).toBeGreaterThan(200);
       expect(comparison.answer).toContain("Hunk");
+      expect(comparison.answer, comparison.slug).toContain(comparison.rival.name);
       expect(comparison.title.length).toBeLessThanOrEqual(70);
       expect(comparison.description.length).toBeLessThanOrEqual(200);
     }
@@ -55,12 +56,34 @@ describe("comparison catalog", () => {
     for (const comparison of COMPARISONS) {
       expect(comparison.faqs.length).toBeGreaterThan(2);
       expect(comparison.sources.length).toBeGreaterThan(1);
-      // At least one source is the other project's own documentation.
+      // At least one source is the other project's own documentation, not just
+      // some absolute URL: a page that cites only hunk.dev has not been checked.
+      const rivalHost = new URL(comparison.rival.url).host;
       expect(
-        comparison.sources.some((source) => source.url.startsWith("http")),
-        comparison.slug,
+        comparison.sources.some((source) => {
+          if (!source.url.startsWith("http")) return false;
+          return new URL(source.url).host === rivalHost;
+        }),
+        `${comparison.slug} cites no source from ${rivalHost}`,
       ).toBe(true);
-      expect(comparisonUrl(comparison)).toBe(`https://hunk.dev/compare/${comparison.slug}/`);
+    }
+  });
+
+  test("names each capability once, so the two products stay comparable", () => {
+    // The structured data publishes these names as properties of both products
+    // and pairs them by position; a duplicate name silently breaks that pairing.
+    for (const comparison of COMPARISONS) {
+      const names = comparison.capabilities.map((row) => row.capability);
+      expect(new Set(names).size, comparison.slug).toBe(names.length);
+    }
+  });
+
+  test("advertises the year it was actually checked", () => {
+    // The title is the one string search results show; a hardcoded year would go
+    // stale on 1 January with nothing to catch it.
+    const year = COMPARISONS_REVIEWED_ON.slice(0, 4);
+    for (const comparison of COMPARISONS) {
+      expect(comparison.title, comparison.slug).toContain(year);
     }
   });
 

--- a/scripts/check-comparison-catalog.test.ts
+++ b/scripts/check-comparison-catalog.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { BUNDLED_SHIKI_THEME_IDS } from "../src/core/theme/catalog";
+import { COMPARISONS, comparisonUrl } from "../website/src/data/comparisons";
+
+/**
+ * The hunk.dev comparison catalog, held to the standard the pages claim.
+ *
+ * These pages make marked claims about other people's projects and tell readers
+ * the marks were checked against those projects' docs. The rules below are the
+ * ones a reader would notice being broken: every page recommends the other tool
+ * for something, every hedged mark explains itself, and nothing quietly loses
+ * its sources.
+ */
+describe("comparison catalog", () => {
+  test("addresses each competitor at the URL people search for", () => {
+    const slugs = COMPARISONS.map((comparison) => comparison.slug);
+
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const slug of slugs) expect(slug).toMatch(/^hunk-vs-[a-z0-9-]+$/);
+  });
+
+  test("leads with an answer that stands on its own", () => {
+    for (const comparison of COMPARISONS) {
+      // Answer engines quote the lead paragraph, so it has to name both tools
+      // and say enough to be useful when lifted away from the page.
+      expect(comparison.answer.length).toBeGreaterThan(200);
+      expect(comparison.answer).toContain("Hunk");
+      expect(comparison.title.length).toBeLessThanOrEqual(70);
+      expect(comparison.description.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  test("recommends the other tool for something on every page", () => {
+    for (const comparison of COMPARISONS) {
+      expect(comparison.pick.hunk.length).toBeGreaterThan(2);
+      expect(comparison.pick.rival.length, comparison.slug).toBeGreaterThan(2);
+
+      // A table Hunk sweeps is marketing, not a comparison.
+      const conceded = comparison.capabilities.filter((row) => row.hunk !== "yes");
+      expect(conceded.length, `${comparison.slug} concedes nothing`).toBeGreaterThan(0);
+    }
+  });
+
+  test("explains every hedged mark instead of leaving a reader guessing", () => {
+    for (const comparison of COMPARISONS) {
+      for (const row of comparison.capabilities) {
+        if (row.hunk === "partial" || row.rival === "partial") {
+          expect(row.note, `${comparison.slug}: ${row.capability}`).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  test("cites where its claims came from", () => {
+    for (const comparison of COMPARISONS) {
+      expect(comparison.faqs.length).toBeGreaterThan(2);
+      expect(comparison.sources.length).toBeGreaterThan(1);
+      // At least one source is the other project's own documentation.
+      expect(
+        comparison.sources.some((source) => source.url.startsWith("http")),
+        comparison.slug,
+      ).toBe(true);
+      expect(comparisonUrl(comparison)).toBe(`https://hunk.dev/compare/${comparison.slug}/`);
+    }
+  });
+
+  test("evaluates themes everywhere, against the real bundled catalog", () => {
+    for (const comparison of COMPARISONS) {
+      const themes = comparison.capabilities.find((row) => row.capability === "Themes");
+
+      expect(themes, `${comparison.slug} does not compare themes`).toBeDefined();
+      // The note cites a count; a hard-coded one would drift silently.
+      expect(themes?.note).toContain(`${BUNDLED_SHIKI_THEME_IDS.length} bundled themes`);
+    }
+  });
+});

--- a/scripts/check-extension-catalog.test.ts
+++ b/scripts/check-extension-catalog.test.ts
@@ -10,7 +10,6 @@ import {
   installCommand,
   ownerOf,
   repositoryUrl,
-  toJsonLdScriptBody,
 } from "../website/src/data/extensions";
 
 /**
@@ -108,14 +107,6 @@ describe("extension directory catalog", () => {
     for (const payload of [undefined, null, {}, { items: "nope" }, { items: [null, 7] }]) {
       expect(indexActivityByRepo(payload).size).toBe(0);
     }
-  });
-
-  test("neutralizes markup when serializing JSON-LD", () => {
-    const body = toJsonLdScriptBody({ name: "</script><img src=x onerror=alert(1)>" });
-
-    // Nothing can close the script element, and the payload is still JSON-LD.
-    expect(body).not.toContain("<");
-    expect(JSON.parse(body)).toEqual({ name: "</script><img src=x onerror=alert(1)>" });
   });
 
   test("phrases repository recency in coarse, human units", () => {

--- a/scripts/check-website-helpers.test.ts
+++ b/scripts/check-website-helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { withInlineCode, withoutInlineCode } from "../website/src/lib/inlineCode";
+import { toJsonLdScriptBody } from "../website/src/lib/jsonLd";
+
+/**
+ * The hunk.dev helpers that turn stored text into markup.
+ *
+ * Both are used with `set:html` or inside a raw `<script>` body, so a mistake
+ * here is an injection rather than a typo. The catalogs they render are
+ * hand-written today and will be generated later, which is exactly when nobody
+ * is re-reading the escaping.
+ */
+describe("JSON-LD serialization", () => {
+  test("neutralizes markup", () => {
+    const body = toJsonLdScriptBody({ name: "</script><img src=x onerror=alert(1)>" });
+
+    // Nothing can close the script element, and the payload is still JSON-LD.
+    expect(body).not.toContain("<");
+    expect(JSON.parse(body)).toEqual({ name: "</script><img src=x onerror=alert(1)>" });
+  });
+});
+
+describe("inline code rendering", () => {
+  test("promotes backtick spans to code elements", () => {
+    expect(withInlineCode("Run `hunk diff` first.")).toBe("Run <code>hunk diff</code> first.");
+    expect(withInlineCode("`a` then `b`")).toBe("<code>a</code> then <code>b</code>");
+  });
+
+  test("escapes markup before adding any of its own", () => {
+    const rendered = withInlineCode('<img src=x onerror=alert(1)> & "quoted"');
+
+    expect(rendered).not.toContain("<img");
+    expect(rendered).toBe("&lt;img src=x onerror=alert(1)&gt; &amp; &quot;quoted&quot;");
+  });
+
+  test("cannot be tricked into emitting an element from inside a code span", () => {
+    // The escape runs first, so a backtick span can only ever contain text.
+    expect(withInlineCode("`<b>bold</b>`")).toBe("<code>&lt;b&gt;bold&lt;/b&gt;</code>");
+  });
+
+  test("leaves an unpaired backtick alone rather than opening an element", () => {
+    expect(withInlineCode("a ` b")).toBe("a ` b");
+  });
+
+  test("strips backticks for contexts that take plain text", () => {
+    expect(withoutInlineCode("Set `core.pager` to `hunk pager`.")).toBe(
+      "Set core.pager to hunk pager.",
+    );
+  });
+});

--- a/scripts/check-website-helpers.test.ts
+++ b/scripts/check-website-helpers.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { COMPARISONS, type Comparison } from "../website/src/data/comparisons";
+import { renderComparisonMarkdown } from "../website/src/lib/comparisonMarkdown";
 import { withInlineCode, withoutInlineCode } from "../website/src/lib/inlineCode";
 import { toJsonLdScriptBody } from "../website/src/lib/jsonLd";
 
@@ -46,5 +48,91 @@ describe("inline code rendering", () => {
     expect(withoutInlineCode("Set `core.pager` to `hunk pager`.")).toBe(
       "Set core.pager to hunk pager.",
     );
+  });
+});
+
+describe("comparison Markdown rendering", () => {
+  /** A minimal entry, so each assertion below is about one property of the renderer. */
+  function testComparison(overrides: Partial<Comparison> = {}): Comparison {
+    return {
+      slug: "hunk-vs-thing",
+      rival: {
+        name: "thing",
+        kind: "a thing",
+        url: "https://example.com/thing",
+        language: "Rust",
+        license: "MIT",
+      },
+      headline: "Hunk vs thing",
+      title: "Hunk vs thing",
+      description: "A description.",
+      keywords: ["hunk vs thing"],
+      summary: "A summary.",
+      answer: "An answer.",
+      pick: { hunk: ["Because."], rival: ["Because not."] },
+      capabilities: [{ capability: "Does | things", hunk: "yes", rival: "no", note: "A | note" }],
+      sections: [{ heading: "A heading", body: ["A paragraph."] }],
+      faqs: [{ question: "Why?", answer: "Because." }],
+      sources: [{ label: "Docs", url: "/docs/" }],
+      ...overrides,
+    };
+  }
+
+  test("escapes characters that would break out of a table cell", () => {
+    const rendered = renderComparisonMarkdown(testComparison());
+
+    // Both the capability and its note share one cell, so both need escaping.
+    expect(rendered).toContain("| Does \\| things — A \\| note | Yes | No |");
+  });
+
+  test("neutralizes markup that reaches a cell", () => {
+    const rendered = renderComparisonMarkdown(
+      testComparison({
+        capabilities: [{ capability: "<img src=x onerror=alert(1)>", hunk: "yes", rival: "no" }],
+      }),
+    );
+
+    expect(rendered).not.toContain("<img");
+    expect(rendered).toContain("&lt;img src=x onerror=alert(1)>");
+  });
+
+  test("absolutizes site-relative sources and leaves external ones alone", () => {
+    const rendered = renderComparisonMarkdown(testComparison());
+
+    expect(rendered).toContain("- [Docs](https://hunk.dev/docs/)");
+    expect(
+      renderComparisonMarkdown(
+        testComparison({
+          sources: [{ label: "Upstream", url: "https://example.com/thing" }],
+        }),
+      ),
+    ).toContain("- [Upstream](https://example.com/thing)");
+  });
+
+  test("fences every code sample it renders", () => {
+    const rendered = renderComparisonMarkdown(
+      testComparison({
+        sections: [
+          { heading: "Setup", body: ["Do this."], code: { caption: "Run", lines: ["a | b"] } },
+        ],
+      }),
+    );
+
+    // An odd number of fences would leave the rest of the document inside a block.
+    expect((rendered.match(/^```/gm) ?? []).length % 2).toBe(0);
+    expect(rendered).toContain("Run:");
+    expect(rendered).toContain("a | b");
+  });
+
+  test("renders every real comparison with a table and its own canonical URL", () => {
+    for (const comparison of COMPARISONS) {
+      const rendered = renderComparisonMarkdown(comparison);
+
+      expect(rendered, comparison.slug).toStartWith(`# ${comparison.headline}\n`);
+      expect(rendered, comparison.slug).toContain(`https://hunk.dev/compare/${comparison.slug}/`);
+      // One header row plus a delimiter plus one row per capability.
+      const rows = rendered.split("\n").filter((line) => line.startsWith("| "));
+      expect(rows.length, comparison.slug).toBe(comparison.capabilities.length + 2);
+    }
   });
 });

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -45,6 +45,12 @@ export default defineConfig({
               description: "Drop-in agent skill for driving a live Hunk review session.",
             },
             {
+              label: "Hunk compared with other diff tools",
+              url: "https://hunk.dev/compare/",
+              description:
+                "Head-to-head pages for delta, difftastic, diff-so-fancy, git diff, and Plannotator. Each is also served as Markdown at the same URL plus `.md`.",
+            },
+            {
               label: "Hunk changelog",
               url: "https://hunk.dev/changelog/",
               description: "Every release, grouped by minor series, with per-version change lists.",
@@ -178,6 +184,9 @@ export default defineConfig({
         // One link rather than a group: the changelog is generated, grows every release, and
         // carries its own series navigation, so listing 19 versions here would bury the docs.
         { label: "Changelog", link: "/changelog/" },
+        // The comparison cluster lives outside the docs but answers a docs-shaped question
+        // ("should I be using this instead of delta?"), so it gets one link rather than a page.
+        { label: "Compare with other tools", link: "/compare/" },
       ],
     }),
   ],

--- a/website/src/components/BrandFooter.astro
+++ b/website/src/components/BrandFooter.astro
@@ -12,6 +12,7 @@ const NPM = "https://www.npmjs.com/package/hunkdiff";
 <footer class="brand-footer" data-context={context}>
   <div class="brand-footer-links">
     <a href="/docs/">Docs</a>
+    <a href="/compare/">Compare</a>
     <a href={REPO}>GitHub</a>
     <a href={NPM}>npm</a>
     <a href="/llms.txt">llms.txt</a>

--- a/website/src/components/PageHead.astro
+++ b/website/src/components/PageHead.astro
@@ -1,5 +1,6 @@
 ---
 import { toJsonLdScriptBody } from "../lib/jsonLd";
+import { SITE_ORIGIN } from "../lib/site";
 
 /**
  * The `<head>` every hand-built marketing page shares.
@@ -20,7 +21,7 @@ interface Props {
   ogImage?: string;
   ogImageAlt: string;
   /** One JSON-LD object, or several to emit as separate script tags. */
-  schema?: unknown | unknown[];
+  schema?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const {
@@ -28,12 +29,12 @@ const {
   description,
   keywords,
   path,
-  ogImage = "https://hunk.dev/og.png",
+  ogImage = `${SITE_ORIGIN}/og.png`,
   ogImageAlt,
   schema,
 } = Astro.props;
 
-const canonical = `https://hunk.dev${path}`;
+const canonical = `${SITE_ORIGIN}${path}`;
 const schemas = schema === undefined ? [] : Array.isArray(schema) ? schema : [schema];
 ---
 

--- a/website/src/components/PageHead.astro
+++ b/website/src/components/PageHead.astro
@@ -1,0 +1,69 @@
+---
+import { toJsonLdScriptBody } from "../lib/jsonLd";
+
+/**
+ * The `<head>` every hand-built marketing page shares.
+ *
+ * Starlight owns the head for docs; these are the pages outside it — the home
+ * page, the extension directory, and the comparison cluster — which all need the
+ * same canonical URL, Open Graph, Twitter card, icon, and analytics block. They
+ * differ only in title, description, keywords, social image, and structured
+ * data, so those are the props.
+ */
+interface Props {
+  title: string;
+  description: string;
+  /** Comma-separated, matching the `keywords` meta convention already in use. */
+  keywords: string;
+  /** Site-absolute path with a trailing slash, e.g. `/compare/hunk-vs-delta/`. */
+  path: string;
+  ogImage?: string;
+  ogImageAlt: string;
+  /** One JSON-LD object, or several to emit as separate script tags. */
+  schema?: unknown | unknown[];
+}
+
+const {
+  title,
+  description,
+  keywords,
+  path,
+  ogImage = "https://hunk.dev/og.png",
+  ogImageAlt,
+  schema,
+} = Astro.props;
+
+const canonical = `https://hunk.dev${path}`;
+const schemas = schema === undefined ? [] : Array.isArray(schema) ? schema : [schema];
+---
+
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width" />
+<meta name="theme-color" content="#f4f1ea" />
+<meta name="description" content={description} />
+<meta name="keywords" content={keywords} />
+<meta name="author" content="Modem" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="hunk" />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:url" content={canonical} />
+<meta property="og:image" content={ogImage} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content={ogImageAlt} />
+<meta property="og:locale" content="en_US" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={ogImage} />
+<link rel="canonical" href={canonical} />
+<link rel="icon" href="/icon.png" type="image/png" />
+<link rel="apple-touch-icon" href="/apple-icon.png" />
+<title>{title}</title>
+{
+  schemas.map((entry) => (
+    <script type="application/ld+json" is:inline set:html={toJsonLdScriptBody(entry)}></script>
+  ))
+}
+<script is:inline defer src="/_vercel/insights/script.js"></script>

--- a/website/src/data/comparisons.ts
+++ b/website/src/data/comparisons.ts
@@ -1,4 +1,5 @@
 import { BUNDLED_SHIKI_THEME_IDS } from "../../../src/core/theme/catalog";
+import { SITE_ORIGIN } from "../lib/site";
 
 /**
  * Hand-authored comparisons between Hunk and the diff tools people already run.
@@ -9,10 +10,9 @@ import { BUNDLED_SHIKI_THEME_IDS } from "../../../src/core/theme/catalog";
  * a bare mark would mislead, and each page ends with the sources it was checked
  * against. Overstating a rival is the fastest way to lose the reader we came for.
  *
- * The module is the single source for three renderings — the HTML page, the
- * `.md` variant agents read, and the hub's index — so entries stay plain data:
- * prose is unformatted strings, code samples are structured, and nothing here
- * knows about markup.
+ * The HTML page, the `.md` variant agents read, and the hub's index all render
+ * from these entries, so they stay plain data: prose is unformatted strings,
+ * code samples are structured, and nothing here knows about markup.
  */
 
 /** How completely a tool covers one capability. */
@@ -70,8 +70,35 @@ export interface Comparison {
   sources: { label: string; url: string }[];
 }
 
+/** The date these pages first went up. Publication dates do not move when claims are re-checked. */
+export const COMPARISONS_PUBLISHED_ON = "2026-09-01";
+
 /** The date the rival claims on these pages were last checked against their own docs. */
 export const COMPARISONS_REVIEWED_ON = "2026-09-01";
+
+/** Month and year of the last check, for the line every page shows above the fold. */
+export function reviewedOnLabel(): string {
+  return new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * Hunk's own side of the header sentence each table opens with.
+ *
+ * It is a claim about Hunk, so it belongs beside the rival facts in the catalog
+ * rather than typed once per renderer.
+ */
+export const HUNK_FACTS = {
+  language: "TypeScript",
+  license: "MIT",
+  platforms: "macOS, Linux, and Windows",
+} as const;
+
+/** Year the titles advertise, derived so it cannot go stale against the check date. */
+const REVIEW_YEAR = COMPARISONS_REVIEWED_ON.slice(0, 4);
 
 const THEME_COUNT = BUNDLED_SHIKI_THEME_IDS.length;
 
@@ -88,7 +115,7 @@ export const COMPARISONS: Comparison[] = [
       license: "MIT",
     },
     headline: "Hunk vs delta",
-    title: "Hunk vs delta: pager or review UI? (2026)",
+    title: `Hunk vs delta: pager or review UI? (${REVIEW_YEAR})`,
     description:
       "Hunk vs delta. delta restyles git diff output in your pager. Hunk turns the same changeset into a review UI. Capability table, setup for running both, and how to choose.",
     keywords: [
@@ -113,7 +140,7 @@ export const COMPARISONS: Comparison[] = [
       rival: [
         "You want every diff you print to look better, with no change to how you work.",
         "You want `git blame`, `git grep`, and `git log` styled too, not just diffs.",
-        "You want the smallest startup cost on a diff you will glance at and close.",
+        "You want the lowest startup cost on a diff you will glance at and close.",
         "You already tuned delta and you like reading in a pager.",
       ],
     },
@@ -123,7 +150,7 @@ export const COMPARISONS: Comparison[] = [
         capability: "Themes",
         hunk: "yes",
         rival: "yes",
-        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. delta reads bat-compatible themes.`,
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. delta pairs bat syntax themes with its own collection, browsable via \`delta --show-themes\`.`,
       },
       {
         capability: "Side-by-side / split view",
@@ -148,7 +175,7 @@ export const COMPARISONS: Comparison[] = [
         capability: "Hunk-by-hunk navigation across the whole changeset",
         hunk: "yes",
         rival: "partial",
-        note: "delta's `n`/`N` move the pager to the next diff section. Hunk tracks a selected hunk that the rest of the UI reacts to.",
+        note: "With `delta.navigate` enabled, `n`/`N` jump the pager between files, and between commits in `log -p`. Hunk tracks a selected hunk that the rest of the UI reacts to.",
       },
       {
         capability: "Mouse: click, wheel, scrollbar, menus",
@@ -179,7 +206,7 @@ export const COMPARISONS: Comparison[] = [
       { capability: "Works as a Git pager (`core.pager`)", hunk: "yes", rival: "yes" },
       { capability: "Works as a Git difftool", hunk: "yes", rival: "yes" },
       {
-        capability: "Styles `git blame`, `git grep`, and `git log`",
+        capability: "Styles `git blame` and `git grep` output",
         hunk: "no",
         rival: "yes",
         note: "Hunk's pager mode opens the review UI for patches and falls back to a plain-text pager for everything else.",
@@ -197,7 +224,7 @@ export const COMPARISONS: Comparison[] = [
         heading: "What delta is",
         body: [
           "delta is a pager. Git prints a unified diff and pipes it to whatever `core.pager` points at. delta sits in that pipe and rewrites the text on the way through. Two lines of `.gitconfig` and every diff you print looks better, including the ones inside `git add -p`, `git log -p`, and `git show`.",
-          "It does the job well. Syntax highlighting with bat-compatible themes, word-level highlighting inside changed lines, an opt-in side-by-side view with wrapping, line numbers, `n`/`N` navigation between diff sections, hyperlinked commit hashes, and styled `git blame` and `git grep`. Written in Rust, MIT-licensed, well over a hundred config options.",
+          "It does the job well. Syntax highlighting with bat syntax themes plus its own theme collection, word-level highlighting inside changed lines, an opt-in side-by-side view with wrapping, line numbers, opt-in `n`/`N` navigation between files, hyperlinked commit hashes, and styled `git blame` and `git grep`. Written in Rust, MIT-licensed, with a `--help` that runs to about 110 options.",
           "What it does not do is hold a model of your changeset. It sees a stream of text and emits a prettier one. No file list, no selected hunk, no state that survives from one line to the next.",
         ],
       },
@@ -250,7 +277,7 @@ export const COMPARISONS: Comparison[] = [
       {
         question: "Which is faster, Hunk or delta?",
         answer:
-          "delta wins on startup. It is a Rust stream filter doing one pass over text. Hunk builds a review model and mounts a terminal UI, which costs more up front and buys navigation, state, and annotations. `hunk --fast` offloads eligible syntax highlighting to cut that cost.",
+          "delta starts faster, and that is structural: it is a Rust stream filter doing one pass over text. Hunk builds a review model and mounts a terminal UI, which costs more up front and buys navigation, state, and annotations. The experimental `hunk --fast` offloads eligible syntax highlighting to cut that cost.",
       },
       {
         question: "Does Hunk need configuration to be useful?",
@@ -278,7 +305,7 @@ export const COMPARISONS: Comparison[] = [
       license: "MIT",
     },
     headline: "Hunk vs difftastic",
-    title: "Hunk vs difftastic: structural diff or review UI? (2026)",
+    title: `Hunk vs difftastic: structural diff or review UI? (${REVIEW_YEAR})`,
     description:
       "Hunk vs difftastic. difftastic changes what the diff says by parsing your code with tree-sitter. Hunk changes how you read a changeset. What each is for, and why they do not compose.",
     keywords: [
@@ -356,16 +383,10 @@ export const COMPARISONS: Comparison[] = [
         note: "difftastic lists this as a non-goal. Reordering still shows as a change in both tools.",
       },
       {
-        capability: "Predictable cost on heavily-changed files",
-        hunk: "yes",
-        rival: "partial",
-        note: "difftastic's FAQ says it scales relatively poorly on files with many changes and can use a lot of memory.",
-      },
-      {
         capability: "Git integration",
         hunk: "yes",
         rival: "yes",
-        note: "difftastic goes in `GIT_EXTERNAL_DIFF` or a difftool. Hunk runs natively, as a pager, or as a difftool.",
+        note: "difftastic goes in `GIT_EXTERNAL_DIFF` or `diff.external`. Hunk runs natively, as a pager, or as a difftool.",
       },
       {
         capability: "Native Jujutsu and Sapling support",
@@ -380,8 +401,8 @@ export const COMPARISONS: Comparison[] = [
         heading: "What difftastic is",
         body: [
           "difftastic parses both versions of a file with tree-sitter and diffs the trees instead of the lines. The payoff shows up where line diffs are worst. Wrap a block in an `if`, reindent a function, move a closing brace, and difftastic reports the actual change instead of a wall of red and green.",
-          "It supports more than thirty languages and falls back to line-oriented diffing with word highlighting when it cannot parse a file. It is written in Rust and is usually wired in as a Git external diff or difftool.",
-          "Its docs are clear about the limits. Producing applicable patches, merging, and ignoring reordered elements are stated non-goals, and the FAQ says difftastic scales relatively poorly on files with a large number of changes and can use a lot of memory.",
+          "Its manual lists more than fifty programming languages plus ten structured text formats, and `difft --list-languages` prints what your build supports. It falls back to line-oriented diffing with word highlighting when it cannot parse a file, and it is written in Rust and usually wired in as Git's external diff.",
+          "Its docs are clear about the limits. Producing applicable patches, merging, and ignoring reordered elements are stated non-goals, and the README lists under Known Issues that difftastic scales relatively poorly on files with a large number of changes and can use a lot of memory.",
         ],
         code: {
           caption: "The usual difftastic wiring",
@@ -389,8 +410,10 @@ export const COMPARISONS: Comparison[] = [
             "# one command",
             "GIT_EXTERNAL_DIFF=difft git diff",
             "",
-            "# or as a difftool",
+            "# or make it the default external diff",
             "git config --global diff.external difft",
+            "# other subcommands then need --ext-diff:",
+            "git show --ext-diff",
           ],
         },
       },
@@ -404,7 +427,7 @@ export const COMPARISONS: Comparison[] = [
       {
         heading: "They do not compose, and that is fine",
         body: [
-          "You cannot pipe difftastic into Hunk. difftastic emits its own rendered side-by-side output, not a unified diff, and Hunk's review stream is built from unified diffs. Setting `GIT_EXTERNAL_DIFF=difft` and then opening `hunk diff` does not stack the two. Hunk reads Git's own patch output.",
+          "You cannot pipe difftastic into Hunk. difftastic emits its own rendered output, or JSON with `--display json`, but never a unified diff, and Hunk's review stream is built from unified diffs. Setting `GIT_EXTERNAL_DIFF=difft` and then opening `hunk diff` does not stack the two. Hunk reads Git's own patch output.",
           "Not much is lost, because you reach for them at different moments. When one file's diff looks nonsensical after a reformat, run difftastic on that file. When you are reviewing a change across a dozen files, open Hunk.",
         ],
         code: {
@@ -425,7 +448,7 @@ export const COMPARISONS: Comparison[] = [
       {
         question: "Can I use difftastic as Hunk's diff engine?",
         answer:
-          "No. Hunk builds its review stream from unified diffs, and difftastic's output is its own rendered display rather than a patch. Configure difftastic as a Git external diff for the files where structure matters, and use `hunk diff` to review the changeset.",
+          "No. Hunk builds its review stream from unified diffs, and difftastic's output is its own rendered display, or JSON, rather than a patch. Configure difftastic as a Git external diff for the files where structure matters, and use `hunk diff` to review the changeset.",
       },
       {
         question: "Does Hunk do structural or AST diffing?",
@@ -440,7 +463,7 @@ export const COMPARISONS: Comparison[] = [
       {
         question: "Is difftastic slower than Hunk?",
         answer:
-          "Hard to compare directly, since one is a diff algorithm and the other is a UI. What is documented is that difftastic's tree diffing gets expensive on files with many changes. Hunk's cost scales with rendering the changeset, and `hunk --fast` offloads eligible syntax highlighting.",
+          "Hard to compare directly, since one is a diff algorithm and the other is a UI. What is documented is that difftastic's tree diffing gets expensive on files with many changes. Hunk's cost scales with rendering the changeset instead, and the experimental `hunk --fast` offloads eligible syntax highlighting.",
       },
     ],
     sources: [
@@ -460,7 +483,7 @@ export const COMPARISONS: Comparison[] = [
       license: "MIT",
     },
     headline: "Hunk vs diff-so-fancy",
-    title: "Hunk vs diff-so-fancy: what switching gets you (2026)",
+    title: `Hunk vs diff-so-fancy: what switching gets you (${REVIEW_YEAR})`,
     description:
       "Hunk vs diff-so-fancy. diff-so-fancy tidies git diff headers and markers in your pager. Hunk is a review UI with a file sidebar, split layouts, and agent notes. Compared honestly.",
     keywords: [
@@ -483,7 +506,7 @@ export const COMPARISONS: Comparison[] = [
       ],
       rival: [
         "You want minimal, familiar output and nothing more.",
-        "You want one script in `$PATH` and no binary to install.",
+        "You want a Perl script and its `lib/` in `$PATH`, with no binary to install.",
         "Your habits are built around `less` and you do not want a UI.",
       ],
     },
@@ -499,7 +522,7 @@ export const COMPARISONS: Comparison[] = [
         capability: "Word-level highlighting inside a changed line",
         hunk: "yes",
         rival: "partial",
-        note: "diff-so-fancy passes through Git's own word-diff emphasis rather than computing its own.",
+        note: "diff-so-fancy computes character-level emphasis with a bundled copy of Git's contrib/diff-highlight, colored through `color.diff-highlight.*`, rather than a token-level word diff.",
       },
       {
         capability: "Themes",
@@ -523,20 +546,25 @@ export const COMPARISONS: Comparison[] = [
         note: "diff-so-fancy sets `interactive.diffFilter`. Hunk is a review viewer and does not filter interactive staging.",
       },
       {
-        capability: "Runtime dependency",
-        hunk: "yes",
-        rival: "yes",
-        note: "diff-so-fancy needs Perl. Hunk's default install is a standalone binary, and the npm install needs Node.js 22+.",
+        capability: "Runs with no language runtime installed",
+        hunk: "partial",
+        rival: "no",
+        note: "diff-so-fancy needs Perl 5.14+. Hunk's script, Homebrew, mise, and Nix installs are standalone binaries; only the npm install needs Node.js 22+.",
       },
-      { capability: "Native Jujutsu and Sapling support", hunk: "yes", rival: "no" },
+      {
+        capability: "Native Jujutsu and Sapling support",
+        hunk: "yes",
+        rival: "partial",
+        note: "diff-so-fancy works wherever a VCS lets you set a pager, and its docs show a Mercurial recipe. Hunk detects jj and Sapling workspaces and takes native revsets.",
+      },
       { capability: "TypeScript extension API", hunk: "yes", rival: "no" },
     ],
     sections: [
       {
         heading: "What diff-so-fancy is",
         body: [
-          "diff-so-fancy is a Perl script you drop in `$PATH` and put in front of your pager. It takes Git's diff output and makes it more human. File headers collapse to a readable line, the leading `+` and `-` come out of the gutter so copied code stays copyable, empty lines get colored so added and removed blanks are visible, and a ruler separates files.",
-          "It is deliberately small. No syntax highlighting, no side-by-side, no state. It is a text filter, and it has been a reliable one for a decade. It also covers `git add -p` through `interactive.diffFilter`, which Hunk does not replicate.",
+          "diff-so-fancy is a Perl script you drop in `$PATH`, alongside its `lib/` directory, and put in front of your pager. It takes Git's diff output and makes it more human. File headers collapse to a readable line, the leading `+` and `-` come out of the gutter so copied code stays copyable, empty lines get colored so added and removed blanks are visible, and a ruler separates files.",
+          "It is deliberately small. No syntax highlighting, no side-by-side, no state. It is a text filter, and it has been one since 2015. It also covers `git add -p` through `interactive.diffFilter`, which Hunk does not replicate.",
         ],
         code: {
           caption: "The standard diff-so-fancy setup",
@@ -578,7 +606,7 @@ export const COMPARISONS: Comparison[] = [
       {
         question: "Is diff-so-fancy still maintained?",
         answer:
-          "Yes, though development is quiet. It is a mature script doing a fixed job, which is part of why it is still in so many dotfiles.",
+          "Yes. Commits continue through 2026, though tagged releases are infrequent: the last was v1.4.12 in August 2024. It is a mature script doing a fixed job, which is part of why it is still in so many dotfiles.",
       },
       {
         question: "Can I keep diff-so-fancy and add Hunk?",
@@ -605,7 +633,7 @@ export const COMPARISONS: Comparison[] = [
       license: "GPL-2.0",
     },
     headline: "Hunk vs git diff",
-    title: "Hunk vs git diff: a better way to read a changeset (2026)",
+    title: `Hunk vs git diff: a better way to read a changeset (${REVIEW_YEAR})`,
     description:
       "Hunk vs git diff. git diff prints a unified patch. Hunk renders the same data as a navigable review UI with a file sidebar, split view, and agent notes. What changes, and what does not.",
     keywords: [
@@ -657,7 +685,13 @@ export const COMPARISONS: Comparison[] = [
         capability: "Themes",
         hunk: "yes",
         rival: "partial",
-        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. Git has color settings rather than themes.`,
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. Git has \`color.diff.*\` settings rather than themes.`,
+      },
+      {
+        capability: "Word-level highlighting inside a changed line",
+        hunk: "yes",
+        rival: "partial",
+        note: "Git has `--word-diff` and `--color-words`, opt-in per invocation. Hunk highlights word-level changes by default.",
       },
       { capability: "File sidebar you can jump from", hunk: "yes", rival: "no" },
       { capability: "Hunk-by-hunk navigation across the changeset", hunk: "yes", rival: "no" },
@@ -728,7 +762,7 @@ export const COMPARISONS: Comparison[] = [
       {
         heading: "What stays the same",
         body: [
-          "Git is still the source of truth. Hunk does not reimplement diffing, does not change what counts as a change, and does not touch your repository. It reads what Git reports and draws it. Rename detection, `--color-moved`, and path filtering all still come from Git, and `hunk show HEAD~1 -- src/ui README.md` filters the way you would expect.",
+          "Git is still the source of truth. Hunk does not reimplement diffing, does not change what counts as a change, and does not modify your files or Git state. It reads what Git reports and draws it. Rename detection, `--color-moved`, and path filtering all still come from Git, and `hunk show HEAD~1 -- src/ui README.md` filters the way you would expect.",
           "It also takes nothing away. `git diff` keeps working, scripts that parse it keep working, and an alias gives you Hunk only when you want it, without changing your default pager.",
         ],
       },
@@ -779,7 +813,7 @@ export const COMPARISONS: Comparison[] = [
       license: "Apache-2.0 or MIT",
     },
     headline: "Hunk vs Plannotator",
-    title: "Hunk vs Plannotator: terminal or browser review (2026)",
+    title: `Hunk vs Plannotator: terminal or browser review (${REVIEW_YEAR})`,
     description:
       "Hunk vs Plannotator. Two review surfaces built for coding-agent output. Plannotator reviews plans and diffs in your browser. Hunk keeps the review in the terminal. Where each fits.",
     keywords: [
@@ -804,6 +838,7 @@ export const COMPARISONS: Comparison[] = [
         "You want to review the agent's plan before it writes any code.",
         "You prefer a browser UI, with wider text, images, and rendered Markdown.",
         "You want to review a GitHub PR or GitLab MR by pasting its URL.",
+        "You want AI reviews built into the tool, posting comments on the diff for you.",
         "You work in Perforce or GitButler.",
       ],
     },
@@ -812,14 +847,14 @@ export const COMPARISONS: Comparison[] = [
         capability: "Reviews agent plans before implementation",
         hunk: "no",
         rival: "yes",
-        note: "Plan review is Plannotator's original purpose. Hunk starts once there is a diff.",
+        note: "Plan review is what Plannotator leads with. Hunk starts once there is a diff.",
       },
       { capability: "Reviews local code changes as a diff", hunk: "yes", rival: "yes" },
       {
         capability: "Terminal-native UI",
         hunk: "yes",
         rival: "partial",
-        note: "Plannotator is browser-first. A separate terminal annotator exists as a plugin.",
+        note: "Plannotator is browser-first. A separate terminal annotator ships as a Herdr plugin and as a standalone TUI, for documents rather than diffs.",
       },
       {
         capability: "Browser UI",
@@ -835,10 +870,16 @@ export const COMPARISONS: Comparison[] = [
       },
       { capability: "Line-level comments returned to the agent", hunk: "yes", rival: "yes" },
       {
+        capability: "Built-in AI review that posts its own comments",
+        hunk: "no",
+        rival: "yes",
+        note: "Plannotator can launch AI reviews that comment on the diff and answer questions about it. Hunk relies on the agent you already have.",
+      },
+      {
         capability: "Agent can read and drive the live review session",
         hunk: "yes",
-        rival: "no",
-        note: "`hunk session` lets an agent list, inspect, and navigate the review you have open.",
+        rival: "partial",
+        note: "Plannotator exposes WebMCP tools on its plan and annotate surfaces to a WebMCP-capable browser, not on its diff review. Hunk's `hunk session` works from any shell against the diff review itself.",
       },
       {
         capability: "Reviews a GitHub PR or GitLab MR by URL",
@@ -856,20 +897,35 @@ export const COMPARISONS: Comparison[] = [
         rival: "no",
         note: "Hunk also stands in for `core.pager` and `git difftool` on ordinary, non-agent work.",
       },
-      { capability: "Watch mode that reloads the review", hunk: "yes", rival: "no" },
-      { capability: "Split and stack layouts switchable mid-review", hunk: "yes", rival: "no" },
+      {
+        capability: "Watch mode that reloads the review",
+        hunk: "yes",
+        rival: "partial",
+        note: "Plannotator polls the repo while a review is open and offers a Refresh when the working tree moves. Hunk's `--watch` reloads the review itself.",
+      },
+      {
+        capability: "Split and unified layouts switchable mid-review",
+        hunk: "yes",
+        rival: "yes",
+        note: "Plannotator toggles Split and Unified from its settings panel. Hunk adds a responsive auto layout and switches from the keyboard.",
+      },
       {
         capability: "Themes",
         hunk: "yes",
         rival: "yes",
         note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. Plannotator ships its own set, chosen in its settings panel.`,
       },
-      { capability: "Third-party extension API", hunk: "yes", rival: "no" },
+      {
+        capability: "Third-party extension API",
+        hunk: "yes",
+        rival: "no",
+        note: "Meaning third-party code that extends the review UI itself. Plannotator has agent integrations, editor extensions, and custom review skills, but no such API.",
+      },
       {
         capability: "Data stays on your machine",
         hunk: "yes",
         rival: "yes",
-        note: "Plannotator is local by default and offers a separate hosted product. Hunk has no hosted component.",
+        note: "Plannotator is local by default and is building a separate hosted product, Workspaces, for team sharing. Hunk has no hosted component.",
       },
     ],
     sections: [
@@ -883,9 +939,9 @@ export const COMPARISONS: Comparison[] = [
       {
         heading: "What Plannotator does",
         body: [
-          "Plannotator runs a local binary that starts a temporary server and opens the session in your browser. Its distinguishing move is plan review. When an agent proposes a plan, that plan opens for annotation before any code is written, and you can delete, insert, replace, or comment inline, then approve or request changes.",
-          "Its code review surface handles local changes across Git, Jujutsu, Perforce, and GitButler, and it can open a GitHub pull request or GitLab merge request from a URL. It integrates with a long list of agents through host-specific hooks and commands, and it is dual-licensed under Apache 2.0 or MIT. Plans, diffs, and annotations stay local by default.",
-          "If reviewing plans before implementation is part of how you work, or you want one tool to cover hosted PRs too, that is a real capability Hunk does not have.",
+          "Plannotator runs a local binary that starts a temporary server and opens the session in your browser. What it leads with is plan review. When an agent proposes a plan, that plan opens for annotation before any code is written, and you can comment, redline, mark up, and label inline, then approve or send structured feedback back to the agent.",
+          "Its code review surface handles local changes across Git, Jujutsu, Perforce, and GitButler, and it can open a GitHub pull request or GitLab merge request from a URL. It has AI review built in, so it can answer questions about what you are reading and launch reviews that post their own comments on the diff. It integrates with a long list of agents through host-specific hooks and commands, and it is dual-licensed under Apache 2.0 or MIT. Plans, diffs, and annotations stay local by default.",
+          "If reviewing plans before implementation is part of how you work, or you want hosted PRs and built-in AI review in the same tool, those are real capabilities Hunk does not have.",
         ],
       },
       {
@@ -911,7 +967,7 @@ export const COMPARISONS: Comparison[] = [
       {
         heading: "Choosing",
         body: [
-          "Take Plannotator if the plan is where you most want to catch problems, if you would rather read in a browser, or if you need Perforce, GitButler, or hosted PR review in the same tool.",
+          "Take Plannotator if the plan is where you most want to catch problems, if you would rather read in a browser, or if you need Perforce, GitButler, hosted PR review, or built-in AI review in the same tool.",
           "Take Hunk if the diff is what you review, if you want the agent's reasoning rendered in the diff rather than alongside it, if the agent should be able to read and drive the session you have open, or if you want one terminal tool that is also your everyday Git pager and difftool.",
           "They are not exclusive. They hook into agents at different points, so nothing stops you annotating a plan in one and reviewing the resulting diff in the other.",
         ],
@@ -931,12 +987,12 @@ export const COMPARISONS: Comparison[] = [
       {
         question: "Which works better over SSH?",
         answer:
-          "Hunk, because it never needs a browser. It is a terminal UI, so a remote shell or a tmux session on a server is a normal place to run it. Plannotator opens a local server and expects a browser to reach it.",
+          "Hunk, because it never needs a browser. It is a terminal UI, so a remote shell or a tmux session on a server is a normal place to run it. Plannotator documents SSH and devcontainer setups, auto-detecting SSH and switching to a fixed port you forward, but the reading still happens in a browser on some machine.",
       },
       {
         question: "Do both send my code anywhere?",
         answer:
-          "Neither, by default. Hunk runs locally with a loopback daemon for session control and has no hosted component. Plannotator keeps plans, diffs, and annotations local by default, and separately offers a hosted product for sharing.",
+          "Neither, by default. Hunk runs locally with a loopback daemon for session control and has no hosted component. Plannotator keeps plans, diffs, and annotations local by default, and is separately building a hosted product, Workspaces, for team sharing.",
       },
       {
         question: "Which agents does each support?",
@@ -958,7 +1014,7 @@ export const COMPARISONS: Comparison[] = [
 
 /** Absolute URL for a comparison page, for canonical links and structured data. */
 export function comparisonUrl(comparison: Comparison): string {
-  return `https://hunk.dev/compare/${comparison.slug}/`;
+  return `${SITE_ORIGIN}/compare/${comparison.slug}/`;
 }
 
 /** Symbol and screen-reader label for one support mark. */

--- a/website/src/data/comparisons.ts
+++ b/website/src/data/comparisons.ts
@@ -1,0 +1,969 @@
+import { BUNDLED_SHIKI_THEME_IDS } from "../../../src/core/theme/catalog";
+
+/**
+ * Hand-authored comparisons between Hunk and the diff tools people already run.
+ *
+ * These pages answer a question a reader arrives with ("hunk vs delta"), so every
+ * claim about another project has to survive that project's own documentation:
+ * capability rows are marked from published behavior, notes carry the caveat when
+ * a bare mark would mislead, and each page ends with the sources it was checked
+ * against. Overstating a rival is the fastest way to lose the reader we came for.
+ *
+ * The module is the single source for three renderings — the HTML page, the
+ * `.md` variant agents read, and the hub's index — so entries stay plain data:
+ * prose is unformatted strings, code samples are structured, and nothing here
+ * knows about markup.
+ */
+
+/** How completely a tool covers one capability. */
+export type Support = "yes" | "partial" | "no";
+
+/** One row of a head-to-head capability table. */
+export interface CapabilityRow {
+  capability: string;
+  hunk: Support;
+  rival: Support;
+  /** One clause of context, required whenever a bare mark would mislead. */
+  note?: string;
+}
+
+/** A prose section, optionally ending in a copyable command block. */
+export interface ComparisonSection {
+  heading: string;
+  body: string[];
+  code?: { caption?: string; lines: string[] };
+}
+
+export interface ComparisonFaq {
+  question: string;
+  answer: string;
+}
+
+export interface Comparison {
+  /** URL segment under `/compare/`, written the way the query is typed. */
+  slug: string;
+  rival: {
+    name: string;
+    /** Short appositive used in prose, e.g. "a syntax-highlighting pager". */
+    kind: string;
+    url: string;
+    language: string;
+    license: string;
+  };
+  /** Page `<h1>`. */
+  headline: string;
+  /** `<title>`, which search results show instead of the h1. */
+  title: string;
+  description: string;
+  keywords: string[];
+  /** Card copy on the hub, and the list-item description in its ItemList schema. */
+  summary: string;
+  /**
+   * The extractable answer. Answer engines quote the first paragraph under an
+   * h1, so this has to stand alone: no "as shown above", no unresolved pronouns.
+   */
+  answer: string;
+  pick: { hunk: string[]; rival: string[] };
+  capabilities: CapabilityRow[];
+  sections: ComparisonSection[];
+  faqs: ComparisonFaq[];
+  sources: { label: string; url: string }[];
+}
+
+/** The date the rival claims on these pages were last checked against their own docs. */
+export const COMPARISONS_REVIEWED_ON = "2026-09-01";
+
+const THEME_COUNT = BUNDLED_SHIKI_THEME_IDS.length;
+
+const HUNK_INSTALL = "curl -fsSL https://hunk.dev/install.sh | sh";
+
+export const COMPARISONS: Comparison[] = [
+  {
+    slug: "hunk-vs-delta",
+    rival: {
+      name: "delta",
+      kind: "a syntax-highlighting pager for Git",
+      url: "https://github.com/dandavison/delta",
+      language: "Rust",
+      license: "MIT",
+    },
+    headline: "Hunk vs delta",
+    title: "Hunk vs delta: pager or review UI? (2026)",
+    description:
+      "Hunk vs delta. delta restyles git diff output in your pager. Hunk turns the same changeset into a review UI. Capability table, setup for running both, and how to choose.",
+    keywords: [
+      "hunk vs delta",
+      "delta alternative",
+      "git delta",
+      "terminal diff viewer",
+      "git diff side by side",
+    ],
+    summary:
+      "delta restyles the text Git already printed. Hunk turns the same changeset into a review UI. Most people keep both.",
+    answer:
+      "delta is a pager. It restyles the text `git diff` already printed and hands it to `less`. Hunk is a review UI. It turns the same changeset into one scrollable stream with a file sidebar, split and stack layouts, mouse support, watch mode, and agent notes beside the hunks they explain. Keep delta for everyday diffs. Open Hunk when you sit down to review.",
+    pick: {
+      hunk: [
+        "You review whole changesets and want a sidebar and per-hunk navigation.",
+        "You want to change layout, wrapping, or theme while reading, not in `.gitconfig`.",
+        "You want more context around a hunk without re-running the diff.",
+        "An agent wrote the change and you want its reasoning next to the code.",
+        "You want the diff to reload as the working tree changes.",
+      ],
+      rival: [
+        "You want every diff you print to look better, with no change to how you work.",
+        "You want `git blame`, `git grep`, and `git log` styled too, not just diffs.",
+        "You want the smallest startup cost on a diff you will glance at and close.",
+        "You already tuned delta and you like reading in a pager.",
+      ],
+    },
+    capabilities: [
+      { capability: "Syntax highlighting", hunk: "yes", rival: "yes" },
+      {
+        capability: "Themes",
+        hunk: "yes",
+        rival: "yes",
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. delta reads bat-compatible themes.`,
+      },
+      {
+        capability: "Side-by-side / split view",
+        hunk: "yes",
+        rival: "yes",
+        note: "delta opts in with `--side-by-side`. Hunk's `auto` layout picks split on wide terminals and stack on narrow ones.",
+      },
+      { capability: "Word-level highlighting inside a changed line", hunk: "yes", rival: "yes" },
+      {
+        capability: "Moved-line detection",
+        hunk: "yes",
+        rival: "yes",
+        note: "Both build on Git's `--color-moved`. Hunk honors `diff.colorMoved` from your Git config.",
+      },
+      {
+        capability: "File sidebar you can jump from",
+        hunk: "yes",
+        rival: "no",
+        note: "delta emits a linear stream, so navigation is whatever your pager offers.",
+      },
+      {
+        capability: "Hunk-by-hunk navigation across the whole changeset",
+        hunk: "yes",
+        rival: "partial",
+        note: "delta's `n`/`N` move the pager to the next diff section. Hunk tracks a selected hunk that the rest of the UI reacts to.",
+      },
+      {
+        capability: "Mouse: click, wheel, scrollbar, menus",
+        hunk: "yes",
+        rival: "partial",
+        note: "delta leaves scrolling to your pager, which has no file list or clickable chrome.",
+      },
+      {
+        capability: "Change layout, wrapping, and theme mid-review",
+        hunk: "yes",
+        rival: "no",
+        note: "delta's options are fixed for the invocation, set in `.gitconfig` or on the command line.",
+      },
+      {
+        capability: "Expand unchanged context in place",
+        hunk: "yes",
+        rival: "no",
+        note: "More context around a delta hunk means re-running the diff with a larger `-U`.",
+      },
+      { capability: "Watch mode that reloads the review", hunk: "yes", rival: "no" },
+      { capability: "Inline agent and human annotations on a hunk", hunk: "yes", rival: "no" },
+      {
+        capability: "Programmatic session control for coding agents",
+        hunk: "yes",
+        rival: "no",
+        note: "`hunk session` lets an agent read and navigate the review you have open.",
+      },
+      { capability: "Works as a Git pager (`core.pager`)", hunk: "yes", rival: "yes" },
+      { capability: "Works as a Git difftool", hunk: "yes", rival: "yes" },
+      {
+        capability: "Styles `git blame`, `git grep`, and `git log`",
+        hunk: "no",
+        rival: "yes",
+        note: "Hunk's pager mode opens the review UI for patches and falls back to a plain-text pager for everything else.",
+      },
+      {
+        capability: "Native Jujutsu and Sapling support",
+        hunk: "yes",
+        rival: "partial",
+        note: "delta works wherever a VCS lets you set a pager. Hunk detects jj and Sapling workspaces and takes native revsets.",
+      },
+      { capability: "TypeScript extension API", hunk: "yes", rival: "no" },
+    ],
+    sections: [
+      {
+        heading: "What delta is",
+        body: [
+          "delta is a pager. Git prints a unified diff and pipes it to whatever `core.pager` points at. delta sits in that pipe and rewrites the text on the way through. Two lines of `.gitconfig` and every diff you print looks better, including the ones inside `git add -p`, `git log -p`, and `git show`.",
+          "It does the job well. Syntax highlighting with bat-compatible themes, word-level highlighting inside changed lines, an opt-in side-by-side view with wrapping, line numbers, `n`/`N` navigation between diff sections, hyperlinked commit hashes, and styled `git blame` and `git grep`. Written in Rust, MIT-licensed, well over a hundred config options.",
+          "What it does not do is hold a model of your changeset. It sees a stream of text and emits a prettier one. No file list, no selected hunk, no state that survives from one line to the next.",
+        ],
+      },
+      {
+        heading: "What Hunk does differently",
+        body: [
+          "Hunk parses the changeset into a document, then draws a UI over it. Every visible file becomes one continuous review stream, and the sidebar indexes that stream instead of hiding the rest of the change. `[` and `]` walk hunks across the whole changeset, `,` and `.` walk files, and the selection is real state that the sidebar, note cards, and context expansion all follow.",
+          "Holding the model in memory makes things easy that a pager cannot do at all. Press `z` to expand unchanged context around a hunk without re-running the diff. Press `1`, `2`, or `0` for split, stack, or responsive layout. Press `w` for wrapping or `t` for another theme, mid-review. `hunk diff --watch` reloads as you keep editing.",
+          "The part with no delta equivalent is agent context. An agent that wrote the change can attach its reasoning to specific hunks through `hunk session`, and Hunk renders those notes inline, next to the code, instead of in a pane you correlate by hand.",
+        ],
+      },
+      {
+        heading: "Use both",
+        body: [
+          "There is no conflict. delta is a good default pager, Hunk is a good review session. Leave delta configured and reach for Hunk deliberately.",
+          "If you would rather have Git open Hunk for diffs too, point `core.pager` at `hunk pager`. Non-patch output still falls through to your normal text pager. Either way `hunk diff` is the native entry point, and it is the only one that can pull untracked files into the review.",
+        ],
+        code: {
+          caption: "Keep delta as the pager, add Hunk as the review step",
+          lines: [
+            HUNK_INSTALL,
+            "",
+            "# delta stays exactly as you configured it",
+            'git config --global core.pager "delta"',
+            "",
+            "# Hunk is what you open to review",
+            "hunk diff          # working tree, including untracked files",
+            "hunk show HEAD     # the last commit",
+            "hunk diff --watch  # reload as you keep editing",
+          ],
+        },
+      },
+    ],
+    faqs: [
+      {
+        question: "Can I use Hunk and delta at the same time?",
+        answer:
+          "Yes. They sit in different slots. delta goes in `core.pager` and styles everything Git prints. Hunk is a command you run, `hunk diff` or `hunk show`, when you want to review. Nothing has to be uninstalled.",
+      },
+      {
+        question: "Is Hunk a drop-in replacement for delta?",
+        answer:
+          "Not quite. `hunk pager` covers the diff half: set it as `core.pager` and patch-like output opens in the review UI, while everything else falls through to your plain-text pager. Hunk does not style `git blame` or `git grep`, so keep delta if that output matters to you.",
+      },
+      {
+        question: "Does Hunk support side-by-side diffs like `delta --side-by-side`?",
+        answer:
+          "Yes, and it is the default on wide terminals. Hunk's `auto` layout picks split on wide terminals and stack on narrow ones. `1` forces split and `2` forces stack, at any point in the review.",
+      },
+      {
+        question: "Which is faster, Hunk or delta?",
+        answer:
+          "delta wins on startup. It is a Rust stream filter doing one pass over text. Hunk builds a review model and mounts a terminal UI, which costs more up front and buys navigation, state, and annotations. `hunk --fast` offloads eligible syntax highlighting to cut that cost.",
+      },
+      {
+        question: "Does Hunk need configuration to be useful?",
+        answer:
+          "No. `hunk diff` works with no config file. You can save preferences on quit, and a repository can carry its own `.hunk/config.toml`, but none of that is required to start.",
+      },
+    ],
+    sources: [
+      { label: "delta, GitHub repository", url: "https://github.com/dandavison/delta" },
+      {
+        label: "delta manual: side-by-side view",
+        url: "https://dandavison.github.io/delta/side-by-side-view.html",
+      },
+      { label: "Hunk: Git pager and difftool", url: "/docs/workflows/git-pager-and-difftool/" },
+      { label: "Hunk: keyboard and mouse", url: "/docs/start/keyboard-and-mouse/" },
+    ],
+  },
+  {
+    slug: "hunk-vs-difftastic",
+    rival: {
+      name: "difftastic",
+      kind: "a structural diff tool",
+      url: "https://github.com/Wilfred/difftastic",
+      language: "Rust",
+      license: "MIT",
+    },
+    headline: "Hunk vs difftastic",
+    title: "Hunk vs difftastic: structural diff or review UI? (2026)",
+    description:
+      "Hunk vs difftastic. difftastic changes what the diff says by parsing your code with tree-sitter. Hunk changes how you read a changeset. What each is for, and why they do not compose.",
+    keywords: [
+      "hunk vs difftastic",
+      "difftastic alternative",
+      "structural diff",
+      "AST diff git",
+      "difft",
+    ],
+    summary:
+      "difftastic changes what the diff says. Hunk changes how you read the changeset. Different problems, both worth solving.",
+    answer:
+      "difftastic changes what the diff says. It parses both versions with tree-sitter and reports syntactic changes, so a reindent or a wrapped block stops reading as a rewrite. Hunk changes how you read a changeset: one multi-file stream, a file sidebar, split layouts, expandable context, agent notes. Hunk is line-based and does no AST diffing. difftastic has no review UI. They do not pipe into each other, so most people run difftastic as an external diff and review in Hunk.",
+    pick: {
+      hunk: [
+        "You review changesets that span many files and want navigation, not a longer scroll.",
+        "You want a diff you can drive with the mouse and reconfigure while reading it.",
+        "An agent wrote the change and you want its notes anchored to hunks.",
+        "You need patch input. `hunk patch -` reviews any unified diff from stdin.",
+      ],
+      rival: [
+        "The change is a refactor and the line diff is lying about what moved.",
+        "You want reformatting and wrapped blocks reported structurally.",
+        "You work in one file at a time and a pager is enough.",
+        "Your languages are among difftastic's tree-sitter parsers.",
+      ],
+    },
+    capabilities: [
+      {
+        capability: "Structural / AST-aware diffing",
+        hunk: "no",
+        rival: "yes",
+        note: "difftastic's whole reason to exist. Hunk is line-based with word-level highlighting inside changed lines.",
+      },
+      {
+        capability: "Line-oriented unified diff",
+        hunk: "yes",
+        rival: "partial",
+        note: "difftastic falls back to line-oriented diffing with word highlighting for files it cannot parse.",
+      },
+      {
+        capability: "Interactive review UI",
+        hunk: "yes",
+        rival: "no",
+        note: "difftastic prints to the terminal, so scrolling is your pager's job.",
+      },
+      { capability: "Multi-file review stream with a sidebar", hunk: "yes", rival: "no" },
+      { capability: "Split and stack layouts switchable mid-review", hunk: "yes", rival: "no" },
+      {
+        capability: "Themes",
+        hunk: "yes",
+        rival: "partial",
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. difftastic has a light or dark background setting rather than a theme catalog.`,
+      },
+      { capability: "Mouse-driven navigation", hunk: "yes", rival: "no" },
+      { capability: "Expand unchanged context in place", hunk: "yes", rival: "no" },
+      { capability: "Watch mode that reloads the review", hunk: "yes", rival: "no" },
+      { capability: "Inline agent and human annotations on a hunk", hunk: "yes", rival: "no" },
+      {
+        capability: "Reads a unified diff or patch from stdin",
+        hunk: "yes",
+        rival: "no",
+        note: "`hunk patch -` reviews any patch. difftastic reads the two files, not a patch.",
+      },
+      {
+        capability: "Output usable as a patch",
+        hunk: "no",
+        rival: "no",
+        note: "Producing applicable patches is a stated difftastic non-goal, and Hunk is a viewer.",
+      },
+      {
+        capability: "Insensitive to reordered elements",
+        hunk: "no",
+        rival: "no",
+        note: "difftastic lists this as a non-goal. Reordering still shows as a change in both tools.",
+      },
+      {
+        capability: "Predictable cost on heavily-changed files",
+        hunk: "yes",
+        rival: "partial",
+        note: "difftastic's FAQ says it scales relatively poorly on files with many changes and can use a lot of memory.",
+      },
+      {
+        capability: "Git integration",
+        hunk: "yes",
+        rival: "yes",
+        note: "difftastic goes in `GIT_EXTERNAL_DIFF` or a difftool. Hunk runs natively, as a pager, or as a difftool.",
+      },
+      {
+        capability: "Native Jujutsu and Sapling support",
+        hunk: "yes",
+        rival: "partial",
+        note: "difftastic works wherever a VCS accepts an external diff command. Hunk detects jj and Sapling workspaces and takes native revsets.",
+      },
+      { capability: "TypeScript extension API", hunk: "yes", rival: "no" },
+    ],
+    sections: [
+      {
+        heading: "What difftastic is",
+        body: [
+          "difftastic parses both versions of a file with tree-sitter and diffs the trees instead of the lines. The payoff shows up where line diffs are worst. Wrap a block in an `if`, reindent a function, move a closing brace, and difftastic reports the actual change instead of a wall of red and green.",
+          "It supports more than thirty languages and falls back to line-oriented diffing with word highlighting when it cannot parse a file. It is written in Rust and is usually wired in as a Git external diff or difftool.",
+          "Its docs are clear about the limits. Producing applicable patches, merging, and ignoring reordered elements are stated non-goals, and the FAQ says difftastic scales relatively poorly on files with a large number of changes and can use a lot of memory.",
+        ],
+        code: {
+          caption: "The usual difftastic wiring",
+          lines: [
+            "# one command",
+            "GIT_EXTERNAL_DIFF=difft git diff",
+            "",
+            "# or as a difftool",
+            "git config --global diff.external difft",
+          ],
+        },
+      },
+      {
+        heading: "What Hunk is",
+        body: [
+          "Hunk is line-based and is not competing on diff algorithms. It changes the reading. Every visible file is one continuous review stream, the sidebar indexes that stream, `[` and `]` walk hunks across the whole changeset, and `z` expands unchanged context around the hunk you are on without re-running anything.",
+          "It is a real terminal UI, not printed output, so layout, wrapping, line numbers, and theme all change while you read, the mouse works, and `hunk diff --watch` keeps the review current. If an agent produced the change, it can attach reasoning to specific hunks through `hunk session`, and those notes render inline beside the code.",
+        ],
+      },
+      {
+        heading: "They do not compose, and that is fine",
+        body: [
+          "You cannot pipe difftastic into Hunk. difftastic emits its own rendered side-by-side output, not a unified diff, and Hunk's review stream is built from unified diffs. Setting `GIT_EXTERNAL_DIFF=difft` and then opening `hunk diff` does not stack the two. Hunk reads Git's own patch output.",
+          "Not much is lost, because you reach for them at different moments. When one file's diff looks nonsensical after a reformat, run difftastic on that file. When you are reviewing a change across a dozen files, open Hunk.",
+        ],
+        code: {
+          caption: "Both, at the moments each is good",
+          lines: [
+            HUNK_INSTALL,
+            "",
+            "# structure, for one confusing file",
+            "GIT_EXTERNAL_DIFF=difft git diff -- src/parser.ts",
+            "",
+            "# review, for the whole changeset",
+            "hunk diff",
+          ],
+        },
+      },
+    ],
+    faqs: [
+      {
+        question: "Can I use difftastic as Hunk's diff engine?",
+        answer:
+          "No. Hunk builds its review stream from unified diffs, and difftastic's output is its own rendered display rather than a patch. Configure difftastic as a Git external diff for the files where structure matters, and use `hunk diff` to review the changeset.",
+      },
+      {
+        question: "Does Hunk do structural or AST diffing?",
+        answer:
+          "No. Hunk highlights changes at word level within a line and honors Git's `--color-moved` for moved blocks, but it does not parse code into a syntax tree. If you need AST-level diffing, difftastic is the right tool.",
+      },
+      {
+        question: "Which one handles a big refactor better?",
+        answer:
+          "Depends on the shape of it. For one file that was reformatted or rewrapped, difftastic tells you the truth faster. For a refactor spread across many files, Hunk's review stream plus `--color-moved` is the more workable read, because the problem is tracking thirty files rather than understanding one.",
+      },
+      {
+        question: "Is difftastic slower than Hunk?",
+        answer:
+          "Hard to compare directly, since one is a diff algorithm and the other is a UI. What is documented is that difftastic's tree diffing gets expensive on files with many changes. Hunk's cost scales with rendering the changeset, and `hunk --fast` offloads eligible syntax highlighting.",
+      },
+    ],
+    sources: [
+      { label: "difftastic, GitHub repository", url: "https://github.com/Wilfred/difftastic" },
+      { label: "Difftastic manual", url: "https://difftastic.wilfred.me.uk/" },
+      { label: "Hunk: files and patches", url: "/docs/workflows/files-and-patches/" },
+      { label: "Hunk: quick start", url: "/docs/start/quick-start/" },
+    ],
+  },
+  {
+    slug: "hunk-vs-diff-so-fancy",
+    rival: {
+      name: "diff-so-fancy",
+      kind: "a Git diff prettifier",
+      url: "https://github.com/so-fancy/diff-so-fancy",
+      language: "Perl",
+      license: "MIT",
+    },
+    headline: "Hunk vs diff-so-fancy",
+    title: "Hunk vs diff-so-fancy: what switching gets you (2026)",
+    description:
+      "Hunk vs diff-so-fancy. diff-so-fancy tidies git diff headers and markers in your pager. Hunk is a review UI with a file sidebar, split layouts, and agent notes. Compared honestly.",
+    keywords: [
+      "hunk vs diff-so-fancy",
+      "diff-so-fancy alternative",
+      "diff so fancy",
+      "better git diff output",
+      "git diff readable",
+    ],
+    summary:
+      "diff-so-fancy tidies Git's diff output. Hunk replaces the reading experience. The gap is bigger than it looks.",
+    answer:
+      "diff-so-fancy is a Perl script that tidies Git's diff output before your pager shows it: simpler file headers, `+` and `-` out of the gutter, colored empty lines, rulers between files. It adds no syntax highlighting and has no side-by-side view. Hunk is a review UI rather than a filter: a multi-file stream with a file sidebar, split and stack layouts, syntax highlighting, mouse support, watch mode, and inline agent annotations.",
+    pick: {
+      hunk: [
+        "You want syntax highlighting, which diff-so-fancy does not do.",
+        "You want a side-by-side view, which diff-so-fancy does not do.",
+        "You review multi-file changesets and want a sidebar and hunk navigation.",
+        "You want the diff to reload as you edit, or agent notes attached to hunks.",
+      ],
+      rival: [
+        "You want minimal, familiar output and nothing more.",
+        "You want one script in `$PATH` and no binary to install.",
+        "Your habits are built around `less` and you do not want a UI.",
+      ],
+    },
+    capabilities: [
+      {
+        capability: "Syntax highlighting",
+        hunk: "yes",
+        rival: "no",
+        note: "diff-so-fancy restyles diff structure. It does not color code by language.",
+      },
+      { capability: "Side-by-side / split view", hunk: "yes", rival: "no" },
+      {
+        capability: "Word-level highlighting inside a changed line",
+        hunk: "yes",
+        rival: "partial",
+        note: "diff-so-fancy passes through Git's own word-diff emphasis rather than computing its own.",
+      },
+      {
+        capability: "Themes",
+        hunk: "yes",
+        rival: "partial",
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. diff-so-fancy takes its colors from your Git color settings.`,
+      },
+      { capability: "Cleaned-up file headers and gutter", hunk: "yes", rival: "yes" },
+      { capability: "File sidebar you can jump from", hunk: "yes", rival: "no" },
+      { capability: "Hunk-by-hunk navigation across the changeset", hunk: "yes", rival: "no" },
+      { capability: "Mouse: click, wheel, scrollbar, menus", hunk: "yes", rival: "no" },
+      { capability: "Change layout, wrapping, and theme mid-review", hunk: "yes", rival: "no" },
+      { capability: "Expand unchanged context in place", hunk: "yes", rival: "no" },
+      { capability: "Watch mode that reloads the review", hunk: "yes", rival: "no" },
+      { capability: "Inline agent and human annotations on a hunk", hunk: "yes", rival: "no" },
+      { capability: "Works as a Git pager (`core.pager`)", hunk: "yes", rival: "yes" },
+      {
+        capability: "Works in `git add -p`",
+        hunk: "no",
+        rival: "yes",
+        note: "diff-so-fancy sets `interactive.diffFilter`. Hunk is a review viewer and does not filter interactive staging.",
+      },
+      {
+        capability: "Runtime dependency",
+        hunk: "yes",
+        rival: "yes",
+        note: "diff-so-fancy needs Perl. Hunk's default install is a standalone binary, and the npm install needs Node.js 22+.",
+      },
+      { capability: "Native Jujutsu and Sapling support", hunk: "yes", rival: "no" },
+      { capability: "TypeScript extension API", hunk: "yes", rival: "no" },
+    ],
+    sections: [
+      {
+        heading: "What diff-so-fancy is",
+        body: [
+          "diff-so-fancy is a Perl script you drop in `$PATH` and put in front of your pager. It takes Git's diff output and makes it more human. File headers collapse to a readable line, the leading `+` and `-` come out of the gutter so copied code stays copyable, empty lines get colored so added and removed blanks are visible, and a ruler separates files.",
+          "It is deliberately small. No syntax highlighting, no side-by-side, no state. It is a text filter, and it has been a reliable one for a decade. It also covers `git add -p` through `interactive.diffFilter`, which Hunk does not replicate.",
+        ],
+        code: {
+          caption: "The standard diff-so-fancy setup",
+          lines: [
+            'git config --global core.pager "diff-so-fancy | less --tabs=4 -RF"',
+            'git config --global interactive.diffFilter "diff-so-fancy --patch"',
+          ],
+        },
+      },
+      {
+        heading: "What you get by moving to Hunk",
+        body: [
+          "The two usual reasons people leave are the two things diff-so-fancy does not do: syntax highlighting and side-by-side. Hunk has both, with a responsive `auto` layout that picks split on wide terminals and stack on narrow ones, plus theme selection you change from inside the review.",
+          "Past that it is a different category of tool. Every visible file forms one review stream with a sidebar indexing it, `[` and `]` walk hunks across the whole changeset, `z` expands unchanged context without re-running the diff, and the mouse works for scrolling, menus, and jumping to a file. `hunk diff --watch` keeps the review current while you edit, and agent notes render inline beside the hunks they explain.",
+          "The trade is real. Hunk is a bigger program than a Perl script, and it takes over the screen instead of printing into your scrollback. If tidy output in `less` is what you want, diff-so-fancy is still fine.",
+        ],
+        code: {
+          caption: "Try it without changing your Git config",
+          lines: [
+            HUNK_INSTALL,
+            "",
+            "hunk diff        # working tree, including untracked files",
+            "hunk show HEAD   # the last commit",
+          ],
+        },
+      },
+    ],
+    faqs: [
+      {
+        question: "Does diff-so-fancy have syntax highlighting?",
+        answer:
+          "No. It restyles the structure of Git's diff output, meaning headers, markers, empty lines, and rulers, but it does not color code by language. That is a common reason people move to a tool that does.",
+      },
+      {
+        question: "Does diff-so-fancy have a side-by-side view?",
+        answer:
+          "No. Its output is a single column. Hunk's split layout is side-by-side and is the default on wide terminals.",
+      },
+      {
+        question: "Is diff-so-fancy still maintained?",
+        answer:
+          "Yes, though development is quiet. It is a mature script doing a fixed job, which is part of why it is still in so many dotfiles.",
+      },
+      {
+        question: "Can I keep diff-so-fancy and add Hunk?",
+        answer:
+          "Yes. Leave `core.pager` pointed at diff-so-fancy and run `hunk diff` when you want to review. If you would rather have Git open Hunk for diff output, set `core.pager` to `hunk pager` instead. Non-patch output still falls through to your plain-text pager.",
+      },
+    ],
+    sources: [
+      {
+        label: "diff-so-fancy, GitHub repository",
+        url: "https://github.com/so-fancy/diff-so-fancy",
+      },
+      { label: "Hunk: Git pager and difftool", url: "/docs/workflows/git-pager-and-difftool/" },
+      { label: "Hunk: layout and display", url: "/docs/configure/layout-and-display/" },
+    ],
+  },
+  {
+    slug: "hunk-vs-git-diff",
+    rival: {
+      name: "git diff",
+      kind: "Git's built-in diff command",
+      url: "https://git-scm.com/docs/git-diff",
+      language: "C",
+      license: "GPL-2.0",
+    },
+    headline: "Hunk vs git diff",
+    title: "Hunk vs git diff: a better way to read a changeset (2026)",
+    description:
+      "Hunk vs git diff. git diff prints a unified patch. Hunk renders the same data as a navigable review UI with a file sidebar, split view, and agent notes. What changes, and what does not.",
+    keywords: [
+      "hunk vs git diff",
+      "better git diff",
+      "git diff side by side terminal",
+      "git diff tool",
+      "how to read git diff",
+    ],
+    summary:
+      "git diff prints the patch. Hunk renders the same patch as something you can navigate. Git stays the source of truth.",
+    answer:
+      "`git diff` prints a unified patch to standard output. One long stream, one file after another, with no navigation past your pager's search. Hunk reads the same data and draws a review UI: one multi-file stream, a file sidebar, split or stacked layouts, syntax highlighting, mouse support, expandable context, watch mode, and agent annotations on hunks. Git still computes the diff. Hunk replaces the reading. Run `hunk diff` where you would run `git diff`, or point `core.pager` at `hunk pager`.",
+    pick: {
+      hunk: [
+        "The changeset spans more than a couple of files and scrolling stopped working as navigation.",
+        "You want side-by-side, syntax highlighting, and a file list without configuring anything.",
+        "You want more context around one hunk without re-running the command with `-U`.",
+        "An agent wrote the change and you want its reasoning beside the code.",
+      ],
+      rival: [
+        "You are scripting, piping, or generating a patch to apply somewhere else.",
+        "You want the exact bytes Git produces, with no renderer in between.",
+        "You are on a machine where installing anything is not an option.",
+        "The change is two lines and you already know what they are.",
+      ],
+    },
+    capabilities: [
+      {
+        capability: "Produces the diff",
+        hunk: "no",
+        rival: "yes",
+        note: "Hunk runs Git underneath. Git is still the thing that computes the changeset.",
+      },
+      {
+        capability: "Output usable as a patch",
+        hunk: "no",
+        rival: "yes",
+        note: "`git diff` is what you pipe into `git apply`. Hunk is a viewer.",
+      },
+      { capability: "Syntax highlighting", hunk: "yes", rival: "no" },
+      {
+        capability: "Side-by-side / split view",
+        hunk: "yes",
+        rival: "no",
+        note: "`git diff` has no split view. `git difftool` shells out to another program for one.",
+      },
+      {
+        capability: "Themes",
+        hunk: "yes",
+        rival: "partial",
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. Git has color settings rather than themes.`,
+      },
+      { capability: "File sidebar you can jump from", hunk: "yes", rival: "no" },
+      { capability: "Hunk-by-hunk navigation across the changeset", hunk: "yes", rival: "no" },
+      { capability: "Mouse: click, wheel, scrollbar, menus", hunk: "yes", rival: "no" },
+      { capability: "Change layout, wrapping, and theme mid-review", hunk: "yes", rival: "no" },
+      {
+        capability: "Expand unchanged context in place",
+        hunk: "yes",
+        rival: "no",
+        note: "In Git, more context means re-running with a larger `-U`.",
+      },
+      {
+        capability: "Shows untracked files in the review",
+        hunk: "yes",
+        rival: "no",
+        note: "`hunk diff` pulls untracked files into the changeset. `git diff` omits them.",
+      },
+      { capability: "Watch mode that reloads the review", hunk: "yes", rival: "no" },
+      { capability: "Inline agent and human annotations on a hunk", hunk: "yes", rival: "no" },
+      {
+        capability: "Moved-line detection",
+        hunk: "yes",
+        rival: "yes",
+        note: "Both use Git's `--color-moved`. Hunk honors `diff.colorMoved` from your Git config.",
+      },
+      {
+        capability: "Scriptable, pipeable output",
+        hunk: "partial",
+        rival: "yes",
+        note: "Hunk is interactive. `hunk session review --json` is its machine-readable surface, aimed at agents rather than shell pipelines.",
+      },
+      { capability: "Available everywhere with no install", hunk: "no", rival: "yes" },
+      { capability: "Native Jujutsu and Sapling support", hunk: "yes", rival: "no" },
+    ],
+    sections: [
+      {
+        heading: "What `git diff` gives you",
+        body: [
+          "`git diff` is not a bad tool. It is a precise one aimed at a different job. It computes a changeset and writes a unified patch to standard output, and that output is the interchange format of the whole ecosystem. `git apply` consumes it, review systems parse it, and every diff viewer including Hunk is ultimately rendering it.",
+          "It does not try to be a reading interface. No syntax highlighting, no side-by-side, no file list, no sense of where you are. Once a changeset gets past a few files your only navigation is your pager's search, and the usual workaround is re-running the command with narrower paths until the output fits on a screen.",
+        ],
+      },
+      {
+        heading: "What Hunk changes",
+        body: [
+          "Hunk runs Git underneath and renders the result as a UI. Every visible file becomes one continuous review stream and the sidebar indexes it, so selecting a file jumps you there without hiding the rest of the change. `[` and `]` move hunk by hunk across the changeset, `,` and `.` move file by file, and `z` expands unchanged context without re-running anything.",
+          "Layout, line numbers, wrapping, and theme all change while you read. The mouse works: click a file, use the wheel or scrollbar, open menus. `hunk diff` also includes untracked files, which `git diff` leaves out and which is a routine source of confusion about files you know you wrote.",
+          "The rest is agents. When one produced the change, it can attach reasoning to specific hunks via `hunk session`, and Hunk renders those notes inline beside the code instead of in a chat window you read separately.",
+        ],
+        code: {
+          caption: "Three ways to reach it",
+          lines: [
+            HUNK_INSTALL,
+            "",
+            "# 1. directly, where you would have typed git diff",
+            "hunk diff",
+            "hunk show HEAD~1",
+            "",
+            "# 2. as an opt-in Git alias",
+            "git config --global alias.hdiff '-c core.pager=\"hunk pager\" diff'",
+            "git hdiff",
+            "",
+            "# 3. from any patch at all",
+            "git diff --no-color | hunk patch -",
+          ],
+        },
+      },
+      {
+        heading: "What stays the same",
+        body: [
+          "Git is still the source of truth. Hunk does not reimplement diffing, does not change what counts as a change, and does not touch your repository. It reads what Git reports and draws it. Rename detection, `--color-moved`, and path filtering all still come from Git, and `hunk show HEAD~1 -- src/ui README.md` filters the way you would expect.",
+          "It also takes nothing away. `git diff` keeps working, scripts that parse it keep working, and an alias gives you Hunk only when you want it, without changing your default pager.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Does Hunk replace git diff?",
+        answer:
+          "No. Hunk runs Git underneath and renders its output. `git diff` works exactly as before, and it is still the right tool for scripting, piping, and generating patches to apply.",
+      },
+      {
+        question: "How do I get a side-by-side git diff in the terminal?",
+        answer:
+          "`git diff` has no side-by-side mode. Run `hunk diff` instead, where split view is the default on wide terminals, or configure a difftool. Press `1` for split, `2` for stack, and `0` for the responsive layout at any point.",
+      },
+      {
+        question: "Can I make `git diff` itself open Hunk?",
+        answer:
+          "Yes. Set `core.pager` to `hunk pager` and patch-like output opens in the review UI, while everything else falls through to your plain-text pager. To keep your current pager, add an alias instead: `git config --global alias.hdiff '-c core.pager=\"hunk pager\" diff'`.",
+      },
+      {
+        question: "Why does `hunk diff` show files that `git diff` does not?",
+        answer:
+          "It includes untracked files by default, which is usually what you want when reviewing your own work in progress. Pass `--exclude-untracked` to match Git's behavior.",
+      },
+      {
+        question: "What about GNU diff, the one that is not part of Git?",
+        answer:
+          "GNU `diff` compares two files or directories outside version control. The closest Hunk equivalent is `hunk diff --files before.ts after.ts`, which opens the same review UI on a pair of files and can watch both for changes.",
+      },
+    ],
+    sources: [
+      { label: "git-diff, Git documentation", url: "https://git-scm.com/docs/git-diff" },
+      {
+        label: "Hunk: working trees and commits",
+        url: "/docs/workflows/working-trees-and-commits/",
+      },
+      { label: "Hunk: Git pager and difftool", url: "/docs/workflows/git-pager-and-difftool/" },
+    ],
+  },
+  {
+    slug: "hunk-vs-plannotator",
+    rival: {
+      name: "Plannotator",
+      kind: "a browser-based review surface for coding agents",
+      url: "https://github.com/backnotprop/plannotator",
+      language: "TypeScript",
+      license: "Apache-2.0 or MIT",
+    },
+    headline: "Hunk vs Plannotator",
+    title: "Hunk vs Plannotator: terminal or browser review (2026)",
+    description:
+      "Hunk vs Plannotator. Two review surfaces built for coding-agent output. Plannotator reviews plans and diffs in your browser. Hunk keeps the review in the terminal. Where each fits.",
+    keywords: [
+      "hunk vs plannotator",
+      "plannotator alternative",
+      "review AI generated code",
+      "claude code diff review",
+      "coding agent code review tool",
+    ],
+    summary:
+      "Both exist because agents write more code than you can read. Plannotator reviews it in the browser and covers plans. Hunk stays in the terminal.",
+    answer:
+      "Both tools exist because a coding agent writes more code than you can comfortably read, and they answer it in different places. Plannotator runs a local server and opens the review in your browser. It also covers agent plans before any code exists, plus GitHub pull requests and GitLab merge requests by URL. Hunk keeps the review in the terminal next to the agent that wrote the change, with its reasoning rendered beside the hunks it explains. Pick by where you want to be reading.",
+    pick: {
+      hunk: [
+        "You want to stay in the terminal, including over SSH or in a remote tmux with no browser.",
+        "You want the agent's reasoning rendered in the diff, attached to specific hunks.",
+        "You want the agent to read and navigate the review session you have open.",
+        "You also want a general diff viewer for ordinary Git work, pager and difftool included.",
+      ],
+      rival: [
+        "You want to review the agent's plan before it writes any code.",
+        "You prefer a browser UI, with wider text, images, and rendered Markdown.",
+        "You want to review a GitHub PR or GitLab MR by pasting its URL.",
+        "You work in Perforce or GitButler.",
+      ],
+    },
+    capabilities: [
+      {
+        capability: "Reviews agent plans before implementation",
+        hunk: "no",
+        rival: "yes",
+        note: "Plan review is Plannotator's original purpose. Hunk starts once there is a diff.",
+      },
+      { capability: "Reviews local code changes as a diff", hunk: "yes", rival: "yes" },
+      {
+        capability: "Terminal-native UI",
+        hunk: "yes",
+        rival: "partial",
+        note: "Plannotator is browser-first. A separate terminal annotator exists as a plugin.",
+      },
+      {
+        capability: "Browser UI",
+        hunk: "no",
+        rival: "yes",
+        note: "Hunk's review surface is a terminal UI.",
+      },
+      {
+        capability: "Works with no browser available",
+        hunk: "yes",
+        rival: "no",
+        note: "Plannotator opens a local server and a browser tab to reach it.",
+      },
+      { capability: "Line-level comments returned to the agent", hunk: "yes", rival: "yes" },
+      {
+        capability: "Agent can read and drive the live review session",
+        hunk: "yes",
+        rival: "no",
+        note: "`hunk session` lets an agent list, inspect, and navigate the review you have open.",
+      },
+      {
+        capability: "Reviews a GitHub PR or GitLab MR by URL",
+        hunk: "no",
+        rival: "yes",
+        note: "Hunk reviews local working trees, commits, patches, and file pairs.",
+      },
+      { capability: "Git", hunk: "yes", rival: "yes" },
+      { capability: "Jujutsu", hunk: "yes", rival: "yes" },
+      { capability: "Sapling", hunk: "yes", rival: "no" },
+      { capability: "Perforce and GitButler", hunk: "no", rival: "yes" },
+      {
+        capability: "General-purpose Git pager and difftool",
+        hunk: "yes",
+        rival: "no",
+        note: "Hunk also stands in for `core.pager` and `git difftool` on ordinary, non-agent work.",
+      },
+      { capability: "Watch mode that reloads the review", hunk: "yes", rival: "no" },
+      { capability: "Split and stack layouts switchable mid-review", hunk: "yes", rival: "no" },
+      {
+        capability: "Themes",
+        hunk: "yes",
+        rival: "yes",
+        note: `Hunk ships ${THEME_COUNT} bundled themes and takes custom ones. Plannotator ships its own set, chosen in its settings panel.`,
+      },
+      { capability: "Third-party extension API", hunk: "yes", rival: "no" },
+      {
+        capability: "Data stays on your machine",
+        hunk: "yes",
+        rival: "yes",
+        note: "Plannotator is local by default and offers a separate hosted product. Hunk has no hosted component.",
+      },
+    ],
+    sections: [
+      {
+        heading: "The problem they share",
+        body: [
+          "When you wrote the code, reading the diff was a formality. When an agent wrote it, the diff is the only place you find out what actually happened, and the volume went up at the moment your context went down.",
+          "Both tools answer with a review surface that talks back to the agent. You mark something up and your feedback returns to the agent session as structured input instead of a message you retype. The difference is where the reading happens and how early in the loop it starts.",
+        ],
+      },
+      {
+        heading: "What Plannotator does",
+        body: [
+          "Plannotator runs a local binary that starts a temporary server and opens the session in your browser. Its distinguishing move is plan review. When an agent proposes a plan, that plan opens for annotation before any code is written, and you can delete, insert, replace, or comment inline, then approve or request changes.",
+          "Its code review surface handles local changes across Git, Jujutsu, Perforce, and GitButler, and it can open a GitHub pull request or GitLab merge request from a URL. It integrates with a long list of agents through host-specific hooks and commands, and it is dual-licensed under Apache 2.0 or MIT. Plans, diffs, and annotations stay local by default.",
+          "If reviewing plans before implementation is part of how you work, or you want one tool to cover hosted PRs too, that is a real capability Hunk does not have.",
+        ],
+      },
+      {
+        heading: "What Hunk does",
+        body: [
+          "Hunk stays in the terminal. Run `hunk diff` in a second pane and it renders every visible file as one continuous review stream with a sidebar, split or stacked layouts, syntax highlighting, mouse support, and `--watch` to reload as the agent keeps working.",
+          "The agent-facing part runs the other direction from a comment box. Each session registers with a local loopback daemon, and the agent uses non-interactive `hunk session` commands to inspect the review you are looking at, navigate it, and leave notes. `hunk session review --json` gives it the structure of the changeset without pushing the whole patch into its context. Its reasoning then renders inline as note cards on specific hunks, so the explanation sits next to the code instead of in a separate transcript.",
+          "Hunk is also an ordinary diff viewer. The same binary is your Git pager, difftool, patch reader, and two-file comparison tool, which matters if you would rather not install a second thing for non-agent work.",
+        ],
+        code: {
+          caption: "The Hunk agent loop",
+          lines: [
+            HUNK_INSTALL,
+            "",
+            "# terminal 1: your review, stays open",
+            "hunk diff --watch",
+            "",
+            "# terminal 2: point the agent at the review skill",
+            "hunk skill path",
+          ],
+        },
+      },
+      {
+        heading: "Choosing",
+        body: [
+          "Take Plannotator if the plan is where you most want to catch problems, if you would rather read in a browser, or if you need Perforce, GitButler, or hosted PR review in the same tool.",
+          "Take Hunk if the diff is what you review, if you want the agent's reasoning rendered in the diff rather than alongside it, if the agent should be able to read and drive the session you have open, or if you want one terminal tool that is also your everyday Git pager and difftool.",
+          "They are not exclusive. They hook into agents at different points, so nothing stops you annotating a plan in one and reviewing the resulting diff in the other.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Does Hunk review agent plans like Plannotator does?",
+        answer:
+          "No. Hunk's review starts once there is a diff: a working tree, a commit, a patch, or a file pair. Plan review before implementation is Plannotator's territory.",
+      },
+      {
+        question: "Can Hunk review a GitHub pull request?",
+        answer:
+          "Not from a URL. Hunk reviews local input: working trees, commits and revsets, patches on stdin, and file pairs. You can check out the PR branch and run `hunk diff main...HEAD`, but there is no PR-by-URL mode.",
+      },
+      {
+        question: "Which works better over SSH?",
+        answer:
+          "Hunk, because it never needs a browser. It is a terminal UI, so a remote shell or a tmux session on a server is a normal place to run it. Plannotator opens a local server and expects a browser to reach it.",
+      },
+      {
+        question: "Do both send my code anywhere?",
+        answer:
+          "Neither, by default. Hunk runs locally with a loopback daemon for session control and has no hosted component. Plannotator keeps plans, diffs, and annotations local by default, and separately offers a hosted product for sharing.",
+      },
+      {
+        question: "Which agents does each support?",
+        answer:
+          "Plannotator ships host-specific hooks and commands for a long list of agents, including Claude Code, Codex, Copilot CLI, Gemini CLI, and OpenCode. Hunk is agent-neutral: any agent that can run shell commands can use the `hunk session` surface and load the skill returned by `hunk skill path`.",
+      },
+    ],
+    sources: [
+      {
+        label: "Plannotator, GitHub repository",
+        url: "https://github.com/backnotprop/plannotator",
+      },
+      { label: "Plannotator, project site", url: "https://plannotator.ai/" },
+      { label: "Hunk: review with an agent", url: "/docs/agents/review-with-an-agent/" },
+      { label: "Hunk: live session control", url: "/docs/agents/live-session-control/" },
+    ],
+  },
+];
+
+/** Absolute URL for a comparison page, for canonical links and structured data. */
+export function comparisonUrl(comparison: Comparison): string {
+  return `https://hunk.dev/compare/${comparison.slug}/`;
+}
+
+/** Symbol and screen-reader label for one support mark. */
+export const SUPPORT_MARKS: Record<Support, { symbol: string; label: string }> = {
+  yes: { symbol: "●", label: "Yes" },
+  partial: { symbol: "◐", label: "Partly" },
+  no: { symbol: "○", label: "No" },
+};

--- a/website/src/data/extensions.ts
+++ b/website/src/data/extensions.ts
@@ -203,19 +203,6 @@ export const EXTENSION_CATALOG: readonly ExtensionListing[] = [
   },
 ];
 
-/**
- * Serialize one value for a raw `<script type="application/ld+json">` body.
- *
- * `JSON.stringify` leaves `<` alone, so a listing whose text contained
- * `</script>` would close the element and turn the rest of the payload into
- * markup. Escaping `<` as its JSON unicode escape keeps the document valid
- * JSON-LD while making that impossible. The catalog is hand-reviewed today and
- * will be generated from repository descriptions nobody reviews.
- */
-export function toJsonLdScriptBody(value: unknown) {
-  return JSON.stringify(value).replaceAll("<", "\\u003c");
-}
-
 /** GitHub account that publishes one listing. */
 export function ownerOf(listing: ExtensionListing) {
   return listing.repo.split("/")[0] ?? listing.repo;

--- a/website/src/lib/comparisonMarkdown.ts
+++ b/website/src/lib/comparisonMarkdown.ts
@@ -1,0 +1,108 @@
+import {
+  COMPARISONS,
+  COMPARISONS_REVIEWED_ON,
+  HUNK_FACTS,
+  SUPPORT_MARKS,
+  comparisonUrl,
+  type Comparison,
+  type Support,
+} from "../data/comparisons";
+import { SITE_ORIGIN } from "./site";
+
+/**
+ * Render one comparison as the Markdown served at its URL plus `.md`.
+ *
+ * The docs already publish Markdown through starlight-dot-md and robots.txt
+ * tells answer engines to prefer it over scraping HTML; these pages are
+ * hand-built Astro, so they need their own renderer to keep that promise. It
+ * lives here rather than in the endpoint because it is a pure function of the
+ * catalog, which is what makes it testable and keeps Astro's types out of any
+ * program that only wants the text.
+ */
+
+/** Markdown table cell for one support mark, readable without the legend. */
+function cell(support: Support): string {
+  return SUPPORT_MARKS[support].label;
+}
+
+/**
+ * Escape one catalog string for a Markdown table cell.
+ *
+ * `|` would split the cell, and `<` would let a future entry smuggle raw HTML
+ * into a renderer that allows it. The catalog is hand-written today and grows
+ * without anyone re-reading this function.
+ */
+function tableText(text: string): string {
+  return text.replaceAll("|", "\\|").replaceAll("<", "&lt;");
+}
+
+export function renderComparisonMarkdown(comparison: Comparison): string {
+  const { rival } = comparison;
+  const lines: string[] = [
+    `# ${comparison.headline}`,
+    "",
+    `> ${comparison.description}`,
+    "",
+    `Source: ${comparisonUrl(comparison)} · Last checked: ${COMPARISONS_REVIEWED_ON}`,
+    "",
+    comparison.answer,
+    "",
+    "## Choose Hunk if",
+    "",
+    ...comparison.pick.hunk.map((reason) => `- ${reason}`),
+    "",
+    `## Choose ${rival.name} if`,
+    "",
+    ...comparison.pick.rival.map((reason) => `- ${reason}`),
+    "",
+  ];
+
+  for (const section of comparison.sections) {
+    lines.push(`## ${section.heading}`, "");
+    for (const paragraph of section.body) lines.push(paragraph, "");
+    if (section.code) {
+      if (section.code.caption) lines.push(`${section.code.caption}:`, "");
+      lines.push("```bash", ...section.code.lines, "```", "");
+    }
+  }
+
+  lines.push(
+    `## Hunk vs ${rival.name}, capability by capability`,
+    "",
+    `${rival.name} is written in ${rival.language} and licensed ${rival.license}. Hunk is ${HUNK_FACTS.language}, ${HUNK_FACTS.license}, and ships as a standalone binary for ${HUNK_FACTS.platforms}.`,
+    "",
+    `| Capability | Hunk | ${tableText(rival.name)} |`,
+    "| --- | --- | --- |",
+    ...comparison.capabilities.map((row) => {
+      const capability = row.note
+        ? `${tableText(row.capability)} — ${tableText(row.note)}`
+        : tableText(row.capability);
+      return `| ${capability} | ${cell(row.hunk)} | ${cell(row.rival)} |`;
+    }),
+    "",
+    "## Questions people ask",
+    "",
+  );
+
+  for (const faq of comparison.faqs) {
+    lines.push(`### ${faq.question}`, "", faq.answer, "");
+  }
+
+  lines.push(
+    "## Sources",
+    "",
+    ...comparison.sources.map((source) => {
+      const url = source.url.startsWith("/") ? `${SITE_ORIGIN}${source.url}` : source.url;
+      return `- [${source.label}](${url})`;
+    }),
+    "",
+    "## Other comparisons",
+    "",
+    ...COMPARISONS.filter((entry) => entry.slug !== comparison.slug).map(
+      (entry) => `- [${entry.headline}](${comparisonUrl(entry)}) — ${entry.summary}`,
+    ),
+    "",
+  );
+
+  return lines.join("\n");
+}

--- a/website/src/lib/inlineCode.ts
+++ b/website/src/lib/inlineCode.ts
@@ -1,0 +1,31 @@
+/**
+ * Render authored prose that carries Markdown-style `inline code` spans.
+ *
+ * Comparison copy is stored once and rendered three ways — as HTML, as the `.md`
+ * variant agents read, and as structured-data strings — so it is authored in the
+ * lowest common denominator: plain text with backticks. These are the two
+ * conversions the other renderings need.
+ */
+
+const ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+};
+
+/**
+ * Escape one string for HTML, then promote `backtick spans` to `<code>`.
+ *
+ * Escaping runs first so authored text can never introduce an element; the
+ * `<code>` tags are added afterward against already-safe content.
+ */
+export function withInlineCode(text: string): string {
+  const escaped = text.replace(/[&<>"]/g, (character) => ESCAPES[character] ?? character);
+  return escaped.replace(/`([^`]+)`/g, "<code>$1</code>");
+}
+
+/** Drop the backticks, for contexts that take plain text (JSON-LD, meta tags). */
+export function withoutInlineCode(text: string): string {
+  return text.replaceAll("`", "");
+}

--- a/website/src/lib/jsonLd.ts
+++ b/website/src/lib/jsonLd.ts
@@ -1,0 +1,13 @@
+/**
+ * Serialize one value for a raw `<script type="application/ld+json">` body.
+ *
+ * `JSON.stringify` leaves `<` alone, so a payload whose text contained
+ * `</script>` would close the element and turn the rest of it into markup.
+ * Escaping `<` as its JSON unicode escape keeps the document valid JSON-LD
+ * while making that impossible. Structured data is assembled from catalog and
+ * comparison text that grows without anyone re-reviewing the escaping, so this
+ * is the one place any page serializes it.
+ */
+export function toJsonLdScriptBody(value: unknown) {
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}

--- a/website/src/lib/jsonLd.ts
+++ b/website/src/lib/jsonLd.ts
@@ -5,8 +5,7 @@
  * `</script>` would close the element and turn the rest of it into markup.
  * Escaping `<` as its JSON unicode escape keeps the document valid JSON-LD
  * while making that impossible. Structured data is assembled from catalog and
- * comparison text that grows without anyone re-reviewing the escaping, so this
- * is the one place any page serializes it.
+ * comparison text that grows without anyone re-reviewing the escaping.
  */
 export function toJsonLdScriptBody(value: unknown) {
   return JSON.stringify(value).replaceAll("<", "\\u003c");

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -1,0 +1,2 @@
+/** Origin every hand-built page uses for canonical URLs and structured data. */
+export const SITE_ORIGIN = "https://hunk.dev";

--- a/website/src/pages/compare/[slug].astro
+++ b/website/src/pages/compare/[slug].astro
@@ -4,12 +4,16 @@ import BrandHeader from "../../components/BrandHeader.astro";
 import PageHead from "../../components/PageHead.astro";
 import {
   COMPARISONS,
+  COMPARISONS_PUBLISHED_ON,
   COMPARISONS_REVIEWED_ON,
+  HUNK_FACTS,
   SUPPORT_MARKS,
   comparisonUrl,
+  reviewedOnLabel,
   type Comparison,
 } from "../../data/comparisons";
 import { withInlineCode, withoutInlineCode } from "../../lib/inlineCode";
+import { SITE_ORIGIN } from "../../lib/site";
 import "../../styles/marketing.css";
 import "../../styles/compare.css";
 
@@ -18,10 +22,9 @@ import "../../styles/compare.css";
  *
  * The page is ordered for the reader who arrived from a "hunk vs X" query: the
  * answer first, then the two-sided verdict, then the argument, then the table,
- * then the questions that query usually implies. Structured data mirrors that
- * same content rather than restating it, and `.md` variants of these URLs are
- * built from the identical catalog entry, so nothing here is the only place a
- * claim lives.
+ * then the questions that query usually implies. The structured data and the
+ * `.md` variant of this URL render from the same catalog entry, so a capability
+ * mark cannot differ between what a reader sees and what a crawler reads.
  */
 export function getStaticPaths() {
   return COMPARISONS.map((comparison) => ({
@@ -44,23 +47,27 @@ const url = comparisonUrl(comparison);
  *
  * The rendered table is a `<table>` an answer engine has to infer meaning from.
  * `additionalProperty` states each row as a named property of the product it
- * describes, with the row's caveat as its description, so the comparison is
- * readable without parsing the layout. Both products get the same property
- * names, which is what makes the two lists comparable.
+ * describes, and both products get the same property names, which is what makes
+ * the two lists comparable.
+ *
+ * Row notes are deliberately left out. A note is a clause about the row, not
+ * about either product ("delta emits a linear stream", "Hunk honors
+ * `diff.colorMoved`"), so attaching it to one product's property would publish a
+ * claim about the other tool under this tool's name. The table and the `.md`
+ * variant carry the notes in the place they belong.
  */
 function capabilityProperties(side: "hunk" | "rival") {
   return comparison.capabilities.map((row) => ({
     "@type": "PropertyValue",
     name: withoutInlineCode(row.capability),
     value: SUPPORT_MARKS[row[side]].label,
-    ...(row.note ? { description: withoutInlineCode(row.note) } : {}),
   }));
 }
 
 const hunkApplication = {
-  "@type": "SoftwareApplication",
+  "@type": ["SoftwareApplication", "Product"],
   name: "Hunk",
-  url: "https://hunk.dev/",
+  url: `${SITE_ORIGIN}/`,
   applicationCategory: "DeveloperApplication",
   operatingSystem: "macOS, Linux, Windows",
   offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
@@ -76,14 +83,14 @@ const schema = [
     url,
     mainEntityOfPage: url,
     inLanguage: "en",
-    datePublished: COMPARISONS_REVIEWED_ON,
+    datePublished: COMPARISONS_PUBLISHED_ON,
     dateModified: COMPARISONS_REVIEWED_ON,
     author: { "@type": "Organization", name: "Modem", url: "https://modem.dev" },
     publisher: { "@type": "Organization", name: "Modem", url: "https://modem.dev" },
     about: [
       hunkApplication,
       {
-        "@type": "SoftwareApplication",
+        "@type": ["SoftwareApplication", "Product"],
         name: rival.name,
         url: rival.url,
         applicationCategory: "DeveloperApplication",
@@ -105,18 +112,15 @@ const schema = [
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Compare", item: "https://hunk.dev/compare/" },
-      { "@type": "ListItem", position: 2, name: comparison.headline, item: url },
+      { "@type": "ListItem", position: 1, name: "Hunk", item: `${SITE_ORIGIN}/` },
+      { "@type": "ListItem", position: 2, name: "Compare", item: `${SITE_ORIGIN}/compare/` },
+      { "@type": "ListItem", position: 3, name: comparison.headline, item: url },
     ],
   },
 ];
 
 const siblings = COMPARISONS.filter((entry) => entry.slug !== comparison.slug);
-const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDateString("en-US", {
-  month: "long",
-  year: "numeric",
-  timeZone: "UTC",
-});
+const reviewedOn = reviewedOnLabel();
 ---
 
 <!doctype html>
@@ -127,10 +131,14 @@ const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDate
       description={comparison.description}
       keywords={comparison.keywords.join(", ")}
       path={path}
-      ogImageAlt={`${comparison.headline}: how the two terminal diff tools compare`}
+      ogImageAlt="hunk: terminal diffs for humans and agents"
       schema={schema}
     />
-    <link rel="alternate" type="text/markdown" href={`https://hunk.dev/compare/${comparison.slug}.md`} />
+    <link
+      rel="alternate"
+      type="text/markdown"
+      href={`${SITE_ORIGIN}/compare/${comparison.slug}.md`}
+    />
   </head>
   <body>
     <div class="marketing">
@@ -195,8 +203,9 @@ const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDate
         <section class="cmp cmp-section" aria-labelledby="capabilities">
           <h2 id="capabilities">Hunk vs {rival.name}, capability by capability</h2>
           <p class="cmp-prose">
-            {rival.name} is written in {rival.language} and licensed {rival.license}. Hunk is
-            TypeScript, MIT, and ships as a standalone binary for macOS, Linux, and Windows.
+            {rival.name} is written in {rival.language} and licensed {rival.license}. Hunk is{" "}
+            {HUNK_FACTS.language}, {HUNK_FACTS.license}, and ships as a standalone binary for{" "}
+            {HUNK_FACTS.platforms}.
           </p>
           <div
             class="cmp-table-wrap"

--- a/website/src/pages/compare/[slug].astro
+++ b/website/src/pages/compare/[slug].astro
@@ -1,0 +1,302 @@
+---
+import BrandFooter from "../../components/BrandFooter.astro";
+import BrandHeader from "../../components/BrandHeader.astro";
+import PageHead from "../../components/PageHead.astro";
+import {
+  COMPARISONS,
+  COMPARISONS_REVIEWED_ON,
+  SUPPORT_MARKS,
+  comparisonUrl,
+  type Comparison,
+} from "../../data/comparisons";
+import { withInlineCode, withoutInlineCode } from "../../lib/inlineCode";
+import "../../styles/marketing.css";
+import "../../styles/compare.css";
+
+/**
+ * One head-to-head page per entry in the comparison catalog.
+ *
+ * The page is ordered for the reader who arrived from a "hunk vs X" query: the
+ * answer first, then the two-sided verdict, then the argument, then the table,
+ * then the questions that query usually implies. Structured data mirrors that
+ * same content rather than restating it, and `.md` variants of these URLs are
+ * built from the identical catalog entry, so nothing here is the only place a
+ * claim lives.
+ */
+export function getStaticPaths() {
+  return COMPARISONS.map((comparison) => ({
+    params: { slug: comparison.slug },
+    props: { comparison },
+  }));
+}
+
+interface Props {
+  comparison: Comparison;
+}
+
+const { comparison } = Astro.props;
+const { rival } = comparison;
+const path = `/compare/${comparison.slug}/`;
+const url = comparisonUrl(comparison);
+
+/**
+ * Republish the capability table as structured data.
+ *
+ * The rendered table is a `<table>` an answer engine has to infer meaning from.
+ * `additionalProperty` states each row as a named property of the product it
+ * describes, with the row's caveat as its description, so the comparison is
+ * readable without parsing the layout. Both products get the same property
+ * names, which is what makes the two lists comparable.
+ */
+function capabilityProperties(side: "hunk" | "rival") {
+  return comparison.capabilities.map((row) => ({
+    "@type": "PropertyValue",
+    name: withoutInlineCode(row.capability),
+    value: SUPPORT_MARKS[row[side]].label,
+    ...(row.note ? { description: withoutInlineCode(row.note) } : {}),
+  }));
+}
+
+const hunkApplication = {
+  "@type": "SoftwareApplication",
+  name: "Hunk",
+  url: "https://hunk.dev/",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "macOS, Linux, Windows",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  additionalProperty: capabilityProperties("hunk"),
+};
+
+const schema = [
+  {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: comparison.headline,
+    description: comparison.description,
+    url,
+    mainEntityOfPage: url,
+    inLanguage: "en",
+    datePublished: COMPARISONS_REVIEWED_ON,
+    dateModified: COMPARISONS_REVIEWED_ON,
+    author: { "@type": "Organization", name: "Modem", url: "https://modem.dev" },
+    publisher: { "@type": "Organization", name: "Modem", url: "https://modem.dev" },
+    about: [
+      hunkApplication,
+      {
+        "@type": "SoftwareApplication",
+        name: rival.name,
+        url: rival.url,
+        applicationCategory: "DeveloperApplication",
+        additionalProperty: capabilityProperties("rival"),
+      },
+    ],
+    abstract: withoutInlineCode(comparison.answer),
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: comparison.faqs.map((faq) => ({
+      "@type": "Question",
+      name: withoutInlineCode(faq.question),
+      acceptedAnswer: { "@type": "Answer", text: withoutInlineCode(faq.answer) },
+    })),
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Compare", item: "https://hunk.dev/compare/" },
+      { "@type": "ListItem", position: 2, name: comparison.headline, item: url },
+    ],
+  },
+];
+
+const siblings = COMPARISONS.filter((entry) => entry.slug !== comparison.slug);
+const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDateString("en-US", {
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <PageHead
+      title={comparison.title}
+      description={comparison.description}
+      keywords={comparison.keywords.join(", ")}
+      path={path}
+      ogImageAlt={`${comparison.headline}: how the two terminal diff tools compare`}
+      schema={schema}
+    />
+    <link rel="alternate" type="text/markdown" href={`https://hunk.dev/compare/${comparison.slug}.md`} />
+  </head>
+  <body>
+    <div class="marketing">
+      <header class="top">
+        <BrandHeader />
+      </header>
+
+      <main>
+        <section class="cmp cmp-intro">
+          <nav class="crumbs" aria-label="Breadcrumb">
+            <a href="/compare/">Compare</a> / {comparison.headline}
+          </nav>
+          <h1>{comparison.headline}</h1>
+          <p class="cmp-answer" set:html={withInlineCode(comparison.answer)} />
+          <p class="cmp-meta">
+            <span>Checked against each project's own docs in {reviewedOn}</span>
+            <a href={`/compare/${comparison.slug}.md`}>Read as Markdown</a>
+          </p>
+        </section>
+
+        <section class="cmp" aria-labelledby="verdict">
+          <h2 id="verdict" class="sr-only">Which to choose</h2>
+          <div class="picks">
+            <div class="pick">
+              <h3>Choose Hunk if</h3>
+              <ul>
+                {comparison.pick.hunk.map((reason) => <li set:html={withInlineCode(reason)} />)}
+              </ul>
+            </div>
+            <div class="pick">
+              <h3>Choose {rival.name} if</h3>
+              <ul>
+                {comparison.pick.rival.map((reason) => <li set:html={withInlineCode(reason)} />)}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {
+          comparison.sections.map((section) => (
+            <section class="cmp cmp-section">
+              <h2>{section.heading}</h2>
+              {section.body.map((paragraph) => (
+                <p class="cmp-prose" set:html={withInlineCode(paragraph)} />
+              ))}
+              {section.code && (
+                <figure class="cmp-code">
+                  <div class="paper-bar">
+                    <span class="dot" />
+                    <span class="dot" />
+                    <span class="dot" />
+                    <span class="pt">{section.code.caption ?? "terminal"}</span>
+                  </div>
+                  {/* Both scroll sideways on a phone, so both need to be reachable by keyboard. */}
+                  <pre tabindex="0"><code>{section.code.lines.join("\n")}</code></pre>
+                </figure>
+              )}
+            </section>
+          ))
+        }
+
+        <section class="cmp cmp-section" aria-labelledby="capabilities">
+          <h2 id="capabilities">Hunk vs {rival.name}, capability by capability</h2>
+          <p class="cmp-prose">
+            {rival.name} is written in {rival.language} and licensed {rival.license}. Hunk is
+            TypeScript, MIT, and ships as a standalone binary for macOS, Linux, and Windows.
+          </p>
+          <div
+            class="cmp-table-wrap"
+            role="region"
+            tabindex="0"
+            aria-label={`Hunk compared with ${rival.name}, capability by capability`}
+          >
+            <table class="cmp-table">
+              <caption class="sr-only">
+                Hunk compared with {rival.name}, capability by capability
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">Capability</th>
+                  <th scope="col" class="cmp-mark">Hunk</th>
+                  <th scope="col" class="cmp-mark">{rival.name}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  comparison.capabilities.map((row) => (
+                    <tr>
+                      <th scope="row">
+                        <span set:html={withInlineCode(row.capability)} />
+                        {row.note && <span class="cmp-note" set:html={withInlineCode(row.note)} />}
+                      </th>
+                      <td class="cmp-mark" data-support={row.hunk}>
+                        <span aria-hidden="true">{SUPPORT_MARKS[row.hunk].symbol}</span>
+                        <span class="sr-only">{SUPPORT_MARKS[row.hunk].label}</span>
+                      </td>
+                      <td class="cmp-mark" data-support={row.rival}>
+                        <span aria-hidden="true">{SUPPORT_MARKS[row.rival].symbol}</span>
+                        <span class="sr-only">{SUPPORT_MARKS[row.rival].label}</span>
+                      </td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+          <p class="cmp-legend">
+            {SUPPORT_MARKS.yes.symbol} yes · {SUPPORT_MARKS.partial.symbol} partly, see the note ·{" "}
+            {SUPPORT_MARKS.no.symbol} no
+          </p>
+        </section>
+
+        <section class="cmp cmp-section faq" aria-labelledby="faq">
+          <h2 id="faq">Questions people ask</h2>
+          {
+            comparison.faqs.map((faq) => (
+              <div class="faq-item">
+                <h3 set:html={withInlineCode(faq.question)} />
+                <p set:html={withInlineCode(faq.answer)} />
+              </div>
+            ))
+          }
+        </section>
+
+        <section class="cmp cmp-section cmp-sources" aria-labelledby="sources">
+          <h2 id="sources">Sources</h2>
+          <p class="cmp-prose">
+            Claims about {rival.name} were checked against its own documentation in {reviewedOn}. If
+            something here has gone stale,{" "}
+            <a href="https://github.com/modem-dev/hunk/issues">open an issue</a> and it gets fixed.
+          </p>
+          <ul>
+            {
+              comparison.sources.map((source) => (
+                <li>
+                  <a href={source.url}>{source.label}</a>
+                </li>
+              ))
+            }
+          </ul>
+        </section>
+
+        <section class="cmp cmp-section" aria-labelledby="more">
+          <h2 id="more">Other comparisons</h2>
+          <div class="cmp-cards">
+            {
+              siblings.map((entry) => (
+                <a class="cmp-card" href={`/compare/${entry.slug}/`}>
+                  <b>{entry.headline}</b>
+                  <span>{entry.summary}</span>
+                </a>
+              ))
+            }
+          </div>
+        </section>
+
+        <section class="cmp cmp-tail">
+          <h2>Try Hunk on your next changeset.</h2>
+          <div class="cta">
+            <a class="ghost" href="/#install">Install hunk</a>
+            <a class="plain" href="/docs/start/quick-start/">Read the quick start</a>
+          </div>
+        </section>
+      </main>
+
+      <BrandFooter />
+    </div>
+  </body>
+</html>

--- a/website/src/pages/compare/[slug].md.ts
+++ b/website/src/pages/compare/[slug].md.ts
@@ -1,0 +1,110 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import {
+  COMPARISONS,
+  COMPARISONS_REVIEWED_ON,
+  SUPPORT_MARKS,
+  comparisonUrl,
+  type Comparison,
+  type Support,
+} from "../../data/comparisons";
+
+/**
+ * Serves every comparison as Markdown at its own URL plus `.md`.
+ *
+ * The docs already do this through starlight-dot-md, and robots.txt tells answer
+ * engines to prefer Markdown over scraping HTML; these pages are hand-built
+ * Astro rather than content collections, so they need their own endpoint to keep
+ * that promise. Output is generated from the same catalog entry the HTML page
+ * renders, so the two can never disagree about a capability mark.
+ */
+export const getStaticPaths: GetStaticPaths = () =>
+  COMPARISONS.map((comparison) => ({
+    params: { slug: comparison.slug },
+    props: { comparison },
+  }));
+
+/** Markdown table cell for one support mark, readable without the legend. */
+function cell(support: Support): string {
+  return SUPPORT_MARKS[support].label;
+}
+
+/** Escape the pipe characters that would otherwise split a Markdown table cell. */
+function tableText(text: string): string {
+  return text.replaceAll("|", "\\|");
+}
+
+function render(comparison: Comparison): string {
+  const { rival } = comparison;
+  const lines: string[] = [
+    `# ${comparison.headline}`,
+    "",
+    `> ${comparison.description}`,
+    "",
+    `Source: ${comparisonUrl(comparison)} · Last checked: ${COMPARISONS_REVIEWED_ON}`,
+    "",
+    comparison.answer,
+    "",
+    "## Choose Hunk if",
+    "",
+    ...comparison.pick.hunk.map((reason) => `- ${reason}`),
+    "",
+    `## Choose ${rival.name} if`,
+    "",
+    ...comparison.pick.rival.map((reason) => `- ${reason}`),
+    "",
+  ];
+
+  for (const section of comparison.sections) {
+    lines.push(`## ${section.heading}`, "");
+    for (const paragraph of section.body) lines.push(paragraph, "");
+    if (section.code) {
+      if (section.code.caption) lines.push(`${section.code.caption}:`, "");
+      lines.push("```bash", ...section.code.lines, "```", "");
+    }
+  }
+
+  lines.push(
+    `## Hunk vs ${rival.name}, capability by capability`,
+    "",
+    `${rival.name} is written in ${rival.language} and licensed ${rival.license}. Hunk is TypeScript, MIT, and ships as a standalone binary for macOS, Linux, and Windows.`,
+    "",
+    `| Capability | Hunk | ${tableText(rival.name)} |`,
+    "| --- | --- | --- |",
+    ...comparison.capabilities.map((row) => {
+      const capability = row.note
+        ? `${tableText(row.capability)} — ${tableText(row.note)}`
+        : tableText(row.capability);
+      return `| ${capability} | ${cell(row.hunk)} | ${cell(row.rival)} |`;
+    }),
+    "",
+    "## Questions people ask",
+    "",
+  );
+
+  for (const faq of comparison.faqs) {
+    lines.push(`### ${faq.question}`, "", faq.answer, "");
+  }
+
+  lines.push(
+    "## Sources",
+    "",
+    ...comparison.sources.map((source) => {
+      const url = source.url.startsWith("/") ? `https://hunk.dev${source.url}` : source.url;
+      return `- [${source.label}](${url})`;
+    }),
+    "",
+    "## Other comparisons",
+    "",
+    ...COMPARISONS.filter((entry) => entry.slug !== comparison.slug).map(
+      (entry) => `- [${entry.headline}](${comparisonUrl(entry)}) — ${entry.summary}`,
+    ),
+    "",
+  );
+
+  return `${lines.join("\n")}`;
+}
+
+export const GET: APIRoute = ({ props }) =>
+  new Response(render(props.comparison as Comparison), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });

--- a/website/src/pages/compare/[slug].md.ts
+++ b/website/src/pages/compare/[slug].md.ts
@@ -1,21 +1,12 @@
 import type { APIRoute, GetStaticPaths } from "astro";
-import {
-  COMPARISONS,
-  COMPARISONS_REVIEWED_ON,
-  SUPPORT_MARKS,
-  comparisonUrl,
-  type Comparison,
-  type Support,
-} from "../../data/comparisons";
+import { COMPARISONS, type Comparison } from "../../data/comparisons";
+import { renderComparisonMarkdown } from "../../lib/comparisonMarkdown";
 
 /**
  * Serves every comparison as Markdown at its own URL plus `.md`.
  *
- * The docs already do this through starlight-dot-md, and robots.txt tells answer
- * engines to prefer Markdown over scraping HTML; these pages are hand-built
- * Astro rather than content collections, so they need their own endpoint to keep
- * that promise. Output is generated from the same catalog entry the HTML page
- * renders, so the two can never disagree about a capability mark.
+ * The rendering lives in `lib/comparisonMarkdown`; this file is the Astro glue
+ * that maps a slug onto it.
  */
 export const getStaticPaths: GetStaticPaths = () =>
   COMPARISONS.map((comparison) => ({
@@ -23,88 +14,9 @@ export const getStaticPaths: GetStaticPaths = () =>
     props: { comparison },
   }));
 
-/** Markdown table cell for one support mark, readable without the legend. */
-function cell(support: Support): string {
-  return SUPPORT_MARKS[support].label;
-}
-
-/** Escape the pipe characters that would otherwise split a Markdown table cell. */
-function tableText(text: string): string {
-  return text.replaceAll("|", "\\|");
-}
-
-function render(comparison: Comparison): string {
-  const { rival } = comparison;
-  const lines: string[] = [
-    `# ${comparison.headline}`,
-    "",
-    `> ${comparison.description}`,
-    "",
-    `Source: ${comparisonUrl(comparison)} · Last checked: ${COMPARISONS_REVIEWED_ON}`,
-    "",
-    comparison.answer,
-    "",
-    "## Choose Hunk if",
-    "",
-    ...comparison.pick.hunk.map((reason) => `- ${reason}`),
-    "",
-    `## Choose ${rival.name} if`,
-    "",
-    ...comparison.pick.rival.map((reason) => `- ${reason}`),
-    "",
-  ];
-
-  for (const section of comparison.sections) {
-    lines.push(`## ${section.heading}`, "");
-    for (const paragraph of section.body) lines.push(paragraph, "");
-    if (section.code) {
-      if (section.code.caption) lines.push(`${section.code.caption}:`, "");
-      lines.push("```bash", ...section.code.lines, "```", "");
-    }
-  }
-
-  lines.push(
-    `## Hunk vs ${rival.name}, capability by capability`,
-    "",
-    `${rival.name} is written in ${rival.language} and licensed ${rival.license}. Hunk is TypeScript, MIT, and ships as a standalone binary for macOS, Linux, and Windows.`,
-    "",
-    `| Capability | Hunk | ${tableText(rival.name)} |`,
-    "| --- | --- | --- |",
-    ...comparison.capabilities.map((row) => {
-      const capability = row.note
-        ? `${tableText(row.capability)} — ${tableText(row.note)}`
-        : tableText(row.capability);
-      return `| ${capability} | ${cell(row.hunk)} | ${cell(row.rival)} |`;
-    }),
-    "",
-    "## Questions people ask",
-    "",
-  );
-
-  for (const faq of comparison.faqs) {
-    lines.push(`### ${faq.question}`, "", faq.answer, "");
-  }
-
-  lines.push(
-    "## Sources",
-    "",
-    ...comparison.sources.map((source) => {
-      const url = source.url.startsWith("/") ? `https://hunk.dev${source.url}` : source.url;
-      return `- [${source.label}](${url})`;
-    }),
-    "",
-    "## Other comparisons",
-    "",
-    ...COMPARISONS.filter((entry) => entry.slug !== comparison.slug).map(
-      (entry) => `- [${entry.headline}](${comparisonUrl(entry)}) — ${entry.summary}`,
-    ),
-    "",
-  );
-
-  return `${lines.join("\n")}`;
-}
-
+// The build is static, so this header only applies under `astro dev`; the deployed
+// files are served with whatever the host infers from the `.md` extension.
 export const GET: APIRoute = ({ props }) =>
-  new Response(render(props.comparison as Comparison), {
+  new Response(renderComparisonMarkdown(props.comparison as Comparison), {
     headers: { "Content-Type": "text/markdown; charset=utf-8" },
   });

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -2,7 +2,8 @@
 import BrandFooter from "../../components/BrandFooter.astro";
 import BrandHeader from "../../components/BrandHeader.astro";
 import PageHead from "../../components/PageHead.astro";
-import { COMPARISONS, COMPARISONS_REVIEWED_ON, comparisonUrl } from "../../data/comparisons";
+import { COMPARISONS, comparisonUrl, reviewedOnLabel } from "../../data/comparisons";
+import { SITE_ORIGIN } from "../../lib/site";
 import "../../styles/marketing.css";
 import "../../styles/compare.css";
 
@@ -24,7 +25,7 @@ const schema = [
     "@type": "ItemList",
     name: "Hunk comparisons",
     description,
-    url: "https://hunk.dev/compare/",
+    url: `${SITE_ORIGIN}/compare/`,
     numberOfItems: COMPARISONS.length,
     itemListElement: COMPARISONS.map((comparison, index) => ({
       "@type": "ListItem",
@@ -38,16 +39,13 @@ const schema = [
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Compare", item: "https://hunk.dev/compare/" },
+      { "@type": "ListItem", position: 1, name: "Hunk", item: `${SITE_ORIGIN}/` },
+      { "@type": "ListItem", position: 2, name: "Compare", item: `${SITE_ORIGIN}/compare/` },
     ],
   },
 ];
 
-const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDateString("en-US", {
-  month: "long",
-  year: "numeric",
-  timeZone: "UTC",
-});
+const reviewedOn = reviewedOnLabel();
 ---
 
 <!doctype html>
@@ -58,7 +56,7 @@ const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDate
       description={description}
       keywords="hunk vs delta, hunk vs difftastic, hunk vs git diff, terminal diff tool comparison, best git diff tool"
       path="/compare/"
-      ogImageAlt="Hunk compared with delta, difftastic, diff-so-fancy, git diff, and Plannotator"
+      ogImageAlt="hunk: terminal diffs for humans and agents"
       schema={schema}
     />
   </head>

--- a/website/src/pages/compare/index.astro
+++ b/website/src/pages/compare/index.astro
@@ -1,0 +1,129 @@
+---
+import BrandFooter from "../../components/BrandFooter.astro";
+import BrandHeader from "../../components/BrandHeader.astro";
+import PageHead from "../../components/PageHead.astro";
+import { COMPARISONS, COMPARISONS_REVIEWED_ON, comparisonUrl } from "../../data/comparisons";
+import "../../styles/marketing.css";
+import "../../styles/compare.css";
+
+/**
+ * The hub the individual comparisons link back to.
+ *
+ * It exists for two readers: the person who wants to know where Hunk sits among
+ * the tools they already run, and the crawler that needs one page linking the
+ * whole cluster together. It stays short on purpose. The argument belongs on the
+ * pages themselves.
+ */
+const title = "Hunk vs other diff tools";
+const description =
+  "How Hunk compares with delta, difftastic, diff-so-fancy, git diff, and Plannotator. What each tool is for, capability tables checked against their own docs, and when to run both.";
+
+const schema = [
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "Hunk comparisons",
+    description,
+    url: "https://hunk.dev/compare/",
+    numberOfItems: COMPARISONS.length,
+    itemListElement: COMPARISONS.map((comparison, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: comparison.headline,
+      description: comparison.summary,
+      url: comparisonUrl(comparison),
+    })),
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Compare", item: "https://hunk.dev/compare/" },
+    ],
+  },
+];
+
+const reviewedOn = new Date(`${COMPARISONS_REVIEWED_ON}T00:00:00Z`).toLocaleDateString("en-US", {
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <PageHead
+      title={title}
+      description={description}
+      keywords="hunk vs delta, hunk vs difftastic, hunk vs git diff, terminal diff tool comparison, best git diff tool"
+      path="/compare/"
+      ogImageAlt="Hunk compared with delta, difftastic, diff-so-fancy, git diff, and Plannotator"
+      schema={schema}
+    />
+  </head>
+  <body>
+    <div class="marketing">
+      <header class="top">
+        <BrandHeader />
+      </header>
+
+      <main>
+        <section class="cmp cmp-intro">
+          <p class="kicker"># where hunk fits</p>
+          <h1>Hunk vs the tools<br />you already run.</h1>
+          <p class="cmp-answer">
+            Most terminal diff tools are pagers. They restyle the text Git already printed. Hunk is
+            a review UI: one multi-file stream, a file sidebar, split and stack layouts, expandable
+            context, watch mode, and agent notes beside the code. These pages say where that is
+            worth it, and where the other tool wins.
+          </p>
+          <p class="cmp-meta">
+            <span>{COMPARISONS.length} comparisons · checked against each project's own docs in {
+                reviewedOn
+              }</span>
+          </p>
+        </section>
+
+        <section class="cmp" aria-label="Comparisons">
+          <div class="cmp-cards">
+            {
+              COMPARISONS.map((comparison) => (
+                <a class="cmp-card" href={`/compare/${comparison.slug}/`}>
+                  <b>{comparison.headline}</b>
+                  <span>{comparison.summary}</span>
+                </a>
+              ))
+            }
+          </div>
+        </section>
+
+        <section class="cmp cmp-section">
+          <h2>How these are written</h2>
+          <p class="cmp-prose">
+            Every mark comes from the other project's own docs. Where a bare mark would mislead, the
+            caveat sits next to it. Rows the other tool wins are in the tables too: structural
+            diffing, styled <code>git blame</code>, plan review before code exists. A comparison
+            that concedes nothing is not worth reading.
+          </p>
+          <p class="cmp-prose">
+            Each page is also served as Markdown at the same URL plus <code>.md</code>, and its
+            capability table is published as JSON-LD, so an agent can read the comparison without
+            parsing the layout. The docs corpus is available the same way at{" "}
+            <a href="/llms.txt">/llms.txt</a>.
+          </p>
+        </section>
+
+        <section class="cmp cmp-tail">
+          <h2>Try Hunk on your next changeset.</h2>
+          <div class="cta">
+            <a class="ghost" href="/#install">Install hunk</a>
+            <a class="plain" href="/docs/start/quick-start/">Read the quick start</a>
+          </div>
+        </section>
+      </main>
+
+      <BrandFooter />
+    </div>
+  </body>
+</html>

--- a/website/src/pages/extensions.astro
+++ b/website/src/pages/extensions.astro
@@ -1,6 +1,7 @@
 ---
 import BrandFooter from "../components/BrandFooter.astro";
 import BrandHeader from "../components/BrandHeader.astro";
+import PageHead from "../components/PageHead.astro";
 import {
   avatarUrl,
   categoryFacets,
@@ -9,7 +10,6 @@ import {
   loadExtensionEntries,
   ownerOf,
   repositoryUrl,
-  toJsonLdScriptBody,
 } from "../data/extensions";
 import "../styles/marketing.css";
 import "../styles/extensions.css";
@@ -45,38 +45,15 @@ const schema = {
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="theme-color" content="#f4f1ea" />
-    <meta name="description" content={description} />
-    <meta
-      name="keywords"
-      content="hunk extensions, terminal diff, code review, TypeScript extensions, hunk-extension"
+    <PageHead
+      title={title}
+      description={description}
+      keywords="hunk extensions, terminal diff, code review, TypeScript extensions, hunk-extension"
+      path="/extensions/"
+      ogImage="https://hunk.dev/extensions/og.png"
+      ogImageAlt="Hunk extensions: community extensions for panes, themes, highlighters, and more."
+      schema={schema}
     />
-    <meta name="author" content="Modem" />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="hunk" />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content="https://hunk.dev/extensions/" />
-    <meta property="og:image" content="https://hunk.dev/extensions/og.png" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta
-      property="og:image:alt"
-      content="Hunk extensions: community extensions for panes, themes, highlighters, and more."
-    />
-    <meta property="og:locale" content="en_US" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content="https://hunk.dev/extensions/og.png" />
-    <link rel="canonical" href="https://hunk.dev/extensions/" />
-    <link rel="icon" href="/icon.png" type="image/png" />
-    <link rel="apple-touch-icon" href="/apple-icon.png" />
-    <title>{title}</title>
-    <script type="application/ld+json" is:inline set:html={toJsonLdScriptBody(schema)}></script>
-    <script is:inline defer src="/_vercel/insights/script.js"></script>
   </head>
   <body>
     <div class="marketing">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BrandFooter from "../components/BrandFooter.astro";
 import BrandHeader from "../components/BrandHeader.astro";
+import PageHead from "../components/PageHead.astro";
 import CommunityVideos from "../components/marketing/CommunityVideos.astro";
 import FeatureShowcase from "../components/marketing/FeatureShowcase.astro";
 import InstallTabs from "../components/marketing/InstallTabs.astro";
@@ -73,35 +74,14 @@ const formattedStars =
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <meta name="theme-color" content="#f4f1ea" />
-    <meta name="description" content={description} />
-    <meta
-      name="keywords"
-      content="diff, terminal, TUI, code review, git, jujutsu, AI agents, extensions, OpenTUI"
+    <PageHead
+      title={title}
+      description={description}
+      keywords="diff, terminal, TUI, code review, git, jujutsu, AI agents, extensions, OpenTUI"
+      path="/"
+      ogImageAlt="hunk — terminal diffs for humans & agents"
+      schema={schema}
     />
-    <meta name="author" content="Modem" />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="hunk" />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:url" content="https://hunk.dev/" />
-    <meta property="og:image" content="https://hunk.dev/og.png" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="hunk — terminal diffs for humans & agents" />
-    <meta property="og:locale" content="en_US" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content="https://hunk.dev/og.png" />
-    <link rel="canonical" href="https://hunk.dev/" />
-    <link rel="icon" href="/icon.png" type="image/png" />
-    <link rel="apple-touch-icon" href="/apple-icon.png" />
-    <title>{title}</title>
-    <script type="application/ld+json" is:inline set:html={JSON.stringify(schema)}></script>
-    <script is:inline defer src="/_vercel/insights/script.js"></script>
   </head>
   <body>
     <div class="marketing">
@@ -159,6 +139,7 @@ const formattedStars =
           <div class="cta">
             <a class="ghost" href="#install">Install hunk</a>
             <a class="plain" href="/docs/start/quick-start/">Read the quick start</a>
+            <a class="plain" href="/compare/">Compare with delta &amp; difftastic</a>
           </div>
         </section>
       </main>

--- a/website/src/styles/compare.css
+++ b/website/src/styles/compare.css
@@ -1,0 +1,363 @@
+/*
+ * Comparison pages: the `/compare/` hub and each head-to-head page.
+ *
+ * These are read, not skimmed, so the type block is narrower than the marketing
+ * shell and the rhythm is closer to the docs. Everything reuses the brand tokens
+ * marketing.css already defines; nothing here introduces a new color.
+ */
+
+.marketing .cmp {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 36px;
+}
+
+.marketing .cmp-intro {
+  padding-top: 60px;
+  padding-bottom: 8px;
+}
+
+.marketing .crumbs {
+  margin: 0 0 18px;
+  color: var(--soft);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+.marketing .crumbs a {
+  color: var(--soft);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-underline-offset: 4px;
+}
+
+.marketing .crumbs a:hover {
+  color: var(--ink);
+}
+
+.marketing .cmp h1 {
+  font-size: clamp(30px, 5vw, 48px);
+}
+
+/* The lead answer is what an answer engine quotes, so it reads as the page's thesis. */
+.marketing .cmp-answer {
+  max-width: 660px;
+  margin: 0 0 34px;
+  color: var(--hunk-body);
+  font-size: 17px;
+  line-height: 1.66;
+}
+
+.marketing .cmp-answer code,
+.marketing .cmp-prose code,
+.marketing .cmp-note code,
+.marketing .cmp-cell code {
+  padding: 1px 4px;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--paper);
+  font-size: 0.92em;
+}
+
+.marketing .cmp-meta a {
+  color: var(--soft);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-underline-offset: 4px;
+}
+
+.marketing .cmp-meta a:hover {
+  color: var(--ink);
+}
+
+.marketing .cmp-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  margin: 0 0 8px;
+  color: var(--soft);
+  font-size: 12px;
+}
+
+/* Verdict pair */
+.marketing .picks {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin: 8px 0 12px;
+}
+
+.marketing .pick {
+  padding: 20px 22px;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  background: var(--paper);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.marketing .pick h3 {
+  margin: 0 0 12px;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.marketing .pick ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.marketing .pick li {
+  position: relative;
+  margin: 0 0 10px;
+  padding-left: 18px;
+  color: var(--hunk-body);
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+
+.marketing .pick li::before {
+  position: absolute;
+  left: 0;
+  color: var(--acc);
+  content: "+";
+  font-weight: 700;
+}
+
+.marketing .pick li:last-child {
+  margin-bottom: 0;
+}
+
+/* Prose sections. The section keeps the 960px shell so tables and card grids use
+   the full width; only the measure-sensitive parts narrow. */
+.marketing .cmp-section {
+  padding-top: 46px;
+}
+
+.marketing .cmp-section h2 {
+  margin: 0 0 16px;
+  font-size: clamp(21px, 3vw, 26px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.marketing .cmp-prose {
+  max-width: 720px;
+  margin: 0 0 16px;
+  color: var(--hunk-body);
+  font-size: 15.5px;
+  line-height: 1.68;
+}
+
+.marketing .cmp-code {
+  max-width: 720px;
+  margin: 22px 0 0;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  background: var(--paper);
+  box-shadow: 3px 3px 0 var(--ink);
+  overflow: hidden;
+}
+
+.marketing .cmp-code .paper-bar {
+  border-radius: 0;
+}
+
+.marketing .cmp-code pre {
+  margin: 0;
+  padding: 16px 18px;
+  overflow-x: auto;
+  font-size: 12.5px;
+  line-height: 1.75;
+}
+
+.marketing .cmp-code code {
+  color: var(--hunk-body);
+}
+
+/* Capability table */
+.marketing .cmp-table-wrap {
+  margin-top: 22px;
+  overflow-x: auto;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  background: var(--paper);
+  box-shadow: 3px 3px 0 var(--ink);
+}
+
+.marketing table.cmp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13.5px;
+}
+
+.marketing .cmp-table th,
+.marketing .cmp-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--rule);
+  text-align: left;
+  vertical-align: top;
+}
+
+.marketing .cmp-table thead th {
+  border-bottom: 1.5px solid var(--ink);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.marketing .cmp-table tbody tr:last-child th,
+.marketing .cmp-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.marketing .cmp-table tbody th {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.marketing .cmp-table .cmp-mark {
+  width: 84px;
+  text-align: center;
+  font-size: 15px;
+}
+
+/* JetBrains Mono has no half-filled circle, and the fallback it picks for `partial`
+   is a different size from the other two marks. A symbol-complete stack keeps the
+   three states reading as one set. */
+.marketing .cmp-table td.cmp-mark {
+  font-family: ui-sans-serif, system-ui, "Segoe UI Symbol", "Noto Sans Symbols 2", sans-serif;
+}
+
+.marketing .cmp-mark[data-support="yes"] {
+  color: var(--acc);
+}
+
+.marketing .cmp-mark[data-support="partial"] {
+  color: var(--soft);
+}
+
+.marketing .cmp-mark[data-support="no"] {
+  color: var(--rule);
+}
+
+.marketing .cmp-note {
+  display: block;
+  margin-top: 6px;
+  color: var(--soft);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.marketing .cmp-legend {
+  margin: 10px 0 0;
+  color: var(--soft);
+  font-size: 12px;
+}
+
+/* FAQ */
+.marketing .faq-item {
+  max-width: 720px;
+  padding: 20px 0;
+  border-top: 1px solid var(--rule);
+}
+
+.marketing .faq-item h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.marketing .faq-item p {
+  margin: 0;
+  color: var(--hunk-body);
+  font-size: 14.5px;
+  line-height: 1.65;
+}
+
+/* Sources and sibling navigation */
+.marketing .cmp-sources ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  columns: 2;
+  column-gap: 28px;
+}
+
+.marketing .cmp-sources li {
+  margin: 0 0 8px;
+  font-size: 13px;
+  break-inside: avoid;
+}
+
+.marketing .cmp-sources a {
+  color: var(--hunk-body);
+  text-decoration: underline;
+  text-decoration-color: var(--rule);
+  text-underline-offset: 4px;
+}
+
+.marketing .cmp-sources a:hover {
+  color: var(--ink);
+}
+
+.marketing .cmp-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.marketing a.cmp-card {
+  display: block;
+  padding: 20px 22px;
+  border: 1.5px solid var(--ink);
+  border-radius: 10px;
+  background: var(--paper);
+  box-shadow: 3px 3px 0 var(--ink);
+  color: var(--ink);
+  text-decoration: none;
+  transition: 0.12s;
+}
+
+.marketing a.cmp-card:hover {
+  background: var(--hunk-paper-hover);
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+.marketing .cmp-card b {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+}
+
+.marketing .cmp-card span {
+  display: block;
+  color: var(--hunk-body);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.marketing .cmp-tail {
+  padding-top: 56px;
+  padding-bottom: 96px;
+}
+
+@media (max-width: 720px) {
+  .marketing .cmp {
+    padding-inline: 22px;
+  }
+
+  .marketing .picks {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .marketing .cmp-sources ul {
+    columns: 1;
+  }
+}

--- a/website/tests/compare-smoke.spec.ts
+++ b/website/tests/compare-smoke.spec.ts
@@ -1,0 +1,135 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+const COMPARISONS = [
+  "hunk-vs-delta",
+  "hunk-vs-difftastic",
+  "hunk-vs-diff-so-fancy",
+  "hunk-vs-git-diff",
+  "hunk-vs-plannotator",
+] as const;
+
+test("the hub indexes every comparison and links each one", async ({ page }) => {
+  const response = await page.goto("/compare/");
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Hunk vs the tools");
+
+  const cards = page.locator("a.cmp-card");
+  await expect(cards).toHaveCount(COMPARISONS.length);
+  for (const slug of COMPARISONS) {
+    await expect(page.locator(`a.cmp-card[href="/compare/${slug}/"]`)).toHaveCount(1);
+  }
+});
+
+test("every comparison page leads with an answer, a two-sided verdict, and a table", async ({
+  page,
+}) => {
+  for (const slug of COMPARISONS) {
+    const response = await page.goto(`/compare/${slug}/`);
+    expect(response?.ok(), slug).toBe(true);
+
+    // The lead paragraph is what an answer engine quotes, so it has to be the
+    // first thing after the h1 and long enough to stand on its own.
+    const answer = page.locator(".cmp-answer");
+    await expect(answer, slug).toBeVisible();
+    expect((await answer.innerText()).length, slug).toBeGreaterThan(200);
+
+    // Both sides get a recommendation: a page that only argues one way is the
+    // kind of comparison a reader stops trusting.
+    await expect(page.getByRole("heading", { name: "Choose Hunk if" }), slug).toBeVisible();
+    await expect(page.locator(".pick h3"), slug).toHaveCount(2);
+
+    const rows = page.locator(".cmp-table tbody tr");
+    expect(await rows.count(), slug).toBeGreaterThan(8);
+
+    // Every row is marked for both tools, and at least one row concedes something.
+    const marks = page.locator(".cmp-table tbody td.cmp-mark");
+    expect(await marks.count(), slug).toBe((await rows.count()) * 2);
+    expect(
+      await page.locator('.cmp-table tbody tr td.cmp-mark:nth-child(2)[data-support="no"]').count(),
+      `${slug} never concedes a capability to the other tool`,
+    ).toBeGreaterThan(0);
+
+    await expect(page.locator(".faq-item"), slug).not.toHaveCount(0);
+    await expect(page.locator(".cmp-sources a"), slug).not.toHaveCount(0);
+  }
+});
+
+test("comparison pages carry the structured data answer engines read", async ({ page }) => {
+  await page.goto("/compare/hunk-vs-delta/");
+
+  const types = await page
+    .locator('script[type="application/ld+json"]')
+    .evaluateAll((nodes) => nodes.map((node) => JSON.parse(node.textContent ?? "{}")["@type"]));
+  expect(types).toEqual(["TechArticle", "FAQPage", "BreadcrumbList"]);
+
+  const faq = await page
+    .locator('script[type="application/ld+json"]')
+    .nth(1)
+    .evaluate((node) => JSON.parse(node.textContent ?? "{}"));
+  expect(faq.mainEntity.length).toBe(await page.locator(".faq-item").count());
+  // Structured-data text is plain prose: backticks belong in the rendered page.
+  expect(JSON.stringify(faq)).not.toContain("`");
+
+  // The capability table is republished as properties of each product, so an
+  // answer engine reads the comparison without inferring it from a <table>.
+  const article = await page
+    .locator('script[type="application/ld+json"]')
+    .first()
+    .evaluate((node) => JSON.parse(node.textContent ?? "{}"));
+  const rows = await page.locator(".cmp-table tbody tr").count();
+  expect(article.about).toHaveLength(2);
+  for (const product of article.about) {
+    expect(product.additionalProperty).toHaveLength(rows);
+    expect(product.additionalProperty.every(({ value }) => value)).toBe(true);
+  }
+  expect(article.about[0].additionalProperty.map(({ name }) => name)).toEqual(
+    article.about[1].additionalProperty.map(({ name }) => name),
+  );
+  expect(article.about[0].additionalProperty.some(({ name }) => name === "Themes")).toBe(true);
+
+  await expect(page.locator("link[rel=canonical]")).toHaveAttribute(
+    "href",
+    "https://hunk.dev/compare/hunk-vs-delta/",
+  );
+});
+
+test("every comparison is also served as Markdown for agents", async ({ page, request }) => {
+  for (const slug of COMPARISONS) {
+    const response = await request.get(`/compare/${slug}.md`);
+    expect(response.ok(), slug).toBe(true);
+    expect(response.headers()["content-type"], slug).toContain("text/markdown");
+
+    const body = await response.text();
+    expect(body, slug).toContain(`# Hunk vs`);
+    expect(body, slug).toContain("| Capability | Hunk |");
+    expect(body, slug).toContain(`https://hunk.dev/compare/${slug}/`);
+  }
+
+  await page.goto("/compare/hunk-vs-delta/");
+  await expect(page.locator('link[rel=alternate][type="text/markdown"]')).toHaveAttribute(
+    "href",
+    "https://hunk.dev/compare/hunk-vs-delta.md",
+  );
+});
+
+test("the comparison cluster is reachable from the site's own navigation", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".brand-footer a[href='/compare/']")).toHaveCount(1);
+  await expect(page.locator("main a[href='/compare/']")).toHaveCount(1);
+
+  await page.goto("/compare/hunk-vs-delta/");
+  await expect(page.getByRole("navigation", { name: "Breadcrumb" })).toContainText("Compare");
+  // Each page links every sibling, so the cluster stays crawlable from any entry point.
+  await expect(page.locator("a.cmp-card")).toHaveCount(COMPARISONS.length - 1);
+});
+
+test("comparison pages have no serious automated accessibility violations", async ({ page }) => {
+  await page.goto("/compare/hunk-vs-delta/");
+  const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
+  const blocking = results.violations.filter(
+    ({ impact }) => impact === "critical" || impact === "serious",
+  );
+
+  expect(blocking).toEqual([]);
+});

--- a/website/tests/compare-smoke.spec.ts
+++ b/website/tests/compare-smoke.spec.ts
@@ -61,7 +61,8 @@ test("comparison pages carry the structured data answer engines read", async ({ 
   const types = await page
     .locator('script[type="application/ld+json"]')
     .evaluateAll((nodes) => nodes.map((node) => JSON.parse(node.textContent ?? "{}")["@type"]));
-  expect(types).toEqual(["TechArticle", "FAQPage", "BreadcrumbList"]);
+  expect(types).toHaveLength(3);
+  expect(types).toEqual(expect.arrayContaining(["TechArticle", "FAQPage", "BreadcrumbList"]));
 
   const faq = await page
     .locator('script[type="application/ld+json"]')
@@ -80,8 +81,15 @@ test("comparison pages carry the structured data answer engines read", async ({ 
   const rows = await page.locator(".cmp-table tbody tr").count();
   expect(article.about).toHaveLength(2);
   for (const product of article.about) {
+    // `additionalProperty` is outside SoftwareApplication's schema.org domain, so
+    // the products are multi-typed; without Product a validator drops the payload.
+    expect(product["@type"]).toContain("Product");
     expect(product.additionalProperty).toHaveLength(rows);
-    expect(product.additionalProperty.every(({ value }) => value)).toBe(true);
+    for (const { value, description } of product.additionalProperty) {
+      expect(["Yes", "Partly", "No"]).toContain(value);
+      // A row note describes the row, not one product, so it is not published here.
+      expect(description).toBeUndefined();
+    }
   }
   expect(article.about[0].additionalProperty.map(({ name }) => name)).toEqual(
     article.about[1].additionalProperty.map(({ name }) => name),
@@ -125,11 +133,13 @@ test("the comparison cluster is reachable from the site's own navigation", async
 });
 
 test("comparison pages have no serious automated accessibility violations", async ({ page }) => {
-  await page.goto("/compare/hunk-vs-delta/");
-  const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
-  const blocking = results.violations.filter(
-    ({ impact }) => impact === "critical" || impact === "serious",
-  );
+  for (const path of ["/compare/", ...COMPARISONS.map((slug) => `/compare/${slug}/`)]) {
+    await page.goto(path);
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
+    const blocking = results.violations.filter(
+      ({ impact }) => impact === "critical" || impact === "serious",
+    );
 
-  expect(blocking).toEqual([]);
+    expect(blocking, path).toEqual([]);
+  }
 });

--- a/website/tests/compare-smoke.spec.ts
+++ b/website/tests/compare-smoke.spec.ts
@@ -74,10 +74,15 @@ test("comparison pages carry the structured data answer engines read", async ({ 
 
   // The capability table is republished as properties of each product, so an
   // answer engine reads the comparison without inferring it from a <table>.
-  const article = await page
+  const article = (await page
     .locator('script[type="application/ld+json"]')
     .first()
-    .evaluate((node) => JSON.parse(node.textContent ?? "{}"));
+    .evaluate((node) => JSON.parse(node.textContent ?? "{}"))) as {
+    about: {
+      "@type": string[];
+      additionalProperty: { name: string; value: string; description?: string }[];
+    }[];
+  };
   const rows = await page.locator(".cmp-table tbody tr").count();
   expect(article.about).toHaveLength(2);
   for (const product of article.about) {


### PR DESCRIPTION
## The problem

People deciding on a terminal diff tool search "hunk vs delta", "hunk vs difftastic", "better git diff". hunk.dev had nothing to answer those queries, so the ranking went to third-party listicles that get Hunk wrong.

This adds a `/compare/` section: a hub plus five head-to-head pages, at the URLs the questions are typed as.

| Page | Why this one |
| --- | --- |
| [`/compare/hunk-vs-delta/`](https://hunk.dev/compare/hunk-vs-delta/) | The default answer to "better git diff" |
| [`/compare/hunk-vs-difftastic/`](https://hunk.dev/compare/hunk-vs-difftastic/) | Different axis entirely, worth being honest about |
| [`/compare/hunk-vs-git-diff/`](https://hunk.dev/compare/hunk-vs-git-diff/) | The head term |
| [`/compare/hunk-vs-diff-so-fancy/`](https://hunk.dev/compare/hunk-vs-diff-so-fancy/) | High-volume legacy, still in a lot of dotfiles |
| [`/compare/hunk-vs-plannotator/`](https://hunk.dev/compare/hunk-vs-plannotator/) | The closest direct competitor for reviewing agent output |

## Approach

Each page is one entry in `website/src/data/comparisons.ts`, rendered three ways: the HTML page, a Markdown variant at the same URL plus `.md`, and JSON-LD. One catalog means a capability mark cannot differ between what a reader sees and what a crawler reads.

Page shape is built for the reader who arrived from a "hunk vs X" query: the answer first, then a two-sided verdict, then the argument, then the capability table, then the questions that query implies.

**For answer engines and agents.** Every page carries `TechArticle`, `FAQPage`, and `BreadcrumbList`, with the capability table republished as `additionalProperty` on both products so the comparison is readable without inferring it from a `<table>`. The products are multi-typed `["SoftwareApplication", "Product"]` because `additionalProperty` is outside `SoftwareApplication`'s schema.org domain and a validator would otherwise drop the payload. Row notes are deliberately *not* published as either product's `description`: a note describes the row, so attaching it to one product prints claims about the other tool under this tool's name. Each page is also served as clean Markdown, linked with `<link rel="alternate">` and surfaced in `/llms.txt`, matching what the docs already do for AI crawlers.

**Editorial rule.** Every mark comes from the other project's own documentation, with the caveat beside it wherever a bare mark would mislead, and rows the other tool wins stay in the tables. Tests enforce this rather than trusting it: a page that never recommends the other tool, concedes no capability, leaves a hedged mark unexplained, or cites no source from the rival's own host fails the suite.

## Non-goals

- Not a listicle or a "best diff tools" roundup. Five focused pages beat a thin sprawl.
- No second-tier targets (lazygit, tig, vimdiff, GitHub PR review). Different search intent; adding them would dilute the cluster.
- No change to any existing page's rendered output.

## Incidental refactors

- `PageHead.astro` extracts the `<head>` shared by the hand-built marketing pages, rather than adding a third copy. The emitted head for `/` and `/extensions/` is byte-for-byte identical to before (verified against a build of the parent commit).
- The JSON-LD serializer moves to `website/src/lib/jsonLd.ts` now that two catalogs use it. As a side effect the home page picks up `<`-escaping it previously lacked.
- The Markdown renderer lives in `website/src/lib/comparisonMarkdown.ts` so it is unit-testable without pulling Astro's DOM types into the root TypeScript program.

## Review process

Two Opus reviews ran against the first commit, one fact-checking rival claims against primary sources and one auditing the Hunk-side claims against this repo plus the code. `bc66289` is the fixes; the notable ones:

- **diff-so-fancy** computes character-level emphasis with a bundled copy of git `contrib/diff-highlight`. It does not pass through `git --word-diff`.
- **Plannotator** toggles Split/Unified from its settings panel, polls for a moved working tree, exposes WebMCP tools on its plan and annotate surfaces, and has AI review built in. All four were marked absent, and the AI-review row was missing entirely.
- **`diff.external`** is Git's external diff driver, not a difftool, and other subcommands then need `--ext-diff`.
- **delta's** `n`/`N` are opt-in via `navigate` and move between files, and delta has its own theme collection beyond bat's syntax themes.
- **difftastic's** performance caveat is under README "Known Issues", not a FAQ, and its manual lists many more languages than the README's "over 30".
- **`git diff`** does have `--word-diff` / `--color-words`; the row was missing from the one table where Git is the subject.
- On Hunk's own side: the "Runtime dependency" row was polarity-inverted and contradicted the install docs, `--fast` lost its "experimental" qualifier, and one row asserted a performance property nothing in the repo establishes. All fixed or dropped.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run format:check` — clean
- `bun test scripts/` — 302 pass
- `cd website && bun run check` — 0 errors; `bun run build` — 60 pages
- Playwright, both viewport projects — 101 pass, 1 skipped, including axe (`wcag2a`/`wcag2aa`) across the hub and all five comparison pages

Not run: the TUI suites (`test:integration`, `test:tty-smoke`). This change touches no Hunk source, only `website/` and three root test files.

## Known limitations and follow-ups

- **Website unit tests live in root `scripts/`, not beside the code they cover.** Colocation would be better, but nothing currently runs unit tests under `website/src/`: `DEFAULT_TEST_PATTERNS` in `scripts/run-test-suite.ts` does not include `./website`, and the website workspace's only test script is Playwright with `testDir: "./tests"`. Moving them today would silently drop the coverage. Doing it properly means wiring a Bun test runner into the website workspace plus a CI job — a separate change. The current placement follows the existing convention set by `scripts/check-extension-catalog.test.ts`, which tests `website/src/data/extensions.ts` the same way. (Raised by Greptile; discussed on that thread.)
- The five pages share the generic `og.png`. Per-comparison OG images would be better; `website/scripts/generate-og.ts` already exists if that is worth a follow-up.
- Rival claims are true as of the review date each page states. They will need re-checking as those projects move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsaTD6RoPx9Q6sQobq9fFK