### PR TITLE
fix(watch): reload direct files outside repositories

### DIFF
--- a/.changeset/fuzzy-files-reload.md
+++ b/.changeset/fuzzy-files-reload.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Restore automatic and manual reloads for direct-file comparisons launched outside repositories.

--- a/packages/hunk/src/app/session/reloadBounds.test.ts
+++ b/packages/hunk/src/app/session/reloadBounds.test.ts
@@ -210,19 +210,24 @@ describe("session reload filesystem bounds", () => {
     }
   });
 
-  test("rejects direct file reloads launched outside a repo", () => {
-    const dir = mkdtempSync(join(tmpdir(), "hunk-reload-bounds-files-"));
-    const left = join(dir, "before.ts");
-    const right = join(dir, "after.ts");
+  test("allows only the exact direct files when launched outside a repo", () => {
+    const launchDir = mkdtempSync(join(tmpdir(), "hunk-reload-bounds-launch-"));
+    const fileDir = mkdtempSync(join(tmpdir(), "hunk-reload-bounds-files-"));
+    const left = join(fileDir, "before.ts");
+    const right = join(fileDir, "after.ts");
+    const other = join(fileDir, "other.ts");
     writeFileSync(left, "before\n");
     writeFileSync(right, "after\n");
+    writeFileSync(other, "other\n");
 
     try {
       const bounds = createSessionReloadBounds(
         bootstrapFor({ kind: "diff", left, right, options: {} }, "file compare"),
-        { cwd: dir },
+        { cwd: launchDir },
       );
 
+      expect(bounds.roots).toEqual([]);
+      expect(bounds.exactFiles).toEqual([realPath(left), realPath(right)]);
       expect(() =>
         validateSessionReloadWithinBounds(bounds, {
           kind: "diff",
@@ -230,7 +235,22 @@ describe("session reload filesystem bounds", () => {
           right,
           options: {},
         }),
-      ).toThrow("rooted in a repository");
+      ).not.toThrow();
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "diff",
+          left,
+          right: other,
+          options: {},
+        }),
+      ).toThrow("right file outside the initial Hunk root");
+      expect(() =>
+        validateSessionReloadWithinBounds(bounds, {
+          kind: "vcs",
+          staged: false,
+          options: {},
+        }),
+      ).toThrow("repository-backed input");
       expect(() =>
         validateSessionReloadWithinBounds(
           bounds,
@@ -240,11 +260,12 @@ describe("session reload filesystem bounds", () => {
             right,
             options: {},
           },
-          { sourcePath: resolve(dir, "..") },
+          { sourcePath: fileDir },
         ),
-      ).toThrow("rooted in a repository");
+      ).toThrow("source path outside the initial Hunk root");
     } finally {
-      rmSync(dir, { force: true, recursive: true });
+      rmSync(launchDir, { force: true, recursive: true });
+      rmSync(fileDir, { force: true, recursive: true });
     }
   });
 

--- a/packages/hunk/src/app/session/reloadBounds.ts
+++ b/packages/hunk/src/app/session/reloadBounds.ts
@@ -13,8 +13,8 @@ import type { VcsCatalog } from "../../core/vcs/types";
  * | `hunk diff` / `hunk show` / `hunk stash show` | Initial repo root | Anything outside that repo root. |
  * | `hunk diff --files fileA fileB` inside a repo, both files in repo | The repo root | Anything outside that repo root. |
  * | `hunk difftool fileA fileB` inside a repo, both files in repo | The repo root | Anything outside that repo root. |
- * | `hunk diff --files fileA fileB` outside a repo | None | All session reloads. |
- * | `hunk difftool fileA fileB` outside a repo | None | All session reloads. |
+ * | `hunk diff --files fileA fileB` outside a repo | Exact initial files | Other files and every repository-backed reload. |
+ * | `hunk difftool fileA fileB` outside a repo | Exact initial files | Other files and every repository-backed reload. |
  * | `hunk patch patchfile` inside a repo | The repo root | Anything outside that repo root. |
  * | `hunk patch patchfile` outside a repo | Exact initial patch file | Other files and every repository-backed reload. |
  * | stdin-backed patch startup | None | All session reloads. |
