### PR TITLE
perf(ui): restore fast wrapped line rendering

### DIFF
--- a/.changeset/fast-wrapped-cjk-lines.md
+++ b/.changeset/fast-wrapped-cjk-lines.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Restore fast first-frame rendering for long wrapped split-view lines while preserving multiline copy selections and note range guides.

--- a/packages/hunk/src/ui/diff/CodeRowView.test.tsx
+++ b/packages/hunk/src/ui/diff/CodeRowView.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
-import { act } from "react";
+import { Children, act, isValidElement, type ReactNode } from "react";
 import { capturedTestColorToHex } from "../../../../../test/helpers/test-color-helpers";
 import { resolveTheme } from "../themes";
 import { CodeRowView } from "./CodeRowView";
@@ -93,6 +93,54 @@ test("CodeRowView limits character selections to source text instead of cell chr
       setup.renderer.destroy();
     });
   }
+});
+
+test("CodeRowView mounts ordinary wrapped split lines as direct text nodes", () => {
+  const theme = resolveTheme("github-dark-default", null);
+  const plannedRow: PlannedCodeReviewRow = {
+    kind: "diff-row",
+    key: "diff-row:wrapped-fast-path",
+    stableKey: "line:0:new:1",
+    fileId: "paint",
+    hunkIndex: 0,
+    row: {
+      type: "split-line",
+      key: "wrapped-fast-path",
+      fileId: "paint",
+      hunkIndex: 0,
+      left: {
+        kind: "deletion",
+        sign: "-",
+        lineNumber: 1,
+        spans: [{ text: "abcdefghijklmnopqrstuvwxyz0123456789" }],
+      },
+      right: {
+        kind: "addition",
+        sign: "+",
+        lineNumber: 1,
+        spans: [{ text: "abcdefghijklmnopqrstuvwxyz0123456789" }],
+      },
+    },
+  };
+
+  const rendered = CodeRowView({
+    plannedRow,
+    width: 20,
+    lineNumberDigits: 1,
+    showLineNumbers: false,
+    wrapLines: true,
+    codeHorizontalOffset: 0,
+    theme,
+    selected: false,
+    onStartUserNoteAtHunk: () => {},
+  });
+  if (!isValidElement<{ children?: ReactNode }>(rendered)) {
+    throw new Error("Expected CodeRowView to return a wrapped row element");
+  }
+  const visualLines = Children.toArray(rendered.props.children);
+
+  expect(visualLines.length).toBeGreaterThan(1);
+  expect(visualLines.every((line) => isValidElement(line) && line.type === "text")).toBe(true);
 });
 
 test("CodeRowView paints wrapped selection boundaries per visual line", async () => {

--- a/packages/hunk/src/ui/diff/CodeRowView.tsx
+++ b/packages/hunk/src/ui/diff/CodeRowView.tsx
@@ -147,46 +147,51 @@ export function CodeRowView({
   const splitContextRow =
     row.type === "split-line" && row.left.kind === "context" && row.right.kind === "context";
   const onCursorRow = cursorHighlight !== undefined;
-  const selectionHighlight = (visualLineIndex: number): CodeCellHighlight => ({
-    bg: (baseBg) => selectionHighlightBg(baseBg, theme),
-    colRange: copySelectedRangeAtVisualLine(copySelectedRowRange, visualLineIndex),
-  });
   const cursorRowHighlight: CodeCellHighlight | undefined = onCursorRow
     ? {
         bg: (baseBg) => cursorLineHighlightBg(baseBg, theme),
         colRange: cursorHighlight.style === "row" ? FULL_CODE_CELL_COL_RANGE : undefined,
       }
     : undefined;
-  /** Resolve copy-selection boundaries separately for each wrapped visual line. */
-  const highlightsAtVisualLine = (visualLineIndex: number) => {
-    const selectedRange = copySelectedRangeAtVisualLine(copySelectedRowRange, visualLineIndex);
-    const lineHasSelection = selectedRange !== undefined;
-    const lineSelectionHighlight = selectionHighlight(visualLineIndex);
-    return {
-      left: pickRowHighlight(
-        lineSelectionHighlight,
-        cursorRowHighlight,
-        lineHasSelection && copySelectedSide !== "right",
-        onCursorRow && (splitContextRow || cursorHighlight.side === "old"),
-      ),
-      right: pickRowHighlight(
-        lineSelectionHighlight,
-        cursorRowHighlight,
-        lineHasSelection && copySelectedSide !== "left",
-        onCursorRow && (splitContextRow || cursorHighlight.side === "new"),
-      ),
-      unified: pickRowHighlight(
-        lineSelectionHighlight,
-        cursorRowHighlight,
-        lineHasSelection,
-        onCursorRow,
-      ),
-    };
-  };
-  const firstLineHighlights = highlightsAtVisualLine(0);
-  const leftHighlight = firstLineHighlights.left;
-  const rightHighlight = firstLineHighlights.right;
-  const cellHighlight = firstLineHighlights.unified;
+  /** Resolve copy-selection boundaries separately for each wrapped visual line when needed. */
+  const highlightsAtVisualLine =
+    copySelectedRowRange || cursorRowHighlight
+      ? (visualLineIndex: number) => {
+          const selectedRange = copySelectedRangeAtVisualLine(
+            copySelectedRowRange,
+            visualLineIndex,
+          );
+          const lineHasSelection = selectedRange !== undefined;
+          const lineSelectionHighlight: CodeCellHighlight = {
+            bg: (baseBg) => selectionHighlightBg(baseBg, theme),
+            colRange: selectedRange,
+          };
+          return {
+            left: pickRowHighlight(
+              lineSelectionHighlight,
+              cursorRowHighlight,
+              lineHasSelection && copySelectedSide !== "right",
+              onCursorRow && (splitContextRow || cursorHighlight.side === "old"),
+            ),
+            right: pickRowHighlight(
+              lineSelectionHighlight,
+              cursorRowHighlight,
+              lineHasSelection && copySelectedSide !== "left",
+              onCursorRow && (splitContextRow || cursorHighlight.side === "new"),
+            ),
+            unified: pickRowHighlight(
+              lineSelectionHighlight,
+              cursorRowHighlight,
+              lineHasSelection,
+              onCursorRow,
+            ),
+          };
+        }
+      : undefined;
+  const firstLineHighlights = highlightsAtVisualLine?.(0);
+  const leftHighlight = firstLineHighlights?.left;
+  const rightHighlight = firstLineHighlights?.right;
+  const cellHighlight = firstLineHighlights?.unified;
 
   if (row.type === "split-line") {
     // The planner and row type are derived from the same complete planned row.
@@ -269,8 +274,18 @@ export function CodeRowView({
           const styledRow = wrapped.paintLine(
             index,
             showBadgeOnLine ? 0 : addBadgeWidth,
-            highlightsAtVisualLine(index),
+            highlightsAtVisualLine?.(index),
           );
+
+          if (!showBadgeOnLine && !hasRangeGuide) {
+            return (
+              <text
+                key={`${row.key}:wrap:${index}`}
+                content={styledRow}
+                onMouseMove={() => onHoverRow?.(row.key)}
+              />
+            );
+          }
 
           return (
             <box
@@ -377,7 +392,17 @@ export function CodeRowView({
     <box id={anchorId} style={{ width: "100%", flexDirection: "column", overflow: "visible" }}>
       {Array.from({ length: wrapped.lineCount }, (_, index) => {
         const showBadgeOnLine = showAddNoteBadge && index === 0;
-        const styledRow = wrapped.paintLine(index, 0, highlightsAtVisualLine(index));
+        const styledRow = wrapped.paintLine(index, 0, highlightsAtVisualLine?.(index));
+
+        if (!showBadgeOnLine && addBadgeWidth === 0 && !hasRangeGuide) {
+          return (
+            <text
+              key={`${row.key}:wrap:${index}`}
+              content={styledRow}
+              onMouseMove={() => onHoverRow?.(row.key)}
+            />
+          );
+        }
 
         return (
           <box


### PR DESCRIPTION
## Summary

- restore direct terminal text nodes for ordinary wrapped diff lines
- skip visual-line selection calculations when neither copy selection nor cursor paint is active
- retain positioned containers for note badges, spacers, and range guides
- add regression coverage for the wrapped split-line fast path

## Motivation

Release benchmarking against v0.21.1 found a material regression for a pathological 8,736-character wrapped CJK line. Multiline copy-selection support had added a positioned box around every visual continuation line and performed selection work even when no selection existed.

This keeps the multiline-selection behavior while restoring the cheap rendering path for the common case.

## Benchmark

Linux x64, Bun 1.4.2, 10 order-balanced same-host samples:

| Revision | Median |
| --- | ---: |
| v0.21.1 | 24.81 ms |
| This branch | 27.35 ms |

Delta: **+10.2%, +2.54 ms**, within the release gate threshold of +15% and +5 ms.

Before this change, the equivalent comparison was **+20.6%, +5.55 ms**, which failed the gate.

## Validation

- `bun test packages/hunk/src/ui/diff/CodeRowView.test.tsx`
- `bun run typecheck`
- `bun run test:integration` — 159 passed
- `bun run deps:check`
- `git diff --check`
- independent review found no correctness blockers

The full unit suite completed 2,032 tests but encountered two environment-resolution failures caused by `/tmp/node_modules` pointing at another checkout; focused rendering tests and the complete PTY integration suite passed.

No visual behavior is intended to change, so no screenshot is included.

*This PR description was generated by Pi using GPT-5.6 Sol*
