### PR TITLE
fix(ui): retain view preferences across history reviews

### DIFF
--- a/.changeset/bright-views-return.md
+++ b/.changeset/bright-views-return.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep diff view preferences active when moving between history and commit reviews in the same session.

--- a/packages/hunk/src/app/historyBootstrap.test.ts
+++ b/packages/hunk/src/app/historyBootstrap.test.ts
@@ -75,6 +75,7 @@ describe("history bootstrap cursor ownership", () => {
           initialTheme: "github-dark-dimmed",
           customThemes: [],
         },
+        viewPreferences: bootstrap.initialViewPreferences,
       });
       expect(bootstrap.initialViewPreferences).toMatchObject({
         theme: "github-dark-dimmed",

--- a/packages/hunk/src/app/historyBootstrap.ts
+++ b/packages/hunk/src/app/historyBootstrap.ts
@@ -152,6 +152,9 @@ export async function loadHistoryBootstrap({
   }
 
   const resolvedTheme = resolved.configured.input.options.theme;
+  const initialViewPreferences = persistedViewPreferencesFromOptions(
+    resolved.configured.input.options,
+  );
   let closed = false;
   return {
     input: resolvedTheme ? { ...input, theme: resolvedTheme } : input,
@@ -167,9 +170,10 @@ export async function loadHistoryBootstrap({
         initialTheme: resolved.configured.input.options.theme,
         customThemes: sessionThemes.themes,
       },
+      viewPreferences: initialViewPreferences,
     }),
     keybindings: resolved.configured.keybindings,
-    initialViewPreferences: persistedViewPreferencesFromOptions(resolved.configured.input.options),
+    initialViewPreferences,
     viewPreferencesConfigPath: resolved.configured.viewPreferencesConfigPath,
     promptSaveViewPreferences:
       resolved.configured.input.options.promptSaveViewPreferences !== false,

--- a/packages/hunk/src/app/historyReview.test.ts
+++ b/packages/hunk/src/app/historyReview.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import { resolve } from "node:path";
 import { createEmptyExtensionLoadResult } from "../extensions/types";
+import { persistedViewPreferencesFromOptions } from "../core/run/config";
 import { prepareEmbeddedHistoryReview } from "./historyReview";
+
+const viewPreferences = persistedViewPreferencesFromOptions({});
 
 /** Provide only the provider-neutral fields embedded review startup consumes. */
 function createTestRequest() {
@@ -33,14 +36,14 @@ describe("embedded history review bootstrap", () => {
             bootstrap: { extensions: { ...request.extensionSession } },
             cliInput: {},
             controllingTerminal: null,
-            initialization: { theme: { customThemes: [] } },
+            initialization: { theme: { customThemes: [] }, viewPreferences },
           };
         }) as never,
       },
     );
 
     expect(result.bootstrap).toBeDefined();
-    expect(result.initialization).toEqual({ theme: { customThemes: [] } });
+    expect(result.initialization).toEqual({ theme: { customThemes: [] }, viewPreferences });
     expect(captured?.argv).toContain(resolve("invocation", "extensions/provider.ts"));
     expect(captured?.deps).toMatchObject({
       cwd: resolve("invocation"),
@@ -67,7 +70,7 @@ describe("embedded history review bootstrap", () => {
             bootstrap: { extensions: { ...request.extensionSession } },
             cliInput: {},
             controllingTerminal: { close },
-            initialization: { theme: { customThemes: [] } },
+            initialization: { theme: { customThemes: [] }, viewPreferences },
           };
         }) as never,
       }),

--- a/packages/hunk/src/app/sessionBootstrap.test.ts
+++ b/packages/hunk/src/app/sessionBootstrap.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { fileLanguageForPath } from "../core/changeset/fileLanguageLookup";
 import { replaceExtensionFileLanguages } from "../core/changeset/fileLanguage";
-import type { HunkConfigResolution } from "../core/run/config";
+import { persistedViewPreferencesFromOptions, type HunkConfigResolution } from "../core/run/config";
 import type { AppBootstrap } from "../core/bootstrap";
 import type { CliInput } from "../core/run/commandInputs";
 import { createEmptyExtensionLoadResult } from "../extensions/types";
@@ -72,6 +72,7 @@ describe("loadConfiguredSessionBootstrap", () => {
           { id: "extension-theme", accent: "#123456" },
         ],
       },
+      viewPreferences: persistedViewPreferencesFromOptions(input.options),
     });
     expect(result.bootstrap.keybindings).toEqual({ "hunk.review.nextHunk": "]" });
     expect(result.bootstrap.viewPreferencesConfigPath).toBe("/tmp/hunk-config.toml");

