### PR TITLE
feat(log): review contiguous commit ranges

### DIFF
--- a/.changeset/fuzzy-history-ranges.md
+++ b/.changeset/fuzzy-history-ranges.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add cancellable contiguous multi-commit selection to unfiltered interactive history with Shift+Arrow, J/K, and Shift-click controls, opening the inclusive cumulative change in one review.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ date, message, branch/bookmark, remote, and tag details; `--oneline` provides co
 `--theme` uses the same palette as Hunk review. Interactive history groups commits by local-calendar
 day with account-like author handles and relative times, while keeping commit ids right-aligned and
 clickable. Enable **Graph view** from the View menu to replace day groups with commit-topology lanes.
-After opening a commit, quit its normal Hunk review to return to the same selection.
+Use `Shift+Up`/`Shift+Down`, uppercase `K`/`J`, or Shift-click to select a contiguous range; opening it
+reviews the inclusive cumulative change from the oldest commit's parent through the newest commit.
+Range selection is disabled with `--all` or author, message, date, and path filters because traversal can interleave or hide commits.
+After opening a commit or range, quit its normal Hunk review to return to the same selection.
 
 ### Working with Jujutsu and Sapling
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -302,8 +302,9 @@ and retires the replaced instance at that explicit ownership boundary.
 
 ### `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `20`). Branch on it if you want
-one file to support several Hunk versions. Version 20 adds optional commit timestamps to review
+The API generation this Hunk speaks (currently `21`). Branch on it if you want
+one file to support several Hunk versions. Version 21 adds optional inclusive history-range review
+planning; version 20 adds optional commit timestamps to review
 metadata, pane clipboard actions, and the `theme.copyAction` paint token; version 19 adds provider-owned history
 enumeration and review planning; version 18 lets lifecycle and custom-event handlers request
 a host-owned review reload; version 17 adds structured review metadata to delegated patch
@@ -527,7 +528,7 @@ reuses one is skipped with a notice.
 map off entirely — produces a clear "not supported" error for that command
 instead of a crash.
 
-API version 19 adds the optional, read-only `history` capability used by the built-in `hunk log` surface:
+API version 19 adds the optional, read-only `history` capability used by the built-in `hunk log` surface. API version 21 adds optional inclusive range planning:
 
 ```ts
 hunk.registerVcsAdapter({
@@ -553,6 +554,15 @@ hunk.registerVcsAdapter({
           }
         : { kind: "revision-show", revisionId: commit.revisionId };
     },
+    planRangeReview({ newestCommit, oldestCommit }, _context, options) {
+      const parent = options?.parentRevisionId ?? oldestCommit.parentRevisionIds[0];
+      if (!parent) throw new Error("Resolve this provider's empty root baseline here.");
+      return {
+        kind: "revision-range",
+        fromRevisionId: parent,
+        toRevisionId: newestCommit.revisionId,
+      };
+    },
   },
 });
 ```
@@ -565,8 +575,12 @@ opening. Otherwise Enter reports that the corresponding review operation is unsu
 History is deliberately separate from patch-producing `operations`. The built-in host owns command
 routing, graph planning, themes, terminal lifecycle, and static/interactive presentation. The
 adapter owns every repository semantic: traversal and filtering, immutable identities, refs, and
-`planReview`'s decision about how roots and merges open through that adapter's ordinary review
-operations. Hunk treats revision ids as opaque strings and never invents provider revision syntax.
+review-planning decisions about roots, merges, ancestry, and direct endpoints. `planRangeReview` is
+optional so older adapters remain compatible; without it, Hunk reports multi-commit opening as
+unsupported rather than silently opening one commit. A range planner compares the chosen parent—or
+provider-specific empty/root baseline—of `oldestCommit` directly with `newestCommit` and must not use
+merge-base/triple-dot semantics. Hunk treats revision ids as opaque strings and never invents provider
+revision syntax.
 
 Commits must carry an immutable full `revisionId`, display id, ordered parent ids, subject, optional
 message body, author (and optional email), ISO authored time, and structured ref decorations. The

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -48,12 +48,14 @@ The built-in commands and the keys they ship with:
 On a terminal, `hunk log` opens its read-only history browser automatically. Its controls are
 separate from the configurable review command table. `F10` opens File, View, Navigate, Commit, and Help menus;
 View includes Hunk's shared theme selector and an optional **Graph view** that replaces the default
-day-grouped timeline with commit-topology lanes. It uses `Up`/`Down` or `j`/`k` to move, `PageUp`/`PageDown`,
-`g`/`G` or `Home`/`End` to jump, `/` to search, `n`/`N` for matches, `t` to choose a theme, `r` to refresh, `y` to copy
-the full commit id, `Enter` to open the commit in normal Hunk review, and `q` to quit. With a mouse, click a commit
-id to open it immediately, click the adjacent copy icon to copy its full immutable id, click elsewhere
-on a row to select it, or double-click a row to open it.
-Quitting the opened review returns to the retained history selection and viewport. The Commit menu's
+day-grouped timeline with commit-topology lanes. It uses `Up`/`Down` or `j`/`k` to move, `Shift+Up`/`Shift+Down`
+or uppercase `K`/`J` to extend a contiguous commit selection, `PageUp`/`PageDown`, `g`/`G` or `Home`/`End` to jump,
+`/` to search, `n`/`N` for matches, `t` to choose a theme, `r` to refresh, `y` to copy the focused commit's full id,
+`Enter` to open the selection in normal Hunk review, and `q` to quit. With a mouse, Shift-click a row to extend the
+selection when the terminal forwards modifiers, click a commit id to open it immediately, click the adjacent copy
+icon to copy its full immutable id, click elsewhere on a row to select it, or double-click a row to open it.
+Range selection is unavailable with `--all` or author, message, date, and path filters because those traversals
+can interleave unrelated commits or hide intermediate commits. Quitting the opened review returns to the retained history selection and viewport. The Commit menu's
 **Compare with first parent** and **Compare with parent…** actions compare the selected commit against
 an ordered provider-owned parent; they do not navigate the history selection to that parent.
 

--- a/packages/hunk-git/src/commands.ts
+++ b/packages/hunk-git/src/commands.ts
@@ -1089,6 +1089,23 @@ export async function resolveGitCommitRefAsync(
     .trim();
 }
 
