### PR TITLE
feat(review): make inline notes keyboard selectable

### DIFF
--- a/.changeset/bright-notes-navigate.md
+++ b/.changeset/bright-notes-navigate.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": minor
+---
+
+Add visible keyboard selection for review notes. Line-by-line movement now stops on every comment and reply in rendered order; saving or clicking a note makes it active, with next/previous note navigation and persistent edit, reply, and delete shortcuts on the active note.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -115,7 +115,8 @@ Review and shared commands:
 | `hunk.review.alignCurrentLineTop`              | Align current line to viewport top             | _(none)_                     |
 | `hunk.review.clearSelection`                   | Clear the active visual selection              | _(none)_                     |
 | `hunk.review.copySelection`                    | Copy the active visual selection               | `y`                          |
-| `hunk.review.editActiveNote`                   | Edit the active review note                    | `E`                          |
+| `hunk.review.deleteActiveNote`                 | Delete active review note                      | `D`                          |
+| `hunk.review.editActiveNote`                   | Edit active review note                        | `E`                          |
 | `hunk.review.editSelectedFile`                 | Open the selected file in your editor          | `e`                          |
 | `hunk.review.focusFilter`                      | Focus the file filter                          | `/`                          |
 | `hunk.review.halfPageDown`                     | Scroll down half a page                        | `d`, `ctrl+d`                |
@@ -126,19 +127,21 @@ Review and shared commands:
 | `hunk.review.nextAnnotatedHunk`                | Next annotated hunk                            | `}`                          |
 | `hunk.review.nextFile`                         | Next file                                      | `.`                          |
 | `hunk.review.nextHunk`                         | Next hunk                                      | `]`                          |
+| `hunk.review.nextNote`                         | Next review note                               | `n`                          |
 | `hunk.review.pageDown`                         | Scroll down one page                           | `pagedown`, `space`, `f`     |
 | `hunk.review.pageUp`                           | Scroll up one page                             | `pageup`, `b`, `shift+space` |
 | `hunk.review.previousAnnotatedFile`            | Previous annotated file                        | _(none)_                     |
 | `hunk.review.previousAnnotatedHunk`            | Previous annotated hunk                        | `{`                          |
 | `hunk.review.previousFile`                     | Previous file                                  | `,`                          |
 | `hunk.review.previousHunk`                     | Previous hunk                                  | `[`                          |
-| `hunk.review.replyToActiveNote`                | Reply to the active review note                | `R`                          |
+| `hunk.review.previousNote`                     | Previous review note                           | `N`                          |
+| `hunk.review.replyToActiveNote`                | Reply to active review note                    | `R`                          |
 | `hunk.review.scrollCodeLeft`                   | Scroll code left (shifted scrolls fast)        | `left`, `shift+left`         |
 | `hunk.review.scrollCodeRight`                  | Scroll code right (shifted scrolls fast)       | `right`, `shift+right`       |
 | `hunk.review.startNote`                        | Add a review note                              | `c`                          |
 | `hunk.review.startVisualSelection`             | Start visual line selection                    | `v`                          |
-| `hunk.review.stepDown`                         | Scroll down one row                            | `down`, `j`                  |
-| `hunk.review.stepUp`                           | Scroll up one row                              | `up`, `k`                    |
+| `hunk.review.stepDown`                         | Move down one line or note                     | `down`, `j`                  |
+| `hunk.review.stepUp`                           | Move up one line or note                       | `up`, `k`                    |
 | `hunk.review.toggleHunkGap`                    | Expand or collapse the selected context        | `z`                          |
 | `hunk.view.applyFilePresentationToAllMatching` | Apply current file presentation to all matches | _(none)_                     |
 | `hunk.view.cursorLineNumber`                   | Mark the current line number                   | _(none)_                     |

--- a/packages/hunk/src/core/review/actions.ts
+++ b/packages/hunk/src/core/review/actions.ts
@@ -23,6 +23,8 @@ export type ReviewAction =
       hunkIndex: number;
       /** Omitted by state reconciliation, which must not disturb the reviewer's viewport. */
       reveal?: ReviewRevealRequest;
+      /** Set only by exact-note navigation; every other selection clears explicit note focus. */
+      activeNoteId?: string;
     }
   | { type: "filter/set"; filter: string }
   | { type: "notes/set-visibility"; visible: boolean }

--- a/packages/hunk/src/core/review/intents.test.ts
+++ b/packages/hunk/src/core/review/intents.test.ts
@@ -122,6 +122,76 @@ describe("selection movement intent", () => {
     });
   });
 
+  test("moves between exact visible stored notes and carries the active identity atomically", () => {
+    const state = {
+      ...createTestReviewState(undefined, { showAgentNotes: true }),
+      liveNotes: [
+        createTestStoredNote({ id: "later", fileKey: "alpha", hunkIndex: 0, line: 8 }),
+        createTestStoredNote({ id: "next-file", fileKey: "beta", hunkIndex: 1, line: 21 }),
+        createTestStoredNote({ id: "earlier", fileKey: "alpha", hunkIndex: 0, line: 2 }),
+      ],
+    };
+
+    expect(planReviewIntent(state, { type: "selection/move", scope: "note", delta: 1 })).toEqual({
+      actions: [
+        {
+          type: "selection/select",
+          fileKey: "alpha",
+          hunkIndex: 0,
+          activeNoteId: "earlier",
+          reveal: { anchor: "hunk", scrollToNote: true },
+        },
+      ],
+      outcome: { type: "selection/changed", fileKey: "alpha", hunkIndex: 0 },
+    });
+
+    const activeLater = { ...state, activeNoteId: "later" };
+    expect(
+      planReviewIntent(activeLater, { type: "selection/move", scope: "note", delta: 1 }).actions[0],
+    ).toMatchObject({ fileKey: "beta", hunkIndex: 1, activeNoteId: "next-file" });
+    expect(
+      planReviewIntent(
+        { ...activeLater, filter: "alpha" },
+        { type: "selection/move", scope: "note", delta: 1 },
+      ),
+    ).toEqual({ actions: [] });
+  });
+
+  test("selects one exact visible note and rejects a mismatched location", () => {
+    const state = {
+      ...createTestReviewState(undefined, { showAgentNotes: true }),
+      liveNotes: [createTestStoredNote({ id: "target", fileKey: "alpha", hunkIndex: 0 })],
+    };
+    const reveal = { anchor: "none" as const, scrollToNote: false };
+
+    expect(
+      planReviewIntent(state, {
+        type: "selection/select",
+        fileKey: "alpha",
+        hunkIndex: 0,
+        activeNoteId: "target",
+        reveal,
+      }).actions,
+    ).toEqual([
+      {
+        type: "selection/select",
+        fileKey: "alpha",
+        hunkIndex: 0,
+        activeNoteId: "target",
+        reveal,
+      },
+    ]);
+    expect(() =>
+      planReviewIntent(state, {
+        type: "selection/select",
+        fileKey: "beta",
+        hunkIndex: 0,
+        activeNoteId: "target",
+        reveal,
+      }),
+    ).toThrow(ReviewIntentPlanningError);
+  });
+
   test("requires the annotation index for annotated navigation", () => {
     const state = createTestReviewState();
 
@@ -214,6 +284,22 @@ describe("viewport anchor intent", () => {
     const next = plan.actions.reduce(reduceReviewState, state);
     expect(next.selection).toEqual({ fileKey: "beta", hunkIndex: 1 });
     expect(next.reveal).toEqual({ fileTopToken: 0, hunkToken: 0, scrollToNote: false });
+  });
+
+  test("preserves exact note focus when the viewport reports the same hunk", () => {
+    const state = {
+      ...createTestReviewState(),
+      activeNoteId: "note-2",
+      selection: { fileKey: "alpha", hunkIndex: 1 },
+    };
+
+    expect(
+      planReviewIntent(state, {
+        type: "selection/anchor",
+        fileKey: "alpha",
+        hunkIndex: 1,
+      }).actions[0],
+    ).toMatchObject({ activeNoteId: "note-2" });
   });
 });
 

