### PR TITLE
fix(ui): remove duplicate reply range connectors

### DIFF
--- a/.changeset/quiet-reply-range-rails.md
+++ b/.changeset/quiet-reply-range-rails.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Stop drawing duplicate right-side range connectors on threaded reply cards.

--- a/packages/hunk/src/ui/diff/reviewRenderPlan.test.ts
+++ b/packages/hunk/src/ui/diff/reviewRenderPlan.test.ts
@@ -164,6 +164,39 @@ describe("review render plan", () => {
     expect(inlineNotes.map((row) => row.rangeGuideConnection)).toEqual(["continue", "continue"]);
   });
 
+  test("connects only the root card of a reply thread to the external range rail", () => {
+    const theme = resolveTheme("github-dark-default", null);
+    const file = createDiffFile(
+      "thread",
+      "thread.ts",
+      "export const alpha = 1;\n",
+      "export const alpha = 2;\nexport const beta = 3;\n",
+    );
+    const rows = buildSplitRows(file, null, theme);
+    const notes = [
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "root",
+        annotation: { newRange: [2, 2], summary: "Root note" },
+        thread: { noteId: "root", depth: 0, hasNextSibling: false },
+      }),
+      createVisibleAgentNote(file.metadata.hunks, {
+        id: "child",
+        annotation: { newRange: [2, 2], summary: "Child reply" },
+        thread: { noteId: "child", parentId: "root", depth: 1, hasNextSibling: false },
+      }),
+    ];
+    const plannedRows = buildReviewRenderPlan({
+      fileId: file.id,
+      rows,
+      showHunkHeaders: true,
+      visibleAgentNotes: notes,
+    });
+    const inlineNotes = plannedRows.filter((row) => row.kind === "inline-note");
+
+    expect(inlineNotes).toHaveLength(2);
+    expect(inlineNotes.map((row) => row.rangeGuideConnection)).toEqual(["terminate", undefined]);
+  });
+
   test("connects a deletion-only anchor row directly into its inline note", () => {
     const theme = resolveTheme("github-dark-default", null);
     const file = createDiffFile(

--- a/packages/hunk/src/ui/diff/reviewRenderPlan.ts
+++ b/packages/hunk/src/ui/diff/reviewRenderPlan.ts
@@ -493,11 +493,17 @@ export function buildReviewRenderPlan({
     );
 
     const anchoredNotes = placementsByAnchor.get(row.key) ?? [];
-    anchoredNotes.forEach((placement, placementIndex) => {
+    let remainingRootNotes = anchoredNotes.reduce(
+      (count, placement) => count + ((placement.note.thread?.depth ?? 0) === 0 ? 1 : 0),
+      0,
+    );
+
+    anchoredNotes.forEach((placement) => {
       const isThreadReply = (placement.note.thread?.depth ?? 0) > 0;
-      const hasLaterRootNote = anchoredNotes
-        .slice(placementIndex + 1)
-        .some((candidate) => (candidate.note.thread?.depth ?? 0) === 0);
+      if (!isThreadReply) {
+        remainingRootNotes -= 1;
+      }
+      const hasLaterRootNote = remainingRootNotes > 0;
 
       plannedRows.push({
         kind: "inline-note",

--- a/packages/hunk/src/ui/diff/reviewRenderPlan.ts
+++ b/packages/hunk/src/ui/diff/reviewRenderPlan.ts
@@ -493,7 +493,12 @@ export function buildReviewRenderPlan({
     );
 
     const anchoredNotes = placementsByAnchor.get(row.key) ?? [];
-    anchoredNotes.forEach((placement) => {
+    anchoredNotes.forEach((placement, placementIndex) => {
+      const isThreadReply = (placement.note.thread?.depth ?? 0) > 0;
+      const hasLaterRootNote = anchoredNotes
+        .slice(placementIndex + 1)
+        .some((candidate) => (candidate.note.thread?.depth ?? 0) === 0);
+
       plannedRows.push({
         kind: "inline-note",
         key: `inline-note:${placement.note.id}:${row.key}:${placement.noteIndex}`,
@@ -506,11 +511,14 @@ export function buildReviewRenderPlan({
         anchorSide: placement.anchorSide,
         noteCount: placement.noteCount,
         noteIndex: placement.noteIndex,
-        rangeGuideConnection: !noteGuideSideByRowKey.has(row.key)
-          ? undefined
-          : placement.noteIndex < placement.noteCount - 1 || rangeGuideContinuationRows.has(row.key)
-            ? "continue"
-            : "terminate",
+        // Replies already connect through the thread gutter on the left. Keep the
+        // external range rail on root cards so the thread has only one range connection.
+        rangeGuideConnection:
+          isThreadReply || !noteGuideSideByRowKey.has(row.key)
+            ? undefined
+            : hasLaterRootNote || rangeGuideContinuationRows.has(row.key)
+              ? "continue"
+              : "terminate",
       });
     });
   }


### PR DESCRIPTION
## Summary

- keep the external range rail connected to each thread's root comment
- omit the duplicate right-side connector from child replies, which already connect through the left thread gutter
- determine root-card continuation using later root notes rather than child replies

## Visual evidence

Before: child replies repeat the connection on the right even though the thread is already connected on the left.

![Child replies with duplicate right-side connectors](https://glance.sh/0izdhLZNDLGDZskk0odO.png)

## Validation

- `bun test packages/hunk/src/ui/diff/reviewRenderPlan.test.ts packages/hunk/src/ui/components/panes/AgentInlineNote.test.tsx` (59 passed)
- `bun run typecheck`
- `git diff --check`

Platform: Linux. No real-TTY after screenshot captured.

*This PR description was generated by Pi using gpt-5.6-sol*