--- a/packages/hunk/src/app/sessionBootstrap.ts
+++ b/packages/hunk/src/app/sessionBootstrap.ts
@@ -3,7 +3,7 @@ import {
   restoreFileLanguageRegistrations,
   type FileLanguageRegistrationSnapshot,
 } from "../core/changeset/fileLanguage";
-import type { HunkConfigResolution } from "../core/run/config";
+import { persistedViewPreferencesFromOptions, type HunkConfigResolution } from "../core/run/config";
 import { isVcsReviewInput } from "../core/vcs";
 import type { VcsCatalog } from "../core/vcs/types";
 import { getBundledVcsCatalog } from "./vcsCatalog";
@@ -105,6 +105,7 @@ export async function loadConfiguredSessionBootstrap({
         initialThemeMode: bootstrap.initialThemeMode,
         customThemes: sessionThemes.themes,
       },
+      viewPreferences: persistedViewPreferencesFromOptions(input.options),
     });
     bootstrap.extensions = extensions;
     bootstrap.viewPreferencesConfigPath = configured.viewPreferencesConfigPath;

--- a/packages/hunk/src/core/session/initialization.ts
+++ b/packages/hunk/src/core/session/initialization.ts
@@ -1,5 +1,6 @@
 import type { TerminalThemeMode } from "../theme/detection";
 import type { NamedCustomThemeConfig } from "../../extension-api/types";