--- a/packages/hunk/src/core/review/intents.ts
+++ b/packages/hunk/src/core/review/intents.ts
@@ -31,6 +31,8 @@ import {
   isReviewNoteWithinClearScope,
   reviewNoteCurrentOwnerHunkIndex,
   reviewNoteHasDescendants,
+  selectActiveStoredReviewNote,
+  selectNavigableStoredReviewNotes,
   selectNormalizedSelection,
   selectReviewFileByKey,
   selectReviewNavigationFiles,
@@ -86,7 +88,14 @@ export interface ReviewIntentFacts {
 
 export type ReviewIntent =
   /** Select one hunk outright, revealing it the way the caller asks. */
-  | { type: "selection/select"; fileKey: string; hunkIndex: number; reveal: ReviewRevealRequest }
+  | {
+      type: "selection/select";
+      fileKey: string;
+      hunkIndex: number;
+      reveal: ReviewRevealRequest;
+      /** Exact visible stored note to focus instead of the selected hunk's source line. */
+      activeNoteId?: string;
+    }
   /** Step the selection through one navigable scope; the scope decides wrap and reveal. */
   | { type: "selection/move"; scope: ReviewSelectionScope; delta: number }
   /** Jump to one file, landing on its first hunk. */
@@ -344,9 +353,18 @@ function planSelection(
   fileKey: string,
   hunkIndex: number,
   reveal: ReviewRevealRequest,
+  activeNoteId?: string,
 ): ReviewIntentPlan {
   return {
-    actions: [{ type: "selection/select", fileKey, hunkIndex, reveal }],
+    actions: [
+      {
+        type: "selection/select",
+        fileKey,
+        hunkIndex,
+        reveal,
+        ...(activeNoteId ? { activeNoteId } : {}),
+      },
+    ],
     outcome: { type: "selection/changed", fileKey, hunkIndex },
   };
 }
@@ -375,13 +393,21 @@ function planSelectionMove(
     {
       files: selectReviewNavigationFiles(state),
       annotations: facts.annotations ?? EMPTY_REVIEW_ANNOTATION_INDEX,
+      notes: selectNavigableStoredReviewNotes(state).map((item) => ({
+        fileKey: item.fileKey,
+        hunkIndex: item.hunkIndex,
+        noteId: item.entry.note.id,
+      })),
+      activeNoteId: selectActiveStoredReviewNote(state)?.note.id,
     },
     selectNormalizedSelection(state),
     { scope: intent.scope, delta: intent.delta },
   );
   // A refused move publishes nothing at all: no selection change, and no reveal token
   // bump that would scroll a viewport for a key press that went nowhere.
-  return target ? planSelection(target.fileKey, target.hunkIndex, target.reveal) : { actions: [] };
+  return target
+    ? planSelection(target.fileKey, target.hunkIndex, target.reveal, target.activeNoteId)
+    : { actions: [] };
 }
 
 /**
@@ -814,6 +840,17 @@ export function planReviewIntent(
       // Only the file is required: an out-of-range hunk clamps rather than rejecting, so
       // a stale index from a reloaded file still lands the reviewer somewhere real.
       const file = requireReviewFile(state, intent.fileKey);
+      if (intent.activeNoteId) {
+        const target = selectNavigableStoredReviewNotes(state).find(
+          (item) => item.entry.note.id === intent.activeNoteId,
+        );
+        if (!target || target.fileKey !== file.key || target.hunkIndex !== intent.hunkIndex) {
+          throw new ReviewIntentPlanningError(
+            "note-not-found",
+            `No visible review note matches id ${intent.activeNoteId} at the requested selection.`,
+          );
+        }
+      }
       return {
         actions: [
           {
@@ -821,6 +858,7 @@ export function planReviewIntent(
             fileKey: file.key,
             hunkIndex: intent.hunkIndex,
             reveal: intent.reveal,
+            ...(intent.activeNoteId ? { activeNoteId: intent.activeNoteId } : {}),
           },
         ],
       };
@@ -839,6 +877,13 @@ export function planReviewIntent(
     }
     case "selection/anchor": {
       const file = requireReviewFile(state, intent.fileKey);
+      const anchoredHunkIndex = Math.min(
+        Math.max(intent.hunkIndex, 0),
+        Math.max(0, file.hunks.length - 1),
+      );
+      const current = selectNormalizedSelection(state);
+      const preservesActiveNote =
+        current.fileKey === file.key && current.hunkIndex === anchoredHunkIndex;
       return {
         actions: [
           {
@@ -846,6 +891,9 @@ export function planReviewIntent(
             fileKey: file.key,
             hunkIndex: intent.hunkIndex,
             reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL,
+            ...(preservesActiveNote && state.activeNoteId
+              ? { activeNoteId: state.activeNoteId }
+              : {}),
           },
         ],
       };

--- a/packages/hunk/src/core/review/navigation.test.ts
+++ b/packages/hunk/src/core/review/navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   EMPTY_REVIEW_ANNOTATION_INDEX,
+  planReviewNoteMove,
   planReviewSelectionMove,
   REVIEW_SELECTION_WRAP_POLICY,
   reviewAnnotatedCursors,
@@ -59,6 +60,7 @@ describe("review selection movement", () => {
     expect(REVIEW_SELECTION_WRAP_POLICY).toEqual({
       hunk: "clamp",
       file: "clamp",
+      note: "clamp",
       "annotated-hunk": "clamp",
       "annotated-file": "wrap",
     });
@@ -100,6 +102,34 @@ describe("review selection movement", () => {
     expect(move(model(), at("alpha", 0), "hunk", 1).reveal).toEqual({
       anchor: "hunk",
       scrollToNote: false,
+    });
+  });
+
+  test("moves exact notes in order and refuses to reselect at an edge", () => {
+    const notes = [
+      { noteId: "one", fileKey: "alpha", hunkIndex: 0 },
+      { noteId: "two", fileKey: "alpha", hunkIndex: 0 },
+      { noteId: "three", fileKey: "beta", hunkIndex: 1 },
+    ];
+
+    expect(planReviewNoteMove(FILES, notes, at("alpha", 0), "one", 1)).toEqual({
+      fileKey: "alpha",
+      hunkIndex: 0,
+      activeNoteId: "two",
+      reveal: { anchor: "hunk", scrollToNote: true },
+    });
+    expect(planReviewNoteMove(FILES, notes, at("alpha", 0), "two", 1)?.activeNoteId).toBe("three");
+    expect(planReviewNoteMove(FILES, notes, at("beta", 1), "three", 1)).toBeNull();
+    expect(planReviewNoteMove(FILES, notes, at("alpha", 0), "one", -1)).toBeNull();
+    expect(planReviewNoteMove(FILES, notes, at("beta", 0), undefined, 1)?.activeNoteId).toBe(
+      "three",
+    );
+    expect(planReviewNoteMove(FILES, notes, at("beta", 0), undefined, -1)?.activeNoteId).toBe(
+      "two",
+    );
+    expect(move({ ...model(), notes, activeNoteId: "two" }, at("alpha", 0), "note", 1)).toEqual({
+      at: "beta:1",
+      reveal: { anchor: "hunk", scrollToNote: true },
     });
   });
 

--- a/packages/hunk/src/core/review/navigation.ts
+++ b/packages/hunk/src/core/review/navigation.ts
@@ -25,7 +25,7 @@
  */
 import type { ReviewRevealRequest, ReviewSemanticSelection } from "./state";
 
-export type ReviewSelectionScope = "hunk" | "file" | "annotated-hunk" | "annotated-file";
+export type ReviewSelectionScope = "hunk" | "file" | "note" | "annotated-hunk" | "annotated-file";
 
 /** What a move does when it runs off the end of the stream it walks. */
 export type ReviewSelectionWrapPolicy = "clamp" | "wrap";
@@ -42,6 +42,7 @@ export const REVIEW_SELECTION_WRAP_POLICY: Readonly<
 > = Object.freeze({
   hunk: "clamp",
   file: "clamp",
+  note: "clamp",
   "annotated-hunk": "clamp",
   "annotated-file": "wrap",
 });
@@ -89,12 +90,23 @@ export interface ReviewSelectionMoveTarget {
   fileKey: string;
   hunkIndex: number;
   reveal: ReviewRevealRequest;
+  /** Stable stored-note identity set only by exact-note navigation. */
+  activeNoteId?: string;
+}
+
+/** One stored-note stop in the flattened review stream. */
+export interface ReviewNoteCursor extends ReviewHunkCursor {
+  noteId: string;
 }
 
 export interface ReviewNavigationModel {
   /** Navigable files in review order — the visible stream, not the whole document. */
   files: readonly ReviewNavigationFile[];
   annotations: ReviewAnnotationIndex;
+  /** Visible stored notes in exact rendered order; sidecar-only annotations stay excluded. */
+  notes?: readonly ReviewNoteCursor[];
+  /** Effective stored-note identity from which an exact-note move begins. */
+  activeNoteId?: string;
 }
 
 /**
@@ -287,6 +299,76 @@ function planFileMove(
   };
 }
 
+/** Plan a clamped move through exact stored notes in their rendered order. */
+export function planReviewNoteMove(
+  files: readonly ReviewNavigationFile[],
+  cursors: readonly ReviewNoteCursor[],
+  selection: ReviewSemanticSelection,
+  activeNoteId: string | undefined,
+  delta: number,
+): ReviewSelectionMoveTarget | null {
+  if (cursors.length === 0 || delta === 0) {
+    return null;
+  }
+
+  const activeIndex = activeNoteId
+    ? cursors.findIndex((cursor) => cursor.noteId === activeNoteId)
+    : -1;
+  let nextIndex: number;
+  if (activeIndex >= 0) {
+    nextIndex = clamp(activeIndex + delta, 0, cursors.length - 1);
+    if (nextIndex === activeIndex) {
+      return null;
+    }
+  } else {
+    const fileOrder = new Map(files.map((file, index) => [file.fileKey, index] as const));
+    const selectedFileOrder =
+      selection.fileKey === null
+        ? delta > 0
+          ? -1
+          : fileOrder.size
+        : fileOrder.get(selection.fileKey);
+    if (selectedFileOrder === undefined) {
+      nextIndex = delta > 0 ? 0 : cursors.length - 1;
+    } else if (delta > 0) {
+      const firstAfter = cursors.findIndex((cursor) => {
+        const order = fileOrder.get(cursor.fileKey) ?? -1;
+        return (
+          order > selectedFileOrder ||
+          (order === selectedFileOrder && cursor.hunkIndex >= selection.hunkIndex)
+        );
+      });
+      if (firstAfter < 0) return null;
+      nextIndex = Math.min(firstAfter + delta - 1, cursors.length - 1);
+    } else {
+      let firstBefore = -1;
+      for (let index = cursors.length - 1; index >= 0; index -= 1) {
+        const cursor = cursors[index]!;
+        const order = fileOrder.get(cursor.fileKey) ?? -1;
+        if (
+          order < selectedFileOrder ||
+          (order === selectedFileOrder && cursor.hunkIndex <= selection.hunkIndex)
+        ) {
+          firstBefore = index;
+          break;
+        }
+      }
+      if (firstBefore < 0) return null;
+      nextIndex = Math.max(0, firstBefore + delta + 1);
+    }
+  }
+
+  const target = cursors[nextIndex];
+  return target
+    ? {
+        fileKey: target.fileKey,
+        hunkIndex: target.hunkIndex,
+        activeNoteId: target.noteId,
+        reveal: { anchor: "hunk", scrollToNote: true },
+      }
+    : null;
+}
+
 /** Plan a move through only the hunks carrying notes. */
 function planAnnotatedHunkMove(
   model: ReviewNavigationModel,
@@ -350,6 +432,14 @@ export function planReviewSelectionMove(
       return planHunkMove(model, selection, move.delta);
     case "file":
       return planFileMove(model, selection, move.delta);
+    case "note":
+      return planReviewNoteMove(
+        model.files,
+        model.notes ?? [],
+        selection,
+        model.activeNoteId,
+        move.delta,
+      );
     case "annotated-hunk":
       return planAnnotatedHunkMove(model, selection, move.delta);
     case "annotated-file":

--- a/packages/hunk/src/core/review/reducer.test.ts
+++ b/packages/hunk/src/core/review/reducer.test.ts
@@ -128,6 +128,25 @@ describe("selection", () => {
     expect(next.reveal).toEqual(state.reveal);
   });
 
+  test("commits exact note focus with selection and clears it on ordinary selection", () => {
+    const noteSelected = reduceReviewState(createTestReviewState(), {
+      type: "selection/select",
+      fileKey: "beta",
+      hunkIndex: 1,
+      activeNoteId: "note-2",
+      reveal: { anchor: "hunk", scrollToNote: true },
+    });
+    expect(noteSelected.activeNoteId).toBe("note-2");
+    expect(noteSelected.selection).toEqual({ fileKey: "beta", hunkIndex: 1 });
+
+    const ordinarySelection = reduceReviewState(noteSelected, {
+      type: "selection/select",
+      fileKey: "beta",
+      hunkIndex: 0,
+    });
+    expect(ordinarySelection.activeNoteId).toBeNull();
+  });
+
   test("retires a note-scroll request even when the selection is unchanged", () => {
     const noteSelected = reduceReviewState(createTestReviewState(), {
       type: "selection/select",
@@ -497,6 +516,7 @@ describe("drafts", () => {
 
     expect(saved.draftNote).toBeNull();
     expect(saved.userNotes.map((entry) => entry.note.id)).toEqual(["user-1"]);
+    expect(saved.activeNoteId).toBe("user-1");
   });
 
   test("saving an edit replaces the note in place", () => {
@@ -517,6 +537,7 @@ describe("drafts", () => {
       ["user-1", "updated"],
       ["user-2", "note user-2"],
     ]);
+    expect(saved.activeNoteId).toBe("user-1");
   });
 });
 
@@ -584,6 +605,19 @@ describe("filter and note visibility", () => {
 
     expect(next.filter).toBe("alpha");
     expect(next.selection).toEqual(state.selection);
+  });
+
+  test("clears an active agent note when hiding the agent-note layer", () => {
+    const state = {
+      ...createTestReviewState([], { showAgentNotes: true }),
+      activeNoteId: "agent-1",
+      liveNotes: [createTestStoredNote({ id: "agent-1", fileKey: "alpha" })],
+    };
+
+    const next = reduceReviewState(state, { type: "notes/set-visibility", visible: false });
+
+    expect(next.showAgentNotes).toBe(false);
+    expect(next.activeNoteId).toBeNull();
   });
 
   test("ignores a repeated filter or visibility value", () => {

--- a/packages/hunk/src/core/review/reducer.ts
+++ b/packages/hunk/src/core/review/reducer.ts
@@ -158,41 +158,85 @@ export function reduceReviewState(state: ReviewState, action: ReviewAction): Rev
       const hunkIndex = clamp(action.hunkIndex, 0, Math.max(0, file.hunks.length - 1));
       const selectionChanged =
         file.key !== state.selection.fileKey || hunkIndex !== state.selection.hunkIndex;
+      const activeNoteId = action.activeNoteId ?? null;
+      const activeNoteChanged = activeNoteId !== state.activeNoteId;
       const reveal = action.reveal
         ? applyReviewRevealRequest(state.reveal, action.reveal)
         : state.reveal;
-      if (!selectionChanged && reviewRevealIntentsEqual(reveal, state.reveal)) {
+      if (
+        !selectionChanged &&
+        !activeNoteChanged &&
+        reviewRevealIntentsEqual(reveal, state.reveal)
+      ) {
         return state;
       }
-      return { ...state, selection: { fileKey: file.key, hunkIndex }, reveal };
+      return {
+        ...state,
+        selection: { fileKey: file.key, hunkIndex },
+        activeNoteId,
+        reveal,
+      };
     }
     case "filter/set":
       return action.filter === state.filter ? state : { ...state, filter: action.filter };
-    case "notes/set-visibility":
-      return action.visible === state.showAgentNotes
-        ? state
-        : { ...state, showAgentNotes: action.visible };
+    case "notes/set-visibility": {
+      if (action.visible === state.showAgentNotes) {
+        return state;
+      }
+      const activeNote = [...state.liveNotes, ...state.userNotes].find(
+        (entry) => entry.note.id === state.activeNoteId,
+      );
+      return {
+        ...state,
+        showAgentNotes: action.visible,
+        activeNoteId:
+          !action.visible && activeNote?.note.source !== "user" ? null : state.activeNoteId,
+      };
+    }
     case "notes/add-live":
       return action.notes.length === 0
         ? state
         : { ...state, liveNotes: [...state.liveNotes, ...action.notes] };
     case "notes/remove-live": {
       const liveNotes = withoutNote(state.liveNotes, action.noteId);
-      return liveNotes === state.liveNotes ? state : { ...state, liveNotes };
+      return liveNotes === state.liveNotes
+        ? state
+        : {
+            ...state,
+            liveNotes,
+            activeNoteId: state.activeNoteId === action.noteId ? null : state.activeNoteId,
+          };
     }
     case "notes/clear": {
       const keep = (entry: ReviewStoredNote) =>
         !isReviewNoteWithinClearScope(entry, action.fileKey);
       const liveNotes = state.liveNotes.filter(keep);
       const userNotes = action.includeUser ? state.userNotes.filter(keep) : state.userNotes;
-      return liveNotes.length === state.liveNotes.length &&
+      if (
+        liveNotes.length === state.liveNotes.length &&
         userNotes.length === state.userNotes.length
-        ? state
-        : { ...state, liveNotes, userNotes };
+      ) {
+        return state;
+      }
+      const activeStillExists = [...liveNotes, ...userNotes].some(
+        (entry) => entry.note.id === state.activeNoteId,
+      );
+      return {
+        ...state,
+        liveNotes,
+        userNotes,
+        activeNoteId: activeStillExists ? state.activeNoteId : null,
+      };
     }
     case "notes/remove-user": {
       const userNotes = withoutNote(state.userNotes, action.noteId);
-      return userNotes === state.userNotes ? state : { ...state, userNotes };
+      return userNotes === state.userNotes
+        ? state
+        : {
+            ...state,
+            userNotes,
+            activeNoteId: state.activeNoteId === action.noteId ? null : state.activeNoteId,
+          };
     }
     case "draft/start":
       return { ...state, draftNote: action.draft };
@@ -204,7 +248,12 @@ export function reduceReviewState(state: ReviewState, action: ReviewAction): Rev
       return state.draftNote ? { ...state, draftNote: null } : state;
     case "draft/save":
       return state.draftNote
-        ? { ...state, draftNote: null, userNotes: [...state.userNotes, action.note] }
+        ? {
+            ...state,
+            draftNote: null,
+            userNotes: [...state.userNotes, action.note],
+            activeNoteId: action.note.note.id,
+          }
         : state;
     case "draft/save-edit": {
       if (!state.draftNote) {
@@ -216,7 +265,12 @@ export function reduceReviewState(state: ReviewState, action: ReviewAction): Rev
       }
       const userNotes = [...state.userNotes];
       userNotes[index] = action.note;
-      return { ...state, draftNote: null, userNotes };
+      return {
+        ...state,
+        draftNote: null,
+        userNotes,
+        activeNoteId: action.note.note.id,
+      };
     }
     case "expansion/toggle": {
       const index = state.expandedGaps.findIndex(

--- a/packages/hunk/src/core/review/selectors.test.ts
+++ b/packages/hunk/src/core/review/selectors.test.ts
@@ -11,6 +11,8 @@ import {
   reviewFileMatchesFilter,
   selectActiveReplyableReviewNoteId,
   selectActiveRevealNoteId,
+  selectActiveStoredReviewNote,
+  selectNavigableStoredReviewNotes,
   selectExpandedGapIdsByFileKey,
   selectFallbackFileKey,
   selectNormalizedSelection,
@@ -260,7 +262,10 @@ describe("note selectors", () => {
         visibleDepth,
       })),
     ).toEqual([{ id: "user-reply", visibleDepth: 0 }]);
-    expect(selectActiveReplyableReviewNoteId(state)).toBe("user-reply");
+    expect(selectActiveReplyableReviewNoteId(state)).toBeUndefined();
+    expect(selectActiveReplyableReviewNoteId({ ...state, activeNoteId: "user-reply" })).toBe(
+      "user-reply",
+    );
   });
 
   test("group notes by the hunk that owns them, not by range containment", () => {
@@ -287,7 +292,7 @@ describe("note selectors", () => {
   // Intent: the reviewer's own draft is what a "jump to the note" reveal is about.
   test("prefer an active draft in the selected hunk over stored notes", () => {
     const state = {
-      ...createTestReviewState(["alpha"]),
+      ...createTestReviewState(["alpha"], { showAgentNotes: true }),
       selection: { fileKey: "alpha", hunkIndex: 0 },
       liveNotes: [createTestStoredNote({ id: "live-1", fileKey: "alpha", line: 2 })],
       draftNote: {
@@ -307,9 +312,53 @@ describe("note selectors", () => {
     ).toBe("live-1");
   });
 
+  test("uses one explicit active note for reveal and actions", () => {
+    const state = {
+      ...createTestReviewState(["alpha"], { showAgentNotes: true }),
+      activeNoteId: "live-late",
+      selection: { fileKey: "alpha", hunkIndex: 0 },
+      liveNotes: [
+        createTestStoredNote({ id: "live-late", fileKey: "alpha", line: 3 }),
+        createTestStoredNote({ id: "live-early", fileKey: "alpha", line: 1 }),
+      ],
+    };
+
+    expect(selectActiveStoredReviewNote(state)?.note.id).toBe("live-late");
+    expect(selectActiveReplyableReviewNoteId(state)).toBe("live-late");
+    expect(selectActiveRevealNoteId(state)).toBe("live-late");
+  });
+
+  test("orders navigable notes by file, owner hunk, anchor line, then thread order", () => {
+    const state = {
+      ...createTestReviewState(["alpha", "beta"], { showAgentNotes: true }),
+      liveNotes: [
+        createTestStoredNote({ id: "alpha-late", fileKey: "alpha", line: 5 }),
+        createTestStoredNote({ id: "beta", fileKey: "beta", line: 1 }),
+        createTestStoredNote({ id: "alpha-early", fileKey: "alpha", line: 1 }),
+      ],
+    };
+
+    expect(selectNavigableStoredReviewNotes(state).map(({ entry }) => entry.note.id)).toEqual([
+      "alpha-early",
+      "alpha-late",
+      "beta",
+    ]);
+  });
+
+  test("does not navigate retained notes when their file no longer renders hunks", () => {
+    const state = {
+      ...createTestReviewState(["alpha"], { showAgentNotes: true }),
+      liveNotes: [createTestStoredNote({ id: "retained", fileKey: "alpha" })],
+    };
+    state.document.files[0]!.hunks = [];
+
+    expect(selectNavigableStoredReviewNotes(state)).toEqual([]);
+    expect(selectActiveStoredReviewNote(state)).toBeUndefined();
+  });
+
   test("otherwise take the earliest anchored note in the selected hunk", () => {
     const state = {
-      ...createTestReviewState(["alpha"]),
+      ...createTestReviewState(["alpha"], { showAgentNotes: true }),
       selection: { fileKey: "alpha", hunkIndex: 0 },
       liveNotes: [
         createTestStoredNote({ id: "live-late", fileKey: "alpha", line: 3 }),

--- a/packages/hunk/src/core/review/selectors.ts
+++ b/packages/hunk/src/core/review/selectors.ts
@@ -411,6 +411,8 @@ export interface ReviewRevealNoteCandidate {
   line: number;
   /** The reviewer's open draft, which outranks every settled note. */
   draft?: boolean;
+  /** The explicitly selected stored note, which outranks unselected settled notes. */
+  active?: boolean;
 }
 
 /**
@@ -430,6 +432,10 @@ export function resolveReviewRevealNoteId(
   if (draft) {
     return draft.id;
   }
+  const active = candidates.find((candidate) => candidate.active);
+  if (active) {
+    return active.id;
+  }
 
   return candidates
     .map((candidate, arrival) => ({ candidate, arrival }))
@@ -438,61 +444,120 @@ export function resolveReviewRevealNoteId(
     )[0]?.candidate.id;
 }
 
-/** Pick the first stored note in the selection that satisfies one card capability. */
-function selectActiveStoredNoteId(
-  state: Pick<ReviewState, "document" | "liveNotes" | "selection" | "showAgentNotes" | "userNotes">,
-  accepts: (entry: ReviewStoredNote) => boolean,
-): string | undefined {
-  const { fileKey, hunkIndex } = state.selection;
-  const file = selectReviewFileByKey(state, fileKey);
-  if (!file) {
+type ActiveNoteState = Pick<
+  ReviewState,
+  | "activeNoteId"
+  | "document"
+  | "filter"
+  | "liveNotes"
+  | "selection"
+  | "showAgentNotes"
+  | "userNotes"
+>;
+
+/** One keyboard-addressable stored note in top-to-bottom review order. */
+export interface ReviewNavigableStoredNote extends ReviewVisibleThreadedStoredNote {
+  fileKey: string;
+  hunkIndex: number;
+  line: number;
+}
+
+/** Order visible stored notes exactly as keyboard note navigation walks them. */
+export function selectNavigableStoredReviewNotes(
+  state: ActiveNoteState,
+): ReviewNavigableStoredNote[] {
+  const files = selectVisibleReviewFiles(state);
+  const fileOrder = new Map(files.map((file, index) => [file.key, index] as const));
+  const fileByKey = new Map(files.map((file) => [file.key, file] as const));
+
+  return selectVisibleThreadedStoredReviewNotes(state)
+    .map((item, threadedOrder) => {
+      const file = fileByKey.get(item.entry.note.fileKey);
+      return file && file.hunks.length > 0
+        ? {
+            ...item,
+            fileKey: file.key,
+            hunkIndex: reviewNoteCurrentOwnerHunkIndex(item.entry.note, file),
+            line: reviewNoteAnchorLine(item.entry.note).line,
+            threadedOrder,
+          }
+        : null;
+    })
+    .filter((item): item is NonNullable<typeof item> => item !== null)
+    .sort(
+      (left, right) =>
+        (fileOrder.get(left.fileKey) ?? 0) - (fileOrder.get(right.fileKey) ?? 0) ||
+        left.hunkIndex - right.hunkIndex ||
+        left.line - right.line ||
+        left.threadedOrder - right.threadedOrder,
+    )
+    .map(({ threadedOrder: _threadedOrder, ...item }) => item);
+}
+
+/** Resolve the explicitly selected stored note keyboard actions target. */
+export function selectActiveStoredReviewNote(state: ActiveNoteState): ReviewStoredNote | undefined {
+  if (!state.activeNoteId) {
     return undefined;
   }
-  return selectVisibleThreadedStoredReviewNotes(state)
-    .map(({ entry }) => entry)
-    .filter(
-      (entry) =>
-        isRenderableStoredReviewNote(entry) &&
-        entry.note.fileKey === fileKey &&
-        reviewNoteCurrentOwnerHunkIndex(entry.note, file) === hunkIndex &&
-        accepts(entry),
-    )
-    .sort(
-      (left, right) => reviewNoteAnchorLine(left.note).line - reviewNoteAnchorLine(right.note).line,
-    )[0]?.note.id;
+  const { fileKey, hunkIndex } = selectNormalizedSelection(state);
+  if (fileKey === null) {
+    return undefined;
+  }
+  return selectNavigableStoredReviewNotes(state).find(
+    (item) =>
+      item.entry.note.id === state.activeNoteId &&
+      item.fileKey === fileKey &&
+      item.hunkIndex === hunkIndex,
+  )?.entry;
 }
 
 /** Editable reviewer note the keyboard acts on in the selected hunk. */
-export function selectActiveEditableReviewNoteId(
-  state: Pick<ReviewState, "document" | "liveNotes" | "selection" | "showAgentNotes" | "userNotes">,
-) {
-  return selectActiveStoredNoteId(state, ({ note }) => note.source === "user" && note.editable);
+export function selectActiveEditableReviewNoteId(state: ActiveNoteState) {
+  const entry = selectActiveStoredReviewNote(state);
+  return entry?.note.source === "user" && entry.note.editable ? entry.note.id : undefined;
 }
 
 /** Replyable semantic note the keyboard acts on in the selected hunk. */
-export function selectActiveReplyableReviewNoteId(
-  state: Pick<ReviewState, "document" | "liveNotes" | "selection" | "showAgentNotes" | "userNotes">,
-) {
-  return selectActiveStoredNoteId(state, () => true);
+export function selectActiveReplyableReviewNoteId(state: ActiveNoteState) {
+  return selectActiveStoredReviewNote(state)?.note.id;
+}
+
+/** Removable leaf note the keyboard acts on, including its owning collection. */
+export function selectActiveRemovableReviewNote(
+  state: ActiveNoteState,
+): { noteId: string; source: "live" | "user" } | undefined {
+  const entry = selectActiveStoredReviewNote(state);
+  if (!entry || reviewNoteHasDescendants(state, entry.note.id)) {
+    return undefined;
+  }
+  return {
+    noteId: entry.note.id,
+    source: entry.note.source === "user" ? "user" : "live",
+  };
 }
 
 /** Which note a "jump to the note" reveal targets among the notes the store holds. */
 export function selectActiveRevealNoteId(
-  state: Pick<ReviewState, "draftNote" | "liveNotes" | "selection" | "userNotes">,
+  state: ActiveNoteState & Pick<ReviewState, "draftNote">,
 ): string | undefined {
-  const { fileKey, hunkIndex } = state.selection;
+  const { fileKey, hunkIndex } = selectNormalizedSelection(state);
   if (fileKey === null) {
     return undefined;
   }
 
   const draft = state.draftNote;
+  const activeNoteId = selectActiveStoredReviewNote(state)?.note.id;
   return resolveReviewRevealNoteId([
     ...(draft && draft.fileKey === fileKey && draft.hunkIndex === hunkIndex
       ? [{ id: draft.id, line: draft.line, draft: true }]
       : []),
-    ...renderableNotes(state)
-      .filter((note) => note.fileKey === fileKey && reviewNoteOwnerHunkIndex(note) === hunkIndex)
-      .map((note) => ({ id: note.id, line: reviewNoteAnchorLine(note).line })),
+    ...selectNavigableStoredReviewNotes(state)
+      .filter((item) => item.fileKey === fileKey && item.hunkIndex === hunkIndex)
+      .map(({ entry, line }) => ({
+        id: entry.note.id,
+        line,
+        active: entry.note.id === activeNoteId,
+      })),
   ]);
 }
 

--- a/packages/hunk/src/core/review/state.ts
+++ b/packages/hunk/src/core/review/state.ts
@@ -194,6 +194,8 @@ export interface ReviewState {
   reveal: ReviewRevealIntent;
   filter: string;
   showAgentNotes: boolean;
+  /** Stable identity of the stored note the reviewer explicitly selected. */
+  activeNoteId: string | null;
   /** Notes contributed by agents during the review, in arrival order. */
   liveNotes: ReviewStoredNote[];
   /** Notes written by the reviewer, in creation order. */
@@ -222,6 +224,7 @@ export function createInitialReviewState(
     },
     filter: "",
     showAgentNotes: options.showAgentNotes ?? false,
+    activeNoteId: null,
     liveNotes: [],
     userNotes: [],
     draftNote: null,

--- a/packages/hunk/src/core/run/commandCatalog.test.ts
+++ b/packages/hunk/src/core/run/commandCatalog.test.ts
@@ -73,7 +73,20 @@ describe("app command catalog", () => {
     ]);
   });
 
-  test("lowers navigation commands to the move their scope and direction declare", () => {
+  test("keeps presentation-relative note navigation client-local", () => {
+    const state = createTestReviewState();
+
+    expect(entry("hunk.review.previousNote").locus).toBe("client-local");
+    expect(entry("hunk.review.nextNote").locus).toBe("client-local");
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.previousNote"), { count: 1, state }),
+    ).toBeUndefined();
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.nextNote"), { count: 1, state }),
+    ).toBeUndefined();
+  });
+
+  test("lowers semantic navigation commands to the move their scope and direction declare", () => {
     const state = createTestReviewState();
 
     expect(
@@ -157,6 +170,7 @@ describe("app command catalog", () => {
   test("lowers edit and reply commands through the active-note policies", () => {
     const state = {
       ...createTestReviewState(["alpha"]),
+      activeNoteId: "user-1",
       liveNotes: [createTestStoredNote({ id: "live-1", fileKey: "alpha" })],
       userNotes: [
         createTestStoredNote({
@@ -175,6 +189,36 @@ describe("app command catalog", () => {
     expect(
       lowerAppCommandToReviewIntent(entry("hunk.review.replyToActiveNote"), { count: 1, state }),
     ).toEqual({ type: "notes/start-reply", noteId: "user-1" });
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.deleteActiveNote"), { count: 1, state }),
+    ).toEqual({ type: "notes/remove-user", noteId: "user-1" });
+  });
+
+  test("does not retarget actions away from the one active note", () => {
+    const state = {
+      ...createTestReviewState(["alpha"], { showAgentNotes: true }),
+      activeNoteId: "live-1",
+      liveNotes: [createTestStoredNote({ id: "live-1", fileKey: "alpha" })],
+      userNotes: [
+        createTestStoredNote({
+          id: "user-reply",
+          parentId: "live-1",
+          fileKey: "alpha",
+          source: "user",
+          editable: true,
+        }),
+      ],
+    };
+
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.editActiveNote"), { count: 1, state }),
+    ).toBeUndefined();
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.deleteActiveNote"), { count: 1, state }),
+    ).toBeUndefined();
+    expect(
+      lowerAppCommandToReviewIntent(entry("hunk.review.replyToActiveNote"), { count: 1, state }),
+    ).toEqual({ type: "notes/start-reply", noteId: "live-1" });
   });
 
   test("lowers the gap toggle to the gap the shared policy reaches", () => {

--- a/packages/hunk/src/core/run/commandCatalog.ts
+++ b/packages/hunk/src/core/run/commandCatalog.ts
@@ -29,6 +29,7 @@ import type { ReviewIntent } from "../review/intents";
 import type { ReviewSelectionScope } from "../review/navigation";
 import {
   selectActiveEditableReviewNoteId,
+  selectActiveRemovableReviewNote,
   selectActiveReplyableReviewNoteId,
   selectNormalizedSelection,
   selectReviewGapForSelection,
@@ -57,10 +58,12 @@ export type AppCommandReviewEffect =
   | { kind: "notes/toggle-visibility" }
   /** Open a draft at the current selection; the client may supply a measured line. */
   | { kind: "notes/start-draft" }
-  /** Edit the selected hunk's first editable reviewer note. */
+  /** Edit the active note when that same card is an editable reviewer note. */
   | { kind: "notes/start-edit-active" }
-  /** Reply to the selected hunk's first stored note. */
+  /** Reply to the active stored note. */
   | { kind: "notes/start-reply-active" }
+  /** Delete or dismiss the active stored leaf note. */
+  | { kind: "notes/remove-active" }
   /** Flip the gap the shared policy says this selection reaches. */
   | { kind: "expansion/toggle-selected-gap" };
 
@@ -213,6 +216,36 @@ const BUILTIN_COMMANDS = [
     closesMenu: true,
   },
   {
+    id: "hunk.review.deleteActiveNote",
+    title: "Delete active review note",
+    category: "review",
+    defaultKeys: ["D"],
+    locus: "semantic",
+    review: { kind: "notes/remove-active" },
+    publicToExtensions: true,
+    closesMenu: true,
+  },
+  {
+    id: "hunk.review.previousNote",
+    title: "Previous review note",
+    category: "review",
+    defaultKeys: ["N"],
+    locus: "client-local",
+    verticalDirection: -1,
+    publicToExtensions: true,
+    closesMenu: true,
+  },
+  {
+    id: "hunk.review.nextNote",
+    title: "Next review note",
+    category: "review",
+    defaultKeys: ["n"],
+    locus: "client-local",
+    verticalDirection: 1,
+    publicToExtensions: true,
+    closesMenu: true,
+  },
+  {
     id: "hunk.review.pageDown",
     title: "Scroll down one page",
     category: "review",
@@ -250,7 +283,7 @@ const BUILTIN_COMMANDS = [
   },
   {
     id: "hunk.review.stepDown",
-    title: "Scroll down one row",
+    title: "Move down one line or note",
     category: "review",
     defaultKeys: ["down", "j"],
     locus: "client-local",
@@ -259,7 +292,7 @@ const BUILTIN_COMMANDS = [
   },
   {
     id: "hunk.review.stepUp",
-    title: "Scroll up one row",
+    title: "Move up one line or note",
     category: "review",
     defaultKeys: ["up", "k"],
     locus: "client-local",
@@ -664,6 +697,13 @@ export function lowerAppCommandToReviewIntent(
     case "notes/start-reply-active": {
       const noteId = selectActiveReplyableReviewNoteId(state);
       return noteId ? { type: "notes/start-reply", noteId } : undefined;
+    }
+    case "notes/remove-active": {
+      const target = selectActiveRemovableReviewNote(state);
+      if (!target) return undefined;
+      return target.source === "user"
+        ? { type: "notes/remove-user", noteId: target.noteId }
+        : { type: "notes/remove-live", noteId: target.noteId };
     }
     case "expansion/toggle-selected-gap": {
       const target = selectReviewGapForSelection(state);

--- a/packages/hunk/src/session/reviewProtocol.test.ts
+++ b/packages/hunk/src/session/reviewProtocol.test.ts
@@ -57,6 +57,7 @@ describe("review action round trip", () => {
       type: "selection/select",
       fileKey: FILE_KEY,
       hunkIndex: 2,
+      activeNoteId: "user:1",
       reveal: { anchor: "hunk", scrollToNote: false },
     },
     { type: "selection/move", scope: "annotated-hunk", delta: -1 },

--- a/packages/hunk/src/session/reviewProtocol.ts
+++ b/packages/hunk/src/session/reviewProtocol.ts
@@ -406,9 +406,15 @@ const REVIEW_SELECTION_SCOPES = Object.keys(REVIEW_SELECTION_WRAP_POLICY) as Rev
  */
 const ACTION_PARSERS: Record<ReviewIntentType, (record: Record<string, unknown>) => boolean> = {
   "selection/select": (record) =>
-    hasExactKeys(record, ["type", "fileKey", "hunkIndex", "reveal"]) &&
+    hasExactKeys(
+      record,
+      keysWith(["type", "fileKey", "hunkIndex", "reveal"], {
+        activeNoteId: record.activeNoteId,
+      }),
+    ) &&
     isIdentifier(record.fileKey) &&
     isIndex(record.hunkIndex) &&
+    (record.activeNoteId === undefined || isIdentifier(record.activeNoteId)) &&
     parseReveal(record.reveal) !== undefined,
   "selection/move": (record) =>
     hasExactKeys(record, ["type", "scope", "delta"]) &&

--- a/packages/hunk/src/ui/App.tsx
+++ b/packages/hunk/src/ui/App.tsx
@@ -24,7 +24,9 @@ import { isVcsReviewInput } from "../core/vcs";
 import type { AppBootstrap } from "../core/bootstrap";
 import {
   selectActiveEditableReviewNoteId,
+  selectActiveRemovableReviewNote,
   selectActiveReplyableReviewNoteId,
+  selectActiveStoredReviewNote,
 } from "../core/review/selectors";
 import type { CliInput, CursorLine, LayoutMode } from "../core/run/commandInputs";
 import { sanitizeTerminalLine } from "../lib/terminalText";
@@ -95,6 +97,7 @@ import { buildExtensionAppCommands, extensionCommandKeyDefaults } from "./lib/ex
 import { createExtensionReviewReloadControls } from "./lib/extensionReviewReload";
 import type { CurrentLineAlignment } from "./lib/hunkScroll";
 import type { LineCursor } from "./lib/lineCursors";
+import type { ReviewVerticalStop } from "./lib/reviewVerticalStops";
 import { useFilePresentationController } from "./fileViews/useFilePresentationController";
 import { useFilePresentationRendering } from "./fileViews/useFilePresentationRendering";
 import { mergeLineHighlightMaps } from "./highlights/merge";
@@ -204,10 +207,12 @@ export function App({
   // the current values through a ref instead of a render-time parameter.
   const noteGeometryRef = useRef<AgentNoteGeometrySnapshot | null>(null);
   const [lineCursors, setLineCursors] = useState<LineCursor[]>([]);
+  const [reviewVerticalStops, setReviewVerticalStops] = useState<ReviewVerticalStop[]>([]);
   const review = useTerminalReview({
     files: reviewFiles,
     initialShowAgentNotes: bootstrap.initialShowAgentNotes ?? false,
     lineCursors,
+    reviewVerticalStops,
     noteGeometry: noteGeometryRef,
     sourceLabel: bootstrap.changeset.sourceLabel,
     stmlEnabled,
@@ -852,7 +857,7 @@ export function App({
   /** Step one line: move the current line, or scroll the viewport when there is no marker. */
   const stepDiffLine = (delta: number) => {
     if (selectionActionsRef.current?.move(delta)) return;
-    if (!activeLineCursor) {
+    if (cursorLine === "off") {
       scrollDiff(delta, "step");
       return;
     }
@@ -1096,8 +1101,11 @@ export function App({
     publishEvent: publishNoteEvent,
   });
 
-  const activeEditableNoteId = selectActiveEditableReviewNoteId(review.store.getSnapshot());
-  const activeReplyableNoteId = selectActiveReplyableReviewNoteId(review.store.getSnapshot());
+  const reviewSnapshot = review.store.getSnapshot();
+  const activeNoteId = selectActiveStoredReviewNote(reviewSnapshot)?.note.id;
+  const activeEditableNoteId = selectActiveEditableReviewNoteId(reviewSnapshot);
+  const activeReplyableNoteId = selectActiveReplyableReviewNoteId(reviewSnapshot);
+  const activeRemovableNote = selectActiveRemovableReviewNote(reviewSnapshot);
 
   // One dispatch table for every app-level shortcut: the built-in commands
   // over App's live callbacks, then extension commands, so built-ins always
@@ -1107,12 +1115,21 @@ export function App({
       ...buildAppCommands({
         canAlignCurrentLine: cursorLine !== "off" && review.lineCursor !== null,
         canApplyFilePresentationToAllMatching: selectedFileViewBulkTarget !== null,
+        canDeleteActiveNote: activeRemovableNote !== undefined && review.draftNote === null,
         canEditActiveNote: activeEditableNoteId !== undefined && review.draftNote === null,
         canReplyToActiveNote: activeReplyableNoteId !== undefined && review.draftNote === null,
         canRefreshCurrentInput,
         alignCurrentLine,
         applyFilePresentationToAllMatching,
         focusFilter,
+        deleteActiveNote: () => {
+          if (!activeRemovableNote) return;
+          if (activeRemovableNote.source === "user") {
+            review.removeUserNote(activeRemovableNote.noteId);
+          } else {
+            review.removeLiveComment(activeRemovableNote.noteId);
+          }
+        },
         editActiveNote: () => {
           if (activeEditableNoteId) startUserNoteEdit(activeEditableNoteId);
         },
@@ -1120,6 +1137,7 @@ export function App({
           if (activeReplyableNoteId) startUserNoteReply(activeReplyableNoteId);
         },
         moveSelection: review.moveSelection,
+        moveNoteCursor: review.moveNoteCursor,
         openAgentSkill,
         openThemeSelector,
         requestQuit,
@@ -1161,6 +1179,16 @@ export function App({
     ?.keyLabels[0];
   const selectionCopyKeyLabel = findAppCommandById(appCommands, "hunk.review.copySelection")
     ?.keyLabels[0];
+  const deleteNoteKeyLabel =
+    findAppCommandById(appCommands, "hunk.review.deleteActiveNote")?.keyLabels[0] ?? "";
+  const editNoteKeyLabel =
+    findAppCommandById(appCommands, "hunk.review.editActiveNote")?.keyLabels[0] ?? "";
+  const replyNoteKeyLabel =
+    findAppCommandById(appCommands, "hunk.review.replyToActiveNote")?.keyLabels[0] ?? "";
+  const noteActionKeyLabels = useMemo(
+    () => ({ delete: deleteNoteKeyLabel, edit: editNoteKeyLabel, reply: replyNoteKeyLabel }),
+    [deleteNoteKeyLabel, editNoteKeyLabel, replyNoteKeyLabel],
+  );
   useExtensionRuntimeBindings({
     commands: appCommands,
     navigation: extensionNavigationBindings,
@@ -1459,6 +1487,8 @@ export function App({
             scrollRef={diffScrollRef}
             selectedFileId={selectedFile?.id}
             selectedHunkIndex={selectedHunkIndex}
+            activeNoteId={activeNoteId}
+            noteActionKeyLabels={noteActionKeyLabels}
             scrollToNote={review.scrollToNote}
             draftNote={review.draftNote}
             draftNoteFocused={focusArea === "note"}
@@ -1485,6 +1515,7 @@ export function App({
             width={diffPaneWidth}
             height={diffPaneHeight}
             onActiveAddNoteAffordanceChange={onActiveAddNoteAffordanceChange}
+            onActivateNote={review.activateNote}
             onEditUserNote={startUserNoteEdit}
             onReplyToNote={startUserNoteReply}
             onRemoveLiveNote={review.removeLiveComment}
@@ -1506,6 +1537,7 @@ export function App({
               review.anchorSelection(fileId, hunkIndex)
             }
             onLineCursorsChange={setLineCursors}
+            onReviewVerticalStopsChange={setReviewVerticalStops}
             currentLinePaintRequested={currentLinePaintRequested}
             onCurrentLinePaintChange={onCurrentLinePaintChange}
             onViewportLineCursorChange={review.anchorLineCursor}

--- a/packages/hunk/src/ui/AppHost.file-view-modes.test.tsx
+++ b/packages/hunk/src/ui/AppHost.file-view-modes.test.tsx
@@ -89,7 +89,7 @@ function createInteractiveModeExtension() {
           ctx.fileViews.refresh("outline");
           return "handled";
         }
-        if (key.name === "n") return "handled";
+        if (key.name === "i") return "handled";
         if (key.name === "x") return "exit";
         return "pass";
       },
@@ -133,8 +133,8 @@ function createInteractiveModeExtension() {
     ctx.fileViews.exitMode();
     ctx.fileViews.exitMode();
   });
-  hunk.registerCommand({ id: "answered", title: "Answered command", key: "n" }, (ctx) =>
-    ctx.notify("COMMAND N RAN"),
+  hunk.registerCommand({ id: "answered", title: "Answered command", key: "i" }, (ctx) =>
+    ctx.notify("COMMAND I RAN"),
   );
   hunk.registerCommand({ id: "declined", title: "Declined command", key: "p" }, (ctx) =>
     ctx.notify("COMMAND P RAN"),
@@ -443,9 +443,9 @@ describe("AppHost file-view modes", () => {
       await waitForFrame(setup, (frame) => frame.includes("CURSOR 1"));
 
       // "handled" for a key the command table binds: the command must not run.
-      await act(async () => setup.mockInput.typeText("n"));
+      await act(async () => setup.mockInput.typeText("i"));
       await act(async () => setup.renderOnce());
-      expect(notices).not.toContain("COMMAND N RAN");
+      expect(notices).not.toContain("COMMAND I RAN");
 
       // "pass": the command bound to the key still fires, exactly as it would
       // with no mode running.
@@ -461,8 +461,8 @@ describe("AppHost file-view modes", () => {
       expect(notices).not.toContain("MODE KEY escape");
 
       // With the mode gone, the previously answered key reaches its command.
-      await act(async () => setup.mockInput.typeText("n"));
-      await waitForNotice(setup, notices, "COMMAND N RAN");
+      await act(async () => setup.mockInput.typeText("i"));
+      await waitForNotice(setup, notices, "COMMAND I RAN");
     } finally {
       await act(async () => setup.renderer.destroy());
     }

--- a/packages/hunk/src/ui/AppHost.key-routing.test.tsx
+++ b/packages/hunk/src/ui/AppHost.key-routing.test.tsx
@@ -267,8 +267,8 @@ describe("UI key routing with a focused scroll box", () => {
       await flush(setup);
       expect(scrollBox.scrollTop).toBe(scrollTopBefore);
 
-      // "pass" leaves scrolling exactly as it is with no mode running.
-      await act(async () => setup.mockInput.typeText("j"));
+      // "pass" leaves paging exactly as it is with no mode running.
+      await act(async () => setup.mockInput.typeText("f"));
       await flush(setup);
       expect(scrollBox.scrollTop).toBeGreaterThan(scrollTopBefore);
     } finally {

--- a/packages/hunk/src/ui/components/panes/AgentInlineNote.test.tsx
+++ b/packages/hunk/src/ui/components/panes/AgentInlineNote.test.tsx
@@ -54,6 +54,128 @@ test("AgentInlineNote connects a ranged card to the external annotation rail", a
   }
 });
 
+test("AgentInlineNote persistently identifies the active note and resolved action keys", async () => {
+  const setup = await testRender(
+    <AgentInlineNote
+      annotation={{ source: "user", newRange: [2, 2], summary: "Keyboard target" }}
+      active={true}
+      actionKeyLabels={{ delete: "D", edit: "Alt+E", reply: "R" }}
+      actions={{ onDelete: () => {}, onEdit: () => {}, onReply: () => {} }}
+      anchorSide="new"
+      layout="unified"
+      theme={theme}
+      width={60}
+    />,
+    { width: 61, height: 5 },
+  );
+
+  try {
+    await act(async () => {
+      await setup.renderOnce();
+    });
+    const frame = setup.captureCharFrame();
+
+    expect(frame).toContain("●");
+    expect(frame).toContain("R reply");
+    expect(frame).toContain("Alt+E edit");
+    expect(frame).toContain("D delete");
+  } finally {
+    await act(async () => {
+      setup.renderer.destroy();
+    });
+  }
+});
+
+test("AgentInlineNote keeps hover actions pointer-only and activates when clicked", async () => {
+  function HoverHarness() {
+    const [active, setActive] = useState(false);
+    return (
+      <AgentInlineNote
+        annotation={{ source: "user", newRange: [2, 2], summary: "Hover target" }}
+        active={active}
+        actionKeyLabels={active ? { delete: "D", edit: "E", reply: "R" } : undefined}
+        actions={{ onDelete: () => {}, onEdit: () => {}, onReply: () => {} }}
+        onActivate={() => setActive(true)}
+        anchorSide="new"
+        layout="unified"
+        theme={theme}
+        width={60}
+      />
+    );
+  }
+
+  const setup = await testRender(<HoverHarness />, { width: 61, height: 5 });
+
+  try {
+    await act(async () => setup.renderOnce());
+    expect(setup.captureCharFrame()).not.toContain("●");
+
+    await act(async () => {
+      await setup.mockMouse.moveTo(20, 0);
+    });
+    await act(async () => {
+      await Bun.sleep(0);
+      await setup.renderOnce();
+    });
+    const hoveredFrame = setup.captureCharFrame();
+    expect(hoveredFrame).not.toContain("●");
+    expect(hoveredFrame).toContain("reply edit delete");
+    expect(hoveredFrame).not.toContain("R reply");
+
+    await act(async () => {
+      await setup.mockMouse.click(20, 2);
+    });
+    await act(async () => {
+      await Bun.sleep(0);
+      await setup.renderOnce();
+    });
+    const clickedFrame = setup.captureCharFrame();
+    expect(clickedFrame).toContain("●");
+    expect(clickedFrame).toContain("R reply E edit D delete");
+  } finally {
+    await act(async () => setup.renderer.destroy());
+  }
+});
+
+test("AgentInlineNote fits long remapped action keys inside a narrow active card", async () => {
+  const setup = await testRender(
+    <AgentInlineNote
+      annotation={{ source: "user", newRange: [2, 2], summary: "Narrow target" }}
+      active={true}
+      actionKeyLabels={{
+        delete: "Ctrl+Alt+Shift+D",
+        edit: "Ctrl+Alt+Shift+E",
+        reply: "Ctrl+Alt+Shift+R",
+      }}
+      actions={{ onDelete: () => {}, onEdit: () => {}, onReply: () => {} }}
+      anchorSide="new"
+      layout="unified"
+      theme={theme}
+      width={28}
+    />,
+    { width: 29, height: 5 },
+  );
+
+  try {
+    await act(async () => {
+      await setup.renderOnce();
+    });
+    const actionRow = setup
+      .captureCharFrame()
+      .split("\n")
+      .find((line) => line.includes("ft+R"));
+
+    expect(actionRow).toContain("ft+R");
+    expect(actionRow).toContain("ft+E");
+    expect(actionRow).toContain("ft+D");
+    expect(actionRow?.trimEnd().endsWith("╯")).toBe(true);
+  } finally {
+    await act(async () => {
+      setup.renderer.destroy();
+    });
+  }
+});
+
 test("AgentInlineNote continues an aggregate rail through the card", async () => {
   const setup = await testRender(
     <AgentInlineNote

--- a/packages/hunk/src/ui/components/panes/AgentInlineNote.tsx
+++ b/packages/hunk/src/ui/components/panes/AgentInlineNote.tsx
@@ -185,6 +185,8 @@ export function measureAgentInlineNoteHeight({
 /** Render the note card itself before the start of an annotated range. */
 export function AgentInlineNote({
   annotation,
+  active = false,
+  actionKeyLabels,
   anchorSide,
   file,
   layout,
@@ -193,6 +195,7 @@ export function AgentInlineNote({
   rangeGuideConnection,
   draft,
   actions,
+  onActivate,
   onClose,
   thread,
   threadDepth = thread?.depth ?? 0,
@@ -200,6 +203,8 @@ export function AgentInlineNote({
   width,
 }: {
   annotation: AgentAnnotation;
+  active?: boolean;
+  actionKeyLabels?: { delete: string; edit: string; reply: string };
   anchorSide?: "old" | "new";
   file?: DiffFile;
   layout: Exclude<LayoutMode, "auto">;
@@ -217,6 +222,8 @@ export function AgentInlineNote({
     onSave: () => void;
   };
   actions?: AgentInlineNoteActions;
+  /** Make this saved note the keyboard action target when its card is clicked. */
+  onActivate?: () => void;
   /** Legacy compact delete affordance; semantic cards use explicit `actions`. */
   onClose?: () => void;
   thread?: VisibleAgentNote["thread"];
@@ -230,6 +237,8 @@ export function AgentInlineNote({
   const [hoveredActionId, setHoveredActionId] = useState<string | null>(null);
   const isDraft = Boolean(draft);
   const hasSavedActions = Boolean(actions && Object.values(actions).some(Boolean));
+  /** Reveal card actions while the pointer is over a saved note. */
+  const showActions = () => setActionsHovered(true);
 
   useEffect(() => {
     if (isDraft || !hasSavedActions) {
@@ -371,6 +380,7 @@ export function AgentInlineNote({
   const closeText = onClose ? "[x]" : "";
   const closeGapWidth = closeText ? 1 : 0;
   const closeWidth = closeText.length;
+  const savedBorderColor = active ? theme.accent : theme.noteBorder;
   const savedTitleBudget = Math.max(0, boxWidth - 4 - closeGapWidth - closeWidth);
   const savedTitleText = (() => {
     if (!thread || !file) {
@@ -400,7 +410,10 @@ export function AgentInlineNote({
     const fittedRange = fitText(range, rangeBudget, "…");
     return ` ${fittedAuthor} · ${fittedPath} ${fittedRange} `;
   })();
-  const savedTitleWidth = measureTextWidth(savedTitleText);
+  const displayedSavedTitleText = active
+    ? fitText(` ● ${savedTitleText.trim()} `, savedTitleBudget)
+    : savedTitleText;
+  const savedTitleWidth = measureTextWidth(displayedSavedTitleText);
   const savedTopBorderSuffixWidth = Math.max(
     0,
     boxWidth - 3 - savedTitleWidth - closeGapWidth - closeWidth,
@@ -409,35 +422,61 @@ export function AgentInlineNote({
   const savedActionItems: BorderActionItem[] = actions
     ? [
         actions.onReply
-          ? { id: "reply", keyLabel: "r", label: "reply", onMouseUp: actions.onReply }
+          ? {
+              id: "reply",
+              keyLabel: actionKeyLabels?.reply ?? "",
+              label: "reply",
+              onMouseUp: actions.onReply,
+            }
           : null,
         actions.onEdit
-          ? { id: "edit", keyLabel: "e", label: "edit", onMouseUp: actions.onEdit }
+          ? {
+              id: "edit",
+              keyLabel: actionKeyLabels?.edit ?? "",
+              label: "edit",
+              onMouseUp: actions.onEdit,
+            }
           : null,
         actions.onDelete
-          ? { id: "delete", keyLabel: "d", label: "delete", onMouseUp: actions.onDelete }
+          ? {
+              id: "delete",
+              keyLabel: actionKeyLabels?.delete ?? "",
+              label: "delete",
+              onMouseUp: actions.onDelete,
+            }
           : null,
       ].filter((item): item is BorderActionItem => item !== null)
     : [];
 
   /** Render clickable controls in place of the trailing cells of a bottom border. */
-  const renderBottomBorder = (items: readonly BorderActionItem[]) => {
+  const renderBottomBorder = (
+    items: readonly BorderActionItem[],
+    borderColor = theme.noteBorder,
+  ) => {
     const availableItemsWidth = Math.max(0, boxWidth - 4);
+    const itemWidth = (keyLabel: string, label: string) =>
+      measureTextWidth(keyLabel) + (keyLabel && label ? 1 : 0) + measureTextWidth(label);
     const fullItemsWidth = items.reduce(
-      (total, item, index) =>
-        total + item.keyLabel.length + 1 + item.label.length + (index > 0 ? 1 : 0),
+      (total, item, index) => total + itemWidth(item.keyLabel, item.label) + (index > 0 ? 1 : 0),
       0,
     );
-    const renderedItems = items.map((item) => ({
-      ...item,
-      displayLabel: fullItemsWidth <= availableItemsWidth ? item.label : "",
-    }));
+    const showFullItems = fullItemsWidth <= availableItemsWidth;
+    const compactItemWidth = Math.max(
+      0,
+      Math.floor((availableItemsWidth - Math.max(0, items.length - 1)) / items.length),
+    );
+    const renderedItems = items
+      .map((item) => ({
+        ...item,
+        keyLabel: showFullItems
+          ? item.keyLabel
+          : fitTrailingText(item.keyLabel || item.label, compactItemWidth, "…"),
+        displayLabel: showFullItems ? item.label : "",
+      }))
+      .filter((item) => item.keyLabel || item.displayLabel);
     const itemsWidth = renderedItems.reduce(
       (total, item, index) =>
-        total +
-        item.keyLabel.length +
-        (item.displayLabel ? 1 + item.displayLabel.length : 0) +
-        (index > 0 ? 1 : 0),
+        total + itemWidth(item.keyLabel, item.displayLabel) + (index > 0 ? 1 : 0),
       0,
     );
     const innerWidth = Math.max(0, boxWidth - 2);
@@ -452,23 +491,23 @@ export function AgentInlineNote({
           flexDirection: "row",
           backgroundColor: theme.panel,
         }}
-        onMouseMove={() => setActionsHovered(true)}
-        onMouseOver={() => setActionsHovered(true)}
+        onMouseMove={showActions}
+        onMouseOver={showActions}
         onMouseOut={() => setActionsHovered(false)}
+        onMouseUp={onActivate}
       >
-        <text fg={theme.noteBorder} bg={theme.panel}>
+        <text fg={borderColor} bg={theme.panel}>
           {`╰${"─".repeat(leadingWidth)} `}
         </text>
         {renderedItems.map((item, index) => {
           const hovered = hoveredActionId === item.id;
           const backgroundColor = hovered ? theme.accentMuted : theme.panel;
-          const itemWidth =
-            item.keyLabel.length + (item.displayLabel ? 1 + item.displayLabel.length : 0);
+          const renderedItemWidth = itemWidth(item.keyLabel, item.displayLabel);
           return (
             <box
               key={item.id}
               style={{
-                width: itemWidth + (index > 0 ? 1 : 0),
+                width: renderedItemWidth + (index > 0 ? 1 : 0),
                 height: 1,
                 flexDirection: "row",
                 backgroundColor: theme.panel,
@@ -481,19 +520,21 @@ export function AgentInlineNote({
                   setHoveredActionId((current) => (current === item.id ? null : current))
                 }
                 onMouseUp={item.onMouseUp}
-                style={{ width: itemWidth, height: 1, backgroundColor }}
+                style={{ width: renderedItemWidth, height: 1, backgroundColor }}
               >
                 <text bg={backgroundColor}>
                   <span fg={theme.noteTitleText}>{item.keyLabel}</span>
                   {item.displayLabel ? (
-                    <span fg={hovered ? theme.text : theme.muted}>{` ${item.displayLabel}`}</span>
+                    <span fg={hovered ? theme.text : theme.muted}>
+                      {`${item.keyLabel ? " " : ""}${item.displayLabel}`}
+                    </span>
                   ) : null}
                 </text>
               </box>
             </box>
           );
         })}
-        <text fg={theme.noteBorder} bg={theme.panel}>
+        <text fg={borderColor} bg={theme.panel}>
           {" ╯"}
         </text>
       </box>
@@ -712,22 +753,28 @@ export function AgentInlineNote({
           flexDirection: "row",
           backgroundColor: theme.panel,
         }}
-        onMouseMove={() => setActionsHovered(true)}
-        onMouseOver={() => setActionsHovered(true)}
+        onMouseMove={showActions}
+        onMouseOver={showActions}
         onMouseOut={() => setActionsHovered(false)}
+        onMouseDown={onActivate}
+        onMouseUp={onActivate}
       >
         <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.panel}>
+          <text fg={savedBorderColor} bg={theme.panel}>
             │
           </text>
         </box>
         <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
-        <box style={{ width: contentWidth, height: 1, backgroundColor: theme.panel }}>
+        <box
+          style={{ width: contentWidth, height: 1, backgroundColor: theme.panel }}
+          onMouseDown={onActivate}
+          onMouseUp={onActivate}
+        >
           {content}
         </box>
         <box style={{ width: 1, height: 1, backgroundColor: theme.panel }} />
         <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-          <text fg={theme.noteBorder} bg={theme.panel}>
+          <text fg={savedBorderColor} bg={theme.panel}>
             │
           </text>
         </box>
@@ -739,7 +786,7 @@ export function AgentInlineNote({
     const usedWidth = line.spans.reduce((total, span) => total + measureTextWidth(span.text), 0);
     return renderBodyRow(
       key,
-      <text bg={theme.panel}>
+      <text bg={theme.panel} onMouseDown={onActivate} onMouseUp={onActivate}>
         {line.spans.map((span, spanIndex) => (
           <span key={`${key}:span:${spanIndex}`} {...markupSpanProps(span)}>
             {span.text}
@@ -755,13 +802,18 @@ export function AgentInlineNote({
   const renderSavedBodyRow = (key: string, text: string, kind: AgentInlineNoteLine["kind"]) =>
     renderBodyRow(
       key,
-      <text fg={kind === "summary" ? theme.text : theme.muted} bg={theme.panel}>
+      <text
+        fg={kind === "summary" ? theme.text : theme.muted}
+        bg={theme.panel}
+        onMouseDown={onActivate}
+        onMouseUp={onActivate}
+      >
         {padText(text, contentWidth)}
       </text>,
     );
 
   const bottomBorderInnerWidth = Math.max(0, boxWidth - 2);
-  const showActionOverlay = actionsHovered && savedActionItems.length > 0;
+  const showActionOverlay = (active || actionsHovered) && savedActionItems.length > 0;
 
   const savedHeight = (markupLines?.length ?? lines.length) + 3;
 
@@ -788,19 +840,24 @@ export function AgentInlineNote({
             flexDirection: "row",
             backgroundColor: theme.panel,
           }}
-          onMouseMove={() => setActionsHovered(true)}
-          onMouseOver={() => setActionsHovered(true)}
+          onMouseMove={showActions}
+          onMouseOver={showActions}
           onMouseOut={() => setActionsHovered(false)}
+          onMouseUp={onActivate}
         >
-          <box style={{ width: savedTopPrefixWidth, height: 1, backgroundColor: theme.panel }}>
-            <text>
-              <span fg={theme.noteBorder} bg={theme.panel}>
+          <box
+            style={{ width: savedTopPrefixWidth, height: 1, backgroundColor: theme.panel }}
+            onMouseDown={onActivate}
+            onMouseUp={onActivate}
+          >
+            <text onMouseDown={onActivate} onMouseUp={onActivate}>
+              <span fg={savedBorderColor} bg={theme.panel}>
                 ╭─
               </span>
               <span fg={theme.noteTitleText} bg={theme.panel}>
-                {savedTitleText}
+                {displayedSavedTitleText}
               </span>
-              <span fg={theme.noteBorder} bg={theme.panel}>
+              <span fg={savedBorderColor} bg={theme.panel}>
                 {"─".repeat(savedTopBorderSuffixWidth)}
               </span>
             </text>
@@ -821,7 +878,7 @@ export function AgentInlineNote({
             </box>
           ) : null}
           <box style={{ width: 1, height: 1, backgroundColor: theme.panel }}>
-            <text fg={theme.noteBorder} bg={theme.panel}>
+            <text fg={savedBorderColor} bg={theme.panel}>
               {rangeGuideConnection ? "┬" : "╮"}
             </text>
           </box>
@@ -844,14 +901,15 @@ export function AgentInlineNote({
           </text>
         </box>
         {showActionOverlay ? (
-          renderBottomBorder(savedActionItems)
+          renderBottomBorder(savedActionItems, savedBorderColor)
         ) : (
           <box
             style={{ width: boxWidth, height: 1, backgroundColor: theme.panel }}
-            onMouseOver={() => setActionsHovered(true)}
+            onMouseOver={showActions}
             onMouseOut={() => setActionsHovered(false)}
+            onMouseUp={onActivate}
           >
-            <text fg={theme.noteBorder} bg={theme.panel}>
+            <text fg={savedBorderColor} bg={theme.panel}>
               {`╰${"─".repeat(bottomBorderInnerWidth)}╯`}
             </text>
           </box>

--- a/packages/hunk/src/ui/components/panes/DiffPane.tsx
+++ b/packages/hunk/src/ui/components/panes/DiffPane.tsx
@@ -53,6 +53,11 @@ import {
   type LineCursorBoundsLookup,
 } from "../../lib/lineCursors";
 import {
+  buildReviewVerticalStops,
+  createReviewVerticalStopStabilizer,
+  type ReviewVerticalStop,
+} from "../../lib/reviewVerticalStops";
+import {
   measureDiffSectionGeometry,
   type DiffSectionGeometry,
 } from "../../diff/diffSectionGeometry";
@@ -320,6 +325,8 @@ export function DiffPane({
   scrollRef,
   selectedFileId,
   selectedHunkIndex,
+  activeNoteId,
+  noteActionKeyLabels,
   cursorLine = "off",
   lineCursor = null,
   lineCursorRevealRequest = { id: 0, placement: "nearest" },
@@ -355,6 +362,7 @@ export function DiffPane({
   selectionCommentKeyLabel,
   selectionCopyKeyLabel,
   onActiveAddNoteAffordanceChange,
+  onActivateNote,
   onEditUserNote,
   onReplyToNote,
   onRemoveLiveNote,
@@ -372,6 +380,7 @@ export function DiffPane({
   onSelectFile,
   onToggleGap = NOOP_TOGGLE_GAP,
   onLineCursorsChange,
+  onReviewVerticalStopsChange,
   currentLinePaintRequested = false,
   onCurrentLinePaintChange,
   onViewportCenteredHunkChange,
@@ -395,9 +404,15 @@ export function DiffPane({
   scrollRef: RefObject<ScrollBoxRenderable | null>;
   selectedFileId?: string;
   selectedHunkIndex: number;
+  activeNoteId?: string;
+  noteActionKeyLabels?: { delete: string; edit: string; reply: string };
   cursorLine?: CursorLine;
   lineCursor?: LineCursor | null;
-  lineCursorRevealRequest?: { id: number; placement: LineRevealPlacement };
+  lineCursorRevealRequest?: {
+    id: number;
+    placement: LineRevealPlacement;
+    target?: { fileId: string; stableKey: string };
+  };
   lineCursorAlignmentRequest?: { id: number; alignment: CurrentLineAlignment };
   scrollToNote?: boolean;
   draftNote?: DraftReviewNote | null;
@@ -434,6 +449,8 @@ export function DiffPane({
   onActiveAddNoteAffordanceChange?: (
     affordance: (ActiveAddNoteAffordance & { fileId: string }) | null,
   ) => void;
+  /** Select a clicked semantic note as the keyboard action target. */
+  onActivateNote?: (noteId: string) => void;
   onEditUserNote?: (noteId: string, options?: { preserveViewport?: boolean }) => void;
   onReplyToNote?: (noteId: string, options?: { preserveViewport?: boolean }) => void;
   onRemoveLiveNote?: (noteId: string) => void;
@@ -451,6 +468,7 @@ export function DiffPane({
   onSelectFile: (fileId: string) => void;
   onToggleGap?: (fileId: string, gapKey: string) => void;
   onLineCursorsChange?: (cursors: LineCursor[]) => void;
+  onReviewVerticalStopsChange?: (stops: ReviewVerticalStop[]) => void;
   currentLinePaintRequested?: boolean;
   onCurrentLinePaintChange?: (update: ExtensionCurrentLinePaintUpdate) => void;
   onViewportCenteredHunkChange?: (fileId: string, hunkIndex: number) => void;
@@ -649,6 +667,13 @@ export function DiffPane({
             ...(storedTarget ? { target: storedTarget } : {}),
             ...(metadata
               ? {
+                  active: metadata.reviewNoteId === activeNoteId,
+                  ...(metadata.reviewNoteId === activeNoteId && noteActionKeyLabels
+                    ? { actionKeyLabels: noteActionKeyLabels }
+                    : {}),
+                  ...(onActivateNote
+                    ? { onActivate: () => onActivateNote(metadata.reviewNoteId) }
+                    : {}),
                   thread: {
                     noteId: metadata.reviewNoteId,
                     ...(metadata.parentId ? { parentId: metadata.parentId } : {}),
@@ -776,9 +801,11 @@ export function DiffPane({
 
     return next;
   }, [
+    activeNoteId,
     draftNote,
     draftNoteFocused,
     files,
+    onActivateNote,
     onBlurDraftNote,
     onCancelDraftNote,
     onFocusDraftNote,
@@ -788,6 +815,7 @@ export function DiffPane({
     onRemoveUserNote,
     onSaveDraftNote,
     onUpdateDraftNote,
+    noteActionKeyLabels,
     showAgentNotes,
   ]);
 
@@ -1283,6 +1311,20 @@ export function DiffPane({
     onLineCursorsChange?.(lineCursors);
   }, [lineCursors, onLineCursorsChange]);
 
+  const measuredReviewVerticalStops = useMemo(
+    () => buildReviewVerticalStops(files, sectionGeometry, lineCursors),
+    [files, lineCursors, sectionGeometry],
+  );
+  const reviewVerticalStopStabilizerRef = useRef<ReturnType<
+    typeof createReviewVerticalStopStabilizer
+  > | null>(null);
+  reviewVerticalStopStabilizerRef.current ??= createReviewVerticalStopStabilizer();
+  const reviewVerticalStops = reviewVerticalStopStabilizerRef.current(measuredReviewVerticalStops);
+
+  useEffect(() => {
+    onReviewVerticalStopsChange?.(reviewVerticalStops);
+  }, [onReviewVerticalStopsChange, reviewVerticalStops]);
+
   // Read the live scroll box position during render so pinned-header ownership flips
   // immediately after imperative scrolls instead of waiting for the polled viewport snapshot.
   const effectiveScrollTop = pendingScrollEdgeRequest
@@ -1344,8 +1386,11 @@ export function DiffPane({
   // measured cursor list. Because both paths reuse the same cursor object, the follow-up state
   // publication does not invalidate and repaint an expensive wrapped row.
   const renderedLineCursor = useMemo(
-    () => lineCursor ?? firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex),
-    [lineCursor, lineCursors, selectedFileId, selectedHunkIndex],
+    () =>
+      activeNoteId
+        ? null
+        : (lineCursor ?? firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex)),
+    [activeNoteId, lineCursor, lineCursors, selectedFileId, selectedHunkIndex],
   );
 
   // One object per cursor move, so the section and row memos below only see a new reference when
@@ -1561,6 +1606,12 @@ export function DiffPane({
       return;
     }
 
+    // An active note is the vertical cursor. Card relayout after save or click must not let
+    // viewport settlement manufacture a simultaneous source-line cursor and clear that target.
+    if (activeNoteId) {
+      return;
+    }
+
     if (lineCursors.length > 0) {
       const clampedCursor = clampLineCursorToViewport({
         boundsOf: lineCursorBoundsOf,
@@ -1595,6 +1646,7 @@ export function DiffPane({
 
     onViewportCenteredHunkChange?.(centeredTarget.fileId, centeredTarget.hunkIndex);
   }, [
+    activeNoteId,
     fileSectionLayouts,
     files,
     lineCursor,
@@ -1827,6 +1879,7 @@ export function DiffPane({
                     id: note.id,
                     line: reviewNoteAnchorLine(note).line,
                     draft: note.source === "draft",
+                    active: note.active,
                   },
                 ]
               : [],
@@ -2337,11 +2390,16 @@ export function DiffPane({
     previousLineCursorRevealRequestIdRef.current = lineCursorRevealRequest.id;
 
     const scrollBox = scrollRef.current;
-    if (!scrollBox || !lineCursor) {
+    const requestTarget = lineCursorRevealRequest.target;
+    if (!scrollBox || (!lineCursor && !requestTarget)) {
       return;
     }
 
-    const bounds = lineCursorBoundsOf(lineCursor);
+    const bounds = requestTarget
+      ? rowBoundsInStream(requestTarget.fileId, requestTarget.stableKey)
+      : lineCursor
+        ? lineCursorBoundsOf(lineCursor)
+        : undefined;
     if (!bounds) {
       return;
     }
@@ -2350,19 +2408,21 @@ export function DiffPane({
     // A jump lands the line where hunk and note reveals land theirs; stepping only closes the
     // gap to the viewport edge, so a held key does not drag the whole stream past the marker.
     const revealScrollTop =
-      lineCursorRevealRequest.placement === "reveal"
-        ? computeHunkRevealScrollTop({
-            hunkTop: bounds.top,
-            hunkHeight: bounds.height,
-            preferredTopPadding: Math.max(2, Math.floor(viewportHeight * 0.25)),
-            viewportHeight,
-          })
-        : computeLineRevealScrollTop({
-            lineTop: bounds.top,
-            lineHeight: bounds.height,
-            scrollTop: scrollBox.scrollTop,
-            viewportHeight,
-          });
+      requestTarget && bounds.height > viewportHeight
+        ? bounds.top
+        : lineCursorRevealRequest.placement === "reveal"
+          ? computeHunkRevealScrollTop({
+              hunkTop: bounds.top,
+              hunkHeight: bounds.height,
+              preferredTopPadding: Math.max(2, Math.floor(viewportHeight * 0.25)),
+              viewportHeight,
+            })
+          : computeLineRevealScrollTop({
+              lineTop: bounds.top,
+              lineHeight: bounds.height,
+              scrollTop: scrollBox.scrollTop,
+              viewportHeight,
+            });
     // A named line is the final scroll policy for this request, exactly as an
     // explicit alignment is: a cross-file reveal changes the selection, and the
     // selection reveal it schedules would otherwise run its zero-delay retry
@@ -2383,6 +2443,7 @@ export function DiffPane({
     lineCursor,
     lineCursorBoundsOf,
     lineCursorRevealRequest,
+    rowBoundsInStream,
     scrollRef,
     scrollViewport.height,
     supersedePendingSelectionReveal,

--- a/packages/hunk/src/ui/components/panes/FileView.tsx
+++ b/packages/hunk/src/ui/components/panes/FileView.tsx
@@ -168,6 +168,8 @@ function FileViewComponent({
             >
               <AgentInlineNote
                 annotation={plannedRow.annotation}
+                active={plannedRow.note.active}
+                actionKeyLabels={plannedRow.note.actionKeyLabels}
                 anchorSide={plannedRow.anchorSide}
                 file={file}
                 layout="unified"
@@ -175,6 +177,7 @@ function FileViewComponent({
                 noteIndex={plannedRow.noteIndex}
                 draft={plannedRow.note.draft}
                 actions={plannedRow.note.actions}
+                onActivate={plannedRow.note.onActivate}
                 thread={plannedRow.note.thread}
                 theme={theme}
                 width={width}

--- a/packages/hunk/src/ui/components/ui-components.test.tsx
+++ b/packages/hunk/src/ui/components/ui-components.test.tsx
@@ -2863,6 +2863,7 @@ describe("UI components", () => {
         theme={theme}
         width={60}
         actions={actions}
+        actionKeyLabels={{ delete: "d", edit: "e", reply: "r" }}
         thread={thread}
       />,
       { width: 64, height: measured + 1 },
@@ -3874,13 +3875,13 @@ describe("UI components", () => {
       "Controls help",
       "[Esc]",
       "Navigation",
-      "Up / Down                move line-by-line",
+      "Up / Down                move through lines and notes",
       "PageDown / Space / f     page down",
       "PageUp / b / Shift+Space page up",
       "d / u                    half page down / up",
       "[ / ]                    previous / next hunk",
       ", / .                    previous / next file",
-      "{ / }                    previous / next comment",
+      "{ / } / N / n            annotated hunk / exact note",
       "Left / Right             scroll code sideways (Shift = faster)",
       "g / Home                 jump to start",
       "G / End                  jump to end",

--- a/packages/hunk/src/ui/diff/DiffSectionBody.tsx
+++ b/packages/hunk/src/ui/diff/DiffSectionBody.tsx
@@ -394,6 +394,9 @@ export function DiffSectionBody({
                 anchorSide={plannedRow.anchorSide}
                 draft={plannedRow.note.draft}
                 actions={plannedRow.note.actions}
+                active={plannedRow.note.active}
+                actionKeyLabels={plannedRow.note.actionKeyLabels}
+                onActivate={plannedRow.note.onActivate}
                 thread={plannedRow.note.thread}
                 file={file}
                 layout={layout}

--- a/packages/hunk/src/ui/hooks/useTerminalReview.test.tsx
+++ b/packages/hunk/src/ui/hooks/useTerminalReview.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
-import { act, StrictMode, useEffect, useRef, useState } from "react";
+import { act, StrictMode, useEffect, useMemo, useRef, useState } from "react";
 import { builtinAppCommand } from "../../core/run/commandCatalog";
 import { SourceTextTooLargeError } from "../../core/changeset/fileSource";
 import type { DiffFile } from "../../core/changeset/model";
@@ -12,7 +12,9 @@ import {
 } from "../../../../../test/helpers/diff-helpers";
 import { measureDiffSectionGeometry } from "../diff/diffSectionGeometry";
 import { buildLineCursors, type LineCursor } from "../lib/lineCursors";
+import type { ReviewVerticalStop } from "../lib/reviewVerticalStops";
 import { resolveTheme } from "../themes";
+import { createTestStoredNote } from "../../../../../test/helpers/review-store-helpers";
 import { useTerminalReview, type TerminalReview } from "./useTerminalReview";
 
 /** Build a DiffFile with real parsed hunks using the controller's preferred defaults. */
@@ -157,6 +159,7 @@ function TerminalReviewHarness({
   initialFiles,
   noteGeometry,
   publishLineCursors = true,
+  reviewVerticalStops,
   stmlEnabled,
   onController,
   onFirstController,
@@ -166,6 +169,7 @@ function TerminalReviewHarness({
   noteGeometry?: Parameters<typeof useTerminalReview>[0]["noteGeometry"];
   /** Publish measured stops, as the diff pane does unless the current-line marker is off. */
   publishLineCursors?: boolean;
+  reviewVerticalStops?: ReviewVerticalStop[];
   stmlEnabled?: boolean;
   onController: (controller: TerminalReview) => void;
   /** Receive the first render's controller, before any cursors were published. */
@@ -173,8 +177,20 @@ function TerminalReviewHarness({
   onSetFiles?: (setFiles: (nextFiles: DiffFile[]) => void) => void;
 }) {
   const [files, setFiles] = useState(initialFiles);
-  const [lineCursors, setLineCursors] = useState<LineCursor[]>([]);
-  const controller = useTerminalReview({ files, lineCursors, noteGeometry, stmlEnabled });
+  const [lineCursors, setLineCursors] = useState<LineCursor[]>(() =>
+    (reviewVerticalStops ?? []).flatMap((stop) => (stop.kind === "line" ? [stop.cursor] : [])),
+  );
+  const lineOnlyVerticalStops = useMemo(
+    () => lineCursors.map((cursor) => ({ kind: "line" as const, cursor })),
+    [lineCursors],
+  );
+  const controller = useTerminalReview({
+    files,
+    lineCursors,
+    reviewVerticalStops: reviewVerticalStops ?? lineOnlyVerticalStops,
+    noteGeometry,
+    stmlEnabled,
+  });
   // Capture during render, as a memoized consumer's closure would: the effects
   // below have not yet published measured cursors on the first pass.
   const firstControllerRef = useRef<TerminalReview | null>(null);
@@ -229,12 +245,14 @@ async function renderTerminalReview(
     strictMode = false,
     noteGeometry,
     publishLineCursors,
+    reviewVerticalStops,
     stmlEnabled,
     onFirstController,
   }: {
     strictMode?: boolean;
     noteGeometry?: Parameters<typeof useTerminalReview>[0]["noteGeometry"];
     publishLineCursors?: boolean;
+    reviewVerticalStops?: ReviewVerticalStop[];
     stmlEnabled?: boolean;
     onFirstController?: (controller: TerminalReview) => void;
   } = {},
@@ -246,6 +264,7 @@ async function renderTerminalReview(
       initialFiles={initialFiles}
       noteGeometry={noteGeometry}
       publishLineCursors={publishLineCursors}
+      reviewVerticalStops={reviewVerticalStops}
       stmlEnabled={stmlEnabled}
       onFirstController={onFirstController}
       onController={(nextController) => {
@@ -855,6 +874,7 @@ describe("useTerminalReview", () => {
       await flush(setup);
 
       expect(savedNoteId).toStartWith("user:");
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBe(savedNoteId);
       expect(expectValue(controllerRef.current).userNotesByFileId.alpha).toHaveLength(1);
       expect(expectValue(controllerRef.current).reviewNoteSummaries).toMatchObject([
         {
@@ -1848,6 +1868,101 @@ describe("useTerminalReview", () => {
       await act(async () => {
         setup.renderer.destroy();
       });
+    }
+  });
+
+  test("moves between lines, root notes, and replies without dual focus", async () => {
+    const file = createAlphaFile();
+    const cursors = buildLineCursors(
+      [file],
+      [
+        measureDiffSectionGeometry(
+          file,
+          "unified",
+          true,
+          resolveTheme("github-dark-default", null),
+        ),
+      ],
+    );
+    const first = expectValue(cursors[0]);
+    const second = expectValue(cursors[1]);
+    const reviewVerticalStops: ReviewVerticalStop[] = [
+      { kind: "line", cursor: first },
+      {
+        kind: "note",
+        fileId: file.id,
+        hunkIndex: first.hunkIndex,
+        noteId: "root",
+        stableKey: "inline-note:root-card",
+      },
+      {
+        kind: "note",
+        fileId: file.id,
+        hunkIndex: first.hunkIndex,
+        noteId: "reply",
+        stableKey: "inline-note:reply-card",
+      },
+      { kind: "line", cursor: second },
+    ];
+    const { controllerRef, setup } = await renderTerminalReview([file], {
+      publishLineCursors: false,
+      reviewVerticalStops,
+    });
+
+    try {
+      await flush(setup);
+      const controller = expectValue(controllerRef.current);
+      const fileKey = expectValue(controller.store.getSnapshot().document.files[0]).key;
+      await act(async () => {
+        controller.store.dispatch({
+          type: "notes/add-live",
+          notes: [
+            createTestStoredNote({ id: "root", fileKey, source: "user" }),
+            createTestStoredNote({ id: "reply", fileKey, parentId: "root", source: "user" }),
+          ],
+        });
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).lineCursor).toEqual(first);
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBeNull();
+
+      await act(async () => expectValue(controllerRef.current).moveLineCursor(1));
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toBeNull();
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBe("root");
+      expect(expectValue(controllerRef.current).lineCursorRevealRequest.target).toEqual({
+        fileId: file.id,
+        stableKey: "inline-note:root-card",
+      });
+
+      await act(async () => expectValue(controllerRef.current).moveLineCursor(1));
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toBeNull();
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBe("reply");
+
+      await act(async () => expectValue(controllerRef.current).moveLineCursor(1));
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toEqual(second);
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBeNull();
+
+      await act(async () => expectValue(controllerRef.current).moveLineCursor(-1));
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toBeNull();
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBe("reply");
+
+      await act(async () => expectValue(controllerRef.current).moveNoteCursor(-1));
+      await flush(setup);
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBe("root");
+
+      const revealRequest = expectValue(controllerRef.current).lineCursorRevealRequest;
+      await act(async () => expectValue(controllerRef.current).activateNote("reply"));
+      await flush(setup);
+      expect(expectValue(controllerRef.current).lineCursor).toBeNull();
+      expect(expectValue(controllerRef.current).store.getSnapshot().activeNoteId).toBe("reply");
+      expect(expectValue(controllerRef.current).lineCursorRevealRequest).toBe(revealRequest);
+    } finally {
+      await act(async () => setup.renderer.destroy());
     }
   });
 

--- a/packages/hunk/src/ui/hooks/useTerminalReview.ts
+++ b/packages/hunk/src/ui/hooks/useTerminalReview.ts
@@ -44,7 +44,9 @@ import { reviewHunkIndexForLine } from "../../core/review/geometry";
 import type { ReviewSelectionScope } from "../../core/review/navigation";
 import {
   reviewFileKeysWithRetiredContent,
+  selectActiveStoredReviewNote,
   selectExpandedGapIdsByFileKey,
+  selectNavigableStoredReviewNotes,
   selectNormalizedSelection,
   selectThreadedStoredReviewNotes,
   selectVisibleThreadedStoredReviewNotes,
@@ -89,13 +91,18 @@ import type { LineRevealPlacement } from "../lib/hunkScroll";
 import {
   EMPTY_LINE_CURSORS,
   findLineCursorAt,
-  findNextLineCursor,
   firstLineCursorInHunk,
   hasLineCursor,
   lineCursorAt,
   resolveLineCursor,
   type LineCursor,
 } from "../lib/lineCursors";
+import {
+  EMPTY_REVIEW_VERTICAL_STOPS,
+  findNextReviewNoteStop,
+  findNextReviewVerticalStop,
+  type ReviewVerticalStop,
+} from "../lib/reviewVerticalStops";
 import { agentNoteMarkupWidth } from "../lib/agentNoteGeometry";
 import { reviewNoteSource } from "../lib/agentAnnotations";
 import { STML_REFERENCE_WIDTH, validateStmlMarkup } from "../lib/stml/layout";
@@ -164,6 +171,8 @@ interface SourceLoadRequest {
 export interface LineCursorRevealRequest {
   id: number;
   placement: LineRevealPlacement;
+  /** Explicit measured row used when the active vertical stop is a note rather than a line. */
+  target?: { fileId: string; stableKey: string };
 }
 
 /**
@@ -226,6 +235,10 @@ export interface TerminalReview {
   /** Adopt the hunk a viewport settled on, without asking any viewport to move. */
   anchorSelection: (fileId: string, hunkIndex: number) => void;
   moveLineCursor: (delta: number) => void;
+  /** Select a visible semantic note without moving the viewport. */
+  activateNote: (noteId: string) => void;
+  /** Step only between semantic note cards in their rendered order. */
+  moveNoteCursor: (delta: number) => void;
   /** Step the selection through one navigable scope; the scope owns wrap and reveal. */
   moveSelection: (scope: ReviewSelectionScope, delta: number) => void;
   revealLine: (fileId: string, side: "old" | "new", line: number) => RevealedLineResult;
@@ -300,6 +313,7 @@ export function useTerminalReview({
   files,
   initialShowAgentNotes = false,
   lineCursors = EMPTY_LINE_CURSORS,
+  reviewVerticalStops = EMPTY_REVIEW_VERTICAL_STOPS,
   noteGeometry,
   sourceLabel = "",
   stmlEnabled = false,
@@ -312,6 +326,8 @@ export function useTerminalReview({
    * Headless callers get none, which leaves `j` and `k` scrolling the viewport.
    */
   lineCursors?: LineCursor[];
+  /** Mixed rendered line and semantic-note stops used by vertical keyboard movement. */
+  reviewVerticalStops?: ReviewVerticalStop[];
   /**
    * Identity of the review's input as a whole.
    *
@@ -643,15 +659,28 @@ export function useTerminalReview({
   /** Move the current line to a row the reviewer just asked to see, and scroll to it. */
   const revealLineCursor = useCallback(
     (cursor: LineCursor, placement: LineRevealPlacement = "nearest") => {
+      const fileKey = keyByFileId.get(cursor.fileId);
+      if (!fileKey) return;
       applyLineCursor(cursor);
       setLineCursorRevealRequest((current) => ({ id: current.id + 1, placement }));
-      // The line cursor carries its own reveal request; the selection only follows it.
-      anchorSelection(cursor.fileId, cursor.hunkIndex);
+      // A source line and note card are mutually exclusive vertical stops. This viewport-preserving
+      // selection follows the line while clearing any exact semantic note focus.
+      runIntent({
+        type: "selection/select",
+        fileKey,
+        hunkIndex: cursor.hunkIndex,
+        reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL,
+      });
     },
-    [anchorSelection, applyLineCursor],
+    [applyLineCursor, keyByFileId, runIntent],
   );
 
   const reconcileLineCursor = useCallback(() => {
+    if (selectActiveStoredReviewNote(store.getSnapshot())) {
+      applyLineCursor(null);
+      return;
+    }
+
     // Expansion remeasures before its source text loads, so a toggle records what it wants and
     // this waits for the list that actually carries the revealed rows. Each request survives until
     // it resolves or the next toggle replaces it.
@@ -696,7 +725,15 @@ export function useTerminalReview({
     }
 
     applyLineCursor(firstLineCursorInHunk(lineCursors, selectedFileId, selectedHunkIndex));
-  }, [applyLineCursor, lineCursors, revealLineCursor, selectedFileId, selectedHunkIndex]);
+  }, [
+    applyLineCursor,
+    lineCursors,
+    revealLineCursor,
+    selectedFileId,
+    selectedHunkIndex,
+    state.activeNoteId,
+    store,
+  ]);
 
   useEffect(() => {
     reconcileLineCursor();
@@ -705,23 +742,99 @@ export function useTerminalReview({
   /** Adopt a current line the viewport already settled on, without scrolling back to it. */
   const anchorLineCursor = useCallback(
     (cursor: LineCursor) => {
+      const fileKey = keyByFileId.get(cursor.fileId);
+      if (!fileKey) return;
       applyLineCursor(cursor);
-      anchorSelection(cursor.fileId, cursor.hunkIndex);
+      runIntent({
+        type: "selection/select",
+        fileKey,
+        hunkIndex: cursor.hunkIndex,
+        reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL,
+      });
     },
-    [anchorSelection, applyLineCursor],
+    [applyLineCursor, keyByFileId, runIntent],
   );
 
-  /** Move the current line one row through the visible review stream. */
+  /** Read the exact rendered stop that currently owns keyboard focus. */
+  const currentReviewVerticalStop = useCallback((): ReviewVerticalStop | null => {
+    const activeNoteId = selectActiveStoredReviewNote(store.getSnapshot())?.note.id;
+    if (activeNoteId) {
+      return (
+        reviewVerticalStops.find((stop) => stop.kind === "note" && stop.noteId === activeNoteId) ??
+        null
+      );
+    }
+    return lineCursorRef.current ? { kind: "line", cursor: lineCursorRef.current } : null;
+  }, [reviewVerticalStops, store]);
+
+  /** Focus one measured note stop through its current semantic owner. */
+  const focusReviewNoteStop = useCallback(
+    (next: Extract<ReviewVerticalStop, { kind: "note" }>) => {
+      const snapshot = store.getSnapshot();
+      const target = selectNavigableStoredReviewNotes(snapshot).find(
+        (item) => item.entry.note.id === next.noteId,
+      );
+      if (!target || keyByFileId.get(next.fileId) !== target.fileKey) return;
+
+      applyLineCursor(null);
+      runIntent({
+        type: "selection/select",
+        fileKey: target.fileKey,
+        hunkIndex: target.hunkIndex,
+        activeNoteId: next.noteId,
+        reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL,
+      });
+      setLineCursorRevealRequest((request) => ({
+        id: request.id + 1,
+        placement: "nearest",
+        target: { fileId: next.fileId, stableKey: next.stableKey },
+      }));
+    },
+    [applyLineCursor, keyByFileId, runIntent, store],
+  );
+
+  /** Select one visible semantic note as the keyboard action target without scrolling. */
+  const activateNote = useCallback(
+    (noteId: string) => {
+      const target = selectNavigableStoredReviewNotes(store.getSnapshot()).find(
+        (item) => item.entry.note.id === noteId,
+      );
+      if (!target) return;
+
+      applyLineCursor(null);
+      runIntent({
+        type: "selection/select",
+        fileKey: target.fileKey,
+        hunkIndex: target.hunkIndex,
+        activeNoteId: noteId,
+        reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL,
+      });
+    },
+    [applyLineCursor, runIntent, store],
+  );
+
+  /** Move through source lines and semantic note cards in exact rendered order. */
   const moveLineCursor = useCallback(
     (delta: number) => {
-      const nextCursor = findNextLineCursor(lineCursors, lineCursorRef.current, delta);
-      if (!nextCursor) {
-        return;
-      }
-
-      revealLineCursor(nextCursor);
+      const next = findNextReviewVerticalStop(
+        reviewVerticalStops,
+        currentReviewVerticalStop(),
+        delta,
+      );
+      if (!next) return;
+      if (next.kind === "line") revealLineCursor(next.cursor);
+      else focusReviewNoteStop(next);
     },
-    [lineCursors, revealLineCursor],
+    [currentReviewVerticalStop, focusReviewNoteStop, reviewVerticalStops, revealLineCursor],
+  );
+
+  /** Move only through note cards, using the active presentation's visual order. */
+  const moveNoteCursor = useCallback(
+    (delta: number) => {
+      const next = findNextReviewNoteStop(reviewVerticalStops, currentReviewVerticalStop(), delta);
+      if (next) focusReviewNoteStop(next);
+    },
+    [currentReviewVerticalStop, focusReviewNoteStop, reviewVerticalStops],
   );
 
   // `revealLine` is handed to surfaces that hold it across commits — a memoized
@@ -1503,8 +1616,13 @@ export function useTerminalReview({
               timestamp,
             },
           );
+    if (saved) {
+      // Saving transfers vertical focus to the note in the same synchronous input turn, before
+      // viewport settlement can re-anchor the source-line cursor that opened the composer.
+      applyLineCursor(null);
+    }
     return saved ? storedNoteToUserNote(saved.note.note, file.path) : null;
-  }, [fileByKey, runIntent, store]);
+  }, [applyLineCursor, fileByKey, runIntent, store]);
 
   /** Remove one in-memory user note by id. */
   const removeUserNote = useCallback(
@@ -1616,6 +1734,7 @@ export function useTerminalReview({
     addLiveComment,
     addLiveCommentBatch,
     agentLineHighlightsByFileId,
+    activateNote,
     anchorLineCursor,
     anchorSelection,
     clearAgentLineHighlights,
@@ -1623,6 +1742,7 @@ export function useTerminalReview({
     cancelDraftNote,
     clearLiveComments,
     moveLineCursor,
+    moveNoteCursor,
     moveSelection,
     navigateToLocation,
     removeLiveComment,

--- a/packages/hunk/src/ui/lib/agentAnnotations.ts
+++ b/packages/hunk/src/ui/lib/agentAnnotations.ts
@@ -20,6 +20,12 @@ export interface VisibleAgentNote {
   anchor: ReviewRangeAnchorV1;
   source?: ReviewNoteSource | "draft";
   editable?: boolean;
+  /** Whether keyboard note actions currently address this semantic card. */
+  active?: boolean;
+  /** Resolved keyboard labels advertised while the card is active. */
+  actionKeyLabels?: { delete: string; edit: string; reply: string };
+  /** Make this semantic card the keyboard action target when its card is clicked. */
+  onActivate?: () => void;
   /** Shared semantic relationship metadata; static sidecars omit it. */
   thread?: {
     noteId: string;

--- a/packages/hunk/src/ui/lib/appCommands.test.ts
+++ b/packages/hunk/src/ui/lib/appCommands.test.ts
@@ -51,6 +51,7 @@ function createTestCommands(resolvedKeys?: ResolvedCommandKeys) {
     applyFilePresentationToAllMatching: record("applyFilePresentationToAllMatching"),
     focusFilter: record("focusFilter"),
     moveSelection: record("moveSelection"),
+    moveNoteCursor: record("moveNoteCursor"),
     openAgentSkill: record("openAgentSkill"),
     openThemeSelector: record("openThemeSelector"),
     requestQuit: record("requestQuit"),
@@ -364,9 +365,15 @@ describe("executeAppCommand", () => {
     const { commands, ran } = createTestCommands();
 
     expect(executeAppCommand(commands, "hunk.review.nextHunk", { count: 3 })).toBe(true);
+    expect(executeAppCommand(commands, "hunk.review.previousNote", { count: 2 })).toBe(true);
     expect(executeAppCommand(commands, "hunk.review.stepUp", { count: 4 })).toBe(true);
     expect(executeAppCommand(commands, "hunk.review.pageDown", { count: 2 })).toBe(true);
-    expect(ran).toEqual(["moveSelection:hunk,3", "stepDiffLine:-4", "scrollDiff:2,viewport"]);
+    expect(ran).toEqual([
+      "moveSelection:hunk,3",
+      "moveNoteCursor:-2",
+      "stepDiffLine:-4",
+      "scrollDiff:2,viewport",
+    ]);
   });
 
   test("runs one-shot commands once regardless of count", () => {

--- a/packages/hunk/src/ui/lib/appCommands.ts
+++ b/packages/hunk/src/ui/lib/appCommands.ts
@@ -114,16 +114,20 @@ interface BuiltinCommandHandler {
 export interface BuildAppCommandsOptions {
   canAlignCurrentLine: boolean;
   canApplyFilePresentationToAllMatching: boolean;
+  canDeleteActiveNote?: boolean;
   canEditActiveNote?: boolean;
   canReplyToActiveNote?: boolean;
   canRefreshCurrentInput: boolean;
   alignCurrentLine: (alignment: "top" | "center" | "bottom") => void;
   applyFilePresentationToAllMatching: () => void;
   focusFilter: () => void;
+  deleteActiveNote?: () => void;
   editActiveNote?: () => void;
   replyToActiveNote?: () => void;
-  /** Step the review selection through one scope, as the catalog entry declares it. */
+  /** Step shared semantic selection through one scope. */
   moveSelection: (scope: ReviewSelectionScope, delta: number) => void;
+  /** Step note selection through the active surface's measured card order. */
+  moveNoteCursor: (delta: number) => void;
   openAgentSkill: () => void;
   openThemeSelector: () => void;
   requestQuit: () => void;
@@ -207,6 +211,16 @@ function builtinCommandHandlers(
     "hunk.review.replyToActiveNote": {
       isEnabled: () => Boolean(options.canReplyToActiveNote),
       run: () => options.replyToActiveNote?.(),
+    },
+    "hunk.review.deleteActiveNote": {
+      isEnabled: () => Boolean(options.canDeleteActiveNote),
+      run: () => options.deleteActiveNote?.(),
+    },
+    "hunk.review.previousNote": {
+      run: (_key, count, entry) => options.moveNoteCursor((entry.verticalDirection ?? -1) * count),
+    },
+    "hunk.review.nextNote": {
+      run: (_key, count, entry) => options.moveNoteCursor((entry.verticalDirection ?? 1) * count),
     },
     "hunk.review.pageDown": { run: (_key, count) => options.scrollDiff(count, "viewport") },
     "hunk.review.pageUp": { run: (_key, count) => options.scrollDiff(-count, "viewport") },
@@ -344,6 +358,7 @@ const NOOP_COMMAND_OPTIONS: BuildAppCommandsOptions = (() => {
     applyFilePresentationToAllMatching: noop,
     focusFilter: noop,
     moveSelection: noop,
+    moveNoteCursor: noop,
     openAgentSkill: noop,
     openThemeSelector: noop,
     requestQuit: noop,

--- a/packages/hunk/src/ui/lib/appMenus.test.ts
+++ b/packages/hunk/src/ui/lib/appMenus.test.ts
@@ -44,6 +44,7 @@ function createTestCommands(overrides: Partial<BuildAppCommandsOptions> = {}) {
     applyFilePresentationToAllMatching: record("applyFilePresentationToAllMatching"),
     focusFilter: noop,
     moveSelection: record("moveSelection"),
+    moveNoteCursor: record("moveNoteCursor"),
     openAgentSkill: record("openAgentSkill"),
     openThemeSelector: noop,
     requestQuit: record("requestQuit"),

--- a/packages/hunk/src/ui/lib/helpContent.test.ts
+++ b/packages/hunk/src/ui/lib/helpContent.test.ts
@@ -31,7 +31,7 @@ describe("buildHelpSections", () => {
     ]);
     expect(keysFor(sections, "previous / next hunk")).toBe("[ / ]");
     expect(keysFor(sections, "half page down / up")).toBe("d / u");
-    expect(keysFor(sections, "move line-by-line")).toBe("Up / Down");
+    expect(keysFor(sections, "move through lines and notes")).toBe("Up / Down");
     expect(keysFor(sections, "split / unified / auto")).toBe("1 / 2 / 0");
     expect(keysFor(sections, "lines / wrap / metadata / menu")).toBe("l / w / m / M");
   });

--- a/packages/hunk/src/ui/lib/helpContent.ts
+++ b/packages/hunk/src/ui/lib/helpContent.ts
@@ -42,7 +42,7 @@ const HELP_SECTIONS: readonly HelpSectionSpec[] = [
     entries: [
       {
         commandIds: ["hunk.review.stepUp", "hunk.review.stepDown"],
-        description: "move line-by-line",
+        description: "move through lines and notes",
       },
       { commandIds: ["hunk.review.pageDown"], description: "page down" },
       { commandIds: ["hunk.review.pageUp"], description: "page up" },
@@ -59,8 +59,13 @@ const HELP_SECTIONS: readonly HelpSectionSpec[] = [
         description: "previous / next file",
       },
       {
-        commandIds: ["hunk.review.previousAnnotatedHunk", "hunk.review.nextAnnotatedHunk"],
-        description: "previous / next comment",
+        commandIds: [
+          "hunk.review.previousAnnotatedHunk",
+          "hunk.review.nextAnnotatedHunk",
+          "hunk.review.previousNote",
+          "hunk.review.nextNote",
+        ],
+        description: "annotated hunk / exact note",
       },
       {
         commandIds: ["hunk.review.scrollCodeLeft", "hunk.review.scrollCodeRight"],
@@ -108,8 +113,12 @@ const HELP_SECTIONS: readonly HelpSectionSpec[] = [
       { commandIds: ["hunk.review.focusFilter"], description: "focus file filter" },
       { commandIds: ["hunk.review.startNote"], description: "create review note" },
       {
-        commandIds: ["hunk.review.editActiveNote", "hunk.review.replyToActiveNote"],
-        description: "edit / reply to active note",
+        commandIds: [
+          "hunk.review.editActiveNote",
+          "hunk.review.replyToActiveNote",
+          "hunk.review.deleteActiveNote",
+        ],
+        description: "edit / reply / delete active note",
       },
       { commandIds: ["hunk.app.toggleFocusArea"], description: "toggle files/filter focus" },
       { keys: "F10", description: "open menus" },

--- a/packages/hunk/src/ui/lib/reviewVerticalStops.test.ts
+++ b/packages/hunk/src/ui/lib/reviewVerticalStops.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { createTestDiffFile, lines } from "../../../../../test/helpers/diff-helpers";
+import { measureDiffSectionGeometry, type DiffSectionGeometry } from "../diff/diffSectionGeometry";
+import { createVisibleAgentNote } from "./agentAnnotations";
+import { buildLineCursors, type LineCursor } from "./lineCursors";
+import { resolveTheme } from "../themes";
+import {
+  buildReviewVerticalStops,
+  createReviewVerticalStopStabilizer,
+  findNextReviewNoteStop,
+  findNextReviewVerticalStop,
+} from "./reviewVerticalStops";
+
+const theme = resolveTheme("github-dark-default", null);
+
+/** Summarize mixed stops for ordering assertions. */
+function stopLabel(stop: ReturnType<typeof buildReviewVerticalStops>[number]) {
+  return stop.kind === "note"
+    ? `note:${stop.noteId}`
+    : `line:${stop.cursor.target.side}:${stop.cursor.target.line}`;
+}
+
+describe("review vertical stops", () => {
+  test("places semantic roots and replies after their rendered source line", () => {
+    const file = createTestDiffFile({
+      id: "alpha",
+      path: "alpha.ts",
+      before: lines("one", "two", "three", "four", "five"),
+      after: lines("one", "two", "THREE", "four", "five"),
+      context: 3,
+    });
+    const notes = [
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "root-card",
+        annotation: { source: "user", summary: "root", newRange: [3, 3] },
+        thread: { noteId: "root", depth: 0 },
+      }),
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "reply-card",
+        annotation: { source: "user", summary: "reply", newRange: [3, 3] },
+        thread: { noteId: "reply", parentId: "root", depth: 1 },
+      }),
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "sidecar-card",
+        annotation: { source: "agent", summary: "decoration", newRange: [3, 3] },
+      }),
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "draft-card",
+        annotation: { source: "user-draft", summary: "draft", newRange: [3, 3] },
+        source: "draft",
+        thread: { noteId: "draft", depth: 0 },
+      }),
+    ];
+    const geometry = measureDiffSectionGeometry(file, "unified", true, theme, notes, 80);
+    const cursors = buildLineCursors([file], [geometry]);
+    const stops = buildReviewVerticalStops([file], [geometry], cursors);
+    const labels = stops.map(stopLabel);
+    const changedLine = labels.indexOf("line:new:3");
+
+    expect(labels.slice(changedLine, changedLine + 4)).toEqual([
+      "line:new:3",
+      "note:root",
+      "note:reply",
+      "line:new:4",
+    ]);
+    expect(labels).not.toContain("note:sidecar-card");
+    expect(labels).not.toContain("note:draft");
+
+    const root = stops[changedLine + 1]!;
+    const reply = findNextReviewVerticalStop(stops, root, 1);
+    expect(reply && stopLabel(reply)).toBe("note:reply");
+    expect(stopLabel(findNextReviewVerticalStop(stops, reply, -1)!)).toBe("note:root");
+    expect(findNextReviewVerticalStop(stops, stops[0]!, -1)).toBe(stops[0]!);
+    expect(findNextReviewVerticalStop(stops, stops.at(-1)!, 1)).toBe(stops.at(-1)!);
+    expect(findNextReviewVerticalStop(stops, null, -1)).toBe(stops.at(-1)!);
+    expect(findNextReviewNoteStop(stops, stops[changedLine]!, 1)?.noteId).toBe("root");
+    expect(findNextReviewNoteStop(stops, stops[changedLine + 3]!, -1)?.noteId).toBe("reply");
+  });
+
+  test("uses alternate file-view inline-note rows as selectable stops", () => {
+    const file = createTestDiffFile({
+      id: "alpha",
+      path: "alpha.ts",
+      before: lines("one", "two"),
+      after: lines("ONE", "two"),
+      context: 1,
+    });
+    const first: LineCursor = {
+      fileId: file.id,
+      hunkIndex: 0,
+      stableKey: "line:0:new:1",
+      target: { side: "new", line: 1 },
+    };
+    const second: LineCursor = {
+      fileId: file.id,
+      hunkIndex: 0,
+      stableKey: "line:0:context:2:2",
+      target: { side: "new", line: 2 },
+    };
+    const note = createVisibleAgentNote(file.metadata.hunks, {
+      id: "view-card",
+      annotation: { source: "user", summary: "view note", newRange: [1, 1] },
+      thread: { noteId: "view-note", depth: 0 },
+    });
+    const geometry = {
+      bodyHeight: 3,
+      hunkAnchorRows: new Map(),
+      hunkBounds: new Map(),
+      hunkSpans: file.metadata.hunks,
+      lineNumberDigits: 1,
+      plannedRows: [],
+      fileViewRows: [
+        {
+          kind: "file-view-row",
+          key: "row-1",
+          stableKey: first.stableKey,
+          row: { id: "1", spans: [] },
+          rowIndex: 0,
+        },
+        {
+          kind: "inline-note",
+          key: "note",
+          stableKey: "inline-note:view-card",
+          annotation: note.annotation,
+          anchorRowIndex: 0,
+          anchorSide: "new",
+          hunkIndex: 0,
+          note,
+          noteCount: 1,
+          noteIndex: 0,
+        },
+        {
+          kind: "file-view-row",
+          key: "row-2",
+          stableKey: second.stableKey,
+          row: { id: "2", spans: [] },
+          rowIndex: 1,
+        },
+      ],
+      rowBounds: [
+        {
+          key: "row-1",
+          stableKey: first.stableKey,
+          stableKeys: [first.stableKey],
+          top: 0,
+          height: 1,
+        },
+        {
+          key: "note",
+          stableKey: "inline-note:view-card",
+          stableKeys: ["inline-note:view-card"],
+          top: 1,
+          height: 1,
+        },
+        {
+          key: "row-2",
+          stableKey: second.stableKey,
+          stableKeys: [second.stableKey],
+          top: 2,
+          height: 1,
+        },
+      ],
+      rowBoundsByKey: new Map(),
+      rowBoundsByStableKey: new Map(),
+    } satisfies DiffSectionGeometry;
+
+    const stops = buildReviewVerticalStops([file], [geometry], [first, second]);
+    expect(stops.map(stopLabel)).toEqual(["line:new:1", "note:view-note", "line:new:2"]);
+    expect(findNextReviewNoteStop(stops, stops[0]!, 1)?.noteId).toBe("view-note");
+    expect(findNextReviewNoteStop(stops, stops[2]!, -1)?.noteId).toBe("view-note");
+  });
+
+  test("stabilizes equivalent remeasurements", () => {
+    const stabilize = createReviewVerticalStopStabilizer();
+    const cursor: LineCursor = {
+      fileId: "alpha",
+      hunkIndex: 0,
+      stableKey: "line:0:new:1",
+      target: { side: "new", line: 1 },
+    };
+    const first = [{ kind: "line" as const, cursor }];
+    const second = [{ kind: "line" as const, cursor: { ...cursor } }];
+
+    expect(stabilize(first)).toBe(first);
+    expect(stabilize(second)).toBe(first);
+  });
+});

--- a/packages/hunk/src/ui/lib/reviewVerticalStops.ts
+++ b/packages/hunk/src/ui/lib/reviewVerticalStops.ts
@@ -1,0 +1,165 @@
+/**
+ * Builds the keyboard's vertical review stops from the rows the active presentation measures.
+ * Source lines and semantic note cards share visual order; decoration-only annotations never
+ * become stops because they carry no stored-note identity.
+ */
+import type { DiffFile } from "../../core/changeset/model";
+import type { DiffSectionGeometry } from "../diff/diffSectionGeometry";
+import type { LineCursor } from "./lineCursors";
+
+export type ReviewVerticalStop =
+  | { kind: "line"; cursor: LineCursor }
+  | {
+      kind: "note";
+      fileId: string;
+      hunkIndex: number;
+      noteId: string;
+      stableKey: string;
+    };
+
+export const EMPTY_REVIEW_VERTICAL_STOPS: ReviewVerticalStop[] = [];
+
+const indexesByStopList = new WeakMap<ReviewVerticalStop[], Map<string, number>>();
+
+/** Identify one stop independently of newly allocated wrapper objects. */
+function reviewVerticalStopId(stop: ReviewVerticalStop) {
+  return stop.kind === "line"
+    ? `line\u0000${stop.cursor.fileId}\u0000${stop.cursor.stableKey}`
+    : `note\u0000${stop.fileId}\u0000${stop.noteId}`;
+}
+
+/** Flatten canonical measured rows into source-line and semantic-note stops. */
+export function buildReviewVerticalStops(
+  files: DiffFile[],
+  sectionGeometry: DiffSectionGeometry[],
+  lineCursors: LineCursor[],
+): ReviewVerticalStop[] {
+  const lineCursorByKey = new Map(
+    lineCursors.map((cursor) => [`${cursor.fileId}\u0000${cursor.stableKey}`, cursor] as const),
+  );
+
+  return files.flatMap((file, sectionIndex) => {
+    const geometry = sectionGeometry[sectionIndex];
+    if (!geometry) return [];
+
+    const plannedRows = geometry.fileViewRows ?? geometry.plannedRows;
+    const plannedRowByStableKey = new Map(plannedRows.map((row) => [row.stableKey, row] as const));
+    const stops: ReviewVerticalStop[] = [];
+
+    for (const bounds of geometry.rowBounds) {
+      const plannedRow = plannedRowByStableKey.get(bounds.stableKey);
+      if (plannedRow?.kind === "inline-note") {
+        const noteId =
+          plannedRow.note.source === "draft" ? undefined : plannedRow.note.thread?.noteId;
+        if (noteId) {
+          stops.push({
+            kind: "note",
+            fileId: file.id,
+            hunkIndex: plannedRow.hunkIndex,
+            noteId,
+            stableKey: bounds.stableKey,
+          });
+        }
+        continue;
+      }
+
+      const stableKeys = [
+        bounds.stableKey,
+        ...bounds.stableKeys.filter((key) => key !== bounds.stableKey),
+      ];
+      for (const stableKey of stableKeys) {
+        const cursor = lineCursorByKey.get(`${file.id}\u0000${stableKey}`);
+        if (cursor) stops.push({ kind: "line", cursor });
+      }
+    }
+
+    return stops;
+  });
+}
+
+/** Reuse the previous stop list when remeasurement preserved the same visual targets. */
+export function reuseEquivalentReviewVerticalStops(
+  previous: ReviewVerticalStop[],
+  next: ReviewVerticalStop[],
+) {
+  return previous.length === next.length &&
+    next.every(
+      (stop, index) => reviewVerticalStopId(stop) === reviewVerticalStopId(previous[index]!),
+    )
+    ? previous
+    : next;
+}
+
+/** Create a stabilizer that compares only newly measured stop lists. */
+export function createReviewVerticalStopStabilizer() {
+  let measured = EMPTY_REVIEW_VERTICAL_STOPS;
+  let stable = EMPTY_REVIEW_VERTICAL_STOPS;
+  return (next: ReviewVerticalStop[]) => {
+    if (next !== measured) {
+      measured = next;
+      stable = reuseEquivalentReviewVerticalStops(stable, next);
+    }
+    return stable;
+  };
+}
+
+/** Index one stable stop list so repeated vertical movement stays constant-time. */
+function reviewVerticalStopIndexes(stops: ReviewVerticalStop[]) {
+  let indexes = indexesByStopList.get(stops);
+  if (!indexes) {
+    indexes = new Map(stops.map((stop, index) => [reviewVerticalStopId(stop), index]));
+    indexesByStopList.set(stops, indexes);
+  }
+  return indexes;
+}
+
+/** Move through mixed review stops, clamping at the first and last rendered target. */
+export function findNextReviewVerticalStop(
+  stops: ReviewVerticalStop[],
+  current: ReviewVerticalStop | null,
+  delta: number,
+): ReviewVerticalStop | null {
+  if (stops.length === 0) return null;
+  const currentId = current ? reviewVerticalStopId(current) : null;
+  const currentIndex = currentId ? (reviewVerticalStopIndexes(stops).get(currentId) ?? -1) : -1;
+  if (currentIndex < 0) return delta < 0 ? (stops.at(-1) ?? null) : (stops[0] ?? null);
+  const nextIndex = Math.min(Math.max(currentIndex + delta, 0), stops.length - 1);
+  return stops[nextIndex] ?? null;
+}
+
+/** Move only between semantic note stops using the active surface's rendered order. */
+export function findNextReviewNoteStop(
+  stops: ReviewVerticalStop[],
+  current: ReviewVerticalStop | null,
+  delta: number,
+): Extract<ReviewVerticalStop, { kind: "note" }> | null {
+  if (delta === 0) return null;
+  const notes = stops.filter(
+    (stop): stop is Extract<ReviewVerticalStop, { kind: "note" }> => stop.kind === "note",
+  );
+  if (notes.length === 0) return null;
+
+  if (current?.kind === "note") {
+    const currentIndex = notes.findIndex((note) => note.noteId === current.noteId);
+    if (currentIndex >= 0) {
+      const nextIndex = Math.min(Math.max(currentIndex + delta, 0), notes.length - 1);
+      return nextIndex === currentIndex ? null : (notes[nextIndex] ?? null);
+    }
+  }
+
+  const currentIndex = current
+    ? (reviewVerticalStopIndexes(stops).get(reviewVerticalStopId(current)) ?? -1)
+    : -1;
+  const candidates = notes.filter((note) => {
+    const index = reviewVerticalStopIndexes(stops).get(reviewVerticalStopId(note)) ?? -1;
+    return delta > 0 ? index > currentIndex : currentIndex < 0 || index < currentIndex;
+  });
+  const nearest = delta > 0 ? candidates[0] : candidates.at(-1);
+  if (!nearest) return null;
+  const remaining = Math.abs(delta) - 1;
+  const nearestIndex = notes.indexOf(nearest);
+  return (
+    notes[Math.min(Math.max(nearestIndex + Math.sign(delta) * remaining, 0), notes.length - 1)] ??
+    null
+  );
+}

--- a/test/pty/chrome.test.ts
+++ b/test/pty/chrome.test.ts
@@ -261,12 +261,12 @@ describe("PTY chrome", () => {
         session,
         (text) =>
           (text.includes("Keyboard help") || text.includes("Controls help")) &&
-          text.includes("move line-by-line"),
+          text.includes("move through lines and notes"),
         5_000,
       );
 
       expect(help.includes("Keyboard help") || help.includes("Controls help")).toBe(true);
-      expect(help).toContain("move line-by-line");
+      expect(help).toContain("move through lines and notes");
     } finally {
       session.close();
     }

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -280,6 +280,143 @@ describe("PTY notes", () => {
     }
   });
 
+  test("saved notes are visibly active and keyboard-navigable without hover", async () => {
+    const fixture = harness.createLongWrapFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "unified"],
+      cols: 100,
+      rows: 30,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+
+      await session.press("c");
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await session.type("First keyboard note.");
+      await session.type("\x13");
+      await session.waitForText(/First keyboard note\./, { timeout: 5_000 });
+
+      await session.press("c");
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await session.type("Second keyboard note.");
+      await session.type("\x13");
+      const savedActive = await harness.waitForSnapshot(
+        session,
+        (text) =>
+          lineIndexOf(text, "Second keyboard note.") - lineIndexOf(text, "● Your note") === 2,
+        5_000,
+      );
+      expect(savedActive).toContain("R reply");
+      expect(savedActive).toContain("E edit");
+      expect(savedActive).toContain("D delete");
+
+      await session.press("k");
+      await session.press("k");
+      const firstActive = await harness.waitForSnapshot(
+        session,
+        (text) => {
+          const markerRow = lineIndexOf(text, "● Your note");
+          const firstBodyRow = lineIndexOf(text, "First keyboard note.");
+          return markerRow >= 0 && firstBodyRow - markerRow === 2;
+        },
+        5_000,
+      );
+      expect(firstActive).toContain("R reply");
+      expect(firstActive).toContain("E edit");
+      expect(firstActive).toContain("D delete");
+
+      await session.press("down");
+      await session.press("down");
+      const secondActive = await harness.waitForSnapshot(
+        session,
+        (text) => {
+          const markerRow = lineIndexOf(text, "● Your note");
+          const secondBodyRow = lineIndexOf(text, "Second keyboard note.");
+          return markerRow >= 0 && secondBodyRow - markerRow === 2;
+        },
+        5_000,
+      );
+      expect(secondActive).toContain("Second keyboard note.");
+
+      await session.press("k");
+      await session.press("k");
+      await harness.waitForSnapshot(
+        session,
+        (text) => {
+          const markerRow = lineIndexOf(text, "● Your note");
+          const firstBodyRow = lineIndexOf(text, "First keyboard note.");
+          return markerRow >= 0 && firstBodyRow - markerRow === 2;
+        },
+        5_000,
+      );
+      await session.press("j");
+      await session.press("j");
+      await session.type("D");
+      const deleted = await harness.waitForSnapshot(
+        session,
+        (text) => !text.includes("Second keyboard note."),
+        5_000,
+      );
+      expect(deleted).toContain("First keyboard note.");
+    } finally {
+      session.close();
+    }
+  });
+
+  test("next and previous note work when the current-line marker is off", async () => {
+    const fixture = harness.createLongWrapFilePair();
+    const session = await harness.launchHunk({
+      args: [
+        "diff",
+        "--files",
+        fixture.before,
+        fixture.after,
+        "--mode",
+        "unified",
+        "--cursor-line",
+        "off",
+      ],
+      cols: 100,
+      rows: 30,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+      for (const body of ["First note-only stop.", "Second note-only stop."]) {
+        await session.press("c");
+        await session.waitForText(/Draft note/, { timeout: 5_000 });
+        await session.type(body);
+        await session.type("\x13");
+        await session.waitForText(new RegExp(body.replaceAll(".", "\\.")), { timeout: 5_000 });
+      }
+
+      await session.type("N");
+      await harness.waitForSnapshot(
+        session,
+        (text) =>
+          lineIndexOf(text, "First note-only stop.") - lineIndexOf(text, "● Your note") === 2,
+        5_000,
+      );
+      await session.press("n");
+      await harness.waitForSnapshot(
+        session,
+        (text) =>
+          lineIndexOf(text, "Second note-only stop.") - lineIndexOf(text, "● Your note") === 2,
+        5_000,
+      );
+      await session.type("N");
+      await harness.waitForSnapshot(
+        session,
+        (text) =>
+          lineIndexOf(text, "First note-only stop.") - lineIndexOf(text, "● Your note") === 2,
+        5_000,
+      );
+    } finally {
+      session.close();
+    }
+  });
+
   test("saved notes can be edited and replied to through clickable threaded actions", async () => {
     const fixture = harness.createLongWrapFilePair();
     const session = await harness.launchHunk({
@@ -296,11 +433,10 @@ describe("PTY notes", () => {
       await session.type("Root review note.");
       await session.waitForText(/Root review note\./, { timeout: 5_000 });
       await session.type("\x13");
-      const root = await session.waitForText(/Root review note\./, { timeout: 5_000 });
-      expect(root).not.toContain("r reply");
+      const root = await session.waitForText(/R reply E edit D delete/, { timeout: 5_000 });
       expect(root).toMatch(/before\.ts -> after\.ts [LR]1/);
 
-      const revealActionsForBody = async (body: string) => {
+      const selectNoteByBody = async (body: string, assertHoverOnly = false) => {
         const snapshot = await session.waitForText(
           new RegExp(body.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
           {
@@ -310,19 +446,31 @@ describe("PTY notes", () => {
         const row = lineIndexOf(snapshot, body);
         const column = snapshot.split("\n")[row]!.indexOf(body) + 1;
         await moveMouse(session, 0, 0);
-        await moveMouse(session, column, row);
-        return session.waitForText(/r reply e edit/, { timeout: 5_000 });
+        await moveMouse(session, column, row - 2);
+        const hovered = await session.waitForText(/reply.*edit/, { timeout: 5_000 });
+        if (assertHoverOnly) {
+          expect(hovered).not.toContain("● Your note");
+        }
+        await session.clickAt(column, row);
+        return harness.waitForSnapshot(
+          session,
+          (text) => {
+            const markerRow = lineIndexOf(text, "● Your note");
+            return markerRow >= 0 && lineIndexOf(text, body) - markerRow === 2;
+          },
+          5_000,
+        );
       };
 
-      const hoveredRoot = await revealActionsForBody("Root review note.");
+      const hoveredRoot = await selectNoteByBody("Root review note.");
       const rootBottomBorder = hoveredRoot
         .split("\n")
-        .find((line) => line.includes("r reply e edit d delete"));
+        .find((line) => line.includes("R reply E edit D delete"));
       expect(rootBottomBorder?.trimStart().startsWith("╰")).toBe(true);
       expect(rootBottomBorder?.trimEnd().endsWith("╯")).toBe(true);
 
       const rootRowBeforeEdit = lineIndexOf(hoveredRoot, "Root review note.");
-      await session.click(/e edit/);
+      await session.click(/edit/);
       const editing = await session.waitForText(/Edit note/, { timeout: 5_000 });
       expect(editing).toContain("Root review note.");
       expect(lineIndexOf(editing, "Root review note.")).toBe(rootRowBeforeEdit);
@@ -332,54 +480,79 @@ describe("PTY notes", () => {
       await session.type("\x13");
       const edited = await session.waitForText(/Updated\. Root review note\./, { timeout: 5_000 });
       expect((edited.match(/Your note/g) ?? []).length).toBe(1);
-      expect(edited).not.toContain("r reply");
+      await session.press("j");
 
-      const rootBeforeReply = await revealActionsForBody("Updated. Root review note.");
+      const rootBeforeReply = await selectNoteByBody("Updated. Root review note.", true);
       const rootRowBeforeReply = lineIndexOf(rootBeforeReply, "Updated. Root review note.");
-      await session.click(/r reply/);
+      await session.type("R");
       const replying = await session.waitForText(/╰─╭─ Reply -/, { timeout: 5_000 });
       expect(lineIndexOf(replying, "Updated. Root review note.")).toBe(rootRowBeforeReply);
       await session.type("First reply.");
       await session.waitForText(/First reply\./, { timeout: 5_000 });
       await session.type("\x13");
       const firstReply = await session.waitForText(/First reply\./, { timeout: 5_000 });
-      expect(firstReply).toMatch(/╰─╭─ Your note/);
+      expect(firstReply).toMatch(/╰─╭─ ● Your note/);
 
-      await revealActionsForBody("First reply.");
-      await session.click(/r reply/);
+      await session.press("k");
+      await harness.waitForSnapshot(
+        session,
+        (text) => {
+          const markerRow = lineIndexOf(text, "● Your note");
+          return (
+            markerRow >= 0 && lineIndexOf(text, "Updated. Root review note.") - markerRow === 2
+          );
+        },
+        5_000,
+      );
+      await session.press("j");
+      await harness.waitForSnapshot(
+        session,
+        (text) => {
+          const markerRow = lineIndexOf(text, "● Your note");
+          return markerRow >= 0 && lineIndexOf(text, "First reply.") - markerRow === 2;
+        },
+        5_000,
+      );
+      await selectNoteByBody("First reply.");
+      await session.click(/R reply/);
       await session.waitForText(/╰─╭─ Reply -/, { timeout: 5_000 });
       await session.type("Nested reply.");
       await session.waitForText(/Nested reply\./, { timeout: 5_000 });
       await session.type("\x13");
 
       const nested = await session.waitForText(/Nested reply\./, { timeout: 5_000 });
-      expect(nested).toMatch(/╰─╭─ Your note/);
+      expect(nested).toMatch(/╰─╭─ ● Your note/);
 
-      await revealActionsForBody("Updated. Root review note.");
-      await session.click(/r reply/);
+      await selectNoteByBody("Updated. Root review note.");
+      await session.click(/R reply/);
       const siblingDraft = await session.waitForText(/╰─╭─ Reply -/, { timeout: 5_000 });
       expect(siblingDraft).toMatch(/├─╭─ Your note/);
       expect(siblingDraft).toMatch(/│ ╰─╭─ Your note/);
       await session.click(/Esc cancel/);
       await harness.waitForSnapshot(session, (text) => !text.includes("╭─ Reply -"), 5_000);
 
+      await session.press("j");
       await session.type("E");
       await session.waitForText(/╭─ Edit note -/, { timeout: 5_000 });
       await session.click(/Esc cancel/);
       await harness.waitForSnapshot(session, (text) => !text.includes("╭─ Edit note -"), 5_000);
+      await session.press("j");
       await session.type("R");
       const keyboardReply = await session.waitForText(/╭─ Reply -/, { timeout: 5_000 });
 
       const threadedTitles = keyboardReply
         .split("\n")
         .filter((line) => line.includes("╭─ Your note"));
-      expect(threadedTitles.length).toBeGreaterThanOrEqual(3);
+      expect(threadedTitles.length).toBeGreaterThanOrEqual(2);
       expect(threadedTitles[1]!.indexOf("╭")).toBeGreaterThan(threadedTitles[0]!.indexOf("╭"));
 
       await session.click(/Esc cancel/);
       await harness.waitForSnapshot(session, (text) => !text.includes("╭─ Reply -"), 5_000);
-      await revealActionsForBody("Nested reply.");
-      await session.click(/d delete/);
+      await session.press("j");
+      await session.press("j");
+      await session.press("j");
+      await selectNoteByBody("Nested reply.");
+      await session.click(/delete/);
       const deletedLeaf = await harness.waitForSnapshot(
         session,
         (text) => !text.includes("Nested reply."),
@@ -394,7 +567,7 @@ describe("PTY notes", () => {
   test("mouse range across replacement sides opens and saves the exact multiline draft", async () => {
     const fixture = harness.createWideCharacterFilePair();
     const session = await harness.launchHunk({
-      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "stack"],
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "unified"],
       cols: 110,
       rows: 22,
     });

--- a/test/review-conformance/wireFixtures.ts
+++ b/test/review-conformance/wireFixtures.ts
@@ -38,6 +38,16 @@ export const REVIEW_WIRE_FIXTURES: readonly ReviewWireFixture[] = [
     },
   },
   {
+    id: "move-next-note",
+    findings: ["B12"],
+    description: "Exact stored-note navigation uses the same wire intent vocabulary.",
+    action: { type: "selection/move", scope: "note", delta: 1 },
+    expected: {
+      accepted: true,
+      intent: { type: "selection/move", scope: "note", delta: 1 },
+    },
+  },
+  {
     id: "move-annotated-hunk-backwards",
     findings: ["B12"],
     description: "Relative navigation, whose scope and wrap policy are core's to decide.",


### PR DESCRIPTION
## Problem

Inline review comments rendered between source lines, but keyboard movement skipped over them and note actions depended on mouse-only controls. This made threaded comments difficult to review and operate on from the keyboard.

## Approach

- add shared active-note identity and exact-note selection to review state, intents, and wire parsing
- build terminal vertical stops from measured rendered geometry so `j`/`k` and Up/Down visit source lines, comments, and every reply in order
- classify `n`/`N` as presentation-local and resolve them from the active surface’s measured note order before dispatching validated exact-note selection
- expose `R`, `E`, and `D` for replying to, editing, and deleting the active leaf note
- activate a note after saving it or clicking its card; hovering remains pointer-only and does not change selection
- reveal selected note cards minimally and support both raw diffs and alternate file views

Text/range selection remains source-line-only, and ordinary row navigation still clears note focus so line and note selection cannot be active together.

## Validation

- `TMPDIR=/var/tmp bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bun test ./test/review-conformance`
- `bun test test/pty/notes.test.ts`
- `bun run test:tty-smoke`
- focused core, hook, component, command-catalog, protocol, and vertical-stop suites
- independent final diff review

Tested on Linux. The PTY tests drive the real TUI for keyboard, mouse, save, thread, and narrow-layout behavior. No separate video is attached.

## Release

Includes a minor Changeset for `hunkdiff`.

*This PR description was generated by Pi using gpt-5.6-sol*
