### PR TITLE
fix(git): shorten SHAs in comparison titles

### DIFF
--- a/.changeset/short-git-sha-titles.md
+++ b/.changeset/short-git-sha-titles.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Shorten full Git commit IDs to seven characters in comparison titles so the title bar stays compact.

--- a/packages/hunk-git/src/index.test.ts
+++ b/packages/hunk-git/src/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
-import { GitVcsAdapter, statSignature } from ".";
+import { describeGitDiffTitleRange, GitVcsAdapter, statSignature } from ".";
 import type {
   ExtensionVcsDiffInput,
   ExtensionVcsOperations,
@@ -78,6 +78,29 @@ afterEach(() => {
 });
 
 describe("GitVcsAdapter", () => {
+  test("uses GitHub-style seven-character object IDs in comparison titles", () => {
+    const sha1From = "0123456789abcdef0123456789abcdef01234567";
+    const sha1To = "89abcdef0123456789abcdef0123456789abcdef";
+    const sha256 = "a".repeat(64);
+
+    expect(describeGitDiffTitleRange({ rangeEndpoints: { from: sha1From, to: sha1To } })).toBe(
+      "0123456..89abcde",
+    );
+    expect(describeGitDiffTitleRange({ range: `${sha1From}...${sha256}` })).toBe(
+      "0123456...aaaaaaa",
+    );
+    expect(describeGitDiffTitleRange({ range: `..${sha1To}` })).toBe("..89abcde");
+    expect(describeGitDiffTitleRange({ range: `${sha1From}..` })).toBe("0123456..");
+    expect(describeGitDiffTitleRange({ rangeEndpoints: { from: "main", to: "feature" } })).toBe(
+      "main..feature",
+    );
+    expect(
+      describeGitDiffTitleRange({
+        rangeEndpoints: { from: `refs/heads/${"a".repeat(40)}`, to: "main" },
+      }),
+    ).toBe(`refs/heads/${"a".repeat(40)}..main`);
+  });
+
   test("detects Git repositories from nested directories", () => {
     const repo = createTempRepo("hunk-git-adapter-detect-");
     const nested = join(repo, "src", "nested");
@@ -165,7 +188,9 @@ describe("GitVcsAdapter", () => {
     const result = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: repo });
     const file = { path: "tracked.txt", changeType: "change", isUntracked: false } as const;
 
-    expect(result.title).toContain(`${from}..${to}`);
+    expect(result.title).toContain(`${from.slice(0, 7)}..${to.slice(0, 7)}`);
+    expect(result.title).not.toContain(from);
+    expect(result.title).not.toContain(to);
     expect(result.untrackedPaths).toEqual([]);
     expect(await result.readFileSource?.({ ...file, side: "old" })).toBe("old\ncontext\n");
     expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("new\ncontext\n");

--- a/packages/hunk-git/src/index.ts
+++ b/packages/hunk-git/src/index.ts
@@ -25,7 +25,6 @@ import {
 } from "./commands";
 import { openGitHistory } from "./history";
 import { gitEndpointSourceSpec, readGitFileSource } from "./source";
-import { describeDiffRange } from "@hunk/vcs/diff-target";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -54,6 +53,34 @@ import {
 /** Return the last path segment for review titles. */
 function basename(path: string) {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+}
+
+const GIT_SHORT_OBJECT_ID_LENGTH = 7;
+const FULL_GIT_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const GIT_RANGE = /^(.*?)(\.\.\.?)(.*)$/;
+
+/** Shorten one complete Git object ID while preserving every named revision spelling. */
+function shortenGitObjectId(revision: string) {
+  return FULL_GIT_OBJECT_ID.test(revision)
+    ? revision.slice(0, GIT_SHORT_OBJECT_ID_LENGTH)
+    : revision;
+}
+
+/** Shorten full Git object IDs in a display range while preserving named revisions. */
+export function describeGitDiffTitleRange(input: {
+  readonly range?: string;
+  readonly rangeEndpoints?: { readonly from: string; readonly to: string };
+}) {
+  if (input.rangeEndpoints) {
+    return `${shortenGitObjectId(input.rangeEndpoints.from)}..${shortenGitObjectId(input.rangeEndpoints.to)}`;
+  }
+
+  const range = input.range;
+  if (range === undefined) return undefined;
+  const parsedRange = GIT_RANGE.exec(range);
+  return parsedRange
+    ? `${shortenGitObjectId(parsedRange[1]!)}${parsedRange[2]}${shortenGitObjectId(parsedRange[3]!)}`
+    : shortenGitObjectId(range);
 }
 
 /** Walk upward to detect a Git worktree marker without spawning Git during config resolution. */
@@ -310,7 +337,7 @@ export function createGitVcsAdapter({
         async load(input, { cwd, signal }) {
           const repoRoot = await resolveGitRepoRootAsync(input, { cwd, gitExecutable, signal });
           const repoName = basename(repoRoot);
-          const range = describeDiffRange(input);
+          const range = describeGitDiffTitleRange(input);
           const title = input.staged
             ? `${repoName} staged changes`
             : range


### PR DESCRIPTION
## Problem

Comparing full Git commit IDs put both 40-character SHAs in the title bar, crowding out useful review information.

## Approach

- render complete SHA-1 and SHA-256 comparison operands using GitHub-style seven-character notation
- keep the original revisions unchanged for Git commands and source loading
- preserve branch names and other named revision spellings, including qualified refs and omitted range endpoints
- add a patch changeset

## Validation

- `bun test packages/hunk-git/src/index.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bunx oxfmt --check packages/hunk-git/src/index.ts packages/hunk-git/src/index.test.ts .changeset/short-git-sha-titles.md`
- `git diff --check`
- manually verified the title bar using a full-SHA comparison from the source build on Linux

## Visual evidence

The title now renders full-SHA comparisons in compact form such as `0123456..89abcde`. No screenshot is included because this is a text-only title formatting change.

*This PR description was generated by Pi using OpenAI GPT-5.6 Sol*