@@ -92,13 +92,14 @@ export function createSessionReloadBounds(
       roots = [bootstrap.reloadContext.repoRoot ?? bootstrap.reloadContext.cwd];
       break;
     case "diff":
-    case "difftool":
-      roots = resolveRepoReloadRoots(
-        initialCwd,
-        [bootstrap.input.left, bootstrap.input.right],
-        bootstrap.reloadContext.vcsCatalog,
-      );
+    case "difftool": {
+      const inputFiles = [bootstrap.input.left, bootstrap.input.right];
+      roots = resolveRepoReloadRoots(initialCwd, inputFiles, bootstrap.reloadContext.vcsCatalog);
+      if (roots.length === 0) {
+        exactFiles = inputFiles.map((path) => resolve(initialCwd, path));
+      }
       break;
+    }
     case "patch":
       if (bootstrap.input.file && bootstrap.input.file !== "-") {
         roots = resolveRepoReloadRoots(
@@ -206,8 +207,8 @@ export function validateSessionReloadWithinBounds(
   switch (nextInput.kind) {
     case "diff":
     case "difftool":
-      assertReloadFileWithinBounds(bounds, sourceCwd, nextInput.left, "left file");
-      assertReloadFileWithinBounds(bounds, sourceCwd, nextInput.right, "right file");
+      assertReloadFileWithinBounds(bounds, sourceCwd, nextInput.left, "left file", true);
+      assertReloadFileWithinBounds(bounds, sourceCwd, nextInput.right, "right file", true);
       break;
     case "patch":
       if (nextInput.file && nextInput.file !== "-") {

--- a/packages/hunk/src/ui/AppHost.interactions.test.tsx
+++ b/packages/hunk/src/ui/AppHost.interactions.test.tsx
@@ -1664,8 +1664,8 @@ describe("App interactions", () => {
     }
   });
 
-  test("reload shortcut reloads the current file diff from disk", async () => {
-    const dir = mkdtempSync(join(process.cwd(), ".hunk-reload-"));
+  test("reload shortcut refreshes direct files launched outside a repository", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hunk-reload-"));
     const left = join(dir, "before.ts");
     const right = join(dir, "after.ts");
 

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -515,13 +515,12 @@ export function createPtyHarness() {
     return { dir, before, after };
   }
 
-  /** Build direct files whose watched side can be replaced atomically during a PTY test. */
+  /** Build direct files outside a repository for atomic-save watch coverage. */
   function createWatchFilePair() {
     const dir = makeTempDir("hunk-tuistory-watch-files-");
     const before = join(dir, "before.ts");
     const after = join(dir, "after.ts");
 
-    runGit(["init"], dir);
     writeText(before, "export const watchedValue = 'before';\n");
     writeText(after, "export const watchedValue = 'initial change';\n");
 


### PR DESCRIPTION
## Problem

Direct-file reviews launched outside a Git repository could not reload. Automatic `--watch` refreshes and the manual `r` shortcut both passed through session reload bounds with no permitted roots or files, so updates were silently left stale until Hunk was reopened.

## Approach

- permit the exact two initial direct-file inputs when no repository root safely contains them
- retain the existing boundary against reading other files or switching to repository-backed reloads
- exercise atomic-save watch behavior from a real PTY outside any repository
- move manual reload coverage outside the checkout and add focused reload-boundary tests

The VM's root user was not the determining factor; the missing repository root was.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run deps:check`
- `bun run test:integration` — 163 passed, 1 skipped
- focused reload bounds and manual reload tests
- `bun run test` — 2,049 passed, 2 skipped; one unrelated environment-sensitive failure because this checkout is nested in a Jujutsu workspace and the existing test expects Git detection

*This PR description was generated by Pi using GPT-5.6-sol*
