### PR TITLE
fix(ui): persist themes across routed surfaces

### DIFF
--- a/.changeset/fresh-themes-travel.md
+++ b/.changeset/fresh-themes-travel.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep theme changes active when moving between history and review surfaces in the same session.

--- a/packages/hunk/src/ui/App.tsx
+++ b/packages/hunk/src/ui/App.tsx
@@ -112,6 +112,7 @@ import { setMouseCapture } from "./lib/mouseCapture";
 import { openSelectedFileInEditor } from "./lib/openInEditor";
 import { resolveResponsiveLayout } from "./lib/responsive";
 import type { WorkspaceRefreshRequest } from "./currentReviewRefresh";
+import { ThemeController } from "./theme/controller";
 
 type FocusArea = "files" | "filter" | "note";
 
@@ -149,6 +150,7 @@ export function App({
   onWorkspaceWriteCompleted,
   reviewProducer,
   runWorkspaceWrite,
+  themeController,
   returnToHistory = process.env.HUNK_RETURN_TO_HISTORY === "1",
   watchRuntime,
   workspaceFileWriter,
@@ -177,6 +179,8 @@ export function App({
   reviewProducer?: ReviewProducer;
   /** Start and track one irreversible write, or refuse it once graceful shutdown begins. */
   runWorkspaceWrite: WorkspaceWriteRunner;
+  /** Session-owned committed theme state shared across routed surfaces. */
+  themeController?: ThemeController;
   /** Present quit as returning to the owning history surface. */
   returnToHistory?: boolean;
   watchRuntime?: WatchedInputRuntime;
@@ -250,6 +254,15 @@ export function App({
   const extensions = bootstrap.extensions as ExtensionLoadResult | undefined;
   const pendingTrustRepoRoot = extensions?.pendingTrustRepoRoot;
   const extensionToast = useExtensionNotifications(extensions?.notifications);
+  const [ownedThemeController] = useState(
+    () =>
+      new ThemeController({
+        initialTheme: bootstrap.initialTheme,
+        initialThemeMode: bootstrap.initialThemeMode ?? renderer.themeMode,
+        customThemes: bootstrap.customThemes,
+      }),
+  );
+  const activeThemeController = themeController ?? ownedThemeController;
 
   const {
     activeTheme,
@@ -266,9 +279,8 @@ export function App({
     previewThemeSelectorItem,
   } = useThemeSelectorController({
     customThemes: bootstrap.customThemes,
-    initialTheme: bootstrap.initialTheme,
-    initialThemeMode: bootstrap.initialThemeMode ?? renderer.themeMode,
     onTransientNotice: showTransientNotice,
+    themeController: activeThemeController,
     transparentBackground: bootstrap.input.options.transparentBackground ?? false,
   });
   const currentViewPreferences = useMemo<PersistedViewPreferences>(
@@ -370,6 +382,10 @@ export function App({
   }, []);
   const viewPreferenceQuit = useViewPreferenceQuitController({
     currentPreferences: currentViewPreferences,
+    initialPreferences: {
+      ...currentViewPreferences,
+      theme: activeThemeController.initialThemeId,
+    },
     configPath: bootstrap.viewPreferencesConfigPath,
     pagerMode,
     promptSaveViewPreferences:

--- a/packages/hunk/src/ui/AppHost.tsx
+++ b/packages/hunk/src/ui/AppHost.tsx
@@ -1,3 +1,4 @@
+import { useRenderer } from "@opentui/react";
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { resolveConfiguredExtensions } from "../app/extensionBootstrap";
 import { ReviewProducer } from "../app/review/producer";
@@ -39,6 +40,7 @@ import type {
 } from "./hooks/useExtensionWorkspaceControls";
 import { assertReliableWatchRuntime } from "../core/watch/runtime";
 import type { WatchedInputRuntime } from "./hooks/useWatchedInput";
+import { ThemeController } from "./theme/controller";
 
 /** Build the stable refusal returned once quit becomes terminal for reload coordination. */
 function reloadRefusedDuringShutdown() {
@@ -65,6 +67,7 @@ export function AppHost({
   onRequestSessionShutdown,
   reviewProducer,
   startupNoticeResolver,
+  themeController,
   watchRuntime,
   workspaceFileWriter,
   bunVersion = Bun.version,
@@ -93,11 +96,14 @@ export function AppHost({
    */
   reviewProducer?: ReviewProducer;
   startupNoticeResolver?: () => Promise<StartupNotice | null>;
+  /** Session-owned committed theme state shared across routed surfaces. */
+  themeController?: ThemeController;
   watchRuntime?: WatchedInputRuntime;
   workspaceFileWriter?: WorkspaceFileWriter;
   /** Runtime identity injection for reload compatibility tests. */
   bunVersion?: string;
 }) {
+  const renderer = useRenderer();
   const initialBootstrap = bootstrap.reloadContext.vcsCatalog
     ? bootstrap
     : {
@@ -107,6 +113,15 @@ export function AppHost({
           vcsCatalog: getBundledVcsCatalog(),
         },
       };
+  const [ownedThemeController] = useState(
+    () =>
+      new ThemeController({
+        initialTheme: initialBootstrap.initialTheme,
+        initialThemeMode: initialBootstrap.initialThemeMode ?? renderer.themeMode,
+        customThemes: initialBootstrap.customThemes,
+      }),
+  );
+  const activeThemeController = themeController ?? ownedThemeController;
   const [activeExtensionSession] = useState(extensionSession);
   // Direct renderer harnesses can mount extension-free bootstraps while still supplying an
   // explicit empty owner. Production startup always attaches the owner's current result.
@@ -583,6 +598,7 @@ export function AppHost({
       onWorkspaceWriteCompleted={reloadAfterWorkspaceWrite}
       reviewProducer={producer}
       runWorkspaceWrite={runWorkspaceWrite}
+      themeController={activeThemeController}
       watchRuntime={watchRuntime}
       workspaceFileWriter={workspaceFileWriter}
     />

--- a/packages/hunk/src/ui/hooks/useThemeSelectorController.test.tsx
+++ b/packages/hunk/src/ui/hooks/useThemeSelectorController.test.tsx
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { act, useState } from "react";
 import type { NamedCustomThemeConfig } from "../../extension-api/types";
+import type { TerminalThemeMode } from "../../core/theme/detection";
+import { ThemeController } from "../theme/controller";
 import { availableThemes, TRANSPARENT_BACKGROUND } from "../themes";
 import {
   useThemeSelectorController,
@@ -9,16 +11,33 @@ import {
 } from "./useThemeSelectorController";
 
 type ThemeSelectorController = ReturnType<typeof useThemeSelectorController>;
+interface ThemeSelectorHarnessOptions extends Omit<
+  UseThemeSelectorControllerOptions,
+  "themeController"
+> {
+  initialTheme?: string;
+  initialThemeMode?: TerminalThemeMode | null;
+}
 
 /** Mount the controller with replaceable bootstrap-like inputs. */
-async function renderThemeSelectorController(initial: UseThemeSelectorControllerOptions) {
+async function renderThemeSelectorController(initial: ThemeSelectorHarnessOptions) {
   let controller!: ThemeSelectorController;
-  let replaceOptions!: (options: UseThemeSelectorControllerOptions) => void;
+  let replaceOptions!: (options: ThemeSelectorHarnessOptions) => void;
+  const themeController = new ThemeController({
+    initialTheme: initial.initialTheme,
+    initialThemeMode: initial.initialThemeMode,
+    customThemes: initial.customThemes,
+  });
 
   function Probe() {
     const [options, setOptions] = useState(initial);
     replaceOptions = setOptions;
-    controller = useThemeSelectorController(options);
+    const {
+      initialTheme: _initialTheme,
+      initialThemeMode: _initialThemeMode,
+      ...selectorOptions
+    } = options;
+    controller = useThemeSelectorController({ ...selectorOptions, themeController });
     return null;
   }
 
@@ -149,10 +168,8 @@ describe("useThemeSelectorController", () => {
 
   test("pointer and keyboard acceptance commit atomically and preserve notices", async () => {
     const notices: string[] = [];
-    const committed: string[] = [];
     const harness = await renderThemeSelectorController({
       initialTheme: "github-dark-default",
-      onThemeCommitted: (themeId) => committed.push(themeId),
       onTransientNotice: (notice) => notices.push(notice),
       transparentBackground: false,
     });
@@ -177,7 +194,6 @@ describe("useThemeSelectorController", () => {
       expect(harness.controller.themeId).toBe(keyboardItem.id);
       expect(harness.controller.baseTheme.id).toBe(keyboardItem.id);
       expect(notices.at(-1)).toBe(`Theme: ${keyboardItem.label}`);
-      expect(committed).toEqual([pointerItem.id, keyboardItem.id]);
     } finally {
       await destroyController(harness.setup);
     }

--- a/packages/hunk/src/ui/hooks/useThemeSelectorController.ts
+++ b/packages/hunk/src/ui/hooks/useThemeSelectorController.ts
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { TerminalThemeMode } from "../../core/theme/detection";
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { NamedCustomThemeConfig } from "../../extension-api/types";
 import type { ThemeSelectorItem } from "../components/chrome/ThemeSelectorDialog";
+import type { ThemeController } from "../theme/controller";
 import { availableThemes, resolveTheme, withTransparentSurfaces } from "../themes";
 
 interface ThemeSelectorControllerState {
-  committedThemeId: string;
   open: boolean;
   previewThemeId: string | null;
   selectedThemeId: string | null;
@@ -13,28 +12,23 @@ interface ThemeSelectorControllerState {
 
 export interface UseThemeSelectorControllerOptions {
   customThemes?: readonly NamedCustomThemeConfig[];
-  initialTheme?: string;
-  initialThemeMode?: TerminalThemeMode | null;
   onTransientNotice: (text: string) => void;
-  /** Observe committed choices so a remounting surface can retain them. */
-  onThemeCommitted?: (themeId: string) => void;
+  themeController: ThemeController;
   transparentBackground: boolean;
 }
 
 /** Drive theme resolution, committed selection, and transient selector previews. */
 export function useThemeSelectorController({
   customThemes,
-  initialTheme,
-  initialThemeMode,
   onTransientNotice,
-  onThemeCommitted,
+  themeController,
   transparentBackground,
 }: UseThemeSelectorControllerOptions) {
-  // Startup detection is launch state. Soft bootstrap reloads may replace the
-  // incoming record, but they must not reinterpret an in-session theme choice.
-  const [detectedThemeMode] = useState(initialThemeMode);
+  const { themeId: committedThemeId } = useSyncExternalStore(
+    themeController.subscribe,
+    themeController.getSnapshot,
+  );
   const [state, setState] = useState<ThemeSelectorControllerState>(() => ({
-    committedThemeId: resolveTheme(initialTheme, initialThemeMode ?? null, customThemes).id,
     open: false,
     previewThemeId: null,
     selectedThemeId: null,
@@ -42,8 +36,8 @@ export function useThemeSelectorController({
 
   const themeOptions = useMemo(() => availableThemes(customThemes), [customThemes]);
   const committedTheme = useMemo(
-    () => resolveTheme(state.committedThemeId, detectedThemeMode ?? null, customThemes),
-    [customThemes, detectedThemeMode, state.committedThemeId],
+    () => resolveTheme(committedThemeId, themeController.themeMode ?? null, customThemes),
+    [committedThemeId, customThemes, themeController.themeMode],
   );
   const committedIndex = themeOptions.findIndex((theme) => theme.id === committedTheme.id);
   const storedSelectedIndex = themeOptions.findIndex((theme) => theme.id === state.selectedThemeId);
@@ -59,9 +53,9 @@ export function useThemeSelectorController({
   const baseTheme = useMemo(
     () =>
       previewThemeId
-        ? resolveTheme(previewThemeId, detectedThemeMode ?? null, customThemes)
+        ? resolveTheme(previewThemeId, themeController.themeMode ?? null, customThemes)
         : committedTheme,
-    [committedTheme, customThemes, detectedThemeMode, previewThemeId],
+    [committedTheme, customThemes, previewThemeId, themeController.themeMode],
   );
   const activeTheme = useMemo(
     () => (transparentBackground ? withTransparentSurfaces(baseTheme) : baseTheme),
@@ -175,15 +169,14 @@ export function useThemeSelectorController({
       selectedThemeIdRef.current = item.id;
       setState((current) => ({
         ...current,
-        committedThemeId: item.id,
         open: false,
         previewThemeId: null,
         selectedThemeId: item.id,
       }));
-      onThemeCommitted?.(item.id);
+      themeController.commitTheme(item.id);
       onTransientNotice(`Theme: ${item.label}`);
     },
-    [onThemeCommitted, onTransientNotice],
+    [onTransientNotice, themeController],
   );
 
   /** Commit one pointer-selected item when its current catalog entry is valid. */
@@ -204,7 +197,7 @@ export function useThemeSelectorController({
   return {
     activeTheme,
     baseTheme,
-    themeId: state.committedThemeId,
+    themeId: committedThemeId,
     themeSelectorItems: items,
     themeSelectorOpen: state.open,
     themeSelectorSelectedIndex: selectedIndex,

--- a/packages/hunk/src/ui/hooks/useViewPreferenceQuitController.ts
+++ b/packages/hunk/src/ui/hooks/useViewPreferenceQuitController.ts
@@ -47,6 +47,8 @@ export interface ViewPreferenceQuitController {
 /** Surface-owned facts and side effects required by the view-preference quit workflow. */
 export interface UseViewPreferenceQuitControllerOptions {
   currentPreferences: PersistedViewPreferences;
+  /** Preferences active when the owning session began, even if this surface remounts later. */
+  initialPreferences?: PersistedViewPreferences;
   configPath?: string;
   pagerMode: boolean;
   promptSaveViewPreferences: boolean;
@@ -73,6 +75,7 @@ function buildViewPreferenceDiffLines(
 /** Own view-preference dirty state and the save-or-discard quit workflow for one surface. */
 export function useViewPreferenceQuitController({
   currentPreferences,
+  initialPreferences,
   configPath,
   pagerMode,
   promptSaveViewPreferences,
@@ -84,7 +87,9 @@ export function useViewPreferenceQuitController({
   homeDirectory,
   quitScheduler = DEFAULT_QUIT_SCHEDULER,
 }: UseViewPreferenceQuitControllerOptions): ViewPreferenceQuitController {
-  const [savedPreferences, setSavedPreferences] = useState(currentPreferences);
+  const [savedPreferences, setSavedPreferences] = useState(
+    initialPreferences ?? currentPreferences,
+  );
   const [saveConfigPromptOpen, setSaveConfigPromptOpen] = useState(false);
   const pendingQuitTimerRef = useRef<unknown>(undefined);
   const quitPendingRef = useRef(false);

--- a/packages/hunk/src/ui/log/LogApp.tsx
+++ b/packages/hunk/src/ui/log/LogApp.tsx
@@ -24,6 +24,7 @@ import {
 } from "../hooks/useViewPreferenceQuitController";
 import { fitText, measureTextWidth } from "../lib/text";
 import { handleViewPreferenceQuitPromptKey } from "../lib/viewPreferenceQuitKeys";
+import type { ThemeController } from "../theme/controller";
 import type { HistoryRuntime } from "../history/types";
 import type { LogController } from "./controller";
 import { LOG_HELP_SECTIONS } from "./logHelp";
@@ -62,8 +63,6 @@ export type LogAppOutcome =
       commits: readonly ExtensionVcsHistoryCommit[];
       count: number;
       parentRevisionId?: string;
-      themeId: string;
-      themeMode: "dark" | "light";
     };
 
 /** Render the bounded history list inside Hunk's shared desktop chrome. */
@@ -71,12 +70,14 @@ export function LogApp({
   controller,
   runtime,
   onOutcome,
+  themeController,
   useColor,
   quitScheduler,
 }: {
   controller: LogController;
   runtime: HistoryRuntime;
   onOutcome: (outcome: LogAppOutcome) => void | Promise<void>;
+  themeController: ThemeController;
   useColor: boolean;
   quitScheduler?: ViewPreferenceQuitScheduler;
 }) {
@@ -99,21 +100,19 @@ export function LogApp({
   const reviewQuitEnabled = useRef(false);
   const quitRequestCaptured = useRef(false);
   const pendingExitCode = useRef<number | undefined>(undefined);
-  const themeController = useThemeSelectorController({
+  const themeSelector = useThemeSelectorController({
     customThemes: runtime.customThemes,
-    initialTheme: snapshot.themeId,
-    initialThemeMode: renderer.themeMode,
     onTransientNotice: setTransientNotice,
-    onThemeCommitted: (id) => controller.setTheme(id),
+    themeController,
     transparentBackground: false,
   });
   const terminalThemeMode = renderer.themeMode ?? "dark";
   const theme = useColor
-    ? themeController.activeTheme
-    : monochromeLogTheme(themeController.activeTheme, terminalThemeMode);
+    ? themeSelector.activeTheme
+    : monochromeLogTheme(themeSelector.activeTheme, terminalThemeMode);
   const chromeTheme = useColor
-    ? themeController.baseTheme
-    : monochromeLogTheme(themeController.baseTheme, terminalThemeMode);
+    ? themeSelector.baseTheme
+    : monochromeLogTheme(themeSelector.baseTheme, terminalThemeMode);
   const logPalette = resolveInteractiveLogPalette(theme);
   const graphColors = snapshot.presentation.graph ? logPalette.graphLanes : [logPalette.timeline];
   const selection = controller.getSelection();
@@ -121,11 +120,15 @@ export function LogApp({
   const responsiveLayout = resolveLogResponsiveLayout(terminal.width, terminal.height);
   const viewportBodyHeight = responsiveLayout.bodyHeight;
   const currentViewPreferences = useMemo(
-    () => ({ ...runtime.initialViewPreferences, theme: themeController.themeId }),
-    [runtime.initialViewPreferences, themeController.themeId],
+    () => ({ ...runtime.initialViewPreferences, theme: themeSelector.themeId }),
+    [runtime.initialViewPreferences, themeSelector.themeId],
   );
   const viewPreferenceQuit = useViewPreferenceQuitController({
     currentPreferences: currentViewPreferences,
+    initialPreferences: {
+      ...runtime.initialViewPreferences,
+      theme: themeController.initialThemeId,
+    },
     configPath: runtime.viewPreferencesConfigPath,
     pagerMode: false,
     promptSaveViewPreferences: runtime.promptSaveViewPreferences,
@@ -184,8 +187,6 @@ export function LogApp({
         commits: controller.getSelectedRows(8).map((row) => row.commit),
         count: currentSelection.count,
         ...(parentRevisionId === undefined ? {} : { parentRevisionId }),
-        themeId: themeController.themeId,
-        themeMode: terminalThemeMode,
       });
     } catch (error) {
       reviewPending.current = false;
@@ -267,7 +268,7 @@ export function LogApp({
         requestLogQuit(exitCode);
         break;
       case "theme":
-        themeController.openThemeSelector();
+        themeSelector.openThemeSelector();
         break;
       case "toggle-graph":
         controller.togglePresentation("graph");
@@ -490,12 +491,12 @@ export function LogApp({
       consume();
       return;
     }
-    if (themeController.themeSelectorOpen) {
-      if (name === "escape") themeController.closeThemeSelector();
-      else if (name === "up") themeController.moveThemeSelector(-1);
+    if (themeSelector.themeSelectorOpen) {
+      if (name === "escape") themeSelector.closeThemeSelector();
+      else if (name === "up") themeSelector.moveThemeSelector(-1);
       else if (name === "down" || name === "tab")
-        themeController.moveThemeSelector(key.shift ? -1 : 1);
-      else if (name === "return" || name === "enter") themeController.acceptThemeSelector();
+        themeSelector.moveThemeSelector(key.shift ? -1 : 1);
+      else if (name === "return" || name === "enter") themeSelector.acceptThemeSelector();
       else return;
       consume();
       return;
@@ -834,16 +835,16 @@ export function LogApp({
           onSelect={setParentSelectorIndex}
         />
       ) : null}
-      {themeController.themeSelectorOpen ? (
+      {themeSelector.themeSelectorOpen ? (
         <ThemeSelectorDialog
-          items={themeController.themeSelectorItems}
-          selectedIndex={themeController.themeSelectorSelectedIndex}
+          items={themeSelector.themeSelectorItems}
+          selectedIndex={themeSelector.themeSelectorSelectedIndex}
           terminalHeight={terminal.height}
           terminalWidth={terminal.width}
           theme={chromeTheme}
-          onAcceptItem={themeController.acceptThemeSelectorItem}
-          onClose={themeController.closeThemeSelector}
-          onPreviewItem={themeController.previewThemeSelectorItem}
+          onAcceptItem={themeSelector.acceptThemeSelectorItem}
+          onClose={themeSelector.closeThemeSelector}
+          onPreviewItem={themeSelector.previewThemeSelectorItem}
         />
       ) : null}
       {showHelp ? (

--- a/packages/hunk/src/ui/log/controller.test.ts
+++ b/packages/hunk/src/ui/log/controller.test.ts
@@ -247,10 +247,8 @@ describe("LogController", () => {
     const { runtime, closeCount } = createRuntime(["first"]);
     const controller = new LogController(runtime);
     await controller.loadMore();
-    controller.setTheme("github-dark");
     await controller.refresh();
     expect(controller.getSnapshot().rows).toHaveLength(1);
-    expect(controller.getSnapshot().themeId).toBe("github-dark");
     await controller.close();
     await controller.close();
     expect(closeCount()).toBe(1);

--- a/packages/hunk/src/ui/log/controller.ts
+++ b/packages/hunk/src/ui/log/controller.ts
@@ -34,7 +34,6 @@ export interface LogSnapshot {
   historyDone: boolean;
   loading: boolean;
   notice: string;
-  themeId?: string;
   presentation: LogPresentation;
 }
 
@@ -67,7 +66,6 @@ export class LogController {
       historyDone: false,
       loading: false,
       notice: runtime.notices[0] ?? "",
-      themeId: runtime.input.theme,
       presentation: {
         graph: false,
         unicode: !runtime.input.ascii && process.env.TERM !== "dumb",
@@ -306,10 +304,6 @@ export class LogController {
       }, 2500);
       this.noticeTimer.unref?.();
     }
-  }
-
-  setTheme(themeId: string) {
-    this.publish({ themeId });
   }
 
   togglePresentation(key: keyof LogPresentation) {

--- a/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
@@ -158,6 +158,83 @@ test("routes repeated history reviews through fresh runtimes and returns instead
   }
 });
 
+test("shares committed themes across history and repeated review surfaces", async () => {
+  const history = await createHistoryRoute();
+  const requests: Array<{ themeId?: string }> = [];
+  const deps: HunkSessionHostDeps = {
+    prepareReview: (async (request: { themeId?: string }) => {
+      requests.push(request);
+      const bootstrap = createTestVcsAppBootstrap({
+        changesetId: `theme-review-${requests.length}`,
+        files: [createTestDiffFile({ id: "review.ts", path: "review.ts" })],
+      });
+      bootstrap.extensions = history.runtime.extensionSession.current;
+      return { bootstrap, borrowsExtensions: true };
+    }) as never,
+    createReviewRuntime: (() => ({
+      hostClient: undefined,
+      reviewProducer: undefined,
+      stop: mock(() => undefined),
+    })) as never,
+  };
+  const setup = await testRender(
+    <HunkSessionHost
+      initialRoute={history}
+      externalQuitSignal={new AbortController().signal}
+      onQuit={() => undefined}
+      deps={deps}
+    />,
+    { width: 100, height: 20 },
+  );
+  try {
+    await setup.renderOnce();
+    await act(async () => setup.mockInput.typeText("t"));
+    await setup.renderOnce();
+    await act(async () => setup.mockInput.pressArrow("down"));
+    await act(async () => setup.mockInput.pressEnter());
+    await setup.renderOnce();
+
+    await act(async () => setup.mockInput.pressEnter());
+    await settle(setup);
+    expect(requests[0]?.themeId).toBe("github-dark-dimmed");
+
+    await act(async () => setup.mockInput.typeText("t"));
+    await setup.renderOnce();
+    await act(async () => setup.mockInput.pressArrow("down"));
+    await act(async () => setup.mockInput.pressEnter());
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("Theme: github-dark-high-contrast");
+
+    await act(async () => setup.mockInput.pressKey("q"));
+    await settle(setup);
+    expect(setup.captureCharFrame()).toContain("Test history");
+    await act(async () => setup.mockInput.typeText("t"));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("›  github-dark-high-contrast");
+    await act(async () => setup.mockInput.pressEnter());
+    await settle(setup);
+    expect(setup.captureCharFrame()).not.toContain("Theme selector");
+
+    await act(async () => setup.mockInput.pressEnter());
+    await settle(setup);
+    expect(requests[1]?.themeId).toBe("github-dark-high-contrast");
+    await act(async () => setup.mockInput.typeText("t"));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("›  github-dark-high-contrast");
+
+    await act(async () => setup.mockInput.pressEnter());
+    await act(async () => setup.mockInput.pressKey("q"));
+    await settle(setup);
+    await act(async () => setup.mockInput.pressKey("q"));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("Save view preferences?");
+    expect(setup.captureCharFrame()).toContain('+ theme = "github-dark-high-contrast"');
+  } finally {
+    setup.renderer.destroy();
+    await history.controller.close();
+  }
+});
+
 test("opens an extended history selection as one inclusive comparison", async () => {
   const history = await createHistoryRoute(["Newest", "Oldest"]);
   const requests: unknown[] = [];

--- a/packages/hunk/src/ui/session/HunkSessionHost.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.tsx
@@ -1,3 +1,4 @@
+import { useRenderer } from "@opentui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   prepareEmbeddedHistoryReview,
@@ -21,6 +22,7 @@ import { interactiveLogUsesColor } from "../log/colorPolicy";
 import { LogApp, type LogAppOutcome } from "../log/LogApp";
 import type { LogController } from "../log/controller";
 import { resolveHistoryAuthorLabel } from "../log/formatting";
+import { ThemeController } from "../theme/controller";
 
 export interface HistorySurfaceRoute {
   kind: "history";
@@ -133,8 +135,26 @@ export function HunkSessionHost({
   startupNoticeResolver?: () => Promise<StartupNotice | null>;
   deps?: HunkSessionHostDeps;
 }) {
+  const renderer = useRenderer();
   const prepareReview = deps.prepareReview ?? prepareEmbeddedHistoryReview;
   const createReviewRuntime = deps.createReviewRuntime ?? createReviewSessionRuntime;
+  const [themeController] = useState(
+    () =>
+      new ThemeController({
+        initialTheme:
+          initialRoute.kind === "history"
+            ? initialRoute.runtime.input.theme
+            : initialRoute.bootstrap.initialTheme,
+        initialThemeMode:
+          initialRoute.kind === "review"
+            ? (initialRoute.bootstrap.initialThemeMode ?? renderer.themeMode)
+            : renderer.themeMode,
+        customThemes:
+          initialRoute.kind === "history"
+            ? initialRoute.runtime.customThemes
+            : initialRoute.bootstrap.customThemes,
+      }),
+  );
   const [route, setRoute] = useState<ActiveSurfaceRoute>(() =>
     initialRoute.kind === "history"
       ? initialRoute
@@ -266,8 +286,8 @@ export function HunkSessionHost({
         extensionsEnabled: historyRoute.runtime.input.extensionsEnabled,
         extensionPaths: historyRoute.runtime.input.extensionPaths,
         extensionSession: historyRoute.runtime.extensionSession.current,
-        themeId: outcome.themeId,
-        themeMode: outcome.themeMode,
+        themeId: themeController.getSnapshot().themeId,
+        themeMode: themeController.themeMode,
       };
       plan = await prepareReview(request, { signal });
       const historyReview = historyReviewDescriptor(historyRoute.runtime, outcome, action);
@@ -376,6 +396,7 @@ export function HunkSessionHost({
         }
         reviewProducer={route.runtime.reviewProducer}
         startupNoticeResolver={startupNoticeResolver}
+        themeController={themeController}
       />
     );
   }
@@ -387,6 +408,7 @@ export function HunkSessionHost({
       useColor={interactiveLogUsesColor(route.runtime.input.color, process.env)}
       onOutcome={(outcome) => handleHistoryOutcome(route, outcome)}
       quitScheduler={deps.viewPreferenceQuitScheduler}
+      themeController={themeController}
     />
   );
 }

--- a/packages/hunk/src/ui/theme/controller.test.ts
+++ b/packages/hunk/src/ui/theme/controller.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { ThemeController } from "./controller";
+
+describe("ThemeController", () => {
+  test("resolves launch state once and publishes committed identities", () => {
+    const controller = new ThemeController({
+      initialTheme: "auto",
+      initialThemeMode: "light",
+    });
+    let publications = 0;
+    const unsubscribe = controller.subscribe(() => {
+      publications += 1;
+    });
+
+    expect(controller.initialThemeId).toBe("github-light-default");
+    expect(controller.getSnapshot().themeId).toBe("github-light-default");
+    expect(controller.themeMode).toBe("light");
+
+    controller.commitTheme("dracula");
+    controller.commitTheme("dracula");
+    expect(controller.getSnapshot().themeId).toBe("dracula");
+    expect(publications).toBe(1);
+
+    unsubscribe();
+    controller.commitTheme("github-dark-default");
+    expect(publications).toBe(1);
+  });
+});

--- a/packages/hunk/src/ui/theme/controller.ts
+++ b/packages/hunk/src/ui/theme/controller.ts
@@ -1,0 +1,45 @@
+import type { TerminalThemeMode } from "../../core/theme/detection";
+import type { NamedCustomThemeConfig } from "../../extension-api/types";
+import { resolveTheme } from "../themes";
+
+export interface ThemeSnapshot {
+  themeId: string;
+}
+
+/** Retain the committed theme across every surface mounted in one Hunk session. */
+export class ThemeController {
+  readonly initialThemeId: string;
+  readonly themeMode: TerminalThemeMode | undefined;
+  private listeners = new Set<() => void>();
+  private snapshot: ThemeSnapshot;
+
+  constructor({
+    initialTheme,
+    initialThemeMode,
+    customThemes,
+  }: {
+    initialTheme?: string;
+    initialThemeMode?: TerminalThemeMode | null;
+    customThemes?: readonly NamedCustomThemeConfig[];
+  }) {
+    this.initialThemeId = resolveTheme(initialTheme, initialThemeMode ?? null, customThemes).id;
+    this.themeMode = initialThemeMode ?? undefined;
+    this.snapshot = { themeId: this.initialThemeId };
+  }
+
+  /** Return the immutable committed-theme snapshot. */
+  getSnapshot = () => this.snapshot;
+
+  /** Subscribe one mounted surface to committed theme changes. */
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  /** Commit one validated theme identity for all current and future surfaces. */
+  commitTheme(themeId: string) {
+    if (themeId === this.snapshot.themeId) return;
+    this.snapshot = { themeId };
+    for (const listener of this.listeners) listener();
+  }
+}


### PR DESCRIPTION
## Problem

Changing the theme inside a commit review launched from history was lost when returning to the history surface. History and review each owned separate committed theme state, so only history-to-review navigation carried the active choice.

## Approach

- add a session-scoped `ThemeController` owned by `HunkSessionHost`
- subscribe history and review selectors to the same committed theme identity while keeping modal previews surface-local
- remove the duplicate theme state from `LogController`
- retain the session launch theme as the save-preferences baseline across route remounts
- cover history-to-review-to-history navigation and repeated review launches

This belongs in core UI routing because theme selection is shared application chrome state for every routed surface, not extension-specific behavior.

## Validation

- `bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run deps:check`
- `TMPDIR=/var/tmp bun run test` (4,084 passed, 12 skipped)
- `bun run test:integration` (157 passed, 1 skipped)
- `bun run test:tty-smoke` (9 passed)
- `bun run install:bin`
- real TTY render of `hunk diff --no-extensions` against the working-tree diff
- manually changed themes across history and repeated review navigation on Linux

## Visual Evidence

No visual styling changes. The existing selector and themes render unchanged; this PR changes their state lifetime across route transitions.