### PR TITLE
fix(ui): save note drafts without stale input races

### DIFF
--- a/.changeset/calm-drafts-save.md
+++ b/.changeset/calm-drafts-save.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Prevent delayed editor updates from crashing a review after a note is saved.

--- a/packages/hunk/src/ui/components/panes/AgentInlineNote.tsx
+++ b/packages/hunk/src/ui/components/panes/AgentInlineNote.tsx
@@ -219,7 +219,7 @@ export function AgentInlineNote({
     onCancel: () => void;
     onFocus?: () => void;
     onInput: (value: string) => void;
-    onSave: () => void;
+    onSave: (editorBody?: string) => void;
   };
   actions?: AgentInlineNoteActions;
   /** Make this saved note the keyboard action target when its card is clicked. */
@@ -546,7 +546,12 @@ export function AgentInlineNote({
     const draftTitleText = fitText(` ${titleText} `, Math.max(0, boxWidth - 4));
     const draftTopBorderSuffix = `${"─".repeat(Math.max(0, boxWidth - 3 - draftTitleText.length))}${rangeGuideConnection ? "┬" : "╮"}`;
     const draftActionItems: BorderActionItem[] = [
-      { id: "save", keyLabel: "^S", label: "save", onMouseUp: draft.onSave },
+      {
+        id: "save",
+        keyLabel: "^S",
+        label: "save",
+        onMouseUp: () => draft.onSave(textareaRef.current?.plainText),
+      },
       { id: "cancel", keyLabel: "Esc", label: "cancel", onMouseUp: draft.onCancel },
     ];
     const draftTextareaRows = draftVisibleLineCount;

--- a/packages/hunk/src/ui/components/panes/DiffPane.tsx
+++ b/packages/hunk/src/ui/components/panes/DiffPane.tsx
@@ -455,7 +455,7 @@ export function DiffPane({
   onReplyToNote?: (noteId: string, options?: { preserveViewport?: boolean }) => void;
   onRemoveLiveNote?: (noteId: string) => void;
   onRemoveUserNote?: (noteId: string) => void;
-  onSaveDraftNote?: () => void;
+  onSaveDraftNote?: (editorBody?: string) => void;
   onStartUserNoteAtHunk?: StartUserNoteAtHunk;
   onUpdateDraftNote?: (body: string) => void;
   onBlurDraftNote?: () => void;

--- a/packages/hunk/src/ui/hooks/useAppKeyboardShortcuts.ts
+++ b/packages/hunk/src/ui/hooks/useAppKeyboardShortcuts.ts
@@ -70,7 +70,7 @@ export interface UseAppKeyboardShortcutsOptions {
   discardViewPreferencesAndQuit: () => void;
   neverAskToSaveViewPreferencesAndQuit: () => void;
   closeSaveConfigPrompt: () => void;
-  saveDraftNote: () => void;
+  saveDraftNote: (editorBody?: string) => void;
   showAgentSkill: boolean;
   showHelp: boolean;
   switchMenu: (delta: number) => void;
@@ -494,7 +494,7 @@ export function useAppKeyboardShortcuts({
     }
 
     if (isSaveDraftNoteKey(key)) {
-      saveDraftNote();
+      saveDraftNote(renderer.currentFocusedEditor?.plainText);
       return "mine";
     }
 

--- a/packages/hunk/src/ui/hooks/useTerminalReview.test.tsx
+++ b/packages/hunk/src/ui/hooks/useTerminalReview.test.tsx
@@ -1146,6 +1146,39 @@ describe("useTerminalReview", () => {
     }
   });
 
+  test("ignores delayed editor updates from saved and replaced drafts", async () => {
+    const { controllerRef, setup } = await renderTerminalReview([createAlphaFile()]);
+
+    try {
+      await flush(setup);
+      let savedDraftId = "";
+      await act(async () => {
+        const controller = expectValue(controllerRef.current);
+        const draft = controller.startUserNote();
+        savedDraftId = expectValue(draft).id;
+        expect(controller.updateDraftNote("Saved body", savedDraftId)).toBe(true);
+        controller.saveDraftNote();
+        expect(controller.updateDraftNote("Late saved body", savedDraftId)).toBe(false);
+      });
+      await flush(setup);
+
+      await act(async () => {
+        const controller = expectValue(controllerRef.current);
+        const replacement = expectValue(controller.startUserNote());
+        expect(controller.updateDraftNote("Stale replacement body", savedDraftId)).toBe(false);
+        expect(controller.store.getSnapshot().draftNote?.body).toBe("");
+        expect(controller.updateDraftNote("Current replacement body", replacement.id)).toBe(true);
+      });
+      await flush(setup);
+
+      expect(expectValue(controllerRef.current).store.getSnapshot().draftNote?.body).toBe(
+        "Current replacement body",
+      );
+    } finally {
+      await act(async () => setup.renderer.destroy());
+    }
+  });
+
   test("session clear can include human user notes", async () => {
     const { controllerRef, setup } = await renderTerminalReview([createTwoHunkFile()]);
 

--- a/packages/hunk/src/ui/hooks/useTerminalReview.ts
+++ b/packages/hunk/src/ui/hooks/useTerminalReview.ts
@@ -298,7 +298,7 @@ export interface TerminalReview {
     options?: { preserveViewport?: boolean },
   ) => DraftReviewNote | null;
   setFilter: (value: string) => void;
-  updateDraftNote: (body: string) => void;
+  updateDraftNote: (body: string, expectedDraftId?: string) => boolean;
 }
 
 /** Live note-card geometry the app publishes for markup validation. */
@@ -426,6 +426,7 @@ export function useTerminalReview({
   >(null);
   // Monotonic suffix that keeps `user:*` note ids unique within one millisecond.
   const userNoteSequenceRef = useRef(0);
+  const draftNoteSequenceRef = useRef(0);
 
   const keyByFileId = useMemo(
     () => new Map(document.files.map((file) => [file.runtimeId, file.key] as const)),
@@ -1501,7 +1502,9 @@ export function useTerminalReview({
           ...intent,
           ...(options?.preserveViewport ? { reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL } : {}),
         },
-        { draftId: `draft:${file.id}:${hunkIndex}:${Date.now()}` },
+        {
+          draftId: `draft:${file.id}:${hunkIndex}:${Date.now()}-${++draftNoteSequenceRef.current}`,
+        },
       );
       applyLineCursor(
         lineCursorAt(lineCursors, file.id, hunkIndex, { side: draft.side, line: draft.line }),
@@ -1529,7 +1532,9 @@ export function useTerminalReview({
           noteId,
           ...(options?.preserveViewport ? { reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL } : {}),
         },
-        { draftId: `draft:edit:${noteId}:${Date.now()}` },
+        {
+          draftId: `draft:edit:${noteId}:${Date.now()}-${++draftNoteSequenceRef.current}`,
+        },
       );
       const file = fileByKey.get(draft.fileKey);
       if (!file) {
@@ -1557,7 +1562,9 @@ export function useTerminalReview({
           noteId,
           ...(options?.preserveViewport ? { reveal: REVIEW_VIEWPORT_ANCHOR_REVEAL } : {}),
         },
-        { draftId: `draft:reply:${noteId}:${Date.now()}` },
+        {
+          draftId: `draft:reply:${noteId}:${Date.now()}-${++draftNoteSequenceRef.current}`,
+        },
       );
       const file = fileByKey.get(draft.fileKey);
       if (!file) {
@@ -1576,12 +1583,16 @@ export function useTerminalReview({
     [applyLineCursor, fileByKey, runIntent],
   );
 
-  /** Update the body of the active draft note through the shared intent path. */
+  /** Update the expected active draft through the shared intent path. */
   const updateDraftNote = useCallback(
-    (body: string) => {
+    (body: string, expectedDraftId?: string) => {
+      if (expectedDraftId !== undefined && store.getSnapshot().draftNote?.id !== expectedDraftId) {
+        return false;
+      }
       runIntent({ type: "notes/update-draft", body });
+      return true;
     },
-    [runIntent],
+    [runIntent, store],
   );
 
   /** Discard the active human note draft through the shared intent path. */

--- a/packages/hunk/src/ui/hooks/useUserNoteComposer.test.tsx
+++ b/packages/hunk/src/ui/hooks/useUserNoteComposer.test.tsx
@@ -398,6 +398,33 @@ describe("useUserNoteComposer", () => {
     }
   });
 
+  test("does not save when the editor belongs to a stale draft", async () => {
+    const updates: Array<[string, string | undefined]> = [];
+    let saveCount = 0;
+    const harness = await renderComposer(
+      baseOptions({
+        draftNote,
+        updateDraft: (body, expectedDraftId) => {
+          updates.push([body, expectedDraftId]);
+          return false;
+        },
+        saveDraft: () => {
+          saveCount += 1;
+          return savedNote;
+        },
+      }),
+    );
+
+    try {
+      await act(async () => harness.composer().saveDraftNote(draftNote.body));
+
+      expect(updates).toEqual([[draftNote.body, draftNote.id]]);
+      expect(saveCount).toBe(0);
+    } finally {
+      await act(async () => harness.setup.renderer.destroy());
+    }
+  });
+
   test("updates the semantic draft and publishes the editor's current body", async () => {
     const bodies: string[] = [];
     const events: Array<{ event: string; payload: unknown }> = [];

--- a/packages/hunk/src/ui/hooks/useUserNoteComposer.test.tsx
+++ b/packages/hunk/src/ui/hooks/useUserNoteComposer.test.tsx
@@ -68,7 +68,7 @@ function baseOptions(
     keyboardCursorEnabled: true,
     getLineCursor: () => null,
     startDraft: () => null,
-    updateDraft: () => {},
+    updateDraft: () => true,
     saveDraft: () => null,
     cancelDraft: () => {},
     focus: { draft: () => {}, review: () => {}, blurDraft: () => {} },
@@ -365,13 +365,49 @@ describe("useUserNoteComposer", () => {
     }
   });
 
+  test("flushes the editor's current body before saving", async () => {
+    const calls: string[] = [];
+    const events: Array<{ event: string; payload: unknown }> = [];
+    let semanticBody = draftNote.body;
+    const harness = await renderComposer(
+      baseOptions({
+        draftNote,
+        updateDraft: (body, expectedDraftId) => {
+          calls.push(`update:${expectedDraftId}`);
+          semanticBody = body;
+          return true;
+        },
+        saveDraft: () => {
+          calls.push("save");
+          return { ...savedNote, summary: semanticBody };
+        },
+        publishEvent: (event, payload) => events.push({ event, payload }),
+      }),
+    );
+
+    try {
+      await act(async () => harness.composer().saveDraftNote("complete editor body"));
+
+      expect(calls).toEqual([`update:${draftNote.id}`, "save"]);
+      expect(events[0]).toMatchObject({
+        event: "note_created",
+        payload: { note: { body: "complete editor body" } },
+      });
+    } finally {
+      await act(async () => harness.setup.renderer.destroy());
+    }
+  });
+
   test("updates the semantic draft and publishes the editor's current body", async () => {
     const bodies: string[] = [];
     const events: Array<{ event: string; payload: unknown }> = [];
     const harness = await renderComposer(
       baseOptions({
         draftNote: { ...draftNote, newRange: [41, 43] },
-        updateDraft: (body) => bodies.push(body),
+        updateDraft: (body) => {
+          bodies.push(body);
+          return true;
+        },
         publishEvent: (event, payload) => events.push({ event, payload }),
       }),
     );
@@ -398,6 +434,30 @@ describe("useUserNoteComposer", () => {
           },
         },
       ]);
+    } finally {
+      await act(async () => harness.setup.renderer.destroy());
+    }
+  });
+
+  test("ignores an editor update rejected for a stale draft", async () => {
+    const events: Array<{ event: string; payload: unknown }> = [];
+    const updates: Array<[string, string | undefined]> = [];
+    const harness = await renderComposer(
+      baseOptions({
+        draftNote,
+        updateDraft: (body, expectedDraftId) => {
+          updates.push([body, expectedDraftId]);
+          return false;
+        },
+        publishEvent: (event, payload) => events.push({ event, payload }),
+      }),
+    );
+
+    try {
+      await act(async () => harness.composer().updateDraftNote("late editor body"));
+
+      expect(updates).toEqual([["late editor body", draftNote.id]]);
+      expect(events).toEqual([]);
     } finally {
       await act(async () => harness.setup.renderer.destroy());
     }
@@ -433,7 +493,10 @@ describe("useUserNoteComposer", () => {
           staleCalls.push("start");
           return draftNote;
         },
-        updateDraft: () => staleCalls.push("update"),
+        updateDraft: () => {
+          staleCalls.push("update");
+          return true;
+        },
         saveDraft: () => {
           staleCalls.push("save");
           return savedNote;
@@ -457,7 +520,10 @@ describe("useUserNoteComposer", () => {
               currentCalls.push("start");
               return replacementDraft;
             },
-            updateDraft: () => currentCalls.push("update"),
+            updateDraft: () => {
+              currentCalls.push("update");
+              return true;
+            },
             saveDraft: () => {
               currentCalls.push("save");
               return replacementSaved;

--- a/packages/hunk/src/ui/hooks/useUserNoteComposer.ts
+++ b/packages/hunk/src/ui/hooks/useUserNoteComposer.ts
@@ -66,7 +66,7 @@ export interface UseUserNoteComposerOptions {
   ) => DraftReviewNote | null;
   startEdit?: (noteId: string, options?: { preserveViewport?: boolean }) => DraftReviewNote | null;
   startReply?: (noteId: string, options?: { preserveViewport?: boolean }) => DraftReviewNote | null;
-  updateDraft: (body: string) => void;
+  updateDraft: (body: string, expectedDraftId?: string) => boolean;
   saveDraft: () => UserReviewNote | null;
   cancelDraft: () => void;
   focus: {
@@ -159,38 +159,49 @@ export function useUserNoteComposer({
   }, [blurDraftFocus]);
 
   /** Save the current draft, publish it once, and return to review navigation. */
-  const saveDraftNote = useCallback(() => {
-    // `saveDraft` consumes the semantic draft synchronously. Retain its runtime file id
-    // first because the saved terminal projection is keyed by path rather than runtime id.
-    const priorDraft = draftNote;
-    const saved = saveDraft();
-    if (saved && priorDraft) {
-      const note = projectExtensionReviewNote({ ...saved, fileId: priorDraft.fileId }, false);
-      publishEvent(priorDraft.kind === "edit" ? "note_edited" : "note_created", { note });
-    }
-    focusReview();
-  }, [draftNote, focusReview, publishEvent, saveDraft]);
+  const saveDraftNote = useCallback(
+    (editorBody?: string) => {
+      // `saveDraft` consumes the semantic draft synchronously. Retain its runtime file id
+      // first because the saved terminal projection is keyed by path rather than runtime id.
+      const priorDraft = draftNote;
+      if (
+        priorDraft &&
+        editorBody !== undefined &&
+        editorBody !== priorDraft.body &&
+        !updateDraft(editorBody, priorDraft.id)
+      ) {
+        return;
+      }
+      const saved = saveDraft();
+      if (saved && priorDraft) {
+        const note = projectExtensionReviewNote({ ...saved, fileId: priorDraft.fileId }, false);
+        publishEvent(priorDraft.kind === "edit" ? "note_edited" : "note_created", { note });
+      }
+      focusReview();
+    },
+    [draftNote, focusReview, publishEvent, saveDraft, updateDraft],
+  );
 
   /** Update the semantic draft and publish the body supplied by the editor. */
   const updateDraftNote = useCallback(
     (body: string) => {
       const priorDraft = draftNote;
-      updateDraft(body);
-      if (priorDraft) {
-        publishEvent("note_edited", {
-          note: projectExtensionReviewNote(
-            {
-              ...priorDraft,
-              id:
-                priorDraft.kind === "edit" && priorDraft.targetNoteId
-                  ? priorDraft.targetNoteId
-                  : priorDraft.id,
-              body,
-            },
-            true,
-          ),
-        });
+      if (!priorDraft || !updateDraft(body, priorDraft.id)) {
+        return;
       }
+      publishEvent("note_edited", {
+        note: projectExtensionReviewNote(
+          {
+            ...priorDraft,
+            id:
+              priorDraft.kind === "edit" && priorDraft.targetNoteId
+                ? priorDraft.targetNoteId
+                : priorDraft.id,
+            body,
+          },
+          true,
+        ),
+      });
     },
     [draftNote, publishEvent, updateDraft],
   );

--- a/packages/hunk/src/ui/hooks/useUserNoteComposer.ts
+++ b/packages/hunk/src/ui/hooks/useUserNoteComposer.ts
@@ -164,12 +164,7 @@ export function useUserNoteComposer({
       // `saveDraft` consumes the semantic draft synchronously. Retain its runtime file id
       // first because the saved terminal projection is keyed by path rather than runtime id.
       const priorDraft = draftNote;
-      if (
-        priorDraft &&
-        editorBody !== undefined &&
-        editorBody !== priorDraft.body &&
-        !updateDraft(editorBody, priorDraft.id)
-      ) {
+      if (priorDraft && editorBody !== undefined && !updateDraft(editorBody, priorDraft.id)) {
         return;
       }
       const saved = saveDraft();

--- a/test/pty/notes.test.ts
+++ b/test/pty/notes.test.ts
@@ -667,6 +667,36 @@ describe("PTY notes", () => {
     }
   });
 
+  test("late textarea events after a fast save do not crash the review", async () => {
+    const fixture = harness.createLongWrapFilePair();
+    const session = await harness.launchHunk({
+      args: ["diff", "--files", fixture.before, fixture.after, "--mode", "split"],
+      cols: 120,
+      rows: 24,
+    });
+
+    try {
+      await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, { timeout: 15_000 });
+
+      await session.press("c");
+      await session.waitForText(/Draft note/, { timeout: 5_000 });
+      await session.type("Fast sav");
+      await session.waitForText(/Fast sav/, { timeout: 5_000 });
+
+      // Keep the final edits and save in one PTY write so queued textarea events can
+      // arrive after the semantic draft has already been consumed.
+      session.writeRaw("e.\x13");
+      await session.waitIdle();
+
+      const saved = await session.waitForText(/Fast save\./, { timeout: 5_000 });
+      expect(saved).toContain("Your note");
+      await sleep(250);
+      expect(await session.text({ immediate: true })).not.toContain("Console (Focused)");
+    } finally {
+      session.close();
+    }
+  });
+
   test("add-note affordance appears only after mouse movement in a real PTY", async () => {
     const fixture = harness.createScrollableFilePair();
     const session = await harness.launchHunk({


### PR DESCRIPTION
## Summary

- scope textarea updates and saves to the draft instance that emitted them
- flush the focused editor value before Ctrl-S or mouse saves consume the draft
- keep draft identities unique when notes are reopened within one millisecond
- cover stale callbacks and fast-save behavior at unit and PTY levels

## Stack

- bottom PR; #1047 contains the independent Knip cleanup above this branch
- replaces #1048, which GitHub marked merged into its former branch base while the stack order was corrected; no code from #1048 reached `main`

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run deps:check`
- `bun run changeset:status`
- `bun run test` (2,100 passed)
- `bun run test:integration` (163 passed, 1 platform skip)
- `bun run test:tty-smoke` (10 passed)
- rapid-save and delayed-input PTY regressions repeated 10 times each
- real TTY smoke on an actual commit diff
- `bun run build:npm && bun run check:pack`