### PR TITLE
feat(ui): collapse sidebar tree folders

### DIFF
--- a/.changeset/collapsible-file-tree.md
+++ b/.changeset/collapsible-file-tree.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Allow folders in the wide sidebar tree to be collapsed and expanded with the mouse while file navigation reveals destinations hidden inside collapsed folders.

--- a/packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.tsx
+++ b/packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.tsx
@@ -5,8 +5,12 @@ import type { ExtensionPaneProps } from "../../../../extension-api/types";
 import {
   buildFlatSidebarEntries,
   buildTreeSidebarEntries,
+  collapseTreeSidebarEntries,
+  expandCollapsedDirectoryPaths,
   resolveFileSidebarMode,
+  sidebarDirectoryPaths,
   sidebarEntryStatsWidth,
+  toggleCollapsedDirectoryPath,
   type SidebarEntry,
 } from "../../../../ui/lib/files";
 import { fileRowId } from "../../../../ui/lib/ids";
@@ -33,16 +37,23 @@ type FileSidebarVariantProps = Pick<
   viewportHeight: number;
 };
 
+/** Ignore directory toggles for projections that cannot contain directory rows. */
+function ignoreDirectoryToggle() {}
+
 interface VirtualizedFileSidebarRowsProps extends Omit<FileSidebarVariantProps, "files"> {
+  collapsedDirectoryPaths?: ReadonlySet<string>;
   entries: SidebarEntry[];
+  onToggleDirectory?: (path: string) => void;
   paddingLeft?: number;
 }
 
 /** Render one windowed sidebar projection with shared file selection and stats lanes. */
 export function VirtualizedFileSidebarRows({
   actions,
+  collapsedDirectoryPaths,
   entries,
   estimatedViewportRows,
+  onToggleDirectory,
   paddingLeft = 1,
   scrollTop,
   selectedFileId,
@@ -93,7 +104,9 @@ export function VirtualizedFileSidebarRows({
           return (
             <FileDirectoryRow
               key={entry.id}
+              collapsed={collapsedDirectoryPaths?.has(entry.path) ?? false}
               entry={entry}
+              onToggleDirectory={onToggleDirectory ?? ignoreDirectoryToggle}
               paddingLeft={paddingLeft}
               statsWidth={statsWidth}
               textWidth={textWidth}
@@ -125,10 +138,29 @@ export function FlatFileSidebar({ files, ...props }: FileSidebarVariantProps): R
   return <VirtualizedFileSidebarRows {...props} entries={entries} />;
 }
 
-/** Render the fully expanded ordered hierarchy for a wide file sidebar. */
-export function TreeFileSidebar({ files, ...props }: FileSidebarVariantProps): ReactNode {
-  const entries = useMemo(() => buildTreeSidebarEntries(files), [files]);
-  return <VirtualizedFileSidebarRows {...props} entries={entries} paddingLeft={0} />;
+/** Render the ordered hierarchy after applying the sidebar's collapsed directory paths. */
+export function TreeFileSidebar({
+  collapsedDirectoryPaths,
+  files,
+  onToggleDirectory,
+  ...props
+}: FileSidebarVariantProps & {
+  collapsedDirectoryPaths: ReadonlySet<string>;
+  onToggleDirectory: (path: string) => void;
+}): ReactNode {
+  const entries = useMemo(
+    () => collapseTreeSidebarEntries(buildTreeSidebarEntries(files), collapsedDirectoryPaths),
+    [collapsedDirectoryPaths, files],
+  );
+  return (
+    <VirtualizedFileSidebarRows
+      {...props}
+      collapsedDirectoryPaths={collapsedDirectoryPaths}
+      entries={entries}
+      onToggleDirectory={onToggleDirectory}
+      paddingLeft={0}
+    />
+  );
 }
 
 /**
@@ -146,6 +178,11 @@ export function FlexFileSidebar({
   actions,
 }: BuiltInSidebarProps): ReactNode {
   const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+  const previousSelectedFileIdRef = useRef(selectedFileId);
+  const skipSelectedFileRevealRef = useRef(false);
+  const [collapsedDirectoryPaths, setCollapsedDirectoryPaths] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [scrollViewport, setScrollViewport] = useState({ top: 0, height: 0 });
   const terminal = useTerminalDimensions();
   // Mirrors the host layout: one column of row highlight plus row padding.
@@ -161,6 +198,29 @@ export function FlexFileSidebar({
     theme,
     viewportHeight: scrollViewport.height,
   };
+
+  /** Toggle one logical directory everywhere it appears in the ordered tree projection. */
+  const toggleDirectory = (path: string) => {
+    skipSelectedFileRevealRef.current = true;
+    setCollapsedDirectoryPaths((current) => toggleCollapsedDirectoryPath(current, path));
+  };
+
+  useEffect(() => {
+    const previousSelectedFileId = previousSelectedFileIdRef.current;
+    previousSelectedFileIdRef.current = selectedFileId;
+    if (!selectedFileId || selectedFileId === previousSelectedFileId) {
+      return;
+    }
+
+    const selectedFile = files.find((file) => file.id === selectedFileId);
+    if (!selectedFile) {
+      return;
+    }
+
+    setCollapsedDirectoryPaths((current) =>
+      expandCollapsedDirectoryPaths(current, sidebarDirectoryPaths(selectedFile.path)),
+    );
+  }, [files, selectedFileId]);
 
   useEffect(() => {
     const scrollBox = scrollRef.current;
@@ -216,12 +276,16 @@ export function FlexFileSidebar({
   // Selection and projection changes can both move the target row, so follow
   // the stable file id after either event instead of only after navigation.
   useEffect(() => {
+    if (skipSelectedFileRevealRef.current) {
+      skipSelectedFileRevealRef.current = false;
+      return;
+    }
     if (!selectedFileId) {
       return;
     }
 
     scrollRef.current?.scrollChildIntoView(fileRowId(selectedFileId));
-  }, [files, mode, selectedFileId]);
+  }, [collapsedDirectoryPaths, files, mode, selectedFileId]);
 
   return (
     <scrollbox
@@ -239,7 +303,11 @@ export function FlexFileSidebar({
       horizontalScrollbarOptions={{ visible: false }}
     >
       {mode === "tree" ? (
-        <TreeFileSidebar {...variantProps} />
+        <TreeFileSidebar
+          {...variantProps}
+          collapsedDirectoryPaths={collapsedDirectoryPaths}
+          onToggleDirectory={toggleDirectory}
+        />
       ) : (
         <FlatFileSidebar {...variantProps} />
       )}

--- a/packages/hunk/src/opentui/HunkDiffView.test.tsx
+++ b/packages/hunk/src/opentui/HunkDiffView.test.tsx
@@ -220,11 +220,11 @@ describe("OpenTUI public components", () => {
 
     expect(narrowFrame).toContain("src/ui/");
     expect(wideFrame).not.toContain("src/ui/");
-    expect(wideFrame).toContain("src/");
-    expect(wideFrame).toContain("ui/");
+    expect(wideFrame).toContain("⌄ src/");
+    expect(wideFrame).toContain("⌄ ui/");
     const wideLines = wideFrame.split("\n");
-    expect(wideLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(1);
-    expect(wideLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(3);
+    expect(wideLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(3);
+    expect(wideLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(5);
     expect(wideFrame).toContain("alpha.ts");
     expect(wideFrame).toContain("beta.ts");
   });

--- a/packages/hunk/src/opentui/HunkFileNav.tsx
+++ b/packages/hunk/src/opentui/HunkFileNav.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   FileDirectoryRow,
   FileGroupHeader,
@@ -7,8 +7,12 @@ import {
 import {
   buildFlatSidebarEntries,
   buildTreeSidebarEntries,
+  collapseTreeSidebarEntries,
+  expandCollapsedDirectoryPaths,
   resolveFileSidebarMode,
+  sidebarDirectoryPaths,
   sidebarEntryStatsWidth,
+  toggleCollapsedDirectoryPath,
 } from "../ui/lib/files";
 import { resolveTheme } from "../ui/themes";
 import { toInternalDiffFiles } from "./model";
@@ -24,15 +28,44 @@ export function HunkFileNav({
 }: HunkFileNavProps) {
   const resolvedTheme = resolveTheme(theme, null);
   const internalFiles = useMemo(() => toInternalDiffFiles(files), [files]);
+  const previousSelectedFileIdRef = useRef(selectedFileId);
+  const [collapsedDirectoryPaths, setCollapsedDirectoryPaths] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const textWidth = Math.max(1, width - 1);
   const mode = resolveFileSidebarMode(textWidth);
-  const entries = useMemo(
-    () =>
-      mode === "tree"
-        ? buildTreeSidebarEntries(internalFiles)
-        : buildFlatSidebarEntries(internalFiles),
-    [internalFiles, mode],
-  );
+  const entries = useMemo(() => {
+    if (mode === "flat") {
+      return buildFlatSidebarEntries(internalFiles);
+    }
+    return collapseTreeSidebarEntries(
+      buildTreeSidebarEntries(internalFiles),
+      collapsedDirectoryPaths,
+    );
+  }, [collapsedDirectoryPaths, internalFiles, mode]);
+
+  /** Toggle one logical directory everywhere it appears in the ordered tree projection. */
+  const toggleDirectory = (path: string) => {
+    setCollapsedDirectoryPaths((current) => toggleCollapsedDirectoryPath(current, path));
+  };
+
+  useEffect(() => {
+    const previousSelectedFileId = previousSelectedFileIdRef.current;
+    previousSelectedFileIdRef.current = selectedFileId;
+    if (!selectedFileId || selectedFileId === previousSelectedFileId) {
+      return;
+    }
+
+    const selectedFile = internalFiles.find((file) => file.id === selectedFileId);
+    if (!selectedFile) {
+      return;
+    }
+
+    setCollapsedDirectoryPaths((current) =>
+      expandCollapsedDirectoryPaths(current, sidebarDirectoryPaths(selectedFile.path)),
+    );
+  }, [internalFiles, selectedFileId]);
+
   const fileEntries = entries.filter((entry) => entry.kind === "file");
   const statsWidth = Math.max(0, ...fileEntries.map((entry) => sidebarEntryStatsWidth(entry)));
 
@@ -54,7 +87,9 @@ export function HunkFileNav({
           return (
             <FileDirectoryRow
               key={entry.id}
+              collapsed={collapsedDirectoryPaths.has(entry.path)}
               entry={entry}
+              onToggleDirectory={toggleDirectory}
               paddingLeft={0}
               statsWidth={statsWidth}
               textWidth={textWidth}

--- a/packages/hunk/src/ui/AppHost.interactions.test.tsx
+++ b/packages/hunk/src/ui/AppHost.interactions.test.tsx
@@ -158,6 +158,18 @@ function createBootstrap(initialMode: LayoutMode = "split", pager = false): AppB
   });
 }
 
+/** Build nested files that exercise the wide sidebar's directory projection. */
+function createTreeSidebarBootstrap(): AppBootstrap {
+  return createTestVcsAppBootstrap({
+    changesetId: "changeset:tree-sidebar-interactions",
+    files: [
+      createTestDiffFile("alpha", "src/ui/alpha.ts", "a\n", "aa\n"),
+      createTestDiffFile("beta", "src/core/beta.ts", "b\n", "bb\n"),
+      createTestDiffFile("root", "README.md", "r\n", "rr\n"),
+    ],
+  });
+}
+
 function createSingleFileBootstrap(): AppBootstrap {
   return createTestVcsAppBootstrap({
     changesetId: "changeset:app-single-file",
@@ -3644,6 +3656,51 @@ describe("App interactions", () => {
         selectedFilePath: "second.ts",
         selectedHunkIndex: 1,
       });
+    } finally {
+      await act(async () => {
+        setup.renderer.destroy();
+      });
+    }
+  });
+
+  test("clicking a tree directory collapses and expands its file rows", async () => {
+    const setup = await testRender(<AppHost bootstrap={createTreeSidebarBootstrap()} />, {
+      width: 220,
+      height: 14,
+    });
+
+    try {
+      await flush(setup);
+
+      let frame = setup.captureCharFrame();
+      const directoryY = frame
+        .split("\n")
+        .findIndex((line) => line.split("│", 1)[0]?.includes("⌄ src/"));
+      expect(directoryY).toBeGreaterThan(0);
+      expect((frame.match(/alpha\.ts/g) ?? []).length).toBe(2);
+      expect((frame.match(/beta\.ts/g) ?? []).length).toBe(2);
+
+      await act(async () => {
+        await setup.mockMouse.click(5, directoryY);
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame.split("\n")[directoryY]).toContain("› src/");
+      expect(frame.split("\n")[directoryY]?.split("│", 1)[0]).toContain("2 files");
+      expect((frame.match(/alpha\.ts/g) ?? []).length).toBe(1);
+      expect((frame.match(/beta\.ts/g) ?? []).length).toBe(1);
+      expect((frame.match(/README\.md/g) ?? []).length).toBe(2);
+
+      await act(async () => {
+        await setup.mockMouse.click(5, directoryY);
+      });
+      await flush(setup);
+
+      frame = setup.captureCharFrame();
+      expect(frame.split("\n")[directoryY]).toContain("⌄ src/");
+      expect((frame.match(/alpha\.ts/g) ?? []).length).toBe(2);
+      expect((frame.match(/beta\.ts/g) ?? []).length).toBe(2);
     } finally {
       await act(async () => {
         setup.renderer.destroy();

--- a/packages/hunk/src/ui/components/panes/FileListItem.tsx
+++ b/packages/hunk/src/ui/components/panes/FileListItem.tsx
@@ -1,3 +1,4 @@
+import { MouseButton, type MouseEvent as TuiMouseEvent } from "@opentui/core";
 import { memo } from "react";
 import type { ExtensionSidebarTheme } from "../../../extension-api/types";
 import { fileRowId } from "../../lib/ids";
@@ -71,23 +72,36 @@ export function fileSidebarIndentWidth(depth: number, textWidth: number, reserve
   return Math.min(Math.max(0, depth) * 2, Math.max(0, textWidth - reservedWidth - 1));
 }
 
-/** Render one always-expanded directory row in the navigation sidebar. */
+/** Render one mouse-toggleable directory row in the navigation sidebar. */
 export function FileDirectoryRow({
+  collapsed,
   entry,
+  onToggleDirectory,
   paddingLeft = 1,
   statsWidth = 0,
   textWidth,
   theme,
 }: {
+  collapsed: boolean;
   entry: FileDirectoryEntry;
+  onToggleDirectory: (path: string) => void;
   paddingLeft?: number;
   statsWidth?: number;
   textWidth: number;
   theme: ExtensionSidebarTheme;
 }) {
   const statsSectionWidth = statsWidth > 0 ? statsWidth + 1 : 0;
-  const indentWidth = fileSidebarIndentWidth(entry.depth, textWidth, statsSectionWidth + 1);
-  const labelWidth = Math.max(1, textWidth - 1 - statsSectionWidth - indentWidth);
+  const countText = collapsed
+    ? `${entry.descendantFileCount} ${entry.descendantFileCount === 1 ? "file" : "files"}`
+    : null;
+  const trailingWidth = countText ? Math.max(statsSectionWidth, countText.length + 1) : 0;
+  const disclosureWidth = 2;
+  const indentWidth = fileSidebarIndentWidth(
+    entry.depth,
+    textWidth,
+    disclosureWidth + trailingWidth + 1,
+  );
+  const labelWidth = Math.max(1, textWidth - 1 - disclosureWidth - trailingWidth - indentWidth);
 
   return (
     <box
@@ -96,6 +110,11 @@ export function FileDirectoryRow({
         height: 1,
         flexDirection: "row",
         backgroundColor: theme.panel,
+      }}
+      onMouseUp={(event: TuiMouseEvent) => {
+        if (event.button === MouseButton.LEFT) {
+          onToggleDirectory(entry.path);
+        }
       }}
     >
       <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
@@ -108,7 +127,21 @@ export function FileDirectoryRow({
           backgroundColor: theme.panel,
         }}
       >
-        <text fg={theme.muted}>{fitText(entry.label, labelWidth)}</text>
+        <text fg={theme.muted}>{collapsed ? "› " : "⌄ "}</text>
+        <text fg={theme.muted}>{padText(fitText(entry.label, labelWidth), labelWidth)}</text>
+        {countText && (
+          <box
+            style={{
+              width: trailingWidth,
+              height: 1,
+              flexDirection: "row",
+              justifyContent: "flex-end",
+              backgroundColor: theme.panel,
+            }}
+          >
+            <text fg={theme.muted}>{countText}</text>
+          </box>
+        )}
       </box>
     </box>
   );

--- a/packages/hunk/src/ui/components/ui-components.test.tsx
+++ b/packages/hunk/src/ui/components/ui-components.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
-import type { ScrollBoxRenderable } from "@opentui/core";
+import { MouseButton, type ScrollBoxRenderable } from "@opentui/core";
 import { MouseButtons } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { act, createRef, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
@@ -36,6 +36,7 @@ const { MenuBar } = await import("./chrome/MenuBar");
 const { MenuDropdown } = await import("./chrome/MenuDropdown");
 const { StatusBar } = await import("./chrome/StatusBar");
 const { DiffFileHeaderRow } = await import("./panes/DiffFileHeaderRow");
+const { FileDirectoryRow } = await import("./panes/FileListItem");
 const { DiffSectionBody } = await import("../diff/DiffSectionBody");
 const { measurePlannedRenderedRowHeight, measureRenderedRowHeight } =
   await import("../diff/codeRowLayout");
@@ -410,6 +411,63 @@ function renderedWordDiffBackgroundDistance(
 }
 
 describe("UI components", () => {
+  test("directory rows toggle only for the primary mouse button", () => {
+    const toggled: string[] = [];
+    const element = FileDirectoryRow({
+      collapsed: false,
+      entry: {
+        kind: "directory",
+        id: "directory:src",
+        path: "src",
+        label: "src/",
+        depth: 0,
+        descendantFileCount: 2,
+      },
+      onToggleDirectory: (path) => toggled.push(path),
+      textWidth: 32,
+      theme: resolveTheme("github-dark-default", null),
+    }) as unknown as { props: { onMouseUp: (event: { button: MouseButton }) => void } };
+
+    element.props.onMouseUp({ button: MouseButton.RIGHT });
+    expect(toggled).toEqual([]);
+
+    element.props.onMouseUp({ button: MouseButton.LEFT });
+    expect(toggled).toEqual(["src"]);
+  });
+
+  test("collapsed directory rows right-align singular and plural file counts", async () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const renderCollapsedCount = (descendantFileCount: number) =>
+      captureFrame(
+        <FileDirectoryRow
+          collapsed={true}
+          entry={{
+            kind: "directory",
+            id: `directory:components:${descendantFileCount}`,
+            path: "src/very-long-directory/components",
+            label: "very-long-directory-name/",
+            depth: 8,
+            descendantFileCount,
+          }}
+          onToggleDirectory={() => {}}
+          paddingLeft={0}
+          statsWidth={10}
+          textWidth={32}
+          theme={theme}
+        />,
+        36,
+        1,
+      );
+
+    const singular = (await renderCollapsedCount(1)).split("\n")[0]!;
+    const plural = (await renderCollapsedCount(12)).split("\n")[0]!;
+
+    expect(singular.slice(0, 32)).toEndWith("1 file");
+    expect(plural.slice(0, 32)).toEndWith("12 files");
+    expect(singular.slice(32).trim()).toBe("");
+    expect(plural.slice(32).trim()).toBe("");
+  });
+
   test("the bundled sidebar view renders grouped file rows from the public props", async () => {
     const theme = resolveTheme("github-dark-default", null);
     const files = [
@@ -527,11 +585,11 @@ describe("UI components", () => {
         ?.indexOf("src/ui/"),
     ).toBe(1);
     expect(treeFrame).not.toContain("src/ui/");
-    expect(treeFrame).toContain("src/");
-    expect(treeFrame).toContain("ui/");
+    expect(treeFrame).toContain("⌄ src/");
+    expect(treeFrame).toContain("⌄ ui/");
     const treeLines = treeFrame.split("\n");
-    expect(treeLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(1);
-    expect(treeLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(3);
+    expect(treeLines.find((line) => line.includes("src/"))?.indexOf("src/")).toBe(3);
+    expect(treeLines.find((line) => line.includes("ui/"))?.indexOf("ui/")).toBe(5);
     expect(treeFrame).toContain("alpha.ts");
     expect(treeFrame).toContain("beta.ts");
   });

--- a/packages/hunk/src/ui/lib/files.test.ts
+++ b/packages/hunk/src/ui/lib/files.test.ts
@@ -3,8 +3,11 @@ import { createTestDiffFile, lines } from "../../../../../test/helpers/diff-help
 import {
   buildFlatSidebarEntries,
   buildTreeSidebarEntries,
+  collapseTreeSidebarEntries,
+  expandCollapsedDirectoryPaths,
   fileLabelParts,
   resolveFileSidebarMode,
+  sidebarDirectoryPaths,
 } from "./files";
 
 describe("files helpers", () => {
@@ -187,6 +190,66 @@ describe("files helpers", () => {
     expect(entries.filter((entry) => entry.kind === "file").map((entry) => entry.id)).toEqual(
       files.map((file) => file.id),
     );
+    expect(
+      entries
+        .filter((entry) => entry.kind === "directory")
+        .map((entry) => [entry.path, entry.descendantFileCount]),
+    ).toEqual([
+      ["src", 2],
+      ["src/ui", 2],
+      ["src", 1],
+      ["src/core", 1],
+      ["test", 1],
+      ["src", 1],
+    ]);
+  });
+
+  test("collapseTreeSidebarEntries hides descendants without changing review order", () => {
+    const entries = buildTreeSidebarEntries([
+      createTestDiffFile({ id: "ui-a", path: "src/ui/a.ts" }),
+      createTestDiffFile({ id: "core-b", path: "src/core/b.ts" }),
+      createTestDiffFile({ id: "root", path: "README.md" }),
+      createTestDiffFile({ id: "test-c", path: "test/c.ts" }),
+      createTestDiffFile({ id: "ui-d", path: "src/ui/d.ts" }),
+    ]);
+
+    const visible = collapseTreeSidebarEntries(entries, new Set(["src"]));
+
+    expect(visible.map((entry) => (entry.kind === "file" ? entry.id : entry.label))).toEqual([
+      "src/",
+      "root",
+      "test/",
+      "test-c",
+      "src/",
+    ]);
+  });
+
+  test("collapseTreeSidebarEntries preserves nested collapse state", () => {
+    const entries = buildTreeSidebarEntries([
+      createTestDiffFile({ id: "ui-a", path: "src/ui/a.ts" }),
+      createTestDiffFile({ id: "core-b", path: "src/core/b.ts" }),
+    ]);
+
+    expect(
+      collapseTreeSidebarEntries(entries, new Set(["src/ui"])).map((entry) =>
+        entry.kind === "file" ? entry.id : entry.kind === "directory" ? entry.path : entry.label,
+      ),
+    ).toEqual(["src", "src/ui", "src/core", "core-b"]);
+    expect(
+      collapseTreeSidebarEntries(entries, new Set(["src", "src/ui"])).map((entry) =>
+        entry.kind === "file" ? entry.id : entry.kind === "directory" ? entry.path : entry.label,
+      ),
+    ).toEqual(["src"]);
+  });
+
+  test("selected-file ancestors expand without disturbing other collapsed folders", () => {
+    const current = new Set(["src", "src/ui", "test"]);
+
+    expect(sidebarDirectoryPaths("src/ui/alpha.ts")).toEqual(["src", "src/ui"]);
+    expect(
+      expandCollapsedDirectoryPaths(current, sidebarDirectoryPaths("src/ui/alpha.ts")),
+    ).toEqual(new Set(["test"]));
+    expect(expandCollapsedDirectoryPaths(current, ["missing"])).toBe(current);
   });
 
   test("buildTreeSidebarEntries gives repeated directory branches unique row ids", () => {

--- a/packages/hunk/src/ui/lib/files.ts
+++ b/packages/hunk/src/ui/lib/files.ts
@@ -48,8 +48,10 @@ export interface FileGroupEntry {
 export interface FileDirectoryEntry {
   kind: "directory";
   id: string;
+  path: string;
   label: string;
   depth: number;
+  descendantFileCount: number;
 }
 
 export type FileSidebarMode = "flat" | "tree";
@@ -213,33 +215,115 @@ function sharedDirectoryDepth(previous: readonly string[], next: readonly string
   return depth;
 }
 
+/** Return the stable logical paths for every directory containing one review path. */
+export function sidebarDirectoryPaths(path: string): string[] {
+  const terminalPath = formatTerminalPath(normalizeDiffPath(path) ?? path);
+  const directories = sidebarDirectorySegments(dirname(terminalPath));
+  return directories.map((_, depth) => sidebarDirectoryPath(directories.slice(0, depth + 1)));
+}
+
 /** Build an expanded hierarchy without regrouping files away from review order. */
 export function buildTreeSidebarEntries(files: readonly SidebarFileSource[]): SidebarEntry[] {
   const entries: SidebarEntry[] = [];
   let activeDirectories: string[] = [];
+  let activeDirectoryEntries: FileDirectoryEntry[] = [];
 
   files.forEach((file, fileIndex) => {
     const path = formatTerminalPath(normalizeDiffPath(file.path) ?? file.path);
     const parent = dirname(path);
     const directories = sidebarDirectorySegments(parent);
     const sharedDepth = sharedDirectoryDepth(activeDirectories, directories);
+    activeDirectoryEntries = activeDirectoryEntries.slice(0, sharedDepth);
 
     for (let depth = sharedDepth; depth < directories.length; depth += 1) {
       const segment = directories[depth]!;
       const directoryPath = sidebarDirectoryPath(directories.slice(0, depth + 1));
-      entries.push({
+      const directoryEntry: FileDirectoryEntry = {
         kind: "directory",
         id: `directory:${fileIndex}:${depth}:${directoryPath}`,
+        path: directoryPath,
         label: sidebarDirectoryLabel(segment),
         depth,
-      });
+        descendantFileCount: 0,
+      };
+      entries.push(directoryEntry);
+      activeDirectoryEntries.push(directoryEntry);
     }
 
     entries.push(buildSidebarFileEntry(file, directories.length));
+    for (const directoryEntry of activeDirectoryEntries) {
+      directoryEntry.descendantFileCount += 1;
+    }
     activeDirectories = directories;
   });
 
   return entries;
+}
+
+/** Expand the named ancestors while preserving unrelated collapsed directory paths. */
+export function expandCollapsedDirectoryPaths(
+  current: ReadonlySet<string>,
+  paths: readonly string[],
+): ReadonlySet<string> {
+  const expandedPaths = paths.filter((path) => current.has(path));
+  if (expandedPaths.length === 0) {
+    return current;
+  }
+
+  const next = new Set(current);
+  for (const path of expandedPaths) {
+    next.delete(path);
+  }
+  return next;
+}
+
+/** Toggle one directory path without mutating the current collapsed-path set. */
+export function toggleCollapsedDirectoryPath(
+  current: ReadonlySet<string>,
+  path: string,
+): ReadonlySet<string> {
+  const next = new Set(current);
+  if (next.has(path)) {
+    next.delete(path);
+  } else {
+    next.add(path);
+  }
+  return next;
+}
+
+/** Hide descendants of collapsed directory rows without changing the remaining review order. */
+export function collapseTreeSidebarEntries(
+  entries: readonly SidebarEntry[],
+  collapsedDirectoryPaths: ReadonlySet<string>,
+): SidebarEntry[] {
+  if (collapsedDirectoryPaths.size === 0) {
+    return [...entries];
+  }
+
+  const visible: SidebarEntry[] = [];
+  let collapsedDepth: number | null = null;
+
+  for (const entry of entries) {
+    if (entry.kind === "group") {
+      collapsedDepth = null;
+      visible.push(entry);
+      continue;
+    }
+
+    if (collapsedDepth !== null) {
+      if (entry.depth > collapsedDepth) {
+        continue;
+      }
+      collapsedDepth = null;
+    }
+
+    visible.push(entry);
+    if (entry.kind === "directory" && collapsedDirectoryPaths.has(entry.path)) {
+      collapsedDepth = entry.depth;
+    }
+  }
+
+  return visible;
 }
 
 /** Build the canonical file label used across headers and note cards. */

--- a/test/pty/layout.test.ts
+++ b/test/pty/layout.test.ts
@@ -548,14 +548,14 @@ describe("PTY layout", () => {
         .join("\n");
 
       expect(initialSidebar).not.toContain("src/ui/");
-      expect(initialSidebar).toContain("src/");
-      expect(initialSidebar).toContain("ui/");
+      expect(initialSidebar).toContain("⌄ src/");
+      expect(initialSidebar).toContain("⌄ ui/");
       expect(
         initialSidebar
           .split("\n")
           .find((line) => line.includes("src/"))
           ?.indexOf("src/"),
-      ).toBe(2);
+      ).toBe(4);
 
       await dragMouse(session, initialDividerColumn - 2, 6, initialDividerColumn - 4, 6);
       const resized = await harness.waitForSnapshot(

--- a/test/pty/nav.test.ts
+++ b/test/pty/nav.test.ts
@@ -171,6 +171,49 @@ describe("PTY navigation", () => {
     }
   });
 
+  test("file navigation reveals a destination hidden by a collapsed tree folder", async () => {
+    const fixture = harness.createNestedSidebarRepoFixture();
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 220,
+      rows: 12,
+    });
+
+    try {
+      const initial = await session.waitForText(/⌄ src\//, { timeout: 15_000 });
+      const initialAlphaCount = harness.countMatches(initial, /alpha\.ts/g);
+      const initialBetaCount = harness.countMatches(initial, /beta\.ts/g);
+      expect(initialAlphaCount).toBeGreaterThanOrEqual(2);
+      expect(initialBetaCount).toBeGreaterThanOrEqual(2);
+
+      await session.click(/⌄ src\//);
+      const collapsed = await harness.waitForSnapshot(
+        session,
+        (text) =>
+          text.includes("› src/") &&
+          harness.countMatches(text, /alpha\.ts/g) === initialAlphaCount - 1 &&
+          harness.countMatches(text, /beta\.ts/g) === initialBetaCount - 1,
+        5_000,
+      );
+      expect(collapsed).toContain("› src/");
+      expect(collapsed).toContain("2 files");
+
+      await session.press(".");
+      const expanded = await harness.waitForSnapshot(
+        session,
+        (text) =>
+          text.includes("⌄ src/") &&
+          harness.countMatches(text, /alpha\.ts/g) === initialAlphaCount &&
+          harness.countMatches(text, /beta\.ts/g) === initialBetaCount,
+        5_000,
+      );
+      expect(expanded).toContain("⌄ src/");
+    } finally {
+      session.close();
+    }
+  });
+
   test("sidebar selection jumps the main pane without collapsing the review stream", async () => {
     const fixture = harness.createSidebarJumpRepoFixture();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Problem

The wide files sidebar presents reviewed paths as a hierarchy, but every folder is always expanded. Large reviews therefore cannot temporarily hide branches that are not relevant to the current pass.

Closes #971.

## Approach

- make directory rows mouse-toggleable with minimal `⌄` / `›` chevrons
- keep collapsed paths as sidebar-local presentation state without changing review order or the main review stream
- show a muted, right-aligned recursive count such as `12 files` only while a folder is collapsed
- preserve nested collapse state and apply one logical folder toggle everywhere that path appears in the ordered projection
- keep `,` / `.` navigation review-wide; selecting a hidden destination expands only its ancestor folders and leaves unrelated folders collapsed
- apply the same projection and interaction behavior to the public `HunkFileNav` component

Keyboard folder controls are intentionally out of scope for this first pass. Right-click does not toggle folders.

## Visual evidence

Real PTY behavior at 220×12, split layout, GitHub dark theme:

```text
⌄ src/                         › src/                   2 files
  ⌄ ui/                          M README.md             +1 -1
    M alpha.ts      +1 -1
  ⌄ core/
    M beta.ts       +1 -1
M README.md         +1 -1
```

Pressing `.` from a file hidden under the collapsed `src/` branch expands the branch and reveals the destination row.

## Validation

- `bun run typecheck`
- `bun run test` — 2,049 passed, 10 skipped
- `bun run test:integration` — 151 passed, 1 platform skip
- `bun run test:tty-smoke` — 9 passed
- `bun run lint`
- `bun run deps:check`
- `bun run changeset:status`
- `git diff --check`
- `bun run install:bin`
- installed-binary real-TTY smoke against this working-tree diff

Tested on Linux. macOS and Windows were not tested locally; mouse-driven PTY coverage is Unix-only, while the shared projection and component tests run in the portable unit suite.

*This PR description was generated by Pi using gpt-5.6-sol*