+/** Resolve one tree-ish ref to the exact tree object used for later blob reads. */
+export async function resolveGitTreeRefAsync(
+  input: GitBackedInput,
+  ref: string,
+  options: Omit<RunGitTextOptions, "input" | "args"> = {},
+) {
+  return (
+    await runGitTextAsync({
+      input,
+      args: ["rev-parse", "--verify", "--end-of-options", `${ref}^{tree}`],
+      ...options,
+    })
+  )
+    .split("\n")[0]!
+    .trim();
+}
+
 /** Resolve old/new Git endpoints asynchronously for review-load source capabilities. */
 export async function resolveGitDiffEndpointsAsync(
   input: ExtensionVcsDiffInput,
@@ -1102,7 +1119,7 @@ export async function resolveGitDiffEndpointsAsync(
   const range = requireGitDiffRangeArg(input);
   const commandCwd = repoRoot ?? cwd;
   const resolveRef = (ref: string) =>
-    resolveGitCommitRefAsync(input, ref, { cwd: commandCwd, gitExecutable, signal });
+    resolveGitTreeRefAsync(input, ref, { cwd: commandCwd, gitExecutable, signal });
   const resolveRevisions = async (value: string) => {
     const revs = (
       await runGitTextAsync({

--- a/packages/hunk-git/src/history.test.ts
+++ b/packages/hunk-git/src/history.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createGitVcsAdapter } from "./index";
-import { buildGitHistoryArgs, gitHistoryUsesBoundaryTopology, parseGitHistory } from "./history";
+import {
+  buildGitHistoryArgs,
+  gitHistoryUsesBoundaryTopology,
+  parseGitHistory,
+  planGitHistoryRangeReview,
+} from "./history";
 
 describe("Git history production", () => {
   test("builds the strict supported query with literal pathspec separation", () => {
@@ -158,6 +166,125 @@ describe("Git history production", () => {
       toRevisionId: "b".repeat(40),
     });
   });
+
+  test("plans a root-inclusive direct range with Git's native empty tree", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "hunk-git-history-range-"));
+    const git = (...args: string[]) => {
+      const result = Bun.spawnSync(["git", ...args], {
+        cwd: repo,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (result.exitCode !== 0) throw new Error(result.stderr.toString());
+      return result.stdout.toString().trim();
+    };
+    try {
+      git("init", "--quiet");
+      git("config", "user.name", "Test");
+      git("config", "user.email", "test@example.com");
+      writeFileSync(join(repo, "root.txt"), "root\n");
+      git("add", "root.txt");
+      git("commit", "--quiet", "-m", "root");
+      const rootId = git("rev-parse", "HEAD");
+      writeFileSync(join(repo, "newest.txt"), "newest\n");
+      git("add", "newest.txt");
+      git("commit", "--quiet", "-m", "newest");
+      const newestId = git("rev-parse", "HEAD");
+      const commit = (revisionId: string, parentRevisionIds: string[]) => ({
+        revisionId,
+        displayId: revisionId.slice(0, 8),
+        parentRevisionIds,
+        subject: revisionId,
+        authorName: "Test",
+        authoredAt: "2026-01-01T00:00:00Z",
+        decorations: [],
+      });
+      const plan = await createGitVcsAdapter().history!.planRangeReview!(
+        {
+          newestCommit: commit(newestId, [rootId]),
+          oldestCommit: commit(rootId, []),
+        },
+        { cwd: repo },
+      );
+      expect(plan).toMatchObject({ kind: "revision-range", toRevisionId: newestId });
+      expect(plan.kind === "revision-range" && plan.fromRevisionId).toMatch(/^[0-9a-f]{40,64}$/);
+      expect(
+        git(
+          "diff",
+          "--name-only",
+          `${plan.kind === "revision-range" ? plan.fromRevisionId : ""}..${newestId}`,
+        ),
+      ).toEqual("newest.txt\nroot.txt");
+
+      writeFileSync(join(repo, "third.txt"), "third\n");
+      git("add", "third.txt");
+      git("commit", "--quiet", "-m", "third");
+      const thirdId = git("rev-parse", "HEAD");
+      expect(
+        await createGitVcsAdapter().history!.planRangeReview!(
+          {
+            newestCommit: commit(thirdId, [newestId]),
+            oldestCommit: commit(newestId, [rootId]),
+          },
+          { cwd: repo },
+        ),
+      ).toEqual({
+        kind: "revision-range",
+        fromRevisionId: rootId,
+        toRevisionId: thirdId,
+      });
+
+      git("checkout", "--quiet", "-b", "side", rootId);
+      writeFileSync(join(repo, "side.txt"), "side\n");
+      git("add", "side.txt");
+      git("commit", "--quiet", "-m", "side");
+      const sideId = git("rev-parse", "HEAD");
+      await expect(
+        createGitVcsAdapter().history!.planRangeReview!(
+          {
+            newestCommit: commit(sideId, [rootId]),
+            oldestCommit: commit(newestId, [rootId]),
+          },
+          { cwd: repo },
+        ),
+      ).rejects.toThrow("not on one Git ancestry path");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "cancels provider range planning without blocking the renderer",
+    async () => {
+      const temp = mkdtempSync(join(tmpdir(), "hunk-git-range-cancel-"));
+      const executable = join(temp, "slow-git");
+      writeFileSync(executable, "#!/bin/sh\nsleep 30\n");
+      chmodSync(executable, 0o755);
+      const controller = new AbortController();
+      const revision = "a".repeat(40);
+      const commit = {
+        revisionId: revision,
+        displayId: revision.slice(0, 8),
+        parentRevisionIds: ["b".repeat(40)],
+        subject: "commit",
+        authorName: "Test",
+        authoredAt: "2026-01-01T00:00:00Z",
+        decorations: [],
+      };
+
+      try {
+        const planning = planGitHistoryRangeReview(
+          { newestCommit: commit, oldestCommit: commit },
+          { cwd: temp, gitExecutable: executable, signal: controller.signal },
+        );
+        controller.abort(new Error("planning cancelled"));
+        await expect(planning).rejects.toThrow("planning cancelled");
+      } finally {
+        rmSync(temp, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("rejects truncated records and invalid SHA object ids", () => {
     expect(() => parseGitHistory("id\0short\0parent")).toThrow("truncated history record");

--- a/packages/hunk-git/src/history.ts
+++ b/packages/hunk-git/src/history.ts
@@ -1,10 +1,14 @@
 import { spawn } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
+import { runAbortableCommand } from "@hunk/vcs/async-process";
 import {
   HunkExtensionUserError,
   type ExtensionVcsHistoryCommit,
   type ExtensionVcsHistoryDecoration,
   type ExtensionVcsHistoryInput,
+  type ExtensionVcsHistoryRangeReviewAction,
+  type ExtensionVcsHistoryRangeSelection,
+  type ExtensionVcsHistoryReviewOptions,
   type ExtensionVcsHistorySource,
 } from "hunkdiff/extension";
 
@@ -18,19 +22,21 @@ const MAX_HISTORY_STDERR_BYTES = 16 * 1024;
 interface GitHistoryOptions {
   cwd: string;
   gitExecutable?: string;
+  signal?: AbortSignal;
 }
 
-/** Run one shell-free bounded Git query and retain byte-exact NUL delimiters. */
-function runGit(
+/** Run one shell-free bounded Git query and retain its exit status. */
+function runGitResult(
   args: string[],
   { cwd, gitExecutable = "git" }: GitHistoryOptions,
   acceptedExitCodes: readonly number[] = [0],
+  stdin?: Uint8Array,
 ) {
   let result: ReturnType<typeof Bun.spawnSync>;
   try {
     result = Bun.spawnSync([gitExecutable, ...args], {
       cwd,
-      stdin: "ignore",
+      stdin: stdin ?? "ignore",
       stdout: "pipe",
       stderr: "pipe",
       maxBuffer: MAX_SYNC_OUTPUT_BYTES,
@@ -48,7 +54,74 @@ function runGit(
       suggestions: ["Check the revision, filters, and repository, then try again."],
     });
   }
-  return result.stdout?.toString() ?? "";
+  return result;
+}
+
+/** Run one shell-free bounded Git query and retain byte-exact NUL delimiters. */
+function runGit(
+  args: string[],
+  options: GitHistoryOptions,
+  acceptedExitCodes: readonly number[] = [0],
+  stdin?: Uint8Array,
+) {
+  return runGitResult(args, options, acceptedExitCodes, stdin).stdout?.toString() ?? "";
+}
+
+/** Run one cancellable Git query used while preparing a history range. */
+async function runGitPlanningQuery(
+  args: string[],
+  { cwd, gitExecutable = "git", signal }: GitHistoryOptions,
+  acceptedExitCodes: readonly number[] = [0],
+) {
+  let result: Awaited<ReturnType<typeof runAbortableCommand>>;
+  try {
+    result = await runAbortableCommand([gitExecutable, ...args], {
+      cwd,
+      signal,
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+    });
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    throw new HunkExtensionUserError(`Could not run ${gitExecutable}.`, {
+      suggestions: ["Install Git or configure Hunk to use another VCS backend."],
+    });
+  }
+  if (!acceptedExitCodes.includes(result.exitCode)) {
+    throw new HunkExtensionUserError(
+      result.stderr.trim().split("\n")[0] || "Git could not read this repository.",
+      { suggestions: ["Check the revision, filters, and repository, then try again."] },
+    );
+  }
+  return result;
+}
+
+/** Plan an inclusive ancestry range without exposing Git syntax to Hunk core. */
+export async function planGitHistoryRangeReview(
+  selection: ExtensionVcsHistoryRangeSelection,
+  options: GitHistoryOptions,
+  reviewOptions?: ExtensionVcsHistoryReviewOptions,
+): Promise<ExtensionVcsHistoryRangeReviewAction> {
+  const newest = requireRevision(selection.newestCommit.revisionId);
+  const oldest = requireRevision(selection.oldestCommit.revisionId);
+  const ancestry = await runGitPlanningQuery(
+    ["merge-base", "--is-ancestor", oldest, newest],
+    options,
+    [0, 1],
+  );
+  if (ancestry.exitCode === 1) {
+    throw new HunkExtensionUserError("The selected commits are not on one Git ancestry path.", {
+      suggestions: ["Choose a contiguous range whose oldest commit is an ancestor of the newest."],
+    });
+  }
+  const parent = reviewOptions?.parentRevisionId ?? selection.oldestCommit.parentRevisionIds[0];
+  if (parent && !selection.oldestCommit.parentRevisionIds.includes(parent)) {
+    throw new Error("The selected revision is not a parent of the oldest Git commit.");
+  }
+  const fromRevisionId = parent
+    ? requireRevision(parent)
+    : (await runGitPlanningQuery(["hash-object", "-t", "tree", "--stdin"], options)).stdout.trim();
+  if (!fromRevisionId) throw new Error("Git returned an empty root comparison identity.");
+  return { kind: "revision-range", fromRevisionId, toRevisionId: newest };
 }
 
 /** Resolve the repository root, including a bare repository with no worktree. */

--- a/packages/hunk-git/src/index.ts
+++ b/packages/hunk-git/src/index.ts
@@ -23,7 +23,7 @@ import {
   type GitBackedInput,
   type GitDiffEndpoints,
 } from "./commands";
-import { openGitHistory } from "./history";
+import { openGitHistory, planGitHistoryRangeReview } from "./history";
 import { gitEndpointSourceSpec, readGitFileSource } from "./source";
 import { describeDiffRange } from "@hunk/vcs/diff-target";
 import {
@@ -303,6 +303,9 @@ export function createGitVcsAdapter({
               toRevisionId: commit.revisionId,
             }
           : { kind: "revision-show" as const, revisionId: commit.revisionId };
+      },
+      planRangeReview(selection, { cwd, signal }, options?: { parentRevisionId?: string }) {
+        return planGitHistoryRangeReview(selection, { cwd, gitExecutable, signal }, options);
       },
     },
     operations: {

--- a/packages/hunk-jj/src/history.test.ts
+++ b/packages/hunk-jj/src/history.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createJjVcsAdapter } from "./index";
@@ -9,10 +9,12 @@ import {
   jjHistoryUsesBoundaryTopology,
   openJjHistory,
   parseJjHistory,
+  planJjHistoryRangeReview,
 } from "./history";
 
 const tempDirs: string[] = [];
 const jjTest = Bun.which("jj") ? test : test.skip;
+const unixTest = process.platform === "win32" ? test.skip : test;
 
 /** Create a real JJ-only workspace without a colocated `.git` directory. */
 function createJjOnlyTestRepo() {
@@ -49,6 +51,31 @@ afterEach(() => {
 });
 
 describe("Jujutsu history production", () => {
+  unixTest("cancels provider range planning without blocking the renderer", async () => {
+    const temp = mkdtempSync(join(tmpdir(), "hunk-jj-range-cancel-"));
+    tempDirs.push(temp);
+    const executable = join(temp, "slow-jj");
+    writeFileSync(executable, "#!/bin/sh\nsleep 30\n");
+    chmodSync(executable, 0o755);
+    const controller = new AbortController();
+    const revision = "a".repeat(40);
+    const commit = {
+      revisionId: revision,
+      displayId: revision.slice(0, 8),
+      parentRevisionIds: ["b".repeat(40)],
+      subject: "commit",
+      authorName: "Test",
+      authoredAt: "2026-01-01T00:00:00Z",
+      decorations: [],
+    };
+
+    const planning = planJjHistoryRangeReview(
+      { newestCommit: commit, oldestCommit: commit },
+      { cwd: temp, jjExecutable: executable, signal: controller.signal },
+    );
+    controller.abort(new Error("planning cancelled"));
+    await expect(planning).rejects.toThrow("planning cancelled");
+  });
   test("builds a provider-owned revset and preserves literal filesets", () => {
     expect(
       buildJjHistoryArgs({
@@ -257,6 +284,17 @@ describe("Jujutsu history production", () => {
         "cancel fixture",
       );
       await cancelled.close();
+
+      jj(repo, "config", "set", "--repo", "template-aliases.commit_id", '"wrong"');
+      const rangePlan = await createJjVcsAdapter().history!.planRangeReview!(
+        { newestCommit: commits[1]!, oldestCommit: commits[2]! },
+        { cwd: repo },
+      );
+      expect(rangePlan).toMatchObject({
+        kind: "revision-range",
+        toRevisionId: commits[1]!.revisionId,
+      });
+      expect(rangePlan.kind === "revision-range" && rangePlan.fromRevisionId).toMatch(/^0+$/);
     },
     20_000,
   );

--- a/packages/hunk-jj/src/history.ts
+++ b/packages/hunk-jj/src/history.ts
@@ -5,8 +5,12 @@ import {
   type ExtensionVcsHistoryCommit,
   type ExtensionVcsHistoryDecoration,
   type ExtensionVcsHistoryInput,
+  type ExtensionVcsHistoryRangeReviewAction,
+  type ExtensionVcsHistoryRangeSelection,
+  type ExtensionVcsHistoryReviewOptions,
   type ExtensionVcsHistorySource,
 } from "hunkdiff/extension";
+import { runAbortableCommand } from "@hunk/vcs/async-process";
 import { normalizePathForOS } from "@hunk/vcs/path";
 
 const HISTORY_FIELDS_PER_COMMIT = 13;
@@ -36,6 +40,7 @@ const JJ_HISTORY_TEMPLATE =
 export interface JjHistoryOptions {
   cwd: string;
   jjExecutable?: string;
+  signal?: AbortSignal;
 }
 
 /** Return one safely quoted Jujutsu string literal for a generated revset. */
@@ -184,6 +189,72 @@ export function parseJjHistory(
     });
   }
   return commits;
+}
+
+/** Run one cancellable JJ query used while preparing a history range. */
+async function runJjHistoryQuery(
+  args: string[],
+  { cwd, jjExecutable = "jj", signal }: JjHistoryOptions,
+) {
+  let result: Awaited<ReturnType<typeof runAbortableCommand>>;
+  try {
+    result = await runAbortableCommand(
+      [jjExecutable, "--ignore-working-copy", "--no-pager", "--color", "never", ...args],
+      { cwd, signal },
+    );
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    throw new HunkExtensionUserError(`Could not run ${jjExecutable}.`, {
+      suggestions: ["Install Jujutsu or configure Hunk to use another VCS backend."],
+    });
+  }
+  if (result.exitCode !== 0) {
+    throw new HunkExtensionUserError(
+      result.stderr.trim().split("\n")[0] || "Jujutsu could not read this repository.",
+      { suggestions: ["Check the revision and repository, then try again."] },
+    );
+  }
+  return result.stdout;
+}
+
+/** Plan an inclusive ancestry range without exposing JJ revsets to Hunk core. */
+export async function planJjHistoryRangeReview(
+  selection: ExtensionVcsHistoryRangeSelection,
+  options: JjHistoryOptions,
+  reviewOptions?: ExtensionVcsHistoryReviewOptions,
+): Promise<ExtensionVcsHistoryRangeReviewAction> {
+  const newest = selection.newestCommit.revisionId;
+  const oldest = selection.oldestCommit.revisionId;
+  if (!FULL_COMMIT_ID_PATTERN.test(newest) || !FULL_COMMIT_ID_PATTERN.test(oldest)) {
+    throw new Error("Jujutsu history range endpoints must be full immutable commit ids.");
+  }
+  const ancestor = (
+    await runJjHistoryQuery(
+      ["log", "--no-graph", "-r", `${oldest} & ancestors(${newest})`, "-T", "self.commit_id()"],
+      options,
+    )
+  ).trim();
+  if (ancestor !== oldest) {
+    throw new HunkExtensionUserError("The selected commits are not on one Jujutsu ancestry path.", {
+      suggestions: ["Choose a contiguous range whose oldest commit is an ancestor of the newest."],
+    });
+  }
+  const parent = reviewOptions?.parentRevisionId ?? selection.oldestCommit.parentRevisionIds[0];
+  if (parent && !selection.oldestCommit.parentRevisionIds.includes(parent)) {
+    throw new Error("The selected revision is not a parent of the oldest Jujutsu commit.");
+  }
+  const fromRevisionId =
+    parent ??
+    (
+      await runJjHistoryQuery(
+        ["log", "--no-graph", "-r", "root()", "-T", "self.commit_id()"],
+        options,
+      )
+    ).trim();
+  if (!FULL_COMMIT_ID_PATTERN.test(fromRevisionId)) {
+    throw new Error("Jujutsu returned an invalid root comparison identity.");
+  }
+  return { kind: "revision-range", fromRevisionId, toRevisionId: newest };
 }
 
 /** Run a small synchronous JJ query used only to establish the repository root. */

--- a/packages/hunk-jj/src/index.ts
+++ b/packages/hunk-jj/src/index.ts
@@ -11,7 +11,7 @@ import {
   runJjTextAsync,
   type JjDiffEndpoints,
 } from "./commands";
-import { openJjHistory } from "./history";
+import { openJjHistory, planJjHistoryRangeReview } from "./history";
 import { readJjFileSource } from "./source";
 import { describeDiffRange } from "@hunk/vcs/diff-target";
 import {
@@ -152,6 +152,9 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
               toRevisionId: commit.revisionId,
             }
           : { kind: "revision-show" as const, revisionId: commit.revisionId };
+      },
+      planRangeReview(selection, { cwd, signal }, options?: { parentRevisionId?: string }) {
+        return planJjHistoryRangeReview(selection, { cwd, jjExecutable, signal }, options);
       },
     },
     operations: {

--- a/packages/hunk/README.md
+++ b/packages/hunk/README.md
@@ -100,7 +100,10 @@ date, message, branch/bookmark, remote, and tag details; `--oneline` provides co
 `--theme` uses the same palette as Hunk review. Interactive history groups commits by local-calendar
 day with account-like author handles and relative times, while keeping commit ids right-aligned and
 clickable. Enable **Graph view** from the View menu to replace day groups with commit-topology lanes.
-After opening a commit, quit its normal Hunk review to return to the same selection.
+Use `Shift+Up`/`Shift+Down`, uppercase `K`/`J`, or Shift-click to select a contiguous range; opening it
+reviews the inclusive cumulative change from the oldest commit's parent through the newest commit.
+Range selection is disabled with `--all` or author, message, date, and path filters because traversal can interleave or hide commits.
+After opening a commit or range, quit its normal Hunk review to return to the same selection.
 
 ### Working with Jujutsu and Sapling
 

--- a/packages/hunk/src/app/historyBootstrap.ts
+++ b/packages/hunk/src/app/historyBootstrap.ts
@@ -6,6 +6,8 @@ import {
 import { collectSessionCustomThemes } from "../core/theme/customThemes";
 import type {
   ExtensionVcsHistoryCommit,
+  ExtensionVcsHistoryRangeReviewAction,
+  ExtensionVcsHistoryRangeSelection,
   ExtensionVcsHistoryReviewAction,
   ExtensionVcsHistoryReviewOptions,
   NamedCustomThemeConfig,
@@ -17,6 +19,7 @@ import {
   getDefaultVcsAdapter,
   getVcsAdapter,
   openVcsHistory,
+  planVcsHistoryRangeReview,
   planVcsHistoryReview,
 } from "../core/vcs";
 import type { VcsCatalog, VcsHistorySource } from "../core/vcs/types";
@@ -45,7 +48,13 @@ export interface HistoryBootstrap {
   planReview(
     commit: ExtensionVcsHistoryCommit,
     options?: ExtensionVcsHistoryReviewOptions,
+    signal?: AbortSignal,
   ): Promise<ExtensionVcsHistoryReviewAction>;
+  planRangeReview?(
+    selection: ExtensionVcsHistoryRangeSelection,
+    options?: ExtensionVcsHistoryReviewOptions,
+    signal?: AbortSignal,
+  ): Promise<ExtensionVcsHistoryRangeReviewAction>;
   reopenSource(signal?: AbortSignal): Promise<VcsHistorySource>;
   close(): Promise<void>;
 }
@@ -160,9 +169,14 @@ export async function loadHistoryBootstrap({
           ]
         : []),
     ],
-    planReview(commit, options) {
-      return planVcsHistoryReview(adapter, commit, { cwd: repoRoot }, options);
+    planReview(commit, options, signal) {
+      return planVcsHistoryReview(adapter, commit, { cwd: repoRoot, signal }, options);
     },
+    ...(adapter.history?.planRangeReview && {
+      planRangeReview(selection, options, signal) {
+        return planVcsHistoryRangeReview(adapter, selection, { cwd: repoRoot, signal }, options);
+      },
+    }),
     async reopenSource(signal) {
       if (closed) throw new Error("History session is closed.");
       signal?.throwIfAborted();

--- a/packages/hunk/src/core/vcs/index.ts
+++ b/packages/hunk/src/core/vcs/index.ts
@@ -4,6 +4,8 @@ import { HunkUserError } from "../run/errors";
 import type {
   ExtensionVcsHistoryCommit,
   ExtensionVcsHistoryInput,
+  ExtensionVcsHistoryRangeReviewAction,
+  ExtensionVcsHistoryRangeSelection,
   ExtensionVcsHistoryReviewAction,
   ExtensionVcsHistoryReviewOptions,
 } from "../../extension-api/types";
@@ -191,6 +193,21 @@ export async function planVcsHistoryReview(
     ]);
   }
   return await adapter.history.planReview(commit, context, options);
+}
+
+/** Ask the selected provider how an inclusive history range should open in review. */
+export async function planVcsHistoryRangeReview(
+  adapter: VcsAdapter,
+  selection: ExtensionVcsHistoryRangeSelection,
+  context: VcsLoadContext,
+  options?: ExtensionVcsHistoryReviewOptions,
+): Promise<ExtensionVcsHistoryRangeReviewAction> {
+  if (!adapter.history?.planRangeReview) {
+    throw new HunkUserError(`Multi-commit history review is not supported by ${adapter.name}.`, [
+      "Use a VCS adapter that implements range history review.",
+    ]);
+  }
+  return await adapter.history.planRangeReview(selection, context, options);
 }
 
 /** Build an adapter event plan, falling back to signature polling. */

--- a/packages/hunk/src/core/vcs/types.ts
+++ b/packages/hunk/src/core/vcs/types.ts
@@ -2,6 +2,8 @@ import type {
   ExtensionVcsHistoryCommit,
   ExtensionVcsHistoryInput,
   ExtensionVcsHistoryPage,
+  ExtensionVcsHistoryRangeReviewAction,
+  ExtensionVcsHistoryRangeSelection,
   ExtensionVcsHistoryReviewAction,
   ExtensionVcsHistoryReviewOptions,
   ExtensionVcsWatchPlan,
@@ -61,6 +63,11 @@ export interface VcsHistoryCapability {
     context: VcsLoadContext,
     options?: ExtensionVcsHistoryReviewOptions,
   ): Promise<ExtensionVcsHistoryReviewAction>;
+  planRangeReview?(
+    selection: ExtensionVcsHistoryRangeSelection,
+    context: VcsLoadContext,
+    options?: ExtensionVcsHistoryReviewOptions,
+  ): Promise<ExtensionVcsHistoryRangeReviewAction>;
 }
 
 /**

--- a/packages/hunk/src/extension-api/index.ts
+++ b/packages/hunk/src/extension-api/index.ts
@@ -153,6 +153,8 @@ export type {
   ExtensionVcsHistoryDecoration,
   ExtensionVcsHistoryInput,
   ExtensionVcsHistoryPage,
+  ExtensionVcsHistoryRangeReviewAction,
+  ExtensionVcsHistoryRangeSelection,
   ExtensionVcsHistoryReviewAction,
   ExtensionVcsHistoryReviewOptions,
   ExtensionVcsHistorySource,

--- a/packages/hunk/src/extension-api/types.ts
+++ b/packages/hunk/src/extension-api/types.ts
@@ -21,7 +21,7 @@
  * Extensions can branch on `hunk.apiVersion` so a newer Hunk can keep loading
  * older extensions without guessing at their expectations.
  */
-export const HUNK_EXTENSION_API_VERSION = 20;
+export const HUNK_EXTENSION_API_VERSION = 21;
 export type HunkExtensionApiVersion = typeof HUNK_EXTENSION_API_VERSION;
 
 export type ExtensionNotifyType = "info" | "warning" | "error";
@@ -801,7 +801,15 @@ export interface ExtensionVcsHistorySource {
   close(): void | Promise<void>;
 }
 
-/** Optional provider-neutral selection facts for reviewing one history item. */
+/** The inclusive endpoint commits selected from one history page stream. */
+export interface ExtensionVcsHistoryRangeSelection {
+  /** Newer endpoint whose tree becomes the review's new side. */
+  newestCommit: ExtensionVcsHistoryCommit;
+  /** Older endpoint whose chosen parent becomes the review's old side. */
+  oldestCommit: ExtensionVcsHistoryCommit;
+}
+
+/** Optional provider-neutral selection facts for reviewing history items. */
 export interface ExtensionVcsHistoryReviewOptions {
   /** One ordered parent id returned on the commit, when the caller chooses a specific parent. */
   parentRevisionId?: string;
@@ -818,6 +826,12 @@ export type ExtensionVcsHistoryReviewAction =
       fromRevisionId: string;
       toRevisionId: string;
     };
+
+/** Provider-owned direct endpoint action for one inclusive history selection. */
+export type ExtensionVcsHistoryRangeReviewAction = Extract<
+  ExtensionVcsHistoryReviewAction,
+  { kind: "revision-range" }
+>;
 
 /** Optional read-only history capability implemented independently of review operations. */
 export interface ExtensionVcsHistoryCapability {
@@ -836,6 +850,17 @@ export interface ExtensionVcsHistoryCapability {
     context: ExtensionVcsLoadContext,
     options?: ExtensionVcsHistoryReviewOptions,
   ): ExtensionVcsHistoryReviewAction | Promise<ExtensionVcsHistoryReviewAction>;
+  /**
+   * Declare how to compare an inclusive contiguous history selection.
+   *
+   * Providers choose the oldest commit's root or parent baseline and verify
+   * that the endpoints form one ancestry range. Older providers may omit this.
+   */
+  planRangeReview?(
+    selection: ExtensionVcsHistoryRangeSelection,
+    context: ExtensionVcsLoadContext,
+    options?: ExtensionVcsHistoryReviewOptions,
+  ): ExtensionVcsHistoryRangeReviewAction | Promise<ExtensionVcsHistoryRangeReviewAction>;
 }
 
 /** Stash review request, as extension adapters receive it. */

--- a/packages/hunk/src/extensions/runExtension.test.ts
+++ b/packages/hunk/src/extensions/runExtension.test.ts
@@ -988,6 +988,46 @@ describe("toInternalVcsAdapter history boundary", () => {
         } as never,
       }),
     ).toThrow("history must provide open() and planReview() functions");
+    expect(() =>
+      toInternalVcsAdapter({
+        id: "invalid-range",
+        name: "Invalid range",
+        detect: () => null,
+        history: {
+          open: () => ({ read: async () => ({ commits: [], done: true }), close() {} }),
+          planReview: () => ({ kind: "revision-show", revisionId: "revision" }),
+          planRangeReview: true,
+        } as never,
+      }),
+    ).toThrow("history must provide open() and planReview() functions");
+  });
+
+  test("rejects a single-revision action from range planning", async () => {
+    const adapter = toInternalVcsAdapter({
+      id: "bad-range-plan",
+      name: "Bad range plan",
+      detect: () => null,
+      history: {
+        open: () => ({ read: async () => ({ commits: [], done: true }), close() {} }),
+        planReview: (commit) => ({ kind: "revision-show", revisionId: commit.revisionId }),
+        planRangeReview: (() => ({ kind: "revision-show", revisionId: "only-one" })) as never,
+      },
+    });
+    const commit = {
+      revisionId: "revision",
+      displayId: "revision",
+      parentRevisionIds: [],
+      subject: "Revision",
+      authorName: "Ada",
+      authoredAt: "2026-01-01T00:00:00Z",
+      decorations: [],
+    };
+    await expect(
+      adapter.history!.planRangeReview!(
+        { newestCommit: commit, oldestCommit: commit },
+        { cwd: "/repo" },
+      ),
+    ).rejects.toThrow("must return a revision-range action");
   });
 
   test("copies and sanitizes bounded history pages", async () => {
@@ -1217,6 +1257,12 @@ describe("toInternalVcsAdapter history boundary", () => {
               }
             : { kind: "revision-show", revisionId: `opaque:root-view/${selected.revisionId}` };
         },
+        planRangeReview: (selection, _context, options) => ({
+          kind: "revision-range",
+          fromRevisionId:
+            options?.parentRevisionId ?? `opaque:base-for/${selection.oldestCommit.revisionId}`,
+          toRevisionId: selection.newestCommit.revisionId,
+        }),
       },
     });
 
@@ -1240,6 +1286,24 @@ describe("toInternalVcsAdapter history boundary", () => {
       toRevisionId: child.revisionId,
     });
     expect(plannedParent).toBe(root.revisionId);
+    await expect(
+      adapter.history!.planRangeReview!(
+        { newestCommit: child, oldestCommit: child },
+        { cwd: "/repo" },
+        { parentRevisionId: root.revisionId },
+      ),
+    ).resolves.toEqual({
+      kind: "revision-range",
+      fromRevisionId: root.revisionId,
+      toRevisionId: child.revisionId,
+    });
+    await expect(
+      adapter.history!.planRangeReview!(
+        { newestCommit: child, oldestCommit: root },
+        { cwd: "/repo" },
+        { parentRevisionId: child.revisionId },
+      ),
+    ).rejects.toThrow("oldest commit's parents");
     await expect(adapter.history!.planReview(root, { cwd: "/repo" })).resolves.toEqual({
       kind: "revision-show",
       revisionId: `opaque:root-view/${root.revisionId}`,

--- a/packages/hunk/src/extensions/runExtension.ts
+++ b/packages/hunk/src/extensions/runExtension.ts
@@ -29,6 +29,7 @@ import { toUserFacingError } from "../core/run/errors";
 import { toInternalVcsPatchResult } from "./vcsPatchResult";
 import type {
   ExtensionVcsHistoryCommit,
+  ExtensionVcsHistoryRangeSelection,
   ExtensionVcsHistoryReviewAction,
   ExtensionVcsHistorySource,
   ExtensionVcsOperation,
@@ -318,6 +319,18 @@ function normalizeHistoryCommit(value: unknown): ExtensionVcsHistoryCommit {
   };
 }
 
+/** Copy and validate both immutable endpoints in one history range selection. */
+function normalizeHistoryRangeSelection(value: unknown): ExtensionVcsHistoryRangeSelection {
+  if (!isPlainObject(value)) {
+    throw new Error("VCS history range selection must be an object.");
+  }
+  const fields = snapshotProperties(value, ["newestCommit", "oldestCommit"]);
+  return {
+    newestCommit: normalizeHistoryCommit(fields.newestCommit),
+    oldestCommit: normalizeHistoryCommit(fields.oldestCommit),
+  };
+}
+
 /** Copy and validate a provider-owned plan for opening one opaque history item. */
 function normalizeHistoryReviewAction(value: unknown): ExtensionVcsHistoryReviewAction {
   if (!isPlainObject(value)) {
@@ -493,15 +506,17 @@ export function toInternalVcsAdapter(
 
   const history = adapterFields.history;
   const historyFields = isPlainObject(history)
-    ? snapshotProperties(history, ["open", "planReview"])
+    ? snapshotProperties(history, ["open", "planReview", "planRangeReview"])
     : undefined;
   const historyOpen = historyFields?.open;
   const historyPlanReview = historyFields?.planReview;
+  const historyPlanRangeReview = historyFields?.planRangeReview;
   if (
     history !== undefined &&
     (!isPlainObject(history) ||
       typeof historyOpen !== "function" ||
-      typeof historyPlanReview !== "function")
+      typeof historyPlanReview !== "function" ||
+      (historyPlanRangeReview !== undefined && typeof historyPlanRangeReview !== "function"))
   ) {
     throw new Error("registerVcsAdapter history must provide open() and planReview() functions.");
   }
@@ -510,6 +525,9 @@ export function toInternalVcsAdapter(
   const planHistoryReview = historyPlanReview as NonNullable<
     ExtensionVcsAdapter["history"]
   >["planReview"];
+  const planHistoryRangeReview = historyPlanRangeReview as NonNullable<
+    ExtensionVcsAdapter["history"]
+  >["planRangeReview"];
   const detect = adapterFields.detect;
   if (typeof detect !== "function") {
     throw new Error("registerVcsAdapter requires a detect() function.");
@@ -586,6 +604,42 @@ export function toInternalVcsAdapter(
             throw toUserFacingError(error);
           }
         },
+        ...(typeof planHistoryRangeReview === "function" && {
+          async planRangeReview(
+            selection: ExtensionVcsHistoryRangeSelection,
+            context: Parameters<NonNullable<typeof planHistoryRangeReview>>[1],
+            options?: Parameters<NonNullable<typeof planHistoryRangeReview>>[2],
+          ) {
+            try {
+              const normalizedSelection = normalizeHistoryRangeSelection(selection);
+              const parentRevisionId = options?.parentRevisionId;
+              if (
+                parentRevisionId !== undefined &&
+                !normalizedSelection.oldestCommit.parentRevisionIds.includes(parentRevisionId)
+              ) {
+                throw new Error(
+                  "VCS history range parent selection must name one of the oldest commit's parents.",
+                );
+              }
+              const action = normalizeHistoryReviewAction(
+                await planHistoryRangeReview.call(
+                  history,
+                  normalizedSelection,
+                  context,
+                  parentRevisionId === undefined ? undefined : { parentRevisionId },
+                ),
+              );
+              if (action.kind !== "revision-range") {
+                throw new Error(
+                  "VCS history planRangeReview() must return a revision-range action.",
+                );
+              }
+              return action;
+            } catch (error) {
+              throw toUserFacingError(error);
+            }
+          },
+        }),
       },
     }),
   };

--- a/packages/hunk/src/ui/history/types.ts
+++ b/packages/hunk/src/ui/history/types.ts
@@ -4,6 +4,8 @@ import type { VcsHistorySource } from "../../core/vcs/types";
 import type { ExtensionSession } from "../../extensions/session";
 import type {
   ExtensionVcsHistoryCommit,
+  ExtensionVcsHistoryRangeReviewAction,
+  ExtensionVcsHistoryRangeSelection,
   ExtensionVcsHistoryReviewAction,
   ExtensionVcsHistoryReviewOptions,
   NamedCustomThemeConfig,
@@ -29,7 +31,13 @@ export interface HistoryRuntime {
   planReview(
     commit: ExtensionVcsHistoryCommit,
     options?: ExtensionVcsHistoryReviewOptions,
+    signal?: AbortSignal,
   ): Promise<ExtensionVcsHistoryReviewAction>;
+  planRangeReview?(
+    selection: ExtensionVcsHistoryRangeSelection,
+    options?: ExtensionVcsHistoryReviewOptions,
+    signal?: AbortSignal,
+  ): Promise<ExtensionVcsHistoryRangeReviewAction>;
   /** Replace the current provider cursor for an explicit interactive refresh. */
   reopenSource(signal?: AbortSignal): Promise<VcsHistorySource>;
   close(): Promise<void>;

--- a/packages/hunk/src/ui/log/LogApp.tsx
+++ b/packages/hunk/src/ui/log/LogApp.tsx
@@ -2,7 +2,7 @@ import type { KeyEvent, MouseEvent as TuiMouseEvent } from "@opentui/core";
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react";
 import { basename } from "node:path";
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import type { ExtensionVcsHistoryCommit } from "../../extension-api/types";
+import type { ExtensionVcsHistoryRangeSelection } from "../../extension-api/types";
 import { sanitizeTerminalLine } from "../../lib/terminalText";
 import { resolveExtensionSessionOptions } from "../../extensions/apply";
 import { HelpDialog } from "../components/chrome/HelpDialog";
@@ -53,7 +53,8 @@ export type LogAppOutcome =
   | { kind: "cancel-open-review" }
   | {
       kind: "open-review";
-      commit: ExtensionVcsHistoryCommit;
+      selection: ExtensionVcsHistoryRangeSelection;
+      count: number;
       parentRevisionId?: string;
       themeId: string;
       themeMode: "dark" | "light";
@@ -80,7 +81,11 @@ export function LogApp({
   const [parentSelectorIndex, setParentSelectorIndex] = useState<number | null>(null);
   const [transientNotice, setTransientNotice] = useState("");
   const [relativeTimeNow, setRelativeTimeNow] = useState(() => Date.now());
-  const [openingCommit, setOpeningCommit] = useState<{ id: string; subject: string } | null>(null);
+  const [openingCommit, setOpeningCommit] = useState<{
+    id: string;
+    subject: string;
+    count: number;
+  } | null>(null);
   const lastClick = useRef({ index: -1, at: 0 });
   // Lock synchronously before requesting review preparation so coalesced input cannot
   // open two child reviews. Quit remains available while the host settles pending work.
@@ -105,7 +110,8 @@ export function LogApp({
     : monochromeLogTheme(themeController.baseTheme, terminalThemeMode);
   const logPalette = resolveInteractiveLogPalette(theme);
   const graphColors = snapshot.presentation.graph ? logPalette.graphLanes : [logPalette.timeline];
-  const selectedRow = snapshot.rows[snapshot.selected];
+  const selection = controller.getSelection();
+  const parentRow = selection?.oldest;
   const responsiveLayout = resolveLogResponsiveLayout(terminal.width, terminal.height);
   const viewportBodyHeight = responsiveLayout.bodyHeight;
   const currentViewPreferences = useMemo(
@@ -143,15 +149,20 @@ export function LogApp({
       setTransientNotice("Clipboard is unavailable in this terminal.");
     }
   };
-  const openSelected = async (parentRevisionId?: string) => {
-    if (reviewPending.current) return;
-    const currentRow = controller.getSelectedRow();
-    if (!currentRow) return;
+  const openSelected = async (parentRevisionId?: string, pending = false) => {
+    if (reviewPending.current && !pending) return;
     reviewPending.current = true;
     reviewQuitEnabled.current = false;
+    await controller.settleNavigation();
+    const currentSelection = controller.getSelection();
+    if (!currentSelection) {
+      reviewPending.current = false;
+      return;
+    }
     setOpeningCommit({
-      id: sanitizeTerminalLine(currentRow.commit.displayId),
-      subject: sanitizeTerminalLine(currentRow.commit.subject),
+      id: sanitizeTerminalLine(currentSelection.focus.commit.displayId),
+      subject: sanitizeTerminalLine(currentSelection.focus.commit.subject),
+      count: currentSelection.count,
     });
     try {
       // Commit the loading surface and consume input coalesced with the opening key/click before
@@ -160,7 +171,11 @@ export function LogApp({
       reviewQuitEnabled.current = true;
       await onOutcome({
         kind: "open-review",
-        commit: currentRow.commit,
+        selection: {
+          newestCommit: currentSelection.newest.commit,
+          oldestCommit: currentSelection.oldest.commit,
+        },
+        count: currentSelection.count,
         ...(parentRevisionId === undefined ? {} : { parentRevisionId }),
         themeId: themeController.themeId,
         themeMode: terminalThemeMode,
@@ -211,12 +226,29 @@ export function LogApp({
     ...viewPreferenceQuit,
     closeSaveConfigPrompt: closeLogSaveConfigPrompt,
   };
+  const requestOpenSelected = async () => {
+    if (reviewPending.current) return;
+    reviewPending.current = true;
+    reviewQuitEnabled.current = false;
+    await controller.settleNavigation();
+    const currentSelection = controller.getSelection();
+    if (
+      currentSelection &&
+      currentSelection.count > 1 &&
+      currentSelection.oldest.commit.parentRevisionIds.length > 1
+    ) {
+      reviewPending.current = false;
+      setParentSelectorIndex(0);
+      return;
+    }
+    await openSelected(undefined, true);
+  };
   const executeCommand = (id: LogCommandId, exitCode?: number) => {
     clearTransientNotice();
     if (!isLogCommandEnabled(id, controller.getSnapshot())) return;
     switch (id) {
       case "open":
-        void openSelected();
+        void requestOpenSelected();
         break;
       case "copy":
         copySelected();
@@ -250,6 +282,12 @@ export function LogApp({
         break;
       case "next":
         void controller.move(1, viewportBodyHeight);
+        break;
+      case "extend-previous":
+        void controller.move(-1, viewportBodyHeight, { extend: true });
+        break;
+      case "extend-next":
+        void controller.move(1, viewportBodyHeight, { extend: true });
         break;
       case "page-up":
         void controller.page(-1, viewportBodyHeight);
@@ -323,6 +361,8 @@ export function LogApp({
     navigate: [
       commandItem("previous"),
       commandItem("next"),
+      commandItem("extend-previous"),
+      commandItem("extend-next"),
       commandItem("page-up"),
       commandItem("page-down"),
       commandItem("first"),
@@ -392,6 +432,10 @@ export function LogApp({
     }
     if (reviewPending.current) {
       if (!reviewQuitEnabled.current) {
+        const command = matchLogCommand(key);
+        if (command === "quit" && key.ctrl && key.name === "c") {
+          executeCommand(command, 130);
+        }
         consume();
         return;
       }
@@ -423,7 +467,7 @@ export function LogApp({
       return;
     }
     if (parentSelectorIndex !== null) {
-      const parents = controller.getSelectedRow()?.commit.parentRevisionIds ?? [];
+      const parents = controller.getSelection()?.oldest.commit.parentRevisionIds ?? [];
       if (name === "escape") setParentSelectorIndex(null);
       else if (name === "up")
         setParentSelectorIndex((parentSelectorIndex - 1 + parents.length) % parents.length);
@@ -500,7 +544,12 @@ export function LogApp({
     groupByDay: !snapshot.presentation.graph,
   });
   const visible = viewportGeometry.entries;
-  const statusHint = terminal.width >= 60 ? "↑↓ move · Enter open · / search · F10 menu" : "";
+  const statusHint =
+    terminal.width >= 120
+      ? "↑↓ move · Shift-↑↓ / J/K select · Enter open · / search · F10 menu"
+      : terminal.width >= 60
+        ? "J/K select · Enter open · F10 menu"
+        : "";
   const statusTextWidth = Math.max(
     1,
     terminal.width - measureTextWidth(statusHint) - (statusHint ? 3 : 2),
@@ -552,7 +601,11 @@ export function LogApp({
               alignItems: "center",
             }}
           >
-            <text fg={theme.text}>Opening commit</text>
+            <text fg={theme.text}>
+              {openingCommit.count > 1
+                ? `Opening ${openingCommit.count} commits`
+                : "Opening commit"}
+            </text>
             <text fg={theme.accent}>
               {fitText(
                 `${openingCommit.id} · ${openingCommit.subject}`,
@@ -563,7 +616,10 @@ export function LogApp({
           </box>
         ) : (
           visible.map(({ index, row, showDayHeader }) => {
-            const selected = index === snapshot.selected;
+            const selected =
+              selection !== undefined &&
+              index >= selection.newestIndex &&
+              index <= selection.oldestIndex;
             const projected = projectResponsiveLogRow({
               row,
               presentation: snapshot.presentation,
@@ -604,8 +660,13 @@ export function LogApp({
                     flexDirection: "row",
                     backgroundColor: selected ? theme.selectedHunk : theme.background,
                   }}
-                  onMouseUp={() => {
+                  onMouseUp={(event: TuiMouseEvent) => {
                     clearTransientNotice();
+                    if (event.modifiers.shift) {
+                      lastClick.current = { index: -1, at: 0 };
+                      void controller.select(index, viewportBodyHeight, { extend: true });
+                      return;
+                    }
                     const now = Date.now();
                     const shouldOpen =
                       lastClick.current.index === index && now - lastClick.current.at < 400;
@@ -667,6 +728,11 @@ export function LogApp({
                         projected.columnGap +
                         projected.rightWidth -
                         measureTextWidth(projected.copyIcon);
+                      if (event.modifiers.shift) {
+                        lastClick.current = { index: -1, at: 0 };
+                        void controller.select(index, viewportBodyHeight, { extend: true });
+                        return;
+                      }
                       void controller.select(index, viewportBodyHeight).then(() => {
                         if (event.x >= copyIconStart) copySelected(row);
                         else void openSelected();
@@ -705,7 +771,9 @@ export function LogApp({
               ? `/${snapshot.search}`
               : transientNotice ||
                   snapshot.notice ||
-                  `${runtime.providerName} · ${snapshot.rows.length}${snapshot.historyDone ? " commits" : "+ commits"}`,
+                  ((selection?.count ?? 0) > 1
+                    ? `${selection!.count} commits selected`
+                    : `${runtime.providerName} · ${snapshot.rows.length}${snapshot.historyDone ? " commits" : "+ commits"}`),
             statusTextWidth,
           )}
         </text>
@@ -728,15 +796,15 @@ export function LogApp({
           }}
         />
       ) : null}
-      {parentSelectorIndex !== null && selectedRow ? (
+      {parentSelectorIndex !== null && parentRow ? (
         <ParentSelectorDialog
-          parentRevisionIds={selectedRow.commit.parentRevisionIds}
+          parentRevisionIds={parentRow.commit.parentRevisionIds}
           selectedIndex={parentSelectorIndex}
           terminalHeight={terminal.height}
           terminalWidth={terminal.width}
           theme={chromeTheme}
           onAccept={(index) => {
-            const parent = selectedRow.commit.parentRevisionIds[index];
+            const parent = parentRow.commit.parentRevisionIds[index];
             setParentSelectorIndex(null);
             if (parent) void openSelected(parent);
           }}

--- a/packages/hunk/src/ui/log/commands.test.ts
+++ b/packages/hunk/src/ui/log/commands.test.ts
@@ -9,7 +9,8 @@ import {
   matchLogCommand,
 } from "./commands";
 
-const key = (name: string, sequence = name, ctrl = false) => ({ name, sequence, ctrl }) as KeyEvent;
+const key = (name: string, sequence = name, ctrl = false, shift = false) =>
+  ({ name, sequence, ctrl, shift }) as KeyEvent;
 
 const snapshot = (parents: string[] = []): LogSnapshot => ({
   rows: [
@@ -32,6 +33,7 @@ const snapshot = (parents: string[] = []): LogSnapshot => ({
     },
   ],
   selected: 0,
+  selectionAnchor: null,
   top: 0,
   search: "",
   searchEditing: false,
@@ -50,6 +52,10 @@ const snapshot = (parents: string[] = []): LogSnapshot => ({
 describe("log command authority", () => {
   test("drives keyboard dispatch, menu hints, and help from one definition", () => {
     expect(matchLogCommand(key("down", ""))).toBe("next");
+    expect(matchLogCommand(key("down", "", false, true))).toBe("extend-next");
+    expect(matchLogCommand(key("x", "J"))).toBe("extend-next");
+    expect(matchLogCommand(key("up", "", false, true))).toBe("extend-previous");
+    expect(matchLogCommand(key("x", "K"))).toBe("extend-previous");
     expect(matchLogCommand(key("x", "j"))).toBe("next");
     expect(matchLogCommand(key("c", "\x03", true))).toBe("quit");
     expect(matchLogCommand(key("t"))).toBe("theme");
@@ -59,6 +65,10 @@ describe("log command authority", () => {
     expect(logCommand("open-parent").label).toBe("Compare with parent…");
     const helpRows = buildLogHelpSections().flatMap((section) => section.rows);
     expect(helpRows).toContainEqual({ keys: "↓ / j", description: "next commit" });
+    expect(helpRows).toContainEqual({
+      keys: "Shift-↓ / J",
+      description: "extend selection down",
+    });
     expect(helpRows).toContainEqual({ keys: "t", description: "theme…" });
   });
 
@@ -66,6 +76,9 @@ describe("log command authority", () => {
     expect(isLogCommandEnabled("open-first-parent", snapshot())).toBe(false);
     expect(isLogCommandEnabled("open-first-parent", snapshot(["p1", "p2"]))).toBe(true);
     expect(isLogCommandEnabled("open-parent", snapshot(["p1", "p2"]))).toBe(true);
+    const range = { ...snapshot(["p1", "p2"]), selectionAnchor: 1 };
+    expect(isLogCommandEnabled("open-first-parent", range)).toBe(false);
+    expect(isLogCommandEnabled("open-parent", range)).toBe(false);
     expect(isLogCommandEnabled("next-match", snapshot())).toBe(false);
   });
 });

--- a/packages/hunk/src/ui/log/commands.ts
+++ b/packages/hunk/src/ui/log/commands.ts
@@ -16,6 +16,8 @@ export type LogCommandId =
   | "toggle-decorations"
   | "previous"
   | "next"
+  | "extend-previous"
+  | "extend-next"
   | "page-up"
   | "page-down"
   | "first"
@@ -42,7 +44,7 @@ export interface LogCommandDefinition {
 export const LOG_COMMANDS: readonly LogCommandDefinition[] = [
   {
     id: "open",
-    label: "Open selected commit",
+    label: "Open selection",
     menu: "file",
     shortcuts: [{ token: "name:enter", display: "Enter" }],
     helpSection: "Commit",
@@ -83,6 +85,26 @@ export const LOG_COMMANDS: readonly LogCommandDefinition[] = [
   { id: "toggle-author", label: "Show author", menu: "view" },
   { id: "toggle-date", label: "Show date", menu: "view" },
   { id: "toggle-decorations", label: "Show decorations", menu: "view" },
+  {
+    id: "extend-previous",
+    label: "Extend selection up",
+    menu: "navigate",
+    shortcuts: [
+      { token: "shift:up", display: "Shift-↑ / K" },
+      { token: "sequence:K", display: "Shift-↑ / K" },
+    ],
+    helpSection: "Navigation",
+  },
+  {
+    id: "extend-next",
+    label: "Extend selection down",
+    menu: "navigate",
+    shortcuts: [
+      { token: "shift:down", display: "Shift-↓ / J" },
+      { token: "sequence:J", display: "Shift-↓ / J" },
+    ],
+    helpSection: "Navigation",
+  },
   {
     id: "previous",
     label: "Previous commit",
@@ -188,9 +210,10 @@ export function logCommandHint(id: LogCommandId) {
 
 /** Resolve a keyboard event to the canonical log command. */
 export function matchLogCommand(key: KeyEvent): LogCommandId | null {
+  const normalizedName = key.name === "return" ? "enter" : key.name;
   const tokens = [
     key.ctrl ? `ctrl:${key.name}` : "",
-    `name:${key.name === "return" ? "enter" : key.name}`,
+    key.shift ? `shift:${normalizedName}` : `name:${normalizedName}`,
     key.sequence ? `sequence:${key.sequence}` : "",
   ];
   return (
@@ -204,12 +227,17 @@ export function matchLogCommand(key: KeyEvent): LogCommandId | null {
 export function isLogCommandEnabled(id: LogCommandId, snapshot: LogSnapshot) {
   const selected = snapshot.rows[snapshot.selected];
   if (["open", "copy"].includes(id)) return Boolean(selected);
-  if (id === "previous" || id === "page-up" || id === "first") return snapshot.selected > 0;
-  if (id === "next" || id === "page-down" || id === "last")
+  if (id === "previous" || id === "extend-previous" || id === "page-up" || id === "first")
+    return snapshot.selected > 0;
+  if (id === "next" || id === "extend-next" || id === "page-down" || id === "last")
     return !(snapshot.historyDone && snapshot.selected >= snapshot.rows.length - 1);
   if (id === "next-match" || id === "previous-match") return Boolean(snapshot.search);
-  if (id === "open-first-parent") return Boolean(selected?.commit.parentRevisionIds.length);
-  if (id === "open-parent") return (selected?.commit.parentRevisionIds.length ?? 0) > 1;
+  if (id === "open-first-parent")
+    return snapshot.selectionAnchor === null && Boolean(selected?.commit.parentRevisionIds.length);
+  if (id === "open-parent")
+    return (
+      snapshot.selectionAnchor === null && (selected?.commit.parentRevisionIds.length ?? 0) > 1
+    );
   return true;
 }
 

--- a/packages/hunk/src/ui/log/controller.test.ts
+++ b/packages/hunk/src/ui/log/controller.test.ts
@@ -120,6 +120,83 @@ describe("LogController", () => {
     await controller.close();
   });
 
+  test("extends, shrinks, reverses, and collapses an inclusive range", async () => {
+    const { runtime } = createRuntime(["one", "two", "three", "four"]);
+    const controller = new LogController(runtime);
+    await controller.loadMore();
+    await controller.move(1, 1);
+    await Promise.all([
+      controller.move(1, 1, { extend: true }),
+      controller.move(1, 1, { extend: true }),
+    ]);
+    expect(controller.getSelection()).toMatchObject({
+      newestIndex: 1,
+      oldestIndex: 3,
+      count: 3,
+    });
+    await controller.move(-2, 1, { extend: true });
+    expect(controller.getSelection()?.count).toBe(1);
+    await controller.move(-1, 1, { extend: true });
+    expect(controller.getSelection()).toMatchObject({ newestIndex: 0, oldestIndex: 1, count: 2 });
+    expect(controller.getSelection()?.focus.commit.revisionId).toBe("one");
+    await controller.move(1, 1);
+    expect(controller.getSnapshot().selectionAnchor).toBeNull();
+    expect(controller.getSelection()?.count).toBe(1);
+    await controller.close();
+  });
+
+  test("rejects ranges when traversal options can hide or interleave commits", async () => {
+    for (const input of [{ grep: "matching" }, { all: true }]) {
+      const { runtime } = createRuntime(["one", "two", "three"]);
+      runtime.input = { ...runtime.input, ...input };
+      const controller = new LogController(runtime);
+      await controller.loadMore();
+      await controller.move(1, 1, { extend: true });
+
+      expect(controller.getSelection()?.count).toBe(1);
+      expect(controller.getSnapshot().notice).toBe(
+        "Multi-commit selection is unavailable when history traversal can hide or interleave commits.",
+      );
+      await controller.close();
+    }
+  });
+
+  test("settles deferred navigation and prevents stale selection overwrite", async () => {
+    const { runtime } = createRuntime(["one", "two", "three"]);
+    const originalRead = runtime.source.read.bind(runtime.source);
+    let readCount = 0;
+    let release!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    runtime.source.read = async (options) => {
+      readCount += 1;
+      if (readCount === 2) await deferred;
+      return originalRead(options);
+    };
+    const controller = new LogController(runtime);
+    await controller.loadMore();
+    const staleExtension = controller.move(2, 1, { extend: true });
+    const latestSelection = controller.select(0, 1);
+    release();
+    await Promise.all([staleExtension, latestSelection, controller.settleNavigation()]);
+    expect(controller.getSnapshot()).toMatchObject({ selected: 0, selectionAnchor: null });
+    await controller.close();
+  });
+
+  test("refresh reconciles both range endpoints by immutable revision id", async () => {
+    const { runtime } = createRuntime(["one", "two", "three", "four"]);
+    const controller = new LogController(runtime);
+    await controller.loadMore();
+    await controller.move(2, 2, { extend: true });
+    expect(controller.getSelection()?.count).toBe(3);
+    await controller.refresh();
+    expect(controller.getSelection()?.newest.commit.revisionId).toBe("one");
+    expect(controller.getSelection()?.oldest.commit.revisionId).toBe("three");
+    expect(controller.getSelection()?.count).toBe(3);
+    await controller.close();
+  });
+
   test("search reveals its match and refresh preserves immutable selection viewport offset", async () => {
     const { runtime } = createRuntime(["one", "two", "three", "four"]);
     const controller = new LogController(runtime);

--- a/packages/hunk/src/ui/log/controller.ts
+++ b/packages/hunk/src/ui/log/controller.ts
@@ -12,9 +12,22 @@ export interface LogPresentation {
   decorations: boolean;
 }
 
+/** Return whether traversal filters can omit commits between adjacent displayed rows. */
+export function historyFiltersCanHideIntermediateCommits(input: HistoryRuntime["input"]) {
+  return Boolean(
+    input.all ||
+    input.author !== undefined ||
+    input.grep !== undefined ||
+    input.since !== undefined ||
+    input.until !== undefined ||
+    Boolean(input.pathspecs?.length),
+  );
+}
+
 export interface LogSnapshot {
   rows: readonly HistoryGraphRow[];
   selected: number;
+  selectionAnchor: number | null;
   top: number;
   search: string;
   searchEditing: boolean;
@@ -35,6 +48,8 @@ export class LogController {
   private loadingPromise: Promise<void> | null = null;
   private refreshPromise: Promise<void> | null = null;
   private navigationTarget: number | null = null;
+  private navigationPromise: Promise<void> | null = null;
+  private selectionGeneration = 0;
   private closed = false;
   private viewportBodyHeight = 1;
   private noticeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -45,6 +60,7 @@ export class LogController {
     this.snapshot = {
       rows: [],
       selected: 0,
+      selectionAnchor: null,
       top: 0,
       search: "",
       searchEditing: false,
@@ -130,37 +146,71 @@ export class LogController {
       bodyHeight: safeHeight,
       groupByDay: !this.snapshot.presentation.graph,
     });
-    if (selected !== this.snapshot.selected || geometry.top !== this.snapshot.top)
-      this.publish({ selected, top: geometry.top });
+    const selectionAnchor =
+      this.snapshot.selectionAnchor === null
+        ? null
+        : Math.max(
+            0,
+            Math.min(Math.max(0, this.snapshot.rows.length - 1), this.snapshot.selectionAnchor),
+          );
+    if (
+      selected !== this.snapshot.selected ||
+      selectionAnchor !== this.snapshot.selectionAnchor ||
+      geometry.top !== this.snapshot.top
+    )
+      this.publish({ selected, selectionAnchor, top: geometry.top });
   }
 
-  /** Select a target, loading bounded continuation pages until it exists or EOF is known. */
-  async select(index: number, viewportBodyHeight: number) {
+  /** Select a target, optionally extending a contiguous range from the current focus. */
+  select(index: number, viewportBodyHeight: number, { extend = false }: { extend?: boolean } = {}) {
     this.clearNotice();
-    const target = Math.max(0, index);
-    this.navigationTarget = target;
-    while (target >= this.snapshot.rows.length && !this.snapshot.historyDone && !this.closed) {
-      await this.loadMore();
+    if (extend && historyFiltersCanHideIntermediateCommits(this.runtime.input)) {
+      this.setNotice(
+        "Multi-commit selection is unavailable when history traversal can hide or interleave commits.",
+      );
+      return Promise.resolve();
     }
-    if (this.closed) return;
-    this.publish({ selected: Math.max(0, Math.min(this.snapshot.rows.length - 1, target)) });
-    this.clampViewport(viewportBodyHeight);
-    if (this.navigationTarget === target) this.navigationTarget = null;
-    const visibleCount = planLogViewportGeometry({
-      rows: this.snapshot.rows,
-      selected: this.snapshot.selected,
-      requestedTop: this.snapshot.top,
-      bodyHeight: viewportBodyHeight,
-      groupByDay: !this.snapshot.presentation.graph,
-    }).entries.length;
-    if (target + visibleCount >= this.snapshot.rows.length && !this.snapshot.historyDone)
-      void this.loadMore();
+    const target = Math.max(0, index);
+    const anchor = extend ? (this.snapshot.selectionAnchor ?? this.snapshot.selected) : null;
+    const requestGeneration = ++this.selectionGeneration;
+    this.publish({ selectionAnchor: anchor });
+    this.navigationTarget = target;
+    const navigation = (async () => {
+      while (target >= this.snapshot.rows.length && !this.snapshot.historyDone && !this.closed) {
+        await this.loadMore();
+      }
+      if (this.closed || requestGeneration !== this.selectionGeneration) return;
+      const selected = Math.max(0, Math.min(this.snapshot.rows.length - 1, target));
+      this.publish({ selected, selectionAnchor: anchor === selected ? null : anchor });
+      this.clampViewport(viewportBodyHeight);
+      if (this.navigationTarget === target) this.navigationTarget = null;
+      const visibleCount = planLogViewportGeometry({
+        rows: this.snapshot.rows,
+        selected: this.snapshot.selected,
+        requestedTop: this.snapshot.top,
+        bodyHeight: viewportBodyHeight,
+        groupByDay: !this.snapshot.presentation.graph,
+      }).entries.length;
+      if (target + visibleCount >= this.snapshot.rows.length && !this.snapshot.historyDone)
+        void this.loadMore();
+    })();
+    this.navigationPromise = navigation;
+    void navigation.finally(() => {
+      if (this.navigationPromise === navigation) this.navigationPromise = null;
+    });
+    return navigation;
   }
 
-  move(delta: number, viewportBodyHeight: number) {
+  /** Wait until the most recently requested selection has settled. */
+  async settleNavigation() {
+    while (this.navigationPromise) await this.navigationPromise;
+  }
+
+  move(delta: number, viewportBodyHeight: number, options: { extend?: boolean } = {}) {
     return this.select(
       (this.navigationTarget ?? this.snapshot.selected) + delta,
       viewportBodyHeight,
+      options,
     );
   }
 
@@ -231,7 +281,7 @@ export class LogController {
         .join(" ")
         .toLocaleLowerCase();
       if (haystack.includes(needle)) {
-        this.publish({ selected: index, notice: "" });
+        this.publish({ selected: index, selectionAnchor: null, notice: "" });
         this.clampViewport(viewportHeight);
         return;
       }
@@ -284,8 +334,14 @@ export class LogController {
   private async performRefresh() {
     if (this.closed) return;
     const selectedId = this.snapshot.rows[this.snapshot.selected]?.commit.revisionId;
+    const anchorId =
+      this.snapshot.selectionAnchor === null
+        ? undefined
+        : this.snapshot.rows[this.snapshot.selectionAnchor]?.commit.revisionId;
     const viewportOffset = this.snapshot.selected - this.snapshot.top;
     this.generation += 1;
+    this.selectionGeneration += 1;
+    this.navigationTarget = null;
     const generation = this.generation;
     this.abort.abort();
     await this.loadingPromise;
@@ -309,44 +365,72 @@ export class LogController {
     this.publish({
       rows: [],
       selected: 0,
+      selectionAnchor: null,
       top: 0,
       historyDone: false,
       loading: false,
       notice: "",
     });
     await this.loadMore();
-    if (selectedId) {
-      while (
-        !this.snapshot.historyDone &&
-        !this.snapshot.rows.some((row) => row.commit.revisionId === selectedId)
-      ) {
-        await this.loadMore();
-      }
-      const index = this.snapshot.rows.findIndex((row) => row.commit.revisionId === selectedId);
-      if (index >= 0) {
-        const requestedTop = Math.max(0, index - viewportOffset);
-        const geometry = planLogViewportGeometry({
-          rows: this.snapshot.rows,
-          selected: index,
-          requestedTop,
-          bodyHeight: this.viewportBodyHeight,
-          groupByDay: !this.snapshot.presentation.graph,
-        });
-        this.publish({ selected: index, top: geometry.top });
-      }
+    const endpointIds = [selectedId, anchorId].filter((id): id is string => Boolean(id));
+    while (
+      !this.snapshot.historyDone &&
+      endpointIds.some((id) => !this.snapshot.rows.some((row) => row.commit.revisionId === id))
+    ) {
+      await this.loadMore();
     }
+    const selectedIndex = selectedId
+      ? this.snapshot.rows.findIndex((row) => row.commit.revisionId === selectedId)
+      : -1;
+    const anchorIndex = anchorId
+      ? this.snapshot.rows.findIndex((row) => row.commit.revisionId === anchorId)
+      : -1;
+    const restoredSelected = selectedIndex >= 0 ? selectedIndex : Math.max(0, anchorIndex);
+    const restoredAnchor = selectedIndex >= 0 && anchorIndex >= 0 ? anchorIndex : null;
+    const requestedTop = Math.max(0, restoredSelected - viewportOffset);
+    const geometry = planLogViewportGeometry({
+      rows: this.snapshot.rows,
+      selected: restoredSelected,
+      requestedTop,
+      bodyHeight: this.viewportBodyHeight,
+      groupByDay: !this.snapshot.presentation.graph,
+    });
+    this.publish({
+      selected: restoredSelected,
+      selectionAnchor: restoredAnchor === restoredSelected ? null : restoredAnchor,
+      top: geometry.top,
+    });
     this.setNotice("History refreshed.");
   }
 
-  /** Return the currently selected immutable provider history row. */
+  /** Return the focused row and normalized inclusive selection endpoints. */
+  getSelection() {
+    const focus = this.snapshot.rows[this.snapshot.selected];
+    if (!focus) return undefined;
+    const anchor = this.snapshot.selectionAnchor ?? this.snapshot.selected;
+    const newestIndex = Math.min(anchor, this.snapshot.selected);
+    const oldestIndex = Math.max(anchor, this.snapshot.selected);
+    return {
+      focus,
+      newest: this.snapshot.rows[newestIndex]!,
+      oldest: this.snapshot.rows[oldestIndex]!,
+      newestIndex,
+      oldestIndex,
+      count: oldestIndex - newestIndex + 1,
+    };
+  }
+
+  /** Return the currently focused immutable provider history row. */
   getSelectedRow() {
-    return this.snapshot.rows[this.snapshot.selected];
+    return this.getSelection()?.focus;
   }
 
   async close() {
     if (this.closed) return;
     this.closed = true;
     this.generation += 1;
+    this.selectionGeneration += 1;
+    this.navigationTarget = null;
     this.abort.abort();
     if (this.noticeTimer) clearTimeout(this.noticeTimer);
     this.noticeTimer = null;

--- a/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
@@ -19,8 +19,18 @@ import {
 
 mock.restore();
 
-/** Create a loaded one-row history route for session-host navigation tests. */
-async function createHistoryRoute() {
+/** Create a loaded history route for session-host navigation tests. */
+async function createHistoryRoute(subjects = ["History row"]) {
+  const commits = subjects.map((subject, index) => ({
+    revisionId: `revision-${String.fromCharCode(97 + index)}`,
+    displayId: index === 0 ? "revision" : `rev-${index}`,
+    parentRevisionIds:
+      index + 1 < subjects.length ? [`revision-${String.fromCharCode(98 + index)}`] : [],
+    subject,
+    authorName: "Ada",
+    authoredAt: "2026-01-01T00:00:00Z",
+    decorations: [],
+  }));
   const runtime: HistoryRuntime = {
     input: {
       kind: "history",
@@ -34,20 +44,7 @@ async function createHistoryRoute() {
     extensionSession: createTestExtensionSession(),
     source: {
       async read() {
-        return {
-          commits: [
-            {
-              revisionId: "revision-a",
-              displayId: "revision",
-              parentRevisionIds: [],
-              subject: "History row",
-              authorName: "Ada",
-              authoredAt: "2026-01-01T00:00:00Z",
-              decorations: [],
-            },
-          ],
-          done: true,
-        };
+        return { commits, done: true };
       },
       async close() {},
     },
@@ -58,8 +55,16 @@ async function createHistoryRoute() {
     customThemes: [],
     initialViewPreferences: persistedViewPreferencesFromOptions({}),
     promptSaveViewPreferences: true,
-    async planReview() {
-      return { kind: "revision-show", revisionId: "revision-a" };
+    async planReview(commit) {
+      return { kind: "revision-show", revisionId: commit.revisionId };
+    },
+    async planRangeReview(selection, options) {
+      return {
+        kind: "revision-range",
+        fromRevisionId:
+          options?.parentRevisionId ?? selection.oldestCommit.parentRevisionIds[0] ?? "empty",
+        toRevisionId: selection.newestCommit.revisionId,
+      };
     },
     async reopenSource() {
       return this.source;
@@ -147,6 +152,55 @@ test("routes repeated history reviews through fresh runtimes and returns instead
     expect(stops[0]).toHaveBeenCalledTimes(1);
     expect(stops[1]).toHaveBeenCalledTimes(1);
     expect(quit).not.toHaveBeenCalled();
+  } finally {
+    setup.renderer.destroy();
+    await history.controller.close();
+  }
+});
+
+test("opens an extended history selection as one inclusive comparison", async () => {
+  const history = await createHistoryRoute(["Newest", "Oldest"]);
+  const requests: unknown[] = [];
+  const deps: HunkSessionHostDeps = {
+    prepareReview: (async (request: unknown) => {
+      requests.push(request);
+      const bootstrap = createTestVcsAppBootstrap({
+        changesetId: "range-review",
+        files: [createTestDiffFile({ id: "range.ts", path: "range.ts" })],
+      });
+      bootstrap.extensions = history.runtime.extensionSession.current;
+      return { bootstrap, borrowsExtensions: true };
+    }) as never,
+    createReviewRuntime: (() => ({
+      hostClient: undefined,
+      reviewProducer: undefined,
+      stop: mock(() => undefined),
+    })) as never,
+  };
+  const setup = await testRender(
+    <HunkSessionHost
+      initialRoute={history}
+      externalQuitSignal={new AbortController().signal}
+      onQuit={() => undefined}
+      deps={deps}
+    />,
+    { width: 100, height: 20 },
+  );
+  try {
+    await setup.renderOnce();
+    await act(async () => setup.mockInput.typeText("J"));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("2 commits selected");
+    await act(async () => setup.mockInput.pressEnter());
+    await settle(setup);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({
+      action: {
+        kind: "revision-range",
+        fromRevisionId: "empty",
+        toRevisionId: "revision-a",
+      },
+    });
   } finally {
     setup.renderer.destroy();
     await history.controller.close();
@@ -335,7 +389,11 @@ test("waits for non-cooperative provider planning before menu quit", async () =>
   const planning = new Promise<{ kind: "revision-show"; revisionId: string }>((resolve) => {
     resolvePlanning = resolve;
   });
-  history.runtime.planReview = mock(() => planning);
+  let planningSignal: AbortSignal | undefined;
+  history.runtime.planReview = mock((_commit, _options, signal) => {
+    planningSignal = signal;
+    return planning;
+  });
   const prepareReview = mock(async () => {
     throw new Error("cancelled planning reached preparation");
   });
@@ -355,6 +413,7 @@ test("waits for non-cooperative provider planning before menu quit", async () =>
     await Bun.sleep(10);
     await selectHistoryMenuQuit(setup);
     expect(quit).not.toHaveBeenCalled();
+    expect(planningSignal?.aborted).toBeTrue();
 
     resolvePlanning({ kind: "revision-show", revisionId: "revision-a" });
     await settle(setup);

--- a/packages/hunk/src/ui/session/HunkSessionHost.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../app/session/reviewRuntime";
 import type { StartupNotice } from "../../core/process/startupNotice";
 import type { AppBootstrap } from "../../core/bootstrap";
+import type { ExtensionVcsHistoryReviewAction } from "../../extension-api/types";
 import { parseExtensionReviewDescriptor } from "../../core/reviewDescriptor";
 import type { ExtensionSession } from "../../extensions/session";
 import type { ExtensionLoadResult } from "../../extensions/types";
@@ -52,20 +53,35 @@ export interface HunkSessionHostDeps {
   viewPreferenceQuitScheduler?: ViewPreferenceQuitScheduler;
 }
 
-/** Describe the selected history commit with bounded metadata shared by every review surface. */
-function historyCommitReviewDescriptor(
+/** Describe a history selection with bounded metadata shared by every review surface. */
+function historyReviewDescriptor(
   runtime: HistoryRuntime,
   outcome: Extract<LogAppOutcome, { kind: "open-review" }>,
+  action: ExtensionVcsHistoryReviewAction,
 ) {
-  const review = parseExtensionReviewDescriptor({
-    kind: "commit",
-    provider: runtime.providerName,
-    title: outcome.commit.subject,
-    revision: outcome.commit.revisionId,
-    author: resolveHistoryAuthorLabel(outcome.commit),
-    authoredAt: outcome.commit.authoredAt,
-  });
-  return review?.kind === "commit" ? review : undefined;
+  const newest = outcome.selection.newestCommit;
+  const review = parseExtensionReviewDescriptor(
+    outcome.count === 1
+      ? {
+          kind: "commit",
+          provider: runtime.providerName,
+          title: newest.subject,
+          revision: newest.revisionId,
+          author: resolveHistoryAuthorLabel(newest),
+          authoredAt: newest.authoredAt,
+        }
+      : {
+          kind: "comparison",
+          provider: runtime.providerName,
+          title: `${outcome.count} commits`,
+          base:
+            action.kind === "revision-range"
+              ? action.fromRevisionId
+              : outcome.selection.oldestCommit.revisionId,
+          head: action.kind === "revision-range" ? action.toRevisionId : newest.revisionId,
+        },
+  );
+  return review;
 }
 
 /**
@@ -198,12 +214,21 @@ export function HunkSessionHost({
     const startupCwd = historyRoute.runtime.startupCwd ?? historyRoute.runtime.repoRoot;
     let plan: EmbeddedHistoryReview | undefined;
     try {
-      const action = await historyRoute.runtime.planReview(
-        outcome.commit,
+      const reviewOptions =
         outcome.parentRevisionId === undefined
           ? undefined
-          : { parentRevisionId: outcome.parentRevisionId },
-      );
+          : { parentRevisionId: outcome.parentRevisionId };
+      const action =
+        outcome.count === 1
+          ? await historyRoute.runtime.planReview(
+              outcome.selection.newestCommit,
+              reviewOptions,
+              signal,
+            )
+          : await historyRoute.runtime.planRangeReview?.(outcome.selection, reviewOptions, signal);
+      if (!action) {
+        throw new Error("This history provider does not support multi-commit review.");
+      }
       signal.throwIfAborted();
       const request: EmbeddedHistoryReviewRequest = {
         action,
@@ -216,8 +241,8 @@ export function HunkSessionHost({
         themeMode: outcome.themeMode,
       };
       plan = await prepareReview(request, { signal });
-      const commitReview = historyCommitReviewDescriptor(historyRoute.runtime, outcome);
-      if (commitReview) plan.bootstrap.review = commitReview;
+      const historyReview = historyReviewDescriptor(historyRoute.runtime, outcome, action);
+      if (historyReview) plan.bootstrap.review = historyReview;
       if (!plan.bootstrap.extensions) {
         throw new Error("Embedded review startup did not provide extension authority.");
       }

--- a/test/pty/log-integration.test.ts
+++ b/test/pty/log-integration.test.ts
@@ -33,7 +33,8 @@ function createHistoryRepo() {
   tempDirs.push(cwd);
   git(cwd, ["init", "-q"]);
   writeFileSync(join(cwd, "history.ts"), "export const historyValue = 'first';\n");
-  git(cwd, ["add", "history.ts"]);
+  writeFileSync(join(cwd, "root-only.ts"), "export const rootOnly = true;\n");
+  git(cwd, ["add", "history.ts", "root-only.ts"]);
   const firstDate = new Date(2026, 8, 5, 12).toISOString();
   git(cwd, ["commit", "-qm", "First history commit"], {
     GIT_AUTHOR_DATE: firstDate,
@@ -120,6 +121,39 @@ describe("interactive hunk log", () => {
     }
   });
 
+  test("opens an inclusive root range and retains it when returning", async () => {
+    const cwd = createHistoryRepo();
+    const session = await harness.launchHunk({
+      args: ["log", "--color", "never", "--no-extensions"],
+      cwd,
+      cols: 100,
+      rows: 20,
+    });
+
+    try {
+      const history = await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      const rootRowIndex = history
+        .split("\n")
+        .findIndex((line) => line.includes("First history commit"));
+      session.writeRaw("J");
+      await session.waitForText(/2 commits selected/, { timeout: 5_000 });
+      await session.press("enter");
+      const review = await session.waitForText(/rootOnly = true/, { timeout: 15_000 });
+      expect(review).toContain("historyValue = 'second'");
+      await session.press("q");
+      await session.waitForText(/2 commits selected/, { timeout: 15_000 });
+
+      // SGR mouse modifier bit 4 forwards Shift+click through capable terminals.
+      session.writeRaw("k");
+      await harness.waitForSnapshot(session, (text) => !text.includes("2 commits selected"), 5_000);
+      session.writeRaw(`\x1b[<4;50;${rootRowIndex + 1}M\x1b[<4;50;${rootRowIndex + 1}m`);
+      await session.waitForText(/2 commits selected/, { timeout: 5_000 });
+      await session.press("q");
+    } finally {
+      session.close();
+    }
+  });
+
   test("opens the selected immutable commit and returns to the retained history", async () => {
     const cwd = createHistoryRepo();
     const session = await harness.launchHunk({
@@ -139,7 +173,7 @@ describe("interactive hunk log", () => {
 
       // Mouse and keyboard share the same menu model and actions.
       session.writeRaw("\x1b[<0;2;1M\x1b[<0;2;1m");
-      await session.waitForText(/Open selected commit/, { timeout: 5_000 });
+      await session.waitForText(/Open selection/, { timeout: 5_000 });
       await session.press("right");
       await session.press("enter");
       await session.waitForText(/Theme selector/, { timeout: 5_000 });
@@ -185,13 +219,9 @@ describe("interactive hunk log", () => {
 
       // Scrolling the history body dismisses an open dropdown before moving selection.
       await session.press("f10");
-      await session.waitForText(/Open selected commit/, { timeout: 5_000 });
+      await session.waitForText(/Open selection/, { timeout: 5_000 });
       session.writeRaw("\x1b[<65;50;5M");
-      await harness.waitForSnapshot(
-        session,
-        (text) => !text.includes("Open selected commit"),
-        5_000,
-      );
+      await harness.waitForSnapshot(session, (text) => !text.includes("Open selection"), 5_000);
 
       // Clicking outside the id selects the second row without opening it.
       session.writeRaw("\x1b[<0;50;5M\x1b[<0;50;5m");
@@ -205,7 +235,7 @@ describe("interactive hunk log", () => {
 
       // A command key closes an open menu and falls through to canonical dispatch.
       await session.press("f10");
-      await session.waitForText(/Open selected commit/, { timeout: 5_000 });
+      await session.waitForText(/Open selection/, { timeout: 5_000 });
       session.writeRaw("k\r");
       await session.waitForText(/historyValue = 'second'/, { timeout: 15_000 });
       await session.press("q");

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -7,8 +7,9 @@ The extension factory receives one API object. Registration calls are only valid
 
 ## `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `20`). Branch on it if you want
-one file to support several Hunk versions. Version 20 adds optional commit timestamps to review
+The API generation this Hunk speaks (currently `21`). Branch on it if you want
+one file to support several Hunk versions. Version 21 adds optional inclusive history-range review
+planning; version 20 adds optional commit timestamps to review
 metadata, pane clipboard actions, and the `theme.copyAction` paint token; version 19 adds provider-owned history enumeration and review planning; version 18 lets
 lifecycle and custom-event handlers request a host-owned review reload; version 17 adds structured review metadata to delegated
 patch commands and projects it into pane availability and component props; version 16 adds pane-wide


### PR DESCRIPTION
## Summary

- add contiguous multi-commit selection to interactive `hunk log`
- support Shift+Arrow, uppercase J/K, and forwarded Shift+click selection
- open inclusive ranges through provider-owned Git and Jujutsu planning, including root and merge baselines
- preserve selection across review return and history refresh
- add extension API v21 range planning, docs, tests, and a Changeset

## Semantics

The selected range compares the chosen parent (or empty/root baseline) of the oldest commit directly with the newest commit. Git never uses triple-dot semantics. Non-ancestral endpoint selections are rejected clearly.

## Stack

1. **This PR** — contiguous history selection and range review
2. #1032 — keep the review-info panel visible for comparison reviews

Merge this PR before #1032.

## Validation

- `bun run typecheck`
- `bun run deps:check`
- `bun run test` (2243 passed, 9 skipped on the complete stack)
- `bun run test:integration` (155 passed, 1 skipped)
- focused Git/Jujutsu history tests
- PTY coverage for J/K selection, forwarded Shift+click, inclusive root review, and retained return state

Not tested on Windows or in a physical SSH/Mosh session.

*This PR description was generated by Pi using gpt-5.6-sol*