+import type { PersistedViewPreferences } from "../run/config";
 
 /** Theme inputs finalized during startup and retained for every surface in one session. */
 export interface SessionThemeInitialization {
@@ -14,15 +15,19 @@ export interface SessionThemeInitialization {
  */
 export interface InteractiveSessionInitialization {
   theme: SessionThemeInitialization;
+  /** Resolved launch preferences that routed review surfaces may update in memory. */
+  viewPreferences: PersistedViewPreferences;
 }
 
 /** Package finalized cross-surface inputs into one interactive-session launch record. */
 export function createInteractiveSessionInitialization({
   theme,
+  viewPreferences,
 }: {
   theme: Omit<SessionThemeInitialization, "customThemes"> & {
     customThemes?: readonly NamedCustomThemeConfig[];
   };
+  viewPreferences: PersistedViewPreferences;
 }): InteractiveSessionInitialization {
   return {
     theme: {
@@ -30,5 +35,6 @@ export function createInteractiveSessionInitialization({
       ...(theme.initialThemeMode === undefined ? {} : { initialThemeMode: theme.initialThemeMode }),
       customThemes: theme.customThemes ?? [],
     },
+    viewPreferences,
   };
 }

--- a/packages/hunk/src/ui/App.tsx
+++ b/packages/hunk/src/ui/App.tsx
@@ -145,6 +145,7 @@ export function App({
   noticeText,
   onQuit = () => process.exit(0),
   onFirstFrameReady,
+  onViewPreferencesChange,
   onRegisterWorkspaceRefreshRequest,
   onReloadSession,
   onRequestExtensionReviewReload,
@@ -164,6 +165,8 @@ export function App({
   onQuit?: () => void;
   /** Report once OpenTUI has committed the review's first requested frame. */
   onFirstFrameReady?: () => void;
+  /** Publish the complete live preference snapshot to a routed session owner. */
+  onViewPreferencesChange?: (preferences: PersistedViewPreferences) => void;
   /** Register the mounted review descriptor AppHost should reconcile after a completed write. */
   onRegisterWorkspaceRefreshRequest: (request: WorkspaceRefreshRequest) => () => void;
   onReloadSession: (
@@ -307,6 +310,20 @@ export function App({
       wrapLines,
     ],
   );
+  const currentViewPreferencesRef = useRef(currentViewPreferences);
+  currentViewPreferencesRef.current = currentViewPreferences;
+  const publishViewPreferenceChanges = useCallback(
+    (changes: Partial<PersistedViewPreferences>) => {
+      const preferences = { ...currentViewPreferencesRef.current, ...changes };
+      currentViewPreferencesRef.current = preferences;
+      onViewPreferencesChange?.(preferences);
+    },
+    [onViewPreferencesChange],
+  );
+  useLayoutEffect(() => {
+    currentViewPreferencesRef.current = currentViewPreferences;
+    onViewPreferencesChange?.(currentViewPreferences);
+  }, [currentViewPreferences, onViewPreferencesChange]);
   const filteredFiles = review.visibleFiles;
   const semanticFileIdentities = useMemo(
     () =>
@@ -373,8 +390,9 @@ export function App({
   );
 
   const openAgentNotes = useCallback(() => {
+    publishViewPreferenceChanges({ showAgentNotes: true });
     review.setShowAgentNotes(true);
-  }, [review.setShowAgentNotes]);
+  }, [publishViewPreferenceChanges, review.setShowAgentNotes]);
 
   /** Close the modal keyboard help overlay. */
   const closeHelp = useCallback(() => {
@@ -893,25 +911,44 @@ export function App({
   );
 
   /** Preserve the current review position before changing the active diff layout. */
-  const selectLayoutMode = useCallback((mode: LayoutMode) => {
-    layoutToggleScrollTopRef.current = diffScrollRef.current?.scrollTop ?? 0;
-    setLayoutToggleRequestId((current) => current + 1);
-    setLayoutMode(mode);
-  }, []);
+  const selectLayoutMode = useCallback(
+    (mode: LayoutMode) => {
+      layoutToggleScrollTopRef.current = diffScrollRef.current?.scrollTop ?? 0;
+      publishViewPreferenceChanges({ mode });
+      setLayoutToggleRequestId((current) => current + 1);
+      setLayoutMode(mode);
+    },
+    [publishViewPreferenceChanges],
+  );
+
+  /** Select one current-line presentation before coalesced quit input can unmount the review. */
+  const selectCursorLine = useCallback(
+    (nextCursorLine: CursorLine) => {
+      publishViewPreferenceChanges({ cursorLine: nextCursorLine });
+      setCursorLine(nextCursorLine);
+    },
+    [publishViewPreferenceChanges],
+  );
 
   /** Toggle the global agent note layer on or off. */
   const toggleAgentNotes = () => {
-    review.toggleAgentNotes();
+    const nextShowAgentNotes = !currentViewPreferencesRef.current.showAgentNotes;
+    publishViewPreferenceChanges({ showAgentNotes: nextShowAgentNotes });
+    review.setShowAgentNotes(nextShowAgentNotes);
   };
 
   /** Toggle line-number gutters without changing the diff content itself. */
   const toggleLineNumbers = () => {
-    setShowLineNumbers((current) => !current);
+    const nextShowLineNumbers = !currentViewPreferencesRef.current.showLineNumbers;
+    publishViewPreferenceChanges({ showLineNumbers: nextShowLineNumbers });
+    setShowLineNumbers(nextShowLineNumbers);
   };
 
   /** Toggle whether mouse selection copies review decorations or only file content. */
   const toggleCopyDecorations = () => {
-    setCopyDecorations((current) => !current);
+    const nextCopyDecorations = !currentViewPreferencesRef.current.copyDecorations;
+    publishViewPreferenceChanges({ copyDecorations: nextCopyDecorations });
+    setCopyDecorations(nextCopyDecorations);
   };
 
   /** Toggle whether diff code rows wrap instead of truncating to one terminal row. */
@@ -919,18 +956,24 @@ export function App({
     // Capture the pre-toggle viewport position synchronously so DiffPane can restore the same
     // top-most source row after wrapped row heights change.
     wrapToggleScrollTopRef.current = diffScrollRef.current?.scrollTop ?? 0;
+    const nextWrapLines = !currentViewPreferencesRef.current.wrapLines;
+    publishViewPreferenceChanges({ wrapLines: nextWrapLines });
     setCodeHorizontalOffset(0);
-    setWrapLines((current) => !current);
+    setWrapLines(nextWrapLines);
   };
 
   /** Toggle visibility of hunk metadata rows without changing the actual diff lines. */
   const toggleHunkHeaders = () => {
-    setShowHunkHeaders((current) => !current);
+    const nextShowHunkHeaders = !currentViewPreferencesRef.current.showHunkHeaders;
+    publishViewPreferenceChanges({ showHunkHeaders: nextShowHunkHeaders });
+    setShowHunkHeaders(nextShowHunkHeaders);
   };
 
   /** Toggle the top menu bar while keeping F10 menu navigation available. */
   const toggleMenuBar = () => {
-    setShowMenuBar((current) => !current);
+    const nextShowMenuBar = !currentViewPreferencesRef.current.showMenuBar;
+    publishViewPreferenceChanges({ showMenuBar: nextShowMenuBar });
+    setShowMenuBar(nextShowMenuBar);
   };
 
   const { canRefreshCurrentInput, refreshCurrentInput, triggerRefreshCurrentInput } =
@@ -1127,7 +1170,7 @@ export function App({
         scrollCodeHorizontally,
         scrollDiff,
         stepDiffLine,
-        selectCursorLine: setCursorLine,
+        selectCursorLine,
         selectLayoutMode,
         hasVisualSelection: () => selectionActionsRef.current?.hasSelection() ?? false,
         startVisualSelection: () => selectionActionsRef.current?.beginKeyboardSelection(),

--- a/packages/hunk/src/ui/AppHost.tsx
+++ b/packages/hunk/src/ui/AppHost.tsx
@@ -41,6 +41,7 @@ import type {
 import { assertReliableWatchRuntime } from "../core/watch/runtime";
 import type { WatchedInputRuntime } from "./hooks/useWatchedInput";
 import { ThemeController } from "./theme/controller";
+import type { PersistedViewPreferences } from "../core/run/config";
 
 /** Build the stable refusal returned once quit becomes terminal for reload coordination. */
 function reloadRefusedDuringShutdown() {
@@ -61,6 +62,7 @@ export function AppHost({
   onQuit = () => process.exit(0),
   onActiveBootstrapChange,
   onFirstFrameReady,
+  onViewPreferencesChange,
   returnToHistory = false,
   extensionSession,
   extensionOwnership,
@@ -81,6 +83,8 @@ export function AppHost({
   onActiveBootstrapChange?: (bootstrap: AppBootstrap) => void;
   /** Report once the dynamically mounted review has committed its first requested frame. */
   onFirstFrameReady?: () => void;
+  /** Publish live preferences to the owner of a routed review surface. */
+  onViewPreferencesChange?: (preferences: PersistedViewPreferences) => void;
   /** Present quit as returning to an owning history surface. */
   returnToHistory?: boolean;
   /** Session authority shared by every routed surface in this process. */
@@ -593,6 +597,7 @@ export function AppHost({
       noticeText={startupNoticeText}
       onQuit={quitAfterShutdownEvent}
       onFirstFrameReady={onFirstFrameReady}
+      onViewPreferencesChange={onViewPreferencesChange}
       returnToHistory={returnToHistory}
       onRegisterWorkspaceRefreshRequest={registerWorkspaceRefreshRequest}
       onReloadSession={reloadSession}

--- a/packages/hunk/src/ui/log/LogApp.tsx
+++ b/packages/hunk/src/ui/log/LogApp.tsx
@@ -3,6 +3,7 @@ import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react"
 import { basename } from "node:path";
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { APP_COMMAND_NAMES } from "../../core/run/commandCatalog";
+import type { PersistedViewPreferences } from "../../core/run/config";
 import type {
   ExtensionVcsHistoryCommit,
   ExtensionVcsHistoryRangeSelection,
@@ -73,6 +74,7 @@ export function LogApp({
   controller,
   runtime,
   onOutcome,
+  sessionViewPreferences,
   themeController,
   useColor,
   quitScheduler,
@@ -80,6 +82,8 @@ export function LogApp({
   controller: LogController;
   runtime: InteractiveHistoryRuntime;
   onOutcome: (outcome: LogAppOutcome) => void | Promise<void>;
+  /** Latest review preferences retained by the routed interactive session. */
+  sessionViewPreferences: PersistedViewPreferences;
   themeController: ThemeController;
   useColor: boolean;
   quitScheduler?: ViewPreferenceQuitScheduler;
@@ -122,8 +126,8 @@ export function LogApp({
   const responsiveLayout = resolveLogResponsiveLayout(terminal.width, terminal.height);
   const viewportBodyHeight = responsiveLayout.bodyHeight;
   const currentViewPreferences = useMemo(
-    () => ({ ...runtime.initialViewPreferences, theme: themeSelector.themeId }),
-    [runtime.initialViewPreferences, themeSelector.themeId],
+    () => ({ ...sessionViewPreferences, theme: themeSelector.themeId }),
+    [sessionViewPreferences, themeSelector.themeId],
   );
   const viewPreferenceQuit = useViewPreferenceQuitController({
     currentPreferences: currentViewPreferences,

--- a/packages/hunk/src/ui/runInteractiveApp.test.tsx
+++ b/packages/hunk/src/ui/runInteractiveApp.test.tsx
@@ -1,7 +1,10 @@
 import { expect, mock, test } from "bun:test";
 import { createTestVcsAppBootstrap } from "../../../../test/helpers/app-bootstrap";
+import { persistedViewPreferencesFromOptions } from "../core/run/config";
 import { createEmptyExtensionLoadResult, type ExtensionLoadResult } from "../extensions/types";
 import { runInteractiveApp } from "./runInteractiveApp";
+
+const viewPreferences = persistedViewPreferencesFromOptions({});
 
 /** Register one shutdown observer on a test bootstrap's explicit extension authority. */
 function onShutdown(
@@ -30,7 +33,7 @@ test("retires extensions and closes the controlling terminal when review runtime
     runInteractiveApp(
       {
         bootstrap: bootstrap as never,
-        initialization: { theme: { customThemes: [] } },
+        initialization: { theme: { customThemes: [] }, viewPreferences },
         controllingTerminal: {
           stdin: { isTTY: true } as never,
           close,
@@ -77,7 +80,7 @@ test("stops the broker and retires extensions before exceptional renderer teardo
       {
         bootstrap: bootstrap as never,
         controllingTerminal: null,
-        initialization: { theme: { customThemes: [] } },
+        initialization: { theme: { customThemes: [] }, viewPreferences },
       },
       {
         createReviewRuntime: (() => ({
@@ -127,7 +130,7 @@ test("retries broker cleanup before teardown when the exceptional stop attempt f
       {
         bootstrap: bootstrap as never,
         controllingTerminal: null,
-        initialization: { theme: { customThemes: [] } },
+        initialization: { theme: { customThemes: [] }, viewPreferences },
       },
       {
         createReviewRuntime: (() => ({

--- a/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
@@ -43,6 +43,7 @@ async function createHistoryRoute(subjects = ["History row"]) {
     authoredAt: "2026-01-01T00:00:00Z",
     decorations: [],
   }));
+  const initialViewPreferences = persistedViewPreferencesFromOptions({});
   const runtime: InteractiveHistoryRuntime = {
     input: {
       kind: "history",
@@ -65,9 +66,9 @@ async function createHistoryRoute(subjects = ["History row"]) {
     repoRoot: "/repo",
     notices: [],
     customThemes: [],
-    initialization: { theme: { customThemes: [] } },
+    initialization: { theme: { customThemes: [] }, viewPreferences: initialViewPreferences },
     keybindings: {},
-    initialViewPreferences: persistedViewPreferencesFromOptions({}),
+    initialViewPreferences,
     promptSaveViewPreferences: true,
     async planReview(commit) {
       return { kind: "revision-show", revisionId: commit.revisionId };
@@ -190,9 +191,78 @@ test("routes repeated history reviews through fresh runtimes and returns instead
   }
 });
 
+test("retains review view preferences across repeated history reviews", async () => {
+  const history = await createHistoryRoute();
+  const initialViewPreferences = persistedViewPreferencesFromOptions({ mode: "split" });
+  history.runtime.initialViewPreferences = initialViewPreferences;
+  history.runtime.initialization = {
+    ...history.runtime.initialization,
+    viewPreferences: initialViewPreferences,
+  };
+  const quit = mock(() => undefined);
+  const deps: HunkSessionHostDeps = {
+    prepareReview: (async () => {
+      const bootstrap = createTestVcsAppBootstrap({
+        changesetId: "preference-review",
+        files: [createTestDiffFile({ id: "review.ts", path: "review.ts" })],
+        initialMode: "split",
+      });
+      bootstrap.extensions = history.runtime.extensionSession.current;
+      return {
+        bootstrap,
+        initialization: history.runtime.initialization,
+        borrowsExtensions: true,
+      };
+    }) as never,
+    createReviewRuntime: (() => ({
+      hostClient: undefined,
+      reviewProducer: undefined,
+      stop: mock(() => undefined),
+    })) as never,
+  };
+  const setup = await testRender(
+    <HunkSessionHost
+      initialRoute={history}
+      initialization={history.runtime.initialization}
+      externalQuitSignal={new AbortController().signal}
+      onQuit={quit}
+      deps={deps}
+    />,
+    { width: 120, height: 20 },
+  );
+  try {
+    await setup.renderOnce();
+    await act(async () => setup.mockInput.pressEnter());
+    await settle(setup);
+    expect(setup.captureCharFrame()).toMatch(/▌.*▌/);
+
+    await act(async () => setup.mockInput.typeText("2q"));
+    await settle(setup);
+    expect(setup.captureCharFrame()).toContain("Test history");
+    expect(setup.captureCharFrame()).not.toContain("Save view preferences?");
+
+    await act(async () => setup.mockInput.pressEnter());
+    await settle(setup);
+    expect(setup.captureCharFrame()).not.toMatch(/▌.*▌/);
+
+    await act(async () => setup.mockInput.pressKey("q"));
+    await settle(setup);
+    await act(async () => setup.mockInput.pressKey("q"));
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).toContain("Save view preferences?");
+    expect(setup.captureCharFrame()).toContain('- mode = "split"');
+    expect(setup.captureCharFrame()).toContain('+ mode = "unified"');
+    expect(quit).not.toHaveBeenCalled();
+  } finally {
+    setup.renderer.destroy();
+    await history.controller.close();
+  }
+});
+
 test("shares committed themes across history and repeated review surfaces", async () => {
   const history = await createHistoryRoute();
   history.runtime.initialization = {
+    ...history.runtime.initialization,
     theme: { customThemes: [historyCustomTheme] },
   };
   const requests: Array<{ themeId?: string }> = [];
@@ -206,7 +276,10 @@ test("shares committed themes across history and repeated review surfaces", asyn
       bootstrap.extensions = history.runtime.extensionSession.current;
       return {
         bootstrap,
-        initialization: { theme: { customThemes: [reviewCustomTheme] } },
+        initialization: {
+          ...history.runtime.initialization,
+          theme: { customThemes: [reviewCustomTheme] },
+        },
         borrowsExtensions: true,
       };
     }) as never,
@@ -289,6 +362,7 @@ test("seeds the shared catalog from interactive initialization, not static histo
     },
   ];
   history.runtime.initialization = {
+    ...history.runtime.initialization,
     theme: {
       initialTheme: "session-only",
       customThemes: [
@@ -403,6 +477,7 @@ test("quits the session from a standalone review route", async () => {
       }}
       initialization={{
         theme: { initialTheme: bootstrap.initialTheme!, customThemes: [] },
+        viewPreferences: persistedViewPreferencesFromOptions(bootstrap.input.options),
       }}
       externalQuitSignal={abort.signal}
       onQuit={quit}
@@ -447,6 +522,7 @@ test("finishes review navigation even when broker shutdown throws", async () => 
       }}
       initialization={{
         theme: { initialTheme: bootstrap.initialTheme!, customThemes: [] },
+        viewPreferences: persistedViewPreferencesFromOptions(bootstrap.input.options),
       }}
       externalQuitSignal={abort.signal}
       onQuit={quit}
@@ -497,6 +573,7 @@ test("does not start provider planning after shutdown wins the pre-dispatch wind
 test("refuses a nested review that returns independent extension authority", async () => {
   const history = await createHistoryRoute();
   history.runtime.initialization = {
+    ...history.runtime.initialization,
     theme: { initialTheme: historyCustomTheme.id, customThemes: [historyCustomTheme] },
   };
   const foreign = createEmptyExtensionLoadResult("/repo");
@@ -518,7 +595,10 @@ test("refuses a nested review that returns independent extension authority", asy
             }),
             extensions: foreign,
           },
-          initialization: { theme: { customThemes: [reviewCustomTheme] } },
+          initialization: {
+            ...history.runtime.initialization,
+            theme: { customThemes: [reviewCustomTheme] },
+          },
           borrowsExtensions: false,
         })) as never,
         createReviewRuntime: createReviewRuntime as never,

--- a/packages/hunk/src/ui/session/HunkSessionHost.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../app/session/reviewRuntime";
 import type { StartupNotice } from "../../core/process/startupNotice";
 import type { AppBootstrap } from "../../core/bootstrap";
+import type { PersistedViewPreferences } from "../../core/run/config";
 import type { InteractiveSessionInitialization } from "../../core/session/initialization";
 import type { ExtensionVcsHistoryReviewAction } from "../../extension-api/types";
 import { parseExtensionReviewDescriptor } from "../../core/reviewDescriptor";
@@ -24,6 +25,7 @@ import { LogApp, type LogAppOutcome } from "../log/LogApp";
 import type { LogController } from "../log/controller";
 import { resolveHistoryAuthorLabel } from "../log/formatting";
 import { ThemeController } from "../theme/controller";
+import { applySessionViewPreferences } from "./viewPreferences";
 
 export interface HistorySurfaceRoute {
   kind: "history";
@@ -170,6 +172,10 @@ export function HunkSessionHost({
   const shutdownPendingRef = useRef(false);
   const pendingExitCodeRef = useRef<number | undefined>(undefined);
   const failedReviewStopsRef = useRef(new Set<ReviewSessionRuntime>());
+  const sessionViewPreferencesRef = useRef(initialization.viewPreferences);
+  const retainSessionViewPreferences = useCallback((preferences: PersistedViewPreferences) => {
+    sessionViewPreferencesRef.current = preferences;
+  }, []);
 
   /** Attempt broker cleanup and retain failed runtimes for the final unmount retry. */
   const stopReviewRuntime = useCallback((runtime: ReviewSessionRuntime) => {
@@ -305,12 +311,16 @@ export function HunkSessionHost({
         await historyRoute.runtime.extensionSession.retirePrepared(plan.bootstrap.extensions);
         throw new Error("An embedded review cannot replace the owning extension session.");
       }
-      const reviewRuntime = createReviewRuntime(plan.bootstrap, startupCwd);
+      const reviewBootstrap = applySessionViewPreferences(plan.bootstrap, {
+        ...sessionViewPreferencesRef.current,
+        theme: themeController.getSnapshot().themeId,
+      });
+      const reviewRuntime = createReviewRuntime(reviewBootstrap, startupCwd);
       themeController.replaceCustomThemes(plan.initialization.theme.customThemes);
       const reviewRoute: ActiveReviewSurfaceRoute = {
         kind: "review",
         instanceId: nextInstanceRef.current++,
-        bootstrap: plan.bootstrap,
+        bootstrap: reviewBootstrap,
         runtime: reviewRuntime,
         extensionSession: historyRoute.runtime.extensionSession,
         extensionOwnership: "borrowed",
@@ -379,6 +389,9 @@ export function HunkSessionHost({
         externalQuitSignal={externalQuitSignal}
         hostClient={route.runtime.hostClient}
         onQuit={retireReview}
+        {...(route.quitBehavior === "return-to-history"
+          ? { onViewPreferencesChange: retainSessionViewPreferences }
+          : {})}
         {...(route.mountMode === "dynamic" ? { onFirstFrameReady: () => undefined } : {})}
         returnToHistory={route.quitBehavior === "return-to-history"}
         extensionSession={route.extensionSession}
@@ -402,6 +415,7 @@ export function HunkSessionHost({
       useColor={interactiveLogUsesColor(route.runtime.input.color, process.env)}
       onOutcome={(outcome) => handleHistoryOutcome(route, outcome)}
       quitScheduler={deps.viewPreferenceQuitScheduler}
+      sessionViewPreferences={sessionViewPreferencesRef.current}
       themeController={themeController}
     />
   );

--- a/packages/hunk/src/ui/session/viewPreferences.test.ts
+++ b/packages/hunk/src/ui/session/viewPreferences.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { createTestVcsAppBootstrap } from "../../../../../test/helpers/app-bootstrap";
+import type { PersistedViewPreferences } from "../../core/run/config";
+import { applySessionViewPreferences } from "./viewPreferences";
+
+test("projects every retained view preference into a fresh review bootstrap", () => {
+  const bootstrap = createTestVcsAppBootstrap({
+    files: [],
+    initialMode: "split",
+    vcsOptions: { watch: true },
+  });
+  const preferences: PersistedViewPreferences = {
+    mode: "unified",
+    theme: "dracula",
+    showLineNumbers: false,
+    wrapLines: true,
+    showHunkHeaders: false,
+    showMenuBar: false,
+    showAgentNotes: true,
+    copyDecorations: true,
+    cursorLine: "number",
+  };
+
+  const projected = applySessionViewPreferences(bootstrap, preferences);
+
+  expect(projected).not.toBe(bootstrap);
+  expect(projected.input.options).toEqual({
+    agentNotes: true,
+    copyDecorations: true,
+    cursorLine: "number",
+    hunkHeaders: false,
+    lineNumbers: false,
+    menuBar: false,
+    mode: "unified",
+    pager: false,
+    theme: "dracula",
+    watch: true,
+    wrapLines: true,
+  });
+  expect(projected).toMatchObject({
+    initialMode: "unified",
+    initialTheme: "dracula",
+    initialShowLineNumbers: false,
+    initialWrapLines: true,
+    initialShowHunkHeaders: false,
+    initialShowMenuBar: false,
+    initialShowAgentNotes: true,
+    initialCopyDecorations: true,
+    initialCursorLine: "number",
+  });
+  expect(bootstrap.initialMode).toBe("split");
+});

--- a/packages/hunk/src/ui/session/viewPreferences.ts
+++ b/packages/hunk/src/ui/session/viewPreferences.ts
@@ -1,0 +1,36 @@
+import type { AppBootstrap } from "../../core/bootstrap";
+import type { PersistedViewPreferences } from "../../core/run/config";
+
+/** Seed a freshly prepared review from the preferences retained by its routed session. */
+export function applySessionViewPreferences<ExtensionState>(
+  bootstrap: AppBootstrap<ExtensionState>,
+  preferences: PersistedViewPreferences,
+): AppBootstrap<ExtensionState> {
+  return {
+    ...bootstrap,
+    input: {
+      ...bootstrap.input,
+      options: {
+        ...bootstrap.input.options,
+        mode: preferences.mode,
+        theme: preferences.theme,
+        lineNumbers: preferences.showLineNumbers,
+        wrapLines: preferences.wrapLines,
+        hunkHeaders: preferences.showHunkHeaders,
+        menuBar: preferences.showMenuBar,
+        agentNotes: preferences.showAgentNotes,
+        copyDecorations: preferences.copyDecorations,
+        cursorLine: preferences.cursorLine,
+      },
+    },
+    initialMode: preferences.mode,
+    initialTheme: preferences.theme,
+    initialShowLineNumbers: preferences.showLineNumbers,
+    initialWrapLines: preferences.wrapLines,
+    initialShowHunkHeaders: preferences.showHunkHeaders,
+    initialShowMenuBar: preferences.showMenuBar,
+    initialShowAgentNotes: preferences.showAgentNotes,
+    initialCopyDecorations: preferences.copyDecorations,
+    initialCursorLine: preferences.cursorLine,
+  };
+}

--- a/test/pty/log-integration.test.ts
+++ b/test/pty/log-integration.test.ts
@@ -343,6 +343,53 @@ describe("interactive hunk log", () => {
     }
   });
 
+  test("retains changed review layout across repeated history reviews", async () => {
+    const cwd = createHistoryRepo();
+    const configHome = mkdtempSync(join(tmpdir(), "hunk-log-layout-preferences-"));
+    tempDirs.push(configHome);
+    const configDir = join(configHome, "hunk");
+    const configPath = join(configDir, "config.toml");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(configPath, 'mode = "split"\n');
+    const session = await harness.launchHunk({
+      args: ["log", "--color", "never", "--no-extensions"],
+      cwd,
+      cols: 120,
+      rows: 20,
+      env: { XDG_CONFIG_HOME: configHome },
+    });
+
+    try {
+      await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      await session.press("enter");
+      const split = await session.waitForText(/historyValue = 'second'/, { timeout: 15_000 });
+      expect(split).toMatch(/▌.*▌/);
+
+      session.writeRaw("2q");
+      await session.waitForText(/Second history commit/, { timeout: 15_000 });
+
+      await session.press("enter");
+      const retained = await harness.waitForSnapshot(
+        session,
+        (text) => !/▌.*▌/.test(text) && text.includes("historyValue = 'second'"),
+        15_000,
+      );
+      expect(retained).not.toMatch(/▌.*▌/);
+
+      await session.press("q");
+      await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      await session.press("q");
+      const prompt = await session.waitForText(/Save view preferences\?/, { timeout: 5_000 });
+      expect(prompt).toContain('- mode = "split"');
+      expect(prompt).toContain('+ mode = "unified"');
+
+      await session.press("q");
+      expect(readFileSync(configPath, "utf8")).toBe('mode = "split"\n');
+    } finally {
+      session.close();
+    }
+  });
+
   test("adapts GitHub-style grouped rows and right-aligned ids on resize", async () => {
     const cwd = createHistoryRepo();
     const displayId = Bun.spawnSync(["git", "rev-parse", "--short=8", "HEAD"], {


### PR DESCRIPTION
## Context

Changing split/unified layout or another persisted review preference inside a commit opened from `hunk log` only updated the mounted review. Returning to history destroyed that state, so the next commit review started again from the configured value.

## Approach

- include resolved view preferences in `InteractiveSessionInitialization` as the routed session's startup seed
- publish complete preference snapshots from `App`, synchronously for commands so coalesced input such as `2q` cannot lose the change
- retain the latest snapshot in `HunkSessionHost` and project it into each successfully prepared embedded review
- keep intermediate review-to-history navigation prompt-free and I/O-free
- let the final history quit compare retained session preferences with the immutable startup/config baseline and use the existing save/discard flow
- cover all persisted preference fields in a pure bootstrap projection test

```text
startup/config preferences
          |
          v
InteractiveSessionInitialization
          |
          v
HunkSessionHost retained snapshot <---- App preference commands
          |
          +---- fresh embedded review bootstrap
          |
          +---- final history save/discard prompt
```

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run deps:check`
- `git diff --check`
- `TMPDIR=/var/tmp bun run test` (4,114 passed, 12 skipped)
- `bun run test:integration` (160 passed, 1 skipped)
- `bun run test:tty-smoke` (10 passed)
- focused routed-host and projection tests
- focused real PTY regression for coalesced `2q`
- fresh independent code review with no actionable findings

## Manual Tmux Test

Tested the source checkout in tmux at 120x24 with an isolated config containing `mode = "split"`:

1. Opened a history commit and confirmed split layout.
2. Sent raw coalesced `2q` and confirmed return to history.
3. Reopened the commit and confirmed unified layout.
4. Quit history and confirmed the prompt showed `split -> unified`.
5. Discarded and confirmed the config remained `mode = "split"`.

## Visual Evidence

No visual changes.
