### PR TITLE
feat(history): add configurable command ids

### DIFF
--- a/.changeset/canonical-history-keys.md
+++ b/.changeset/canonical-history-keys.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add configurable `hunk.history.*` command keybindings to the interactive history view.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Use `Shift+Up`/`Shift+Down`, uppercase `K`/`J`, or Shift-click to select a conti
 reviews the inclusive cumulative change from the oldest commit's parent through the newest commit.
 Range selection is disabled with `--all` or author, message, date, and path filters because traversal can interleave or hide commits.
 After opening a commit or range, quit its normal Hunk review to return to the same selection.
+History controls are configurable through canonical `hunk.history.*` [keybindings](https://hunk.dev/docs/configure/keybindings/).
 
 ### Working with Jujutsu and Sapling
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -15,7 +15,8 @@ command ids to the keys you want them on:
 Every id starts with the name of whoever owns the command: Hunk's own commands
 live under `hunk.`, and an extension's live under its extension id. That split
 is structural — `hunk` is a reserved extension id, so an extension can never
-mint a command id that shadows a built-in, whatever Hunk adds later.
+mint a command id that shadows a built-in, whatever Hunk adds later. Extension commands currently
+run on review surfaces; history resolves its built-in command set without claiming review-only extension chords.
 
 Rules worth knowing:
 
@@ -51,19 +52,50 @@ deleted until its replies are removed.
 
 The built-in commands and the keys they ship with:
 
-On a terminal, `hunk log` opens its read-only history browser automatically. Its controls are
-separate from the configurable review command table. `F10` opens File, View, Navigate, Commit, and Help menus;
+On a terminal, `hunk log` opens its read-only history browser automatically. Its `hunk.history.*`
+commands use the same configurable keybinding resolver as review while retaining history-specific effects.
+Shared application commands such as `hunk.app.quit`, `hunk.app.toggleHelp`, and
+`hunk.view.openThemeSelector` keep the same ids on both surfaces. `F10` opens File, View, Navigate, Commit, and Help menus;
 View includes Hunk's shared theme selector and an optional **Graph view** that replaces the default
 day-grouped timeline with commit-topology lanes. It uses `Up`/`Down` or `j`/`k` to move, `Shift+Up`/`Shift+Down`
 or uppercase `K`/`J` to extend a contiguous commit selection, `PageUp`/`PageDown`, `g`/`G` or `Home`/`End` to jump,
 `/` to search, `n`/`N` for matches, `t` to choose a theme, `r` to refresh, `y` to copy the focused commit's full id,
-`Enter` to open the selection in normal Hunk review, and `q` to quit. With a mouse, Shift-click a row to extend the
+`Enter` to open the selection in normal Hunk review, and `q` or `Ctrl-C` to quit. With a mouse, Shift-click a row to extend the
 selection when the terminal forwards modifiers, click a commit id to open it immediately, click the adjacent copy
 icon to copy its full immutable id, click elsewhere on a row to select it, or double-click a row to open it.
 Range selection is unavailable with `--all` or author, message, date, and path filters because those traversals
 can interleave unrelated commits or hide intermediate commits. Quitting the opened review returns to the retained history selection and viewport. The Commit menu's
 **Compare with first parent** and **Compare with parent…** actions compare the selected commit against
 an ordered provider-owned parent; they do not navigate the history selection to that parent.
+
+History-specific commands:
+
+| Command id                       | Does                         | Default keys      |
+| -------------------------------- | ---------------------------- | ----------------- |
+| `hunk.history.openSelection`     | Open the selected commit(s)  | `enter`           |
+| `hunk.history.copyRevision`      | Copy the focused commit id   | `y`               |
+| `hunk.history.refresh`           | Refresh repository history   | `r`               |
+| `hunk.history.previousCommit`    | Move to the previous commit  | `up`, `k`         |
+| `hunk.history.nextCommit`        | Move to the next commit      | `down`, `j`       |
+| `hunk.history.extendPrevious`    | Extend selection upward      | `shift+up`, `K`   |
+| `hunk.history.extendNext`        | Extend selection downward    | `shift+down`, `J` |
+| `hunk.history.pageUp`            | Move up one page             | `pageup`          |
+| `hunk.history.pageDown`          | Move down one page           | `pagedown`        |
+| `hunk.history.jumpToFirst`       | Jump to the first commit     | `home`, `g`       |
+| `hunk.history.jumpToLast`        | Jump to the last commit      | `end`, `G`        |
+| `hunk.history.search`            | Search history               | `/`               |
+| `hunk.history.nextMatch`         | Select the next match        | `n`               |
+| `hunk.history.previousMatch`     | Select the previous match    | `N`               |
+| `hunk.history.toggleGraph`       | Toggle graph presentation    | _(none)_          |
+| `hunk.history.toggleUnicode`     | Toggle Unicode graph lines   | _(none)_          |
+| `hunk.history.toggleAuthor`      | Toggle author metadata       | _(none)_          |
+| `hunk.history.toggleDate`        | Toggle date metadata         | _(none)_          |
+| `hunk.history.toggleDecorations` | Toggle ref decorations       | _(none)_          |
+| `hunk.history.openFirstParent`   | Compare with first parent    | _(none)_          |
+| `hunk.history.openParent`        | Choose a parent to compare   | _(none)_          |
+| `hunk.history.showAbout`         | Show application information | _(none)_          |
+
+Review and shared commands:
 
 | Command id                                     | Does                                           | Default keys                 |
 | ---------------------------------------------- | ---------------------------------------------- | ---------------------------- |

--- a/packages/hunk/README.md
+++ b/packages/hunk/README.md
@@ -104,6 +104,7 @@ Use `Shift+Up`/`Shift+Down`, uppercase `K`/`J`, or Shift-click to select a conti
 reviews the inclusive cumulative change from the oldest commit's parent through the newest commit.
 Range selection is disabled with `--all` or author, message, date, and path filters because traversal can interleave or hide commits.
 After opening a commit or range, quit its normal Hunk review to return to the same selection.
+History controls are configurable through canonical `hunk.history.*` [keybindings](https://hunk.dev/docs/configure/keybindings/).
 
 ### Working with Jujutsu and Sapling
 

--- a/packages/hunk/src/app/historyBootstrap.test.ts
+++ b/packages/hunk/src/app/historyBootstrap.test.ts
@@ -25,7 +25,7 @@ describe("history bootstrap cursor ownership", () => {
     mkdirSync(join(configHome, "hunk"), { recursive: true });
     writeFileSync(
       configPath,
-      'theme = "github-dark-dimmed"\nline_numbers = false\nprompt_save_view_preferences = false\n',
+      'theme = "github-dark-dimmed"\nline_numbers = false\nprompt_save_view_preferences = false\n\n[keybindings]\n"hunk.history.nextCommit" = "ctrl+n"\n',
     );
     const closeCounts: number[] = [];
     let opens = 0;
@@ -73,6 +73,7 @@ describe("history bootstrap cursor ownership", () => {
         theme: "github-dark-dimmed",
         showLineNumbers: false,
       });
+      expect(bootstrap.keybindings).toEqual({ "hunk.history.nextCommit": "ctrl+n" });
       expect(bootstrap.viewPreferencesConfigPath).toBe(configPath);
       expect(bootstrap.promptSaveViewPreferences).toBe(false);
 

--- a/packages/hunk/src/app/historyBootstrap.ts
+++ b/packages/hunk/src/app/historyBootstrap.ts
@@ -2,6 +2,7 @@ import type { HistoryCommandInput } from "../core/run/commandInputs";
 import {
   persistedViewPreferencesFromOptions,
   type PersistedViewPreferences,
+  type UserKeyBinding,
 } from "../core/run/config";
 import { collectSessionCustomThemes } from "../core/theme/customThemes";
 import type {
@@ -41,6 +42,8 @@ export interface HistoryBootstrap {
   extensionSession: ExtensionSession;
   notices: readonly string[];
   customThemes: readonly NamedCustomThemeConfig[];
+  /** User command overrides resolved by the active interactive surface. */
+  keybindings: Readonly<Record<string, UserKeyBinding>>;
   /** Launch baseline retained so the owning history surface can persist theme changes on quit. */
   initialViewPreferences: PersistedViewPreferences;
   viewPreferencesConfigPath?: string;
@@ -153,6 +156,7 @@ export async function loadHistoryBootstrap({
     repoRoot,
     extensionSession,
     customThemes: sessionThemes.themes,
+    keybindings: resolved.configured.keybindings,
     initialViewPreferences: persistedViewPreferencesFromOptions(resolved.configured.input.options),
     viewPreferencesConfigPath: resolved.configured.viewPreferencesConfigPath,
     promptSaveViewPreferences:

--- a/packages/hunk/src/core/run/commandCatalog.ts
+++ b/packages/hunk/src/core/run/commandCatalog.ts
@@ -40,7 +40,7 @@ import type { ReviewNoteTargetV1 } from "../review/types";
 export type AppCommandLocus = "semantic" | "client-local" | "host-only";
 
 /** The id group a command lives under, and the menu-level grouping users read. */
-export type AppCommandCategory = "app" | "review" | "view";
+export type AppCommandCategory = "app" | "history" | "review" | "view";
 
 /** The direction a command moves a vertically ordered surface. */
 export type VerticalCommandDirection = -1 | 1;
@@ -572,6 +572,11 @@ const BUILTIN_COMMANDS = [
 export type AppCommandId = (typeof BUILTIN_COMMANDS)[number]["id"];
 
 export const APP_COMMAND_CATALOG: readonly AppCommandCatalogEntry[] = BUILTIN_COMMANDS;
+
+/** Canonical and compatibility names accepted for review-surface built-ins. */
+export const APP_COMMAND_NAMES: ReadonlySet<string> = new Set(
+  APP_COMMAND_CATALOG.flatMap((entry) => [entry.id, ...(entry.aliases ?? [])]),
+);
 
 /** Look one command up by its canonical id or a compatibility alias. */
 export function appCommandCatalogEntry(id: string): AppCommandCatalogEntry | undefined {

--- a/packages/hunk/src/core/run/historyCommandCatalog.test.ts
+++ b/packages/hunk/src/core/run/historyCommandCatalog.test.ts
@@ -18,6 +18,7 @@ describe("history command catalog", () => {
     expect(ids).toContain("hunk.app.toggleHelp");
     expect(ids).toContain("hunk.view.openThemeSelector");
     expect(ids).toContain("hunk.history.nextCommit");
+    expect(historyCommandCatalogEntry("hunk.app.quit")?.defaultKeys).toEqual(["q", "ctrl+c"]);
   });
 
   test("publishes every canonical and compatibility name for cross-surface validation", () => {

--- a/packages/hunk/src/core/run/historyCommandCatalog.test.ts
+++ b/packages/hunk/src/core/run/historyCommandCatalog.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+  HISTORY_COMMAND_CATALOG,
+  HISTORY_COMMAND_NAMES,
+  historyCommandCatalogEntry,
+} from "./historyCommandCatalog";
+
+/** Verify history command identity remains canonical and collision-free. */
+describe("history command catalog", () => {
+  test("uses canonical history ids except for deliberately shared commands", () => {
+    const ids = HISTORY_COMMAND_CATALOG.map((command) => command.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const command of HISTORY_COMMAND_CATALOG) {
+      expect(command.id.startsWith(`hunk.${command.category}.`)).toBe(true);
+      expect(command.title.length).toBeGreaterThan(0);
+    }
+    expect(ids).toContain("hunk.app.quit");
+    expect(ids).toContain("hunk.app.toggleHelp");
+    expect(ids).toContain("hunk.view.openThemeSelector");
+    expect(ids).toContain("hunk.history.nextCommit");
+  });
+
+  test("publishes every canonical and compatibility name for cross-surface validation", () => {
+    for (const command of HISTORY_COMMAND_CATALOG) {
+      expect(HISTORY_COMMAND_NAMES.has(command.id)).toBe(true);
+      expect(historyCommandCatalogEntry(command.id)).toBe(command);
+      for (const alias of command.aliases ?? []) {
+        expect(HISTORY_COMMAND_NAMES.has(alias)).toBe(true);
+        expect(historyCommandCatalogEntry(alias)).toBe(command);
+      }
+    }
+  });
+});

--- a/packages/hunk/src/core/run/historyCommandCatalog.ts
+++ b/packages/hunk/src/core/run/historyCommandCatalog.ts
@@ -1,0 +1,276 @@
+import {
+  builtinAppCommand,
+  type AppCommandCatalogEntry,
+  type AppCommandId,
+} from "./commandCatalog";
+
+/** The menu and help groups used to present one history command. */
+export type HistoryCommandGroup = "file" | "view" | "navigate" | "commit" | "help";
+export type HistoryCommandHelpSection = "Navigation" | "Commit" | "Application";
+
+/** Renderer-neutral identity plus history-surface presentation metadata. */
+export interface HistoryCommandCatalogEntry extends AppCommandCatalogEntry {
+  group: HistoryCommandGroup;
+  helpSection?: HistoryCommandHelpSection;
+}
+
+/** Reuse one shared app/view identity while assigning it to history chrome. */
+function sharedHistoryCommand<const Id extends AppCommandId>(
+  id: Id,
+  group: HistoryCommandGroup,
+  helpSection?: HistoryCommandHelpSection,
+): HistoryCommandCatalogEntry & { id: Id } {
+  return {
+    ...builtinAppCommand(id),
+    group,
+    ...(helpSection ? { helpSection } : {}),
+  } as HistoryCommandCatalogEntry & { id: Id };
+}
+
+/**
+ * Declares every command available on the interactive history surface.
+ *
+ * Shared app/view commands retain their existing identities. Commit traversal and
+ * presentation use `hunk.history.*` ids because matching chords do not make their effects
+ * equivalent to review commands.
+ */
+const HISTORY_COMMANDS = [
+  {
+    id: "hunk.history.openSelection",
+    title: "Open selection",
+    category: "history",
+    defaultKeys: ["enter"],
+    locus: "host-only",
+    publicToExtensions: false,
+    group: "file",
+    helpSection: "Commit",
+  },
+  {
+    id: "hunk.history.copyRevision",
+    title: "Copy commit ID",
+    category: "history",
+    defaultKeys: ["y"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "file",
+    helpSection: "Commit",
+  },
+  {
+    id: "hunk.history.refresh",
+    title: "Refresh history",
+    category: "history",
+    defaultKeys: ["r"],
+    locus: "host-only",
+    publicToExtensions: false,
+    group: "file",
+    helpSection: "Application",
+  },
+  {
+    ...sharedHistoryCommand("hunk.app.quit", "file", "Application"),
+    // Interactive history owns Ctrl-C so it can cancel provider planning before quitting.
+    defaultKeys: ["q", "ctrl+c"],
+  },
+  sharedHistoryCommand("hunk.view.openThemeSelector", "view", "Application"),
+  {
+    id: "hunk.history.toggleGraph",
+    title: "Graph view",
+    category: "history",
+    defaultKeys: [],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "view",
+  },
+  {
+    id: "hunk.history.toggleUnicode",
+    title: "Unicode lines",
+    category: "history",
+    defaultKeys: [],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "view",
+  },
+  {
+    id: "hunk.history.toggleAuthor",
+    title: "Show author",
+    category: "history",
+    defaultKeys: [],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "view",
+  },
+  {
+    id: "hunk.history.toggleDate",
+    title: "Show date",
+    category: "history",
+    defaultKeys: [],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "view",
+  },
+  {
+    id: "hunk.history.toggleDecorations",
+    title: "Show decorations",
+    category: "history",
+    defaultKeys: [],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "view",
+  },
+  {
+    id: "hunk.history.extendPrevious",
+    title: "Extend selection up",
+    category: "history",
+    defaultKeys: ["shift+up", "K"],
+    locus: "client-local",
+    verticalDirection: -1,
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.extendNext",
+    title: "Extend selection down",
+    category: "history",
+    defaultKeys: ["shift+down", "J"],
+    locus: "client-local",
+    verticalDirection: 1,
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.previousCommit",
+    title: "Previous commit",
+    category: "history",
+    defaultKeys: ["up", "k"],
+    locus: "client-local",
+    verticalDirection: -1,
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.nextCommit",
+    title: "Next commit",
+    category: "history",
+    defaultKeys: ["down", "j"],
+    locus: "client-local",
+    verticalDirection: 1,
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.pageUp",
+    title: "Page up",
+    category: "history",
+    defaultKeys: ["pageup"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.pageDown",
+    title: "Page down",
+    category: "history",
+    defaultKeys: ["pagedown"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.jumpToFirst",
+    title: "First commit",
+    category: "history",
+    defaultKeys: ["home", "g"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.jumpToLast",
+    title: "Last commit",
+    category: "history",
+    defaultKeys: ["end", "G"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.search",
+    title: "Search…",
+    category: "history",
+    defaultKeys: ["/"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.nextMatch",
+    title: "Next match",
+    category: "history",
+    defaultKeys: ["n"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.previousMatch",
+    title: "Previous match",
+    category: "history",
+    defaultKeys: ["N"],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "navigate",
+    helpSection: "Navigation",
+  },
+  {
+    id: "hunk.history.openFirstParent",
+    title: "Compare with first parent",
+    category: "history",
+    defaultKeys: [],
+    locus: "host-only",
+    publicToExtensions: false,
+    group: "commit",
+  },
+  {
+    id: "hunk.history.openParent",
+    title: "Compare with parent…",
+    category: "history",
+    defaultKeys: [],
+    locus: "host-only",
+    publicToExtensions: false,
+    group: "commit",
+  },
+  sharedHistoryCommand("hunk.app.toggleHelp", "help", "Application"),
+  {
+    id: "hunk.history.showAbout",
+    title: "About Hunk",
+    category: "history",
+    defaultKeys: [],
+    locus: "client-local",
+    publicToExtensions: false,
+    group: "help",
+  },
+] as const satisfies readonly HistoryCommandCatalogEntry[];
+
+/** Every canonical command id available in interactive history. */
+export type HistoryCommandId = (typeof HISTORY_COMMANDS)[number]["id"];
+
+export const HISTORY_COMMAND_CATALOG: readonly HistoryCommandCatalogEntry[] = HISTORY_COMMANDS;
+
+/** Canonical and compatibility names accepted for history-surface built-ins. */
+export const HISTORY_COMMAND_NAMES: ReadonlySet<string> = new Set(
+  HISTORY_COMMAND_CATALOG.flatMap((entry) => [entry.id, ...(entry.aliases ?? [])]),
+);
+
+/** Look up one history command by canonical id or compatibility alias. */
+export function historyCommandCatalogEntry(id: string): HistoryCommandCatalogEntry | undefined {
+  return HISTORY_COMMAND_CATALOG.find((entry) => entry.id === id || entry.aliases?.includes(id));
+}

--- a/packages/hunk/src/ui/App.tsx
+++ b/packages/hunk/src/ui/App.tsx
@@ -15,6 +15,7 @@ import {
   useState,
 } from "react";
 import type { PersistedViewPreferences } from "../core/run/config";
+import { HISTORY_COMMAND_NAMES } from "../core/run/historyCommandCatalog";
 import type { ExtensionReviewReloadResult } from "../extension-api/types";
 import { experimentalFeatureEnabled, resolveExperimentalDiffFiles } from "../core/run/experimental";
 import { DEFAULT_FILE_GAP, DEFAULT_HUNK_GAP } from "../core/run/reviewGap";
@@ -615,6 +616,7 @@ export function App({
           ...builtinCommandKeyDefaults(),
           ...extensionCommandKeyDefaults(registeredExtensionCommands),
         ],
+        inactiveCommandNames: HISTORY_COMMAND_NAMES,
         userBindings: bootstrap.keybindings,
       }),
     [bootstrap.keybindings, registeredExtensionCommands],

--- a/packages/hunk/src/ui/history/runStaticHistory.test.ts
+++ b/packages/hunk/src/ui/history/runStaticHistory.test.ts
@@ -33,6 +33,7 @@ function runtime(commits: HistoryCommit[], maxCount?: number, closeFailure?: Err
     repoRoot: "/repo",
     notices: [],
     customThemes: [],
+    keybindings: {},
     initialViewPreferences: persistedViewPreferencesFromOptions({}),
     promptSaveViewPreferences: true,
     async planReview(commit) {

--- a/packages/hunk/src/ui/history/types.ts
+++ b/packages/hunk/src/ui/history/types.ts
@@ -1,5 +1,5 @@
 import type { HistoryCommandInput } from "../../core/run/commandInputs";
-import type { PersistedViewPreferences } from "../../core/run/config";
+import type { PersistedViewPreferences, UserKeyBinding } from "../../core/run/config";
 import type { VcsHistorySource } from "../../core/vcs/types";
 import type { ExtensionSession } from "../../extensions/session";
 import type {
@@ -22,6 +22,8 @@ export interface HistoryRuntime {
   repoRoot: string;
   notices: readonly string[];
   customThemes: readonly NamedCustomThemeConfig[];
+  /** User command overrides resolved by the active interactive surface. */
+  keybindings: Readonly<Record<string, UserKeyBinding>>;
   /** Resolved launch preferences retained while history owns the session-wide quit flow. */
   initialViewPreferences: PersistedViewPreferences;
   viewPreferencesConfigPath?: string;

--- a/packages/hunk/src/ui/lib/appCommands.test.ts
+++ b/packages/hunk/src/ui/lib/appCommands.test.ts
@@ -13,6 +13,7 @@ import {
   type ResolvedCommandKeys,
 } from "./appCommands";
 import { APP_COMMAND_CATALOG } from "../../core/run/commandCatalog";
+import { HISTORY_COMMAND_CATALOG } from "../../core/run/historyCommandCatalog";
 import { buildAppMenus } from "./appMenus";
 import { buildHelpSections, HELP_COMMAND_IDS } from "./helpContent";
 import { resolveCommandKeys } from "./keymap";
@@ -237,7 +238,7 @@ describe("built-in commands under user keybindings", () => {
 });
 
 describe("builtinCommandKeyDefaults", () => {
-  test("keeps the documented command-id table sorted and identical to the runtime catalog", () => {
+  test("keeps the documented command-id tables identical to the surface catalogs", () => {
     const markdown = readFileSync(
       resolve(import.meta.dir, "../../../../../docs/keybindings.md"),
       "utf8",
@@ -246,10 +247,13 @@ describe("builtinCommandKeyDefaults", () => {
       markdown.matchAll(/^\| `(hunk\.[^`]+)`\s+\|/gm),
       (match) => match[1],
     );
-    const { commands } = createTestCommands();
-    const sortedRuntimeIds = commands.map((command) => command.id).toSorted();
+    const catalogIds = new Set([
+      ...APP_COMMAND_CATALOG.map((command) => command.id),
+      ...HISTORY_COMMAND_CATALOG.map((command) => command.id),
+    ]);
 
-    expect(documentedIds).toEqual(sortedRuntimeIds);
+    expect(new Set(documentedIds).size).toBe(documentedIds.length);
+    expect(documentedIds.toSorted()).toEqual([...catalogIds].toSorted());
   });
 
   test("reports every built-in command with the chords it ships with", () => {

--- a/packages/hunk/src/ui/lib/keymap.test.ts
+++ b/packages/hunk/src/ui/lib/keymap.test.ts
@@ -138,6 +138,21 @@ describe("resolveCommandKeys", () => {
     expect(issues[0]?.message).not.toContain("may not be loaded");
   });
 
+  test("accepts known commands owned by another surface without claiming their chords", () => {
+    const { keys, issues } = resolveCommandKeys({
+      defaults: [{ id: "hunk.review.nextHunk", defaultKeys: ["]"] }],
+      inactiveCommandNames: new Set(["hunk.history.nextCommit"]),
+      userBindings: {
+        "hunk.review.nextHunk": "ctrl+n",
+        "hunk.history.nextCommit": "ctrl+n",
+      },
+    });
+
+    expect(issues).toEqual([]);
+    expect(keys.get("hunk.review.nextHunk")).toEqual(["ctrl+n"]);
+    expect(keys.has("hunk.history.nextCommit")).toBe(false);
+  });
+
   test("duplicate ids in the command table keep the first entry's keys", () => {
     const { keys, issues } = resolveCommandKeys({
       defaults: [

--- a/packages/hunk/src/ui/lib/keymap.ts
+++ b/packages/hunk/src/ui/lib/keymap.ts
@@ -79,8 +79,10 @@ export function createExtensionPaneKeybindings(
 }
 
 export interface ResolveCommandKeysOptions {
-  /** Every command that can be bound, in dispatch order. */
+  /** Every command active on this surface, in dispatch order. */
   defaults: readonly CommandKeyDefaults[];
+  /** Known commands owned by another surface; accepted but inactive here. */
+  inactiveCommandNames?: ReadonlySet<string>;
   /** The user's `[keybindings]` table, in config order. */
   userBindings?: Readonly<Record<string, UserKeyBinding>>;
 }
@@ -164,6 +166,7 @@ function mirrorCommandAliases(
  */
 export function resolveCommandKeys({
   defaults,
+  inactiveCommandNames,
   userBindings,
 }: ResolveCommandKeysOptions): ResolvedKeymap {
   const issues: KeymapIssue[] = [];
@@ -214,6 +217,9 @@ export function resolveCommandKeys({
   for (const [commandId, binding] of Object.entries(userBindings)) {
     const canonicalId = canonicalByName.get(commandId);
     if (canonicalId === undefined) {
+      if (inactiveCommandNames?.has(commandId)) {
+        continue;
+      }
       issues.push({
         commandId,
         message: namesAnAbsentExtension(commandId, knownOwners)

--- a/packages/hunk/src/ui/log/LogApp.tsx
+++ b/packages/hunk/src/ui/log/LogApp.tsx
@@ -2,12 +2,13 @@ import type { KeyEvent, MouseEvent as TuiMouseEvent } from "@opentui/core";
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react";
 import { basename } from "node:path";
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { APP_COMMAND_NAMES } from "../../core/run/commandCatalog";
 import type {
   ExtensionVcsHistoryCommit,
   ExtensionVcsHistoryRangeSelection,
 } from "../../extension-api/types";
 import { sanitizeTerminalLine } from "../../lib/terminalText";
-import { resolveExtensionSessionOptions } from "../../extensions/apply";
+import { resolveExtensionCommands, resolveExtensionSessionOptions } from "../../extensions/apply";
 import { HelpDialog } from "../components/chrome/HelpDialog";
 import { MenuBar } from "../components/chrome/MenuBar";
 import { MenuDropdown } from "../components/chrome/MenuDropdown";
@@ -27,13 +28,15 @@ import { handleViewPreferenceQuitPromptKey } from "../lib/viewPreferenceQuitKeys
 import type { ThemeController } from "../theme/controller";
 import type { HistoryRuntime } from "../history/types";
 import type { LogController } from "./controller";
-import { LOG_HELP_SECTIONS } from "./logHelp";
+import { dispatchAppCommand, executeAppCommand, findAppCommandById } from "../lib/appCommands";
+import { resolveCommandKeys } from "../lib/keymap";
 import {
-  isLogCommandEnabled,
-  logCommand,
-  logCommandHint,
-  matchLogCommand,
-  type LogCommandId,
+  buildHistoryCommands,
+  buildHistoryHelpSections,
+  historyCommand,
+  historyCommandKeyDefaults,
+  type HistoryCommandHandlers,
+  type HistoryCommandId,
 } from "./commands";
 import { ParentSelectorDialog } from "./ParentSelectorDialog";
 import { monochromeLogTheme, resolveInteractiveLogPalette } from "./colorPolicy";
@@ -251,143 +254,135 @@ export function LogApp({
     }
     await openSelected(undefined, true);
   };
-  const executeCommand = (id: LogCommandId, exitCode?: number) => {
-    clearTransientNotice();
-    if (!isLogCommandEnabled(id, controller.getSnapshot())) return;
-    switch (id) {
-      case "open":
-        void requestOpenSelected();
-        break;
-      case "copy":
-        copySelected();
-        break;
-      case "refresh":
-        void controller.refresh();
-        break;
-      case "quit":
-        requestLogQuit(exitCode);
-        break;
-      case "theme":
-        themeSelector.openThemeSelector();
-        break;
-      case "toggle-graph":
-        controller.togglePresentation("graph");
-        break;
-      case "toggle-unicode":
-        controller.togglePresentation("unicode");
-        break;
-      case "toggle-author":
-        controller.togglePresentation("author");
-        break;
-      case "toggle-date":
-        controller.togglePresentation("date");
-        break;
-      case "toggle-decorations":
-        controller.togglePresentation("decorations");
-        break;
-      case "previous":
-        void controller.move(-1, viewportBodyHeight);
-        break;
-      case "next":
-        void controller.move(1, viewportBodyHeight);
-        break;
-      case "extend-previous":
-        void controller.move(-1, viewportBodyHeight, { extend: true });
-        break;
-      case "extend-next":
-        void controller.move(1, viewportBodyHeight, { extend: true });
-        break;
-      case "page-up":
-        void controller.page(-1, viewportBodyHeight);
-        break;
-      case "page-down":
-        void controller.page(1, viewportBodyHeight);
-        break;
-      case "first":
-        void controller.first(viewportBodyHeight);
-        break;
-      case "last":
-        void controller.last(viewportBodyHeight);
-        break;
-      case "search":
-        controller.beginSearch();
-        break;
-      case "next-match":
-        void controller.findMatch(1, viewportBodyHeight);
-        break;
-      case "previous-match":
-        void controller.findMatch(-1, viewportBodyHeight);
-        break;
-      case "open-first-parent": {
-        const parent = controller.getSelectedRow()?.commit.parentRevisionIds[0];
-        if (parent) void openSelected(parent);
-        break;
-      }
-      case "open-parent":
-        setParentSelectorIndex(0);
-        break;
-      case "help":
-        setShowHelp(true);
-        break;
-      case "about":
-        setTransientNotice("Hunk · terminal-native code review");
-        break;
+  const inactiveHistoryCommandNames = useMemo(() => {
+    const names = new Set(APP_COMMAND_NAMES);
+    for (const registered of resolveExtensionCommands(runtime.extensionSession.current.registry)
+      .commands) {
+      names.add(`${registered.extensionId}.${registered.command.id}`);
     }
+    return names;
+  }, [runtime.extensionSession]);
+  const historyKeymap = useMemo(
+    () =>
+      resolveCommandKeys({
+        defaults: historyCommandKeyDefaults(),
+        inactiveCommandNames: inactiveHistoryCommandNames,
+        userBindings: runtime.keybindings,
+      }),
+    [inactiveHistoryCommandNames, runtime.keybindings],
+  );
+  const commandHandlers: HistoryCommandHandlers = {
+    "hunk.history.openSelection": () => void requestOpenSelected(),
+    "hunk.history.copyRevision": () => copySelected(),
+    "hunk.history.refresh": () => void controller.refresh(),
+    "hunk.app.quit": (key) => requestLogQuit(key.ctrl && key.name === "c" ? 130 : undefined),
+    "hunk.view.openThemeSelector": () => themeSelector.openThemeSelector(),
+    "hunk.history.toggleGraph": () => controller.togglePresentation("graph"),
+    "hunk.history.toggleUnicode": () => controller.togglePresentation("unicode"),
+    "hunk.history.toggleAuthor": () => controller.togglePresentation("author"),
+    "hunk.history.toggleDate": () => controller.togglePresentation("date"),
+    "hunk.history.toggleDecorations": () => controller.togglePresentation("decorations"),
+    "hunk.history.previousCommit": () => void controller.move(-1, viewportBodyHeight),
+    "hunk.history.nextCommit": () => void controller.move(1, viewportBodyHeight),
+    "hunk.history.extendPrevious": () =>
+      void controller.move(-1, viewportBodyHeight, { extend: true }),
+    "hunk.history.extendNext": () => void controller.move(1, viewportBodyHeight, { extend: true }),
+    "hunk.history.pageUp": () => void controller.page(-1, viewportBodyHeight),
+    "hunk.history.pageDown": () => void controller.page(1, viewportBodyHeight),
+    "hunk.history.jumpToFirst": () => void controller.first(viewportBodyHeight),
+    "hunk.history.jumpToLast": () => void controller.last(viewportBodyHeight),
+    "hunk.history.search": () => controller.beginSearch(),
+    "hunk.history.nextMatch": () => void controller.findMatch(1, viewportBodyHeight),
+    "hunk.history.previousMatch": () => void controller.findMatch(-1, viewportBodyHeight),
+    "hunk.history.openFirstParent": () => {
+      const parent = controller.getSelectedRow()?.commit.parentRevisionIds[0];
+      if (parent) void openSelected(parent);
+    },
+    "hunk.history.openParent": () => setParentSelectorIndex(0),
+    "hunk.app.toggleHelp": () => setShowHelp(true),
+    "hunk.history.showAbout": () => setTransientNotice("Hunk · terminal-native code review"),
+  };
+  const commands = buildHistoryCommands({
+    getSnapshot: controller.getSnapshot,
+    handlers: commandHandlers,
+    resolvedKeys: historyKeymap.keys,
+  });
+  const reportedKeymapIssues = useRef(new Set<string>());
+  useEffect(() => {
+    const unreported = historyKeymap.issues.filter(
+      (issue) => !reportedKeymapIssues.current.has(issue.message),
+    );
+    const first = unreported[0];
+    if (!first) return;
+    for (const issue of unreported) reportedKeymapIssues.current.add(issue.message);
+    const remaining = unreported.length - 1;
+    controller.addStartupNotices([
+      remaining > 0
+        ? `${first.message} (+${remaining} more keybinding issue${remaining === 1 ? "" : "s"})`
+        : first.message,
+    ]);
+  }, [controller, historyKeymap]);
+  const executeCommand = (id: HistoryCommandId) => {
+    clearTransientNotice();
+    return executeAppCommand(commands, id);
   };
   const commandItem = (
-    id: LogCommandId,
+    id: HistoryCommandId,
     options: Pick<Extract<MenuEntry, { kind: "item" }>, "checked"> = {},
   ): Extract<MenuEntry, { kind: "item" }> => {
-    const definition = logCommand(id);
+    const definition = historyCommand(id);
+    const command = findAppCommandById(commands, id)!;
     return {
       kind: "item",
-      commandId: `hunk.log.${id}`,
-      label: definition.label,
-      ...(logCommandHint(id) ? { hint: logCommandHint(id) } : {}),
-      disabled: !isLogCommandEnabled(id, snapshot),
+      commandId: id,
+      label: definition.title,
+      ...(command.keyLabels.length ? { hint: command.keyLabels.join(" / ") } : {}),
+      disabled: command.isEnabled ? !command.isEnabled() : false,
       action: () => executeCommand(id),
       ...options,
     };
   };
   const menus: AppMenus = {
     file: [
-      commandItem("open"),
-      commandItem("copy"),
-      commandItem("refresh"),
+      commandItem("hunk.history.openSelection"),
+      commandItem("hunk.history.copyRevision"),
+      commandItem("hunk.history.refresh"),
       { kind: "separator" },
-      commandItem("quit"),
+      commandItem("hunk.app.quit"),
     ],
     view: [
-      commandItem("theme"),
+      commandItem("hunk.view.openThemeSelector"),
       { kind: "separator" },
-      commandItem("toggle-graph", { checked: snapshot.presentation.graph }),
-      commandItem("toggle-unicode", { checked: snapshot.presentation.unicode }),
-      commandItem("toggle-author", { checked: snapshot.presentation.author }),
-      commandItem("toggle-date", { checked: snapshot.presentation.date }),
-      commandItem("toggle-decorations", { checked: snapshot.presentation.decorations }),
+      commandItem("hunk.history.toggleGraph", { checked: snapshot.presentation.graph }),
+      commandItem("hunk.history.toggleUnicode", { checked: snapshot.presentation.unicode }),
+      commandItem("hunk.history.toggleAuthor", { checked: snapshot.presentation.author }),
+      commandItem("hunk.history.toggleDate", { checked: snapshot.presentation.date }),
+      commandItem("hunk.history.toggleDecorations", {
+        checked: snapshot.presentation.decorations,
+      }),
     ],
     navigate: [
-      commandItem("previous"),
-      commandItem("next"),
-      commandItem("extend-previous"),
-      commandItem("extend-next"),
-      commandItem("page-up"),
-      commandItem("page-down"),
-      commandItem("first"),
-      commandItem("last"),
+      commandItem("hunk.history.previousCommit"),
+      commandItem("hunk.history.nextCommit"),
+      commandItem("hunk.history.extendPrevious"),
+      commandItem("hunk.history.extendNext"),
+      commandItem("hunk.history.pageUp"),
+      commandItem("hunk.history.pageDown"),
+      commandItem("hunk.history.jumpToFirst"),
+      commandItem("hunk.history.jumpToLast"),
       { kind: "separator" },
-      commandItem("search"),
-      commandItem("next-match"),
-      commandItem("previous-match"),
+      commandItem("hunk.history.search"),
+      commandItem("hunk.history.nextMatch"),
+      commandItem("hunk.history.previousMatch"),
     ],
     commit: [
-      commandItem("open"),
-      commandItem("copy"),
+      commandItem("hunk.history.openSelection"),
+      commandItem("hunk.history.copyRevision"),
       { kind: "separator" },
-      commandItem("open-first-parent"),
-      commandItem("open-parent"),
+      commandItem("hunk.history.openFirstParent"),
+      commandItem("hunk.history.openParent"),
     ],
-    help: [commandItem("help"), commandItem("about")],
+    help: [commandItem("hunk.app.toggleHelp"), commandItem("hunk.history.showAbout")],
   };
   const menu = useMenuController(menus);
 
@@ -440,9 +435,9 @@ export function LogApp({
     }
     if (reviewPending.current) {
       if (!reviewQuitEnabled.current) {
-        const command = matchLogCommand(key);
-        if (command === "quit" && key.ctrl && key.name === "c") {
-          executeCommand(command, 130);
+        const quit = findAppCommandById(commands, "hunk.app.quit");
+        if (quit?.match(key) && key.ctrl && key.name === "c") {
+          quit.run(key, 1);
         }
         consume();
         return;
@@ -455,10 +450,10 @@ export function LogApp({
         else if (name === "down") menu.moveMenuItem(1);
         else if (name === "return" || name === "enter") menu.activateCurrentMenuItem();
         else {
-          const command = matchLogCommand(key);
-          if (command === "quit") {
+          const quit = findAppCommandById(commands, "hunk.app.quit");
+          if (quit?.match(key)) {
             menu.closeMenu();
-            executeCommand(command, key.ctrl && key.name === "c" ? 130 : undefined);
+            quit.run(key, 1);
           }
         }
         consume();
@@ -466,10 +461,8 @@ export function LogApp({
       }
       if (name === "f10") menu.openMenu("file");
       else {
-        const command = matchLogCommand(key);
-        if (command === "quit") {
-          executeCommand(command, key.ctrl && key.name === "c" ? 130 : undefined);
-        }
+        const quit = findAppCommandById(commands, "hunk.app.quit");
+        if (quit?.match(key)) quit.run(key, 1);
       }
       consume();
       return;
@@ -515,10 +508,9 @@ export function LogApp({
       else if (name === "down") menu.moveMenuItem(1);
       else if (name === "return" || name === "enter") menu.activateCurrentMenuItem();
       else {
-        const command = matchLogCommand(key);
+        const command = dispatchAppCommand(commands, key);
         if (!command) return;
         menu.closeMenu();
-        executeCommand(command, key.ctrl && key.name === "c" ? 130 : undefined);
       }
       consume();
       return;
@@ -538,9 +530,8 @@ export function LogApp({
       consume();
       return;
     }
-    const command = matchLogCommand(key);
+    const command = dispatchAppCommand(commands, key);
     if (!command) return;
-    executeCommand(command, key.ctrl && key.name === "c" ? 130 : undefined);
     consume();
   });
 
@@ -849,7 +840,7 @@ export function LogApp({
       ) : null}
       {showHelp ? (
         <HelpDialog
-          sections={LOG_HELP_SECTIONS}
+          sections={buildHistoryHelpSections(commands)}
           terminalHeight={terminal.height}
           terminalWidth={terminal.width}
           theme={chromeTheme}

--- a/packages/hunk/src/ui/log/commands.test.ts
+++ b/packages/hunk/src/ui/log/commands.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { KeyEvent } from "@opentui/core";
 import type { LogSnapshot } from "./controller";
+import { resolveCommandKeys } from "../lib/keymap";
 import {
-  buildLogHelpSections,
-  isLogCommandEnabled,
-  logCommand,
-  logCommandHint,
-  matchLogCommand,
+  buildHistoryCommands,
+  buildHistoryHelpSections,
+  historyCommand,
+  historyCommandKeyDefaults,
+  isHistoryCommandEnabled,
+  type HistoryCommandHandlers,
+  type HistoryCommandId,
 } from "./commands";
 
 const key = (name: string, sequence = name, ctrl = false, shift = false) =>
@@ -49,36 +52,94 @@ const snapshot = (parents: string[] = []): LogSnapshot => ({
   },
 });
 
-describe("log command authority", () => {
-  test("drives keyboard dispatch, menu hints, and help from one definition", () => {
-    expect(matchLogCommand(key("down", ""))).toBe("next");
-    expect(matchLogCommand(key("down", "", false, true))).toBe("extend-next");
-    expect(matchLogCommand(key("x", "J"))).toBe("extend-next");
-    expect(matchLogCommand(key("up", "", false, true))).toBe("extend-previous");
-    expect(matchLogCommand(key("x", "K"))).toBe("extend-previous");
-    expect(matchLogCommand(key("x", "j"))).toBe("next");
-    expect(matchLogCommand(key("c", "\x03", true))).toBe("quit");
-    expect(matchLogCommand(key("t"))).toBe("theme");
-    expect(logCommandHint("next")).toBe("↓ / j");
-    expect(logCommandHint("theme")).toBe("t");
-    expect(logCommand("open-first-parent").label).toBe("Compare with first parent");
-    expect(logCommand("open-parent").label).toBe("Compare with parent…");
-    const helpRows = buildLogHelpSections().flatMap((section) => section.rows);
-    expect(helpRows).toContainEqual({ keys: "↓ / j", description: "next commit" });
-    expect(helpRows).toContainEqual({
-      keys: "Shift-↓ / J",
-      description: "extend selection down",
+const noopHandlers = Object.fromEntries(
+  historyCommandKeyDefaults().map(({ id }) => [id, () => {}]),
+) as unknown as HistoryCommandHandlers;
+
+/** Return the first canonical command matched by one synthetic terminal key. */
+function matchCommand(
+  event: KeyEvent,
+  userBindings?: Readonly<Record<string, string | readonly string[] | false>>,
+) {
+  const { keys } = resolveCommandKeys({
+    defaults: historyCommandKeyDefaults(),
+    userBindings,
+  });
+  return buildHistoryCommands({
+    getSnapshot: snapshot,
+    handlers: noopHandlers,
+    resolvedKeys: keys,
+  }).find((command) => command.match(event))?.id;
+}
+
+describe("history command authority", () => {
+  test("drives keyboard dispatch, canonical menu identity, and help from resolved bindings", () => {
+    expect(matchCommand(key("down", ""))).toBe("hunk.history.nextCommit");
+    expect(matchCommand(key("down", "", false, true))).toBe("hunk.history.extendNext");
+    expect(matchCommand(key("x", "J"))).toBe("hunk.history.extendNext");
+    expect(matchCommand(key("up", "", false, true))).toBe("hunk.history.extendPrevious");
+    expect(matchCommand(key("x", "K"))).toBe("hunk.history.extendPrevious");
+    expect(matchCommand(key("x", "j"))).toBe("hunk.history.nextCommit");
+    expect(matchCommand(key("c", "\x03", true))).toBe("hunk.app.quit");
+    expect(matchCommand(key("t"))).toBe("hunk.view.openThemeSelector");
+    expect(historyCommand("hunk.history.openFirstParent").title).toBe("Compare with first parent");
+
+    const { keys } = resolveCommandKeys({
+      defaults: historyCommandKeyDefaults(),
+      userBindings: { "hunk.history.nextCommit": "ctrl+n" },
     });
-    expect(helpRows).toContainEqual({ keys: "t", description: "theme…" });
+    const commands = buildHistoryCommands({
+      getSnapshot: snapshot,
+      handlers: noopHandlers,
+      resolvedKeys: keys,
+    });
+    const helpRows = buildHistoryHelpSections(commands).flatMap((section) => section.rows);
+    expect(helpRows).toContainEqual({ keys: "Ctrl+N", description: "next commit" });
+    expect(helpRows).toContainEqual({
+      keys: "Shift+Up / K",
+      description: "extend selection up",
+    });
+    expect(helpRows).toContainEqual({ keys: "t", description: "choose theme" });
+  });
+
+  test("remaps and unbinds history independently through the shared keymap", () => {
+    expect(
+      matchCommand(key("n", "", true), {
+        "hunk.history.nextCommit": "ctrl+n",
+        "hunk.history.previousCommit": false,
+      }),
+    ).toBe("hunk.history.nextCommit");
+    expect(
+      matchCommand(key("down", ""), {
+        "hunk.history.nextCommit": "ctrl+n",
+      }),
+    ).toBeUndefined();
+    expect(
+      matchCommand(key("up", ""), {
+        "hunk.history.previousCommit": false,
+      }),
+    ).toBeUndefined();
+    expect(
+      matchCommand(key("c", "\x03", true), {
+        "hunk.history.nextCommit": "ctrl+c",
+      }),
+    ).toBe("hunk.history.nextCommit");
+    expect(
+      matchCommand(key("c", "\x03", true), {
+        "hunk.app.quit": false,
+      }),
+    ).toBeUndefined();
   });
 
   test("derives parent and search enabled state from current snapshot", () => {
-    expect(isLogCommandEnabled("open-first-parent", snapshot())).toBe(false);
-    expect(isLogCommandEnabled("open-first-parent", snapshot(["p1", "p2"]))).toBe(true);
-    expect(isLogCommandEnabled("open-parent", snapshot(["p1", "p2"]))).toBe(true);
+    const enabled = (id: HistoryCommandId, value = snapshot()) =>
+      isHistoryCommandEnabled(id, value);
+    expect(enabled("hunk.history.openFirstParent")).toBe(false);
+    expect(enabled("hunk.history.openFirstParent", snapshot(["p1", "p2"]))).toBe(true);
+    expect(enabled("hunk.history.openParent", snapshot(["p1", "p2"]))).toBe(true);
     const range = { ...snapshot(["p1", "p2"]), selectionAnchor: 1 };
-    expect(isLogCommandEnabled("open-first-parent", range)).toBe(false);
-    expect(isLogCommandEnabled("open-parent", range)).toBe(false);
-    expect(isLogCommandEnabled("next-match", snapshot())).toBe(false);
+    expect(enabled("hunk.history.openFirstParent", range)).toBe(false);
+    expect(enabled("hunk.history.openParent", range)).toBe(false);
+    expect(enabled("hunk.history.nextMatch")).toBe(false);
   });
 });

--- a/packages/hunk/src/ui/log/commands.ts
+++ b/packages/hunk/src/ui/log/commands.ts
@@ -1,258 +1,111 @@
 import type { KeyEvent } from "@opentui/core";
+import {
+  HISTORY_COMMAND_CATALOG,
+  type HistoryCommandCatalogEntry,
+  type HistoryCommandHelpSection,
+  type HistoryCommandId,
+} from "../../core/run/historyCommandCatalog";
+import { matchesAnyKeyChord } from "../../lib/commandKeys";
 import type { HelpSection } from "../lib/helpContent";
-import type { MenuId } from "../components/chrome/menu";
+import { formatKeyChord, type CommandKeyDefaults } from "../lib/keymap";
+import type { AppCommand, ResolvedCommandKeys } from "../lib/appCommands";
 import type { LogSnapshot } from "./controller";
 
-export type LogCommandId =
-  | "open"
-  | "copy"
-  | "refresh"
-  | "quit"
-  | "theme"
-  | "toggle-graph"
-  | "toggle-unicode"
-  | "toggle-author"
-  | "toggle-date"
-  | "toggle-decorations"
-  | "previous"
-  | "next"
-  | "extend-previous"
-  | "extend-next"
-  | "page-up"
-  | "page-down"
-  | "first"
-  | "last"
-  | "search"
-  | "next-match"
-  | "previous-match"
-  | "open-first-parent"
-  | "open-parent"
-  | "help"
-  | "about";
+export type { HistoryCommandId } from "../../core/run/historyCommandCatalog";
 
-type Shortcut = { token: string; display: string };
+/** What each canonical history command does in the terminal history surface. */
+export type HistoryCommandHandlers = Record<
+  HistoryCommandId,
+  (key: KeyEvent, entry: HistoryCommandCatalogEntry) => void
+>;
 
-export interface LogCommandDefinition {
-  id: LogCommandId;
-  label: string;
-  menu: MenuId;
-  shortcuts?: readonly Shortcut[];
-  helpSection?: "Navigation" | "Commit" | "Application";
+export interface BuildHistoryCommandsOptions {
+  getSnapshot: () => LogSnapshot;
+  handlers: HistoryCommandHandlers;
+  resolvedKeys?: ResolvedCommandKeys;
 }
 
-/** Define log labels and bindings once for keyboard dispatch, menus, and help. */
-export const LOG_COMMANDS: readonly LogCommandDefinition[] = [
-  {
-    id: "open",
-    label: "Open selection",
-    menu: "file",
-    shortcuts: [{ token: "name:enter", display: "Enter" }],
-    helpSection: "Commit",
-  },
-  {
-    id: "copy",
-    label: "Copy commit ID",
-    menu: "file",
-    shortcuts: [{ token: "sequence:y", display: "y" }],
-    helpSection: "Commit",
-  },
-  {
-    id: "refresh",
-    label: "Refresh history",
-    menu: "file",
-    shortcuts: [{ token: "sequence:r", display: "r" }],
-    helpSection: "Application",
-  },
-  {
-    id: "quit",
-    label: "Quit",
-    menu: "file",
-    shortcuts: [
-      { token: "sequence:q", display: "q" },
-      { token: "ctrl:c", display: "Ctrl-C" },
-    ],
-    helpSection: "Application",
-  },
-  {
-    id: "theme",
-    label: "Theme…",
-    menu: "view",
-    shortcuts: [{ token: "sequence:t", display: "t" }],
-    helpSection: "Application",
-  },
-  { id: "toggle-graph", label: "Graph view", menu: "view" },
-  { id: "toggle-unicode", label: "Unicode lines", menu: "view" },
-  { id: "toggle-author", label: "Show author", menu: "view" },
-  { id: "toggle-date", label: "Show date", menu: "view" },
-  { id: "toggle-decorations", label: "Show decorations", menu: "view" },
-  {
-    id: "extend-previous",
-    label: "Extend selection up",
-    menu: "navigate",
-    shortcuts: [
-      { token: "shift:up", display: "Shift-↑ / K" },
-      { token: "sequence:K", display: "Shift-↑ / K" },
-    ],
-    helpSection: "Navigation",
-  },
-  {
-    id: "extend-next",
-    label: "Extend selection down",
-    menu: "navigate",
-    shortcuts: [
-      { token: "shift:down", display: "Shift-↓ / J" },
-      { token: "sequence:J", display: "Shift-↓ / J" },
-    ],
-    helpSection: "Navigation",
-  },
-  {
-    id: "previous",
-    label: "Previous commit",
-    menu: "navigate",
-    shortcuts: [
-      { token: "name:up", display: "↑ / k" },
-      { token: "sequence:k", display: "↑ / k" },
-    ],
-    helpSection: "Navigation",
-  },
-  {
-    id: "next",
-    label: "Next commit",
-    menu: "navigate",
-    shortcuts: [
-      { token: "name:down", display: "↓ / j" },
-      { token: "sequence:j", display: "↓ / j" },
-    ],
-    helpSection: "Navigation",
-  },
-  {
-    id: "page-up",
-    label: "Page up",
-    menu: "navigate",
-    shortcuts: [{ token: "name:pageup", display: "PgUp" }],
-    helpSection: "Navigation",
-  },
-  {
-    id: "page-down",
-    label: "Page down",
-    menu: "navigate",
-    shortcuts: [{ token: "name:pagedown", display: "PgDn" }],
-    helpSection: "Navigation",
-  },
-  {
-    id: "first",
-    label: "First commit",
-    menu: "navigate",
-    shortcuts: [
-      { token: "name:home", display: "Home / g" },
-      { token: "sequence:g", display: "Home / g" },
-    ],
-    helpSection: "Navigation",
-  },
-  {
-    id: "last",
-    label: "Last commit",
-    menu: "navigate",
-    shortcuts: [
-      { token: "name:end", display: "End / G" },
-      { token: "sequence:G", display: "End / G" },
-    ],
-    helpSection: "Navigation",
-  },
-  {
-    id: "search",
-    label: "Search…",
-    menu: "navigate",
-    shortcuts: [{ token: "sequence:/", display: "/" }],
-    helpSection: "Navigation",
-  },
-  {
-    id: "next-match",
-    label: "Next match",
-    menu: "navigate",
-    shortcuts: [{ token: "sequence:n", display: "n" }],
-    helpSection: "Navigation",
-  },
-  {
-    id: "previous-match",
-    label: "Previous match",
-    menu: "navigate",
-    shortcuts: [{ token: "sequence:N", display: "N" }],
-    helpSection: "Navigation",
-  },
-  {
-    id: "open-first-parent",
-    label: "Compare with first parent",
-    menu: "commit",
-  },
-  { id: "open-parent", label: "Compare with parent…", menu: "commit" },
-  {
-    id: "help",
-    label: "Keyboard shortcuts",
-    menu: "help",
-    shortcuts: [{ token: "sequence:?", display: "?" }],
-    helpSection: "Application",
-  },
-  { id: "about", label: "About Hunk", menu: "help" },
-];
-
-const BY_ID = new Map(LOG_COMMANDS.map((command) => [command.id, command]));
-
-/** Return the canonical definition for one command. */
-export function logCommand(id: LogCommandId) {
-  return BY_ID.get(id)!;
-}
-
-/** Derive one menu/help hint from the same shortcuts used for dispatch. */
-export function logCommandHint(id: LogCommandId) {
-  return logCommand(id).shortcuts?.[0]?.display;
-}
-
-/** Resolve a keyboard event to the canonical log command. */
-export function matchLogCommand(key: KeyEvent): LogCommandId | null {
-  const normalizedName = key.name === "return" ? "enter" : key.name;
-  const tokens = [
-    key.ctrl ? `ctrl:${key.name}` : "",
-    key.shift ? `shift:${normalizedName}` : `name:${normalizedName}`,
-    key.sequence ? `sequence:${key.sequence}` : "",
-  ];
-  return (
-    LOG_COMMANDS.find((command) =>
-      command.shortcuts?.some((shortcut) => tokens.includes(shortcut.token)),
-    )?.id ?? null
-  );
+/** Return the history command defaults consumed by shared keymap resolution. */
+export function historyCommandKeyDefaults(): readonly CommandKeyDefaults[] {
+  return HISTORY_COMMAND_CATALOG.map((entry) => ({
+    id: entry.id,
+    aliases: entry.aliases,
+    defaultKeys: entry.defaultKeys,
+  }));
 }
 
 /** Apply context-sensitive availability consistently to keyboard and menus. */
-export function isLogCommandEnabled(id: LogCommandId, snapshot: LogSnapshot) {
+export function isHistoryCommandEnabled(id: HistoryCommandId, snapshot: LogSnapshot) {
   const selected = snapshot.rows[snapshot.selected];
-  if (["open", "copy"].includes(id)) return Boolean(selected);
-  if (id === "previous" || id === "extend-previous" || id === "page-up" || id === "first")
+  if (id === "hunk.history.openSelection" || id === "hunk.history.copyRevision")
+    return Boolean(selected);
+  if (
+    id === "hunk.history.previousCommit" ||
+    id === "hunk.history.extendPrevious" ||
+    id === "hunk.history.pageUp" ||
+    id === "hunk.history.jumpToFirst"
+  )
     return snapshot.selected > 0;
-  if (id === "next" || id === "extend-next" || id === "page-down" || id === "last")
+  if (
+    id === "hunk.history.nextCommit" ||
+    id === "hunk.history.extendNext" ||
+    id === "hunk.history.pageDown" ||
+    id === "hunk.history.jumpToLast"
+  )
     return !(snapshot.historyDone && snapshot.selected >= snapshot.rows.length - 1);
-  if (id === "next-match" || id === "previous-match") return Boolean(snapshot.search);
-  if (id === "open-first-parent")
+  if (id === "hunk.history.nextMatch" || id === "hunk.history.previousMatch")
+    return Boolean(snapshot.search);
+  if (id === "hunk.history.openFirstParent")
     return snapshot.selectionAnchor === null && Boolean(selected?.commit.parentRevisionIds.length);
-  if (id === "open-parent")
+  if (id === "hunk.history.openParent")
     return (
       snapshot.selectionAnchor === null && (selected?.commit.parentRevisionIds.length ?? 0) > 1
     );
   return true;
 }
 
-/** Build log help from the same labels and bindings used by dispatch and menus. */
-export function buildLogHelpSections(): readonly HelpSection[] {
-  const order: NonNullable<LogCommandDefinition["helpSection"]>[] = [
-    "Navigation",
-    "Commit",
-    "Application",
-  ];
+/** Bind canonical history command identity to live terminal handlers. */
+export function buildHistoryCommands({
+  getSnapshot,
+  handlers,
+  resolvedKeys,
+}: BuildHistoryCommandsOptions): AppCommand[] {
+  return HISTORY_COMMAND_CATALOG.map((entry) => {
+    const keys = resolvedKeys?.get(entry.id) ?? entry.defaultKeys;
+    return {
+      id: entry.id,
+      aliases: entry.aliases,
+      title: entry.title,
+      keys,
+      keyLabels: keys.map(formatKeyChord),
+      defaultKeys: entry.defaultKeys,
+      isEnabled: () => isHistoryCommandEnabled(entry.id as HistoryCommandId, getSnapshot()),
+      publicToExtensions: entry.publicToExtensions,
+      verticalDirection: entry.verticalDirection,
+      closesMenu: entry.closesMenu,
+      match: matchesAnyKeyChord(keys),
+      run: (key) => handlers[entry.id as HistoryCommandId](key, entry),
+    };
+  });
+}
+
+/** Find the canonical history definition used by menus and tests. */
+export function historyCommand(id: HistoryCommandId) {
+  return HISTORY_COMMAND_CATALOG.find((entry) => entry.id === id)!;
+}
+
+/** Build history help from effective session bindings rather than shipped defaults. */
+export function buildHistoryHelpSections(commands: readonly AppCommand[]): readonly HelpSection[] {
+  const order: readonly HistoryCommandHelpSection[] = ["Navigation", "Commit", "Application"];
+  const byId = new Map(commands.map((command) => [command.id, command]));
   return order.map((title) => ({
     title,
-    rows: LOG_COMMANDS.filter((command) => command.helpSection === title).map((command) => ({
-      keys: command.shortcuts?.[0]?.display ?? "",
-      description: command.label.toLocaleLowerCase(),
-    })),
+    rows: HISTORY_COMMAND_CATALOG.filter((entry) => entry.helpSection === title)
+      .map((entry) => ({ entry, command: byId.get(entry.id) }))
+      .filter(({ command }) => command !== undefined && command.keyLabels.length > 0)
+      .map(({ entry, command }) => ({
+        keys: command!.keyLabels.join(" / "),
+        description: entry.title.toLocaleLowerCase(),
+      })),
   }));
 }

--- a/packages/hunk/src/ui/log/controller.test.ts
+++ b/packages/hunk/src/ui/log/controller.test.ts
@@ -4,7 +4,7 @@ import { persistedViewPreferencesFromOptions } from "../../core/run/config";
 import type { HistoryRuntime } from "../history/types";
 import { LogController } from "./controller";
 
-function createRuntime(subjects = ["first", "second", "third"]) {
+function createRuntime(subjects = ["first", "second", "third"], notices: readonly string[] = []) {
   let cursor = 0;
   let closeCount = 0;
   const makeSource = () => ({
@@ -42,8 +42,9 @@ function createRuntime(subjects = ["first", "second", "third"]) {
     providerId: "test",
     providerName: "Test",
     repoRoot: "/repo",
-    notices: [],
+    notices,
     customThemes: [],
+    keybindings: {},
     initialViewPreferences: persistedViewPreferencesFromOptions({}),
     promptSaveViewPreferences: true,
     async planReview(commit) {
@@ -62,6 +63,22 @@ function createRuntime(subjects = ["first", "second", "third"]) {
 }
 
 describe("LogController", () => {
+  test("preserves bootstrap notices when keymap diagnostics arrive after mount", async () => {
+    const { runtime } = createRuntime(undefined, [
+      "Configured VCS is unavailable.",
+      "Extension registration was skipped.",
+    ]);
+    const controller = new LogController(runtime);
+
+    controller.addStartupNotices(["Unknown history command."]);
+    controller.addStartupNotices(["Unknown history command."]);
+
+    expect(controller.getSnapshot().notice).toBe(
+      "Configured VCS is unavailable. • Extension registration was skipped. • Unknown history command.",
+    );
+    await controller.close();
+  });
+
   test("loads bounded pages and retains navigation/search state", async () => {
     const { runtime } = createRuntime();
     const controller = new LogController(runtime);

--- a/packages/hunk/src/ui/log/controller.ts
+++ b/packages/hunk/src/ui/log/controller.ts
@@ -52,10 +52,13 @@ export class LogController {
   private closed = false;
   private viewportBodyHeight = 1;
   private noticeTimer: ReturnType<typeof setTimeout> | null = null;
+  private startupNotices = new Set<string>();
   private snapshot: LogSnapshot;
 
   constructor(private readonly runtime: HistoryRuntime) {
     this.source = runtime.source;
+    const startupNotices = runtime.notices.map(sanitizeTerminalLine).filter(Boolean);
+    this.startupNotices = new Set(startupNotices);
     this.snapshot = {
       rows: [],
       selected: 0,
@@ -65,7 +68,7 @@ export class LogController {
       searchEditing: false,
       historyDone: false,
       loading: false,
-      notice: runtime.notices[0] ?? "",
+      notice: startupNotices.join(" • "),
       presentation: {
         graph: false,
         unicode: !runtime.input.ascii && process.env.TERM !== "dumb",
@@ -291,6 +294,17 @@ export class LogController {
     if (this.noticeTimer) clearTimeout(this.noticeTimer);
     this.noticeTimer = null;
     if (this.snapshot.notice) this.publish({ notice: "" });
+  }
+
+  /** Add startup diagnostics without replacing notices gathered before the UI mounted. */
+  addStartupNotices(notices: readonly string[]) {
+    const additions = notices
+      .map(sanitizeTerminalLine)
+      .filter((notice) => notice && !this.startupNotices.has(notice));
+    if (additions.length === 0) return;
+    for (const notice of additions) this.startupNotices.add(notice);
+    const existing = this.snapshot.notice ? [this.snapshot.notice] : [];
+    this.publish({ notice: [...existing, ...additions].join(" • ") });
   }
 
   setNotice(notice: string) {

--- a/packages/hunk/src/ui/log/logHelp.ts
+++ b/packages/hunk/src/ui/log/logHelp.ts
@@ -1,4 +1,0 @@
-import { buildLogHelpSections } from "./commands";
-
-/** Describe only the canonical controls owned by the interactive log surface. */
-export const LOG_HELP_SECTIONS = buildLogHelpSections();

--- a/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
@@ -53,6 +53,7 @@ async function createHistoryRoute(subjects = ["History row"]) {
     repoRoot: "/repo",
     notices: [],
     customThemes: [],
+    keybindings: {},
     initialViewPreferences: persistedViewPreferencesFromOptions({}),
     promptSaveViewPreferences: true,
     async planReview(commit) {

--- a/test/pty/log-integration.test.ts
+++ b/test/pty/log-integration.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createPtyHarness, rightmostColumnOf } from "./harness";
@@ -248,6 +256,42 @@ describe("interactive hunk log", () => {
       // coalesced trailing q must be consumed by the log transition rather than closing the child.
       session.writeRaw("\rq");
       await session.waitForText(/historyValue = 'second'/, { timeout: 15_000 });
+      await session.press("q");
+      await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      await session.press("q");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("resolves canonical history command remaps from user keybindings", async () => {
+    const cwd = createHistoryRepo();
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-log-keybindings-"));
+    tempDirs.push(configHome);
+    const configDir = join(configHome, "hunk");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, "config.toml"),
+      '[keybindings]\n"hunk.history.nextCommit" = "ctrl+n"\n',
+    );
+    const session = await harness.launchHunk({
+      args: ["log", "--color", "never", "--no-extensions"],
+      cwd,
+      cols: 100,
+      rows: 20,
+      env: { XDG_CONFIG_HOME: configHome },
+    });
+
+    try {
+      await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      await session.press("down");
+      await session.press("enter");
+      await session.waitForText(/historyValue = 'second'/, { timeout: 15_000 });
+      await session.press("q");
+      await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      session.writeRaw("\x0e");
+      await session.press("enter");
+      await session.waitForText(/historyValue = 'first'/, { timeout: 15_000 });
       await session.press("q");
       await session.waitForText(/Second history commit/, { timeout: 15_000 });
       await session.press("q");

--- a/website/src/content/docs/docs/configure/keybindings.md
+++ b/website/src/content/docs/docs/configure/keybindings.md
@@ -10,11 +10,12 @@ Every keyboard shortcut is a named command. A `[keybindings]` table in your user
 "hunk.app.quit" = "ctrl+x"               # one chord
 "hunk.review.nextHunk" = ["]", "ctrl+n"] # several chords for one command
 "hunk.review.focusFilter" = "f"          # takes "f" away from page-down
+"hunk.history.nextCommit" = "ctrl+n"     # history has its own command ids
 "hunk.view.toggleMenuBar" = false        # unbind it entirely
 "myext.toggle" = "ctrl+g"                # extension commands too
 ```
 
-Every id starts with the name of whoever owns the command: Hunk's own commands live under `hunk.`, and an extension's live under its extension id. `hunk` is a reserved extension id, so an extension can never shadow a built-in command.
+Every id starts with the name of whoever owns the command: Hunk's own commands live under `hunk.`, and an extension's live under its extension id. `hunk` is a reserved extension id, so an extension can never shadow a built-in command. Interactive history uses `hunk.history.*` for commit-specific behavior while truly shared actions retain ids such as `hunk.app.quit` and `hunk.view.openThemeSelector`.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

- add canonical `hunk.history.*` command identities for interactive history actions
- route history shortcuts through the shared command/keymap resolver and dispatcher
- make history keyboard handling, menus, and help reflect user remaps and unbindings
- retain shared IDs for quit, help, and theme while keeping history-specific effects independent from review commands
- recognize commands inactive on the current surface without creating false unknown-command warnings or cross-surface chord conflicts

## Extension scope

Extension commands remain review-only in history. Loaded extension command IDs are recognized as intentionally inactive, so shared user configuration does not produce misleading warnings or reserve their chords on the history surface.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- targeted command catalog, keymap, history, bootstrap, controller, and session tests
- `bun test test/pty/log-integration.test.ts` — 10 passed
- `bun run test:integration` — 158 passed, 1 platform skip
- independent reviewer follow-up — no blocker, high, or medium findings

`bun run test` passed the affected suites and 2231 tests in its second shard. It retained two known environment-sensitive failures involving the missing-skill fixture and `/tmp/node_modules` host-runtime resolution.

## Platforms

Tested on Linux through unit, component, and real PTY integration coverage. macOS and Windows were not manually tested.

## Visual evidence

No media is attached because this changes command identity and remapping behavior rather than layout. Real PTY coverage verifies that a remapped history command releases its old key and opens the expected commit through its new key.

*This PR description was generated by Pi using gpt-5.6-sol*
