### PR TITLE
feat(cli): show metadata for direct revision reviews

### DIFF
--- a/.changeset/direct-cli-review-info.md
+++ b/.changeset/direct-cli-review-info.md
@@ -1,0 +1,6 @@
+---
+"hunkdiff": minor
+---
+
+Show commit and comparison information, including short revision IDs, above direct CLI revision
+reviews for Git, Jujutsu, and Sapling.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -302,9 +302,10 @@ and retires the replaced instance at that explicit ownership boundary.
 
 ### `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `23`). Branch on it if you want
-one file to support several Hunk versions. Version 23 adds canonical unified-layout fields while
-preserving the previous event vocabulary; version 22 adds frame-derived pane preferred sizing,
+The API generation this Hunk speaks (currently `24`). Branch on it if you want
+one file to support several Hunk versions. Version 24 adds review metadata to VCS patch results and
+short display revisions to commit descriptors; version 23 adds canonical unified-layout fields
+while preserving the previous event vocabulary; version 22 adds frame-derived pane preferred sizing,
 non-resizable dynamic panes, and commit-history paint tokens; version 21 adds optional inclusive history-range review
 planning and bounded comparison commit summaries; version 20 adds optional commit timestamps to review
 metadata, pane clipboard actions, and the `theme.copyAction` paint token; version 19 adds provider-owned history

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -611,14 +611,26 @@ handler from running. Watch signatures remain synchronous because the watch
 runtime calls them as short, noninteractive probes.
 
 A `load` result is patch text plus how to label it. Everything else on it is
-optional, and each optional field buys one thing:
+optional, and each optional field buys one thing. API version 24 adds `review`:
 
 | Field            | What it adds                                                       |
 | ---------------- | ------------------------------------------------------------------ |
+| `review`         | commit or comparison context above a revision-backed review        |
 | `untrackedPaths` | files your VCS calls unknown, synthesized into added-file diffs    |
 | `readFileSource` | exact whole-file contents, for context expansion and highlighting  |
 | `sourceCacheKey` | stable source-snapshot identity for highlight reuse across reloads |
 | `extraFiles`     | files reviewed outside the patch, including skipped placeholders   |
+
+Use the same `ExtensionReviewDescriptor` accepted by delegated CLI reviews. Return a `commit`
+descriptor when the operation resolves one reviewed commit, or a `comparison` descriptor when both
+sides resolve to commits. Comparison `commits` are newest-first and bounded to eight entries; retain
+the exact total in `commitCount` when known. Commit descriptors and comparison commit rows carry the
+full immutable ID in `revision` for copying and should carry the provider-formatted short ID in
+`displayRevision` for display. `displayRevision` remains optional on a single commit for extensions
+built against an older API; Hunk abbreviates `revision` when it is absent. Omit `review` when either
+side is working-copy, staged, stash, or otherwise cannot be identified accurately. Hunk validates,
+copies, and freezes the descriptor before mounting it, then recomputes provider-supplied metadata on
+reload so moving refs do not retain stale information.
 
 `untrackedPaths` is the shorthand: list the repo-root-relative paths your VCS
 reports as unknown and Hunk synthesizes the added-file diffs for you, skipping

--- a/packages/hunk-git/src/commands.ts
+++ b/packages/hunk-git/src/commands.ts
@@ -1198,3 +1198,77 @@ export async function resolveGitDiffEndpointsAsync(
   }
   return null;
 }
+
+/** Resolve a direct diff to two commits when neither side is live working state. */
+export async function resolveGitComparisonEndpointsAsync(
+  input: ExtensionVcsDiffInput,
+  {
+    cwd = process.cwd(),
+    gitExecutable = "git",
+    repoRoot,
+    signal,
+  }: Omit<RunGitTextOptions, "input" | "args"> & { repoRoot?: string } = {},
+): Promise<{ base: string; head: string } | null> {
+  const range = requireGitDiffRangeArg(input);
+  if (input.staged || !range) return null;
+  const commandCwd = repoRoot ?? cwd;
+
+  const symmetric = parseSymmetricDiffRange(range);
+  if (symmetric) {
+    const base = (
+      await runGitTextAsync({
+        input,
+        args: ["merge-base", symmetric.left, symmetric.right],
+        cwd: commandCwd,
+        gitExecutable,
+        signal,
+      })
+    )
+      .split("\n")[0]
+      ?.trim();
+    if (!base) return null;
+    const head = await resolveGitCommitRefAsync(input, symmetric.right, {
+      cwd: commandCwd,
+      gitExecutable,
+      signal,
+    });
+    return { base, head };
+  }
+
+  const revisions = (
+    await runGitTextAsync({
+      input,
+      args: ["rev-parse", "--revs-only", requireGitRevisionArg(input, range)],
+      cwd: commandCwd,
+      gitExecutable,
+      signal,
+    })
+  )
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const positives = revisions.filter((revision) => !revision.startsWith("^"));
+  const negatives = revisions
+    .filter((revision) => revision.startsWith("^"))
+    .map((revision) => revision.slice(1));
+  if (positives.length !== 1 || negatives.length !== 1) return null;
+
+  try {
+    const [base, head] = await Promise.all([
+      resolveGitCommitRefAsync(input, negatives[0]!, {
+        cwd: commandCwd,
+        gitExecutable,
+        signal,
+      }),
+      resolveGitCommitRefAsync(input, positives[0]!, {
+        cwd: commandCwd,
+        gitExecutable,
+        signal,
+      }),
+    ]);
+    return { base, head };
+  } catch (error) {
+    if (signal?.aborted) throw error;
+    return null;
+  }
+}

--- a/packages/hunk-git/src/history.ts
+++ b/packages/hunk-git/src/history.ts
@@ -296,6 +296,32 @@ export function parseGitHistory(
   return commits;
 }
 
+/** Load a bounded newest-first commit list for direct review metadata. */
+export async function loadGitReviewCommits(
+  revision: string,
+  options: GitHistoryOptions,
+  limit = 8,
+) {
+  const result = await runGitPlanningQuery(
+    buildGitHistoryArgs({ revision: requireRevision(revision), maxCount: limit }),
+    options,
+  );
+  return parseGitHistory(result.stdout);
+}
+
+/** Count commits in one provider-owned range without loading their messages. */
+export async function countGitReviewCommits(revision: string, options: GitHistoryOptions) {
+  const result = await runGitPlanningQuery(
+    ["rev-list", "--count", requireRevision(revision)],
+    options,
+  );
+  const count = Number.parseInt(result.stdout.trim(), 10);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error("Git returned an invalid review commit count.");
+  }
+  return count;
+}
+
 /** Return whether traversal filters can omit direct parents from the emitted commit stream. */
 export function gitHistoryUsesBoundaryTopology(input: ExtensionVcsHistoryInput) {
   return Boolean(

--- a/packages/hunk-git/src/index.test.ts
+++ b/packages/hunk-git/src/index.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
-import { describeGitDiffTitleRange, GitVcsAdapter, statSignature } from ".";
+import { createGitVcsAdapter, describeGitDiffTitleRange, GitVcsAdapter, statSignature } from ".";
 import type {
   ExtensionVcsDiffInput,
   ExtensionVcsOperations,
@@ -66,6 +66,29 @@ function createTempRepo(prefix: string) {
   git(dir, "config", "user.email", "test@example.com");
   git(dir, "config", "commit.gpgsign", "false");
   return dir;
+}
+
+/** Wrap Git and move master after review metadata captures an immutable revision. */
+function createRefMovingGitExecutable(repo: string, movedRevision: string) {
+  const gitExecutable = Bun.which("git");
+  if (!gitExecutable) throw new Error("Git is required for adapter tests.");
+  const wrapper = join(repo, "move-ref-git");
+  writeFileSync(
+    wrapper,
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "log" ]; then',
+      `  ${JSON.stringify(gitExecutable)} "$@"`,
+      "  status=$?",
+      `  ${JSON.stringify(gitExecutable)} update-ref refs/heads/master ${JSON.stringify(movedRevision)}`,
+      '  exit "$status"',
+      "fi",
+      `exec ${JSON.stringify(gitExecutable)} "$@"`,
+      "",
+    ].join("\n"),
+  );
+  chmodSync(wrapper, 0o755);
+  return wrapper;
 }
 
 afterEach(() => {
@@ -257,6 +280,76 @@ describe("GitVcsAdapter", () => {
     expect(stashResult.patchText).toContain("+three");
     expect("review" in stashResult).toBe(false);
   });
+
+  test.skipIf(process.platform === "win32")(
+    "pins revision metadata, patch text, and source reads to one resolved commit",
+    async () => {
+      const repo = createTempRepo("hunk-git-adapter-moving-show-ref-");
+      writeFileSync(join(repo, "file.txt"), "one\n");
+      git(repo, "add", "file.txt");
+      git(repo, "commit", "-m", "initial");
+      writeFileSync(join(repo, "file.txt"), "two\n");
+      git(repo, "commit", "-am", "reviewed");
+      const reviewedRevision = git(repo, "rev-parse", "HEAD").trim();
+      writeFileSync(join(repo, "file.txt"), "three\n");
+      git(repo, "commit", "-am", "moved");
+      const movedRevision = git(repo, "rev-parse", "HEAD").trim();
+      git(repo, "reset", "--hard", reviewedRevision);
+
+      const adapter = createGitVcsAdapter({
+        gitExecutable: createRefMovingGitExecutable(repo, movedRevision),
+      });
+      const result = await adapter.operations["revision-show"]!.load(
+        { kind: "show", ref: "HEAD", options: {} },
+        { cwd: repo },
+      );
+      const file = { path: "file.txt", changeType: "change", isUntracked: false } as const;
+
+      expect(git(repo, "rev-parse", "HEAD").trim()).toBe(movedRevision);
+      expect(result.review).toMatchObject({ revision: reviewedRevision, title: "reviewed" });
+      expect(result.patchText).toContain("+two");
+      expect(result.patchText).not.toContain("+three");
+      expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("two\n");
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "pins comparison metadata, patch text, and source reads to one endpoint pair",
+    async () => {
+      const repo = createTempRepo("hunk-git-adapter-moving-diff-ref-");
+      writeFileSync(join(repo, "file.txt"), "one\n");
+      git(repo, "add", "file.txt");
+      git(repo, "commit", "-m", "initial");
+      const baseRevision = git(repo, "rev-parse", "HEAD").trim();
+      writeFileSync(join(repo, "file.txt"), "two\n");
+      git(repo, "commit", "-am", "reviewed");
+      const reviewedRevision = git(repo, "rev-parse", "HEAD").trim();
+      writeFileSync(join(repo, "file.txt"), "three\n");
+      git(repo, "commit", "-am", "moved");
+      const movedRevision = git(repo, "rev-parse", "HEAD").trim();
+      git(repo, "reset", "--hard", reviewedRevision);
+
+      const adapter = createGitVcsAdapter({
+        gitExecutable: createRefMovingGitExecutable(repo, movedRevision),
+      });
+      const result = await adapter.operations["working-tree-diff"]!.load(
+        {
+          kind: "vcs",
+          staged: false,
+          rangeEndpoints: { from: baseRevision, to: "master" },
+          options: {},
+        },
+        { cwd: repo },
+      );
+      const file = { path: "file.txt", changeType: "change", isUntracked: false } as const;
+
+      expect(git(repo, "rev-parse", "HEAD").trim()).toBe(movedRevision);
+      expect(result.review).toMatchObject({ base: baseRevision, head: reviewedRevision });
+      expect(result.patchText).toContain("+two");
+      expect(result.patchText).not.toContain("+three");
+      expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("two\n");
+    },
+  );
 
   test("returns null when no Git marker exists up to the filesystem root", () => {
     // A bare temp dir has no .git in any ancestor, exercising the walk-to-root null return.

--- a/packages/hunk-git/src/index.test.ts
+++ b/packages/hunk-git/src/index.test.ts
@@ -143,6 +143,7 @@ describe("GitVcsAdapter", () => {
     expect(result.patchText).toContain("diff --git a/tracked.txt b/tracked.txt");
     expect(result.patchText).toContain("+new");
     expect(result.untrackedPaths).toContain("untracked.txt");
+    expect(result.review).toBeUndefined();
     expect(result.sourceCacheKey).toContain("git-source-v1");
 
     const equivalentResult = await GitVcsAdapter.operations["working-tree-diff"]!.load(input, {
@@ -192,6 +193,15 @@ describe("GitVcsAdapter", () => {
     expect(result.title).not.toContain(from);
     expect(result.title).not.toContain(to);
     expect(result.untrackedPaths).toEqual([]);
+    expect(result.review).toMatchObject({
+      kind: "comparison",
+      provider: "Git",
+      base: from,
+      head: to,
+      title: "1 commit",
+      commitCount: 1,
+      commits: [{ title: "new", revision: to, displayRevision: to.slice(0, 8) }],
+    });
     expect(await result.readFileSource?.({ ...file, side: "old" })).toBe("old\ncontext\n");
     expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("new\ncontext\n");
   });
@@ -217,6 +227,14 @@ describe("GitVcsAdapter", () => {
     expect(showResult.patchText).toContain("diff --git a/file.txt b/file.txt");
     expect(showResult.patchText).toContain("+two");
     expect(showResult.sourceCacheKey).toContain("git-source-v1");
+    expect(showResult.review).toMatchObject({
+      kind: "commit",
+      provider: "Git",
+      title: "change",
+      revision: git(repo, "rev-parse", "HEAD").trim(),
+      displayRevision: git(repo, "rev-parse", "--short=8", "HEAD").trim(),
+      author: "test",
+    });
 
     const showFile = { path: "file.txt", changeType: "change", isUntracked: false } as const;
     expect(await showResult.readFileSource?.({ ...showFile, side: "old" })).toBe("one\n");
@@ -237,6 +255,7 @@ describe("GitVcsAdapter", () => {
     expect(stashResult.patchText).toContain("diff --git a/file.txt b/file.txt");
     expect(stashResult.sourceCacheKey).toContain("git-source-v1");
     expect(stashResult.patchText).toContain("+three");
+    expect("review" in stashResult).toBe(false);
   });
 
   test("returns null when no Git marker exists up to the filesystem root", () => {

--- a/packages/hunk-git/src/index.ts
+++ b/packages/hunk-git/src/index.ts
@@ -12,6 +12,7 @@ import {
   parseGitNumstat,
   resolveGitColorMovedOptionsAsync,
   resolveGitCommitRefAsync,
+  resolveGitComparisonEndpointsAsync,
   resolveGitDiffEndpoints,
   resolveGitDiffEndpointsAsync,
   resolveGitMetadata,
@@ -23,8 +24,14 @@ import {
   type GitBackedInput,
   type GitDiffEndpoints,
 } from "./commands";
-import { openGitHistory, planGitHistoryRangeReview } from "./history";
+import {
+  countGitReviewCommits,
+  loadGitReviewCommits,
+  openGitHistory,
+  planGitHistoryRangeReview,
+} from "./history";
 import { gitEndpointSourceSpec, readGitFileSource } from "./source";
+import { commitReviewInfo, comparisonReviewInfo } from "@hunk/vcs/review-info";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -118,6 +125,10 @@ interface GitSourceCapability {
   sourceCacheKey: string;
 }
 
+interface GitRevisionSourceCapability extends GitSourceCapability {
+  revisionId: string;
+}
+
 /** Hash index entries without blocking an embedded renderer. */
 async function gitIndexCacheKeyAsync(
   input: GitBackedInput,
@@ -153,19 +164,45 @@ async function createGitRevisionSourceCapabilityAsync(
   repoRoot: string,
   gitExecutable: string,
   signal?: AbortSignal,
-): Promise<GitSourceCapability> {
+): Promise<GitRevisionSourceCapability> {
   const newRef = await resolveGitCommitRefAsync(input, ref, {
     cwd: repoRoot,
     gitExecutable,
     signal,
   });
-  return createGitSourceCapabilityAsync(
-    input,
+  return {
+    ...(await createGitSourceCapabilityAsync(
+      input,
+      repoRoot,
+      { old: { kind: "git-ref", ref: `${newRef}^` }, new: { kind: "git-ref", ref: newRef } },
+      gitExecutable,
+      signal,
+    )),
+    revisionId: newRef,
+  };
+}
+
+/** Describe a direct commit-to-commit Git diff without labeling live state as a comparison. */
+async function createGitComparisonReview(
+  input: ExtensionVcsDiffInput,
+  cwd: string,
+  repoRoot: string,
+  gitExecutable: string,
+  signal?: AbortSignal,
+) {
+  const endpoints = await resolveGitComparisonEndpointsAsync(input, {
+    cwd,
     repoRoot,
-    { old: { kind: "git-ref", ref: `${newRef}^` }, new: { kind: "git-ref", ref: newRef } },
     gitExecutable,
     signal,
-  );
+  });
+  if (!endpoints) return undefined;
+  const revision = `${endpoints.base}..${endpoints.head}`;
+  const [commits, commitCount] = await Promise.all([
+    loadGitReviewCommits(revision, { cwd: repoRoot, gitExecutable, signal }),
+    countGitReviewCommits(revision, { cwd: repoRoot, gitExecutable, signal }),
+  ]);
+  return comparisonReviewInfo("Git", endpoints.base, endpoints.head, commits, commitCount);
 }
 
 /** Build exact source capability data while asynchronously hashing a possible index. */
@@ -367,6 +404,13 @@ export function createGitVcsAdapter({
             gitExecutable,
             signal,
           );
+          const review = await createGitComparisonReview(
+            input,
+            cwd,
+            repoRoot,
+            gitExecutable,
+            signal,
+          );
           const untrackedPaths = await listGitUntrackedFilesAsync(input, {
             cwd,
             repoRoot,
@@ -392,6 +436,7 @@ export function createGitVcsAdapter({
               gitExecutable,
               signal,
             }),
+            review,
             ...sourceCapability,
             extraFiles: largeTrackedFiles.map(
               (file): ExtensionVcsExtraFile => ({
@@ -438,13 +483,24 @@ export function createGitVcsAdapter({
         async load(input, { cwd, signal }) {
           const repoRoot = await resolveGitRepoRootAsync(input, { cwd, gitExecutable, signal });
           const repoName = basename(repoRoot);
-          const sourceCapability = await createGitRevisionSourceCapabilityAsync(
+          const { revisionId, ...sourceCapability } = await createGitRevisionSourceCapabilityAsync(
             input,
             input.ref ?? "HEAD",
             repoRoot,
             gitExecutable,
             signal,
           );
+          const commit = (
+            await loadGitReviewCommits(
+              revisionId,
+              {
+                cwd: repoRoot,
+                gitExecutable,
+                signal,
+              },
+              1,
+            )
+          )[0];
 
           return {
             repoRoot,
@@ -460,6 +516,7 @@ export function createGitVcsAdapter({
               gitExecutable,
               signal,
             }),
+            ...(commit ? { review: commitReviewInfo("Git", commit) } : {}),
             ...sourceCapability,
           };
         },
@@ -480,13 +537,14 @@ export function createGitVcsAdapter({
         async load(input, { cwd, signal }) {
           const repoRoot = await resolveGitRepoRootAsync(input, { cwd, gitExecutable, signal });
           const repoName = basename(repoRoot);
-          const sourceCapability = await createGitRevisionSourceCapabilityAsync(
-            input,
-            input.ref ?? "stash@{0}",
-            repoRoot,
-            gitExecutable,
-            signal,
-          );
+          const { revisionId: _revisionId, ...sourceCapability } =
+            await createGitRevisionSourceCapabilityAsync(
+              input,
+              input.ref ?? "stash@{0}",
+              repoRoot,
+              gitExecutable,
+              signal,
+            );
 
           return {
             repoRoot,

--- a/packages/hunk-git/src/index.ts
+++ b/packages/hunk-git/src/index.ts
@@ -39,6 +39,7 @@ import {
   type ExtensionVcsDirectoryTreeWatchTarget,
   type ExtensionVcsExtraFile,
   type ExtensionVcsFileSourceReader,
+  type ExtensionVcsShowInput,
   type ExtensionVcsWatchPlan,
   type HunkExtensionAPI,
 } from "hunkdiff/extension";
@@ -202,7 +203,10 @@ async function createGitComparisonReview(
     loadGitReviewCommits(revision, { cwd: repoRoot, gitExecutable, signal }),
     countGitReviewCommits(revision, { cwd: repoRoot, gitExecutable, signal }),
   ]);
-  return comparisonReviewInfo("Git", endpoints.base, endpoints.head, commits, commitCount);
+  return {
+    endpoints,
+    review: comparisonReviewInfo("Git", endpoints.base, endpoints.head, commits, commitCount),
+  };
 }
 
 /** Build exact source capability data while asynchronously hashing a possible index. */
@@ -378,6 +382,23 @@ export function createGitVcsAdapter({
           const repoRoot = await resolveGitRepoRootAsync(input, { cwd, gitExecutable, signal });
           const repoName = basename(repoRoot);
           const range = describeGitDiffTitleRange(input);
+          const comparison = await createGitComparisonReview(
+            input,
+            cwd,
+            repoRoot,
+            gitExecutable,
+            signal,
+          );
+          const patchInput: ExtensionVcsDiffInput = comparison
+            ? {
+                ...input,
+                range: undefined,
+                rangeEndpoints: {
+                  from: comparison.endpoints.base,
+                  to: comparison.endpoints.head,
+                },
+              }
+            : input;
           const title = input.staged
             ? `${repoName} staged changes`
             : range
@@ -387,7 +408,7 @@ export function createGitVcsAdapter({
           // excluded from the diff instead of generating output nobody reads.
           const numstat = await runGitTextAsync({
             input,
-            args: buildGitDiffNumstatArgs(input),
+            args: buildGitDiffNumstatArgs(patchInput),
             cwd,
             gitExecutable,
             signal,
@@ -397,20 +418,18 @@ export function createGitVcsAdapter({
             gitExecutable,
             signal,
           });
-          const sourceCapability = await createGitDiffSourceCapabilityAsync(
-            input,
-            repoRoot,
-            cwd,
-            gitExecutable,
-            signal,
-          );
-          const review = await createGitComparisonReview(
-            input,
-            cwd,
-            repoRoot,
-            gitExecutable,
-            signal,
-          );
+          const sourceCapability = comparison
+            ? await createGitSourceCapabilityAsync(
+                input,
+                repoRoot,
+                {
+                  old: { kind: "git-ref", ref: comparison.endpoints.base },
+                  new: { kind: "git-ref", ref: comparison.endpoints.head },
+                },
+                gitExecutable,
+                signal,
+              )
+            : await createGitDiffSourceCapabilityAsync(input, repoRoot, cwd, gitExecutable, signal);
           const untrackedPaths = await listGitUntrackedFilesAsync(input, {
             cwd,
             repoRoot,
@@ -428,7 +447,7 @@ export function createGitVcsAdapter({
             patchText: await runGitTextAsync({
               input,
               args: buildGitDiffArgs(
-                input,
+                patchInput,
                 largeTrackedFiles.map((file) => file.path),
                 colorMoved,
               ),
@@ -436,7 +455,7 @@ export function createGitVcsAdapter({
               gitExecutable,
               signal,
             }),
-            review,
+            review: comparison?.review,
             ...sourceCapability,
             extraFiles: largeTrackedFiles.map(
               (file): ExtensionVcsExtraFile => ({
@@ -501,6 +520,7 @@ export function createGitVcsAdapter({
               1,
             )
           )[0];
+          const patchInput: ExtensionVcsShowInput = { ...input, ref: revisionId };
 
           return {
             repoRoot,
@@ -509,7 +529,7 @@ export function createGitVcsAdapter({
             patchText: await runGitTextAsync({
               input,
               args: buildGitShowArgs(
-                input,
+                patchInput,
                 await resolveGitColorMovedOptionsAsync(input, { cwd, gitExecutable, signal }),
               ),
               cwd,

--- a/packages/hunk-jj/src/history.ts
+++ b/packages/hunk-jj/src/history.ts
@@ -191,6 +191,37 @@ export function parseJjHistory(
   return commits;
 }
 
+/** Load a bounded newest-first commit list for direct review metadata. */
+export async function loadJjReviewCommits(revset: string, options: JjHistoryOptions, limit = 8) {
+  const output = await runJjHistoryQuery(
+    [
+      "log",
+      "--no-graph",
+      "-r",
+      requireHistoryRevision(revset),
+      "--limit",
+      String(limit),
+      "-T",
+      JJ_HISTORY_TEMPLATE,
+    ],
+    options,
+  );
+  return parseJjHistory(output);
+}
+
+/** Count commits in one provider-owned revset without loading their descriptions. */
+export async function countJjReviewCommits(revset: string, options: JjHistoryOptions) {
+  const output = await runJjHistoryQuery(
+    ["log", "-r", requireHistoryRevision(revset), "--count"],
+    options,
+  );
+  const count = Number.parseInt(output.trim(), 10);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error("Jujutsu returned an invalid review commit count.");
+  }
+  return count;
+}
+
 /** Run one cancellable JJ query used while preparing a history range. */
 async function runJjHistoryQuery(
   args: string[],

--- a/packages/hunk-jj/src/index.test.ts
+++ b/packages/hunk-jj/src/index.test.ts
@@ -123,6 +123,7 @@ describe("JjVcsAdapter", () => {
       expect(diffResult.patchText).toContain("diff --git a/file.txt b/file.txt");
       expect(diffResult.patchText).toContain("+two");
       expect(diffResult.sourceCacheKey).toContain("jj-source-v1");
+      expect(diffResult.review).toBeUndefined();
       const reviewedFile = {
         path: "file.txt",
         changeType: "change",
@@ -148,6 +149,13 @@ describe("JjVcsAdapter", () => {
       expect(showResult.title).toContain("show @");
       expect(showResult.patchText).toContain("diff --git a/file.txt b/file.txt");
       expect(showResult.sourceCacheKey).toContain("jj-source-v1");
+      expect(showResult.review).toMatchObject({
+        kind: "commit",
+        provider: "Jujutsu",
+        title: "(no description set)",
+        displayRevision: expect.stringMatching(/^[a-z0-9]{8}$/),
+        author: "test",
+      });
       expect(await showResult.readFileSource?.({ ...reviewedFile, side: "old" })).toBe("one\n");
       expect(await showResult.readFileSource?.({ ...reviewedFile, side: "new" })).toBe("two\n");
 
@@ -192,6 +200,14 @@ describe("JjVcsAdapter", () => {
       const result = await JjVcsAdapter.operations["working-tree-diff"]!.load(input, { cwd: repo });
       const file = { path: "file.txt", changeType: "change", isUntracked: false } as const;
       expect(result.title).toContain(`${from}..@`);
+      expect(result.review).toMatchObject({
+        kind: "comparison",
+        provider: "Jujutsu",
+        base: from,
+        title: "1 commit",
+        commitCount: 1,
+        commits: [{ revision: result.review?.kind === "comparison" ? result.review.head : "" }],
+      });
       expect(result.patchText).toContain("+two");
       expect(await result.readFileSource?.({ ...file, side: "old" })).toBe("one\ncontext\n");
       expect(await result.readFileSource?.({ ...file, side: "new" })).toBe("two\ncontext\n");

--- a/packages/hunk-jj/src/index.ts
+++ b/packages/hunk-jj/src/index.ts
@@ -11,12 +11,19 @@ import {
   runJjTextAsync,
   type JjDiffEndpoints,
 } from "./commands";
-import { openJjHistory, planJjHistoryRangeReview } from "./history";
+import {
+  countJjReviewCommits,
+  loadJjReviewCommits,
+  openJjHistory,
+  planJjHistoryRangeReview,
+} from "./history";
 import { readJjFileSource } from "./source";
 import { describeDiffRange } from "@hunk/vcs/diff-target";
+import { commitReviewInfo, comparisonReviewInfo } from "@hunk/vcs/review-info";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
+  type ExtensionVcsDiffInput,
   type ExtensionVcsFileSourceReader,
   type HunkExtensionAPI,
 } from "hunkdiff/extension";
@@ -117,6 +124,40 @@ function createJjSourceCapability(
   };
 }
 
+/** Describe resolved Jujutsu commits without treating the default working copy as a commit review. */
+async function createJjReviewInfo(
+  input: ExtensionVcsDiffInput,
+  endpoints: JjDiffEndpoints | undefined,
+  repoRoot: string,
+  jjExecutable: string,
+  signal?: AbortSignal,
+) {
+  if (!endpoints) return undefined;
+  if (input.rangeEndpoints && endpoints.oldCommitIds.length === 1) {
+    const base = endpoints.oldCommitIds[0]!;
+    const head = endpoints.newCommitId;
+    const revset = `${base}..${head}`;
+    const [commits, commitCount] = await Promise.all([
+      loadJjReviewCommits(revset, { cwd: repoRoot, jjExecutable, signal }),
+      countJjReviewCommits(revset, { cwd: repoRoot, jjExecutable, signal }),
+    ]);
+    return comparisonReviewInfo("Jujutsu", base, head, commits, commitCount);
+  }
+  if (!input.range) return undefined;
+  const commit = (
+    await loadJjReviewCommits(
+      endpoints.newCommitId,
+      {
+        cwd: repoRoot,
+        jjExecutable,
+        signal,
+      },
+      1,
+    )
+  )[0];
+  return commit ? commitReviewInfo("Jujutsu", commit) : undefined;
+}
+
 /* -------------------------------------------------------------------------- */
 /* The adapter                                                                 */
 /* -------------------------------------------------------------------------- */
@@ -179,6 +220,13 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
           const sourceCapability = sourceEndpoints
             ? createJjSourceCapability(repoRoot, sourceEndpoints, jjExecutable)
             : undefined;
+          const review = await createJjReviewInfo(
+            input,
+            sourceEndpoints,
+            repoRoot,
+            jjExecutable,
+            signal,
+          );
           const pinnedInput = input.rangeEndpoints
             ? sourceEndpoints?.oldCommitIds.length === 1
               ? {
@@ -199,6 +247,7 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
               jjExecutable,
               signal,
             }),
+            review,
             ...sourceCapability,
           };
         },
@@ -224,6 +273,19 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
           const sourceCapability = sourceEndpoints
             ? createJjSourceCapability(repoRoot, sourceEndpoints, jjExecutable)
             : undefined;
+          const commit = sourceEndpoints
+            ? (
+                await loadJjReviewCommits(
+                  sourceEndpoints.newCommitId,
+                  {
+                    cwd: repoRoot,
+                    jjExecutable,
+                    signal,
+                  },
+                  1,
+                )
+              )[0]
+            : undefined;
           return {
             repoRoot,
             sourceLabel: repoRoot,
@@ -235,6 +297,7 @@ export function createJjVcsAdapter({ jjExecutable = "jj" }: Readonly<JjVcsAdapte
               jjExecutable,
               signal,
             }),
+            ...(commit ? { review: commitReviewInfo("Jujutsu", commit) } : {}),
             ...sourceCapability,
           };
         },

--- a/packages/hunk-sapling/src/index.test.ts
+++ b/packages/hunk-sapling/src/index.test.ts
@@ -118,6 +118,7 @@ describe("SaplingVcsAdapter", () => {
       expect(diffResult.title).toContain("working copy");
       expect(diffResult.patchText).toContain("diff --git a/file.txt b/file.txt");
       expect(diffResult.patchText).toContain("+two");
+      expect(diffResult.review).toBeUndefined();
 
       const showInput = {
         kind: "show",
@@ -130,6 +131,13 @@ describe("SaplingVcsAdapter", () => {
 
       expect(showResult.title).toContain("show .");
       expect(showResult.patchText).toContain("diff --git a/file.txt b/file.txt");
+      expect(showResult.review).toMatchObject({
+        kind: "commit",
+        provider: "Sapling",
+        title: "initial",
+        displayRevision: expect.stringMatching(/^[0-9a-f]{12}$/),
+        author: "test",
+      });
       expect(
         SaplingVcsAdapter.operations["working-tree-diff"]!.watchSignature!(diffInput, {
           cwd: repo,
@@ -138,6 +146,41 @@ describe("SaplingVcsAdapter", () => {
       expect(
         SaplingVcsAdapter.operations["revision-show"]!.watchSignature!(showInput, { cwd: repo }),
       ).toContain("diff --git");
+    },
+    SlAdapterIntegrationTestTimeoutMs,
+  );
+
+  test.skipIf(!slAvailable)(
+    "describes direct Sapling revision comparisons with included commits",
+    async () => {
+      const repo = createTempSlRepo("hunk-sl-adapter-comparison-");
+      writeFileSync(join(repo, "file.txt"), "one\n");
+      sl(repo, "add", "file.txt");
+      sl(repo, "commit", "-m", "initial");
+      const from = sl(repo, "log", "-r", ".", "--template", "{node}");
+      writeFileSync(join(repo, "file.txt"), "two\n");
+      sl(repo, "commit", "-m", "second");
+      const to = sl(repo, "log", "-r", ".", "--template", "{node}");
+      const input = {
+        kind: "vcs",
+        rangeEndpoints: { from, to },
+        staged: false,
+        options: {},
+      } satisfies ExtensionVcsDiffInput;
+
+      const result = await SaplingVcsAdapter.operations["working-tree-diff"]!.load(input, {
+        cwd: repo,
+      });
+
+      expect(result.review).toMatchObject({
+        kind: "comparison",
+        provider: "Sapling",
+        base: from,
+        head: to,
+        title: "1 commit",
+        commitCount: 1,
+        commits: [{ title: "second", revision: to }],
+      });
     },
     SlAdapterIntegrationTestTimeoutMs,
   );

--- a/packages/hunk-sapling/src/index.test.ts
+++ b/packages/hunk-sapling/src/index.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
-import { SaplingVcsAdapter } from ".";
+import { createSaplingVcsAdapter, SaplingVcsAdapter } from ".";
 import type {
   ExtensionVcsOperations,
   ExtensionVcsShowInput,
@@ -95,6 +103,88 @@ describe("SaplingVcsAdapter", () => {
 
     expect(SaplingVcsAdapter.detect(repo)).toBeNull();
   });
+
+  test.skipIf(process.platform === "win32")(
+    "pins revision-show patches to the node resolved for metadata",
+    async () => {
+      const repo = createTempDir("hunk-sl-adapter-pinned-show-");
+      const executable = join(repo, "fake-sl");
+      const callsPath = join(repo, "calls.txt");
+      const revision = "a".repeat(40);
+      writeFileSync(
+        executable,
+        [
+          "#!/bin/sh",
+          `printf '%s\\n' "$*" >> ${JSON.stringify(callsPath)}`,
+          'case " $* " in',
+          `  *" root "*) printf '%s\\n' ${JSON.stringify(repo)} ;;`,
+          `  *" log "*) printf '%s\\0%s\\0%s\\0%s\\0%s\\0%s\\0' ${JSON.stringify(revision)} ${JSON.stringify(revision.slice(0, 12))} 'Pinned commit' 'Test User' 'test@example.com' '2026-09-08 12:00:00 +0000' ;;`,
+          `  *" diff "*) printf 'pinned patch\\n' ;;`,
+          "  *) exit 1 ;;",
+          "esac",
+          "",
+        ].join("\n"),
+      );
+      chmodSync(executable, 0o755);
+
+      const adapter = createSaplingVcsAdapter({ slExecutable: executable });
+      const result = await adapter.operations["revision-show"]!.load(
+        { kind: "show", ref: ".", options: {} },
+        { cwd: repo },
+      );
+
+      expect(result.review).toMatchObject({ revision, title: "Pinned commit" });
+      expect(result.patchText).toBe("pinned patch\n");
+      expect(readFileSync(callsPath, "utf8")).toContain(`diff --git --change ${revision}`);
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "pins comparison patches to the nodes resolved for metadata",
+    async () => {
+      const repo = createTempDir("hunk-sl-adapter-pinned-comparison-");
+      const executable = join(repo, "fake-sl");
+      const callsPath = join(repo, "calls.txt");
+      const baseRevision = "a".repeat(40);
+      const headRevision = "b".repeat(40);
+      const record = (revision: string, title: string) =>
+        `printf '%s\\0%s\\0%s\\0%s\\0%s\\0%s\\0' ${JSON.stringify(revision)} ${JSON.stringify(revision.slice(0, 12))} ${JSON.stringify(title)} 'Test User' 'test@example.com' '2026-09-08 12:00:00 +0000'`;
+      writeFileSync(
+        executable,
+        [
+          "#!/bin/sh",
+          `printf '%s\\n' "$*" >> ${JSON.stringify(callsPath)}`,
+          'case " $* " in',
+          `  *" root "*) printf '%s\\n' ${JSON.stringify(repo)} ;;`,
+          `  *" log -r only("*) ${record(headRevision, "Head commit")} ;;`,
+          `  *" log -r base "*) ${record(baseRevision, "Base commit")} ;;`,
+          `  *" log -r head "*) ${record(headRevision, "Head commit")} ;;`,
+          `  *" diff "*) printf 'pinned comparison patch\\n' ;;`,
+          "  *) exit 1 ;;",
+          "esac",
+          "",
+        ].join("\n"),
+      );
+      chmodSync(executable, 0o755);
+
+      const adapter = createSaplingVcsAdapter({ slExecutable: executable });
+      const result = await adapter.operations["working-tree-diff"]!.load(
+        {
+          kind: "vcs",
+          staged: false,
+          rangeEndpoints: { from: "base", to: "head" },
+          options: {},
+        },
+        { cwd: repo },
+      );
+
+      expect(result.review).toMatchObject({ base: baseRevision, head: headRevision });
+      expect(result.patchText).toBe("pinned comparison patch\n");
+      expect(readFileSync(callsPath, "utf8")).toContain(
+        `diff --git -r ${baseRevision} -r ${headRevision}`,
+      );
+    },
+  );
 
   test.skipIf(!slAvailable)(
     "loads working-copy and revision patches through neutral operations",

--- a/packages/hunk-sapling/src/index.ts
+++ b/packages/hunk-sapling/src/index.ts
@@ -12,6 +12,7 @@ import {
   runSlTextAsync,
 } from "./commands";
 import { describeDiffRange } from "@hunk/vcs/diff-target";
+import { createSlCommitReview, createSlComparisonReview } from "./reviewInfo";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
@@ -88,11 +89,20 @@ export const SaplingVcsAdapter = {
         const repoRoot = await resolveSlRepoRootAsync(input, { cwd, signal });
         const repoName = basename(repoRoot);
         const range = describeDiffRange(input);
+        const review = input.rangeEndpoints
+          ? await createSlComparisonReview(
+              input,
+              input.rangeEndpoints.from,
+              input.rangeEndpoints.to,
+              { cwd: repoRoot, signal },
+            )
+          : undefined;
         return {
           repoRoot,
           sourceLabel: repoRoot,
           title: range ? `${repoName} ${range}` : `${repoName} working copy`,
           patchText: await runSlTextAsync({ input, args: diffArgs, cwd, signal }),
+          review,
           untrackedPaths: await listSlUntrackedFilesAsync(input, { cwd, repoRoot, signal }),
         };
       },
@@ -110,11 +120,13 @@ export const SaplingVcsAdapter = {
         const repoRoot = await resolveSlRepoRootAsync(input, { cwd, signal });
         const repoName = basename(repoRoot);
         const revset = input.ref ?? ".";
+        const review = await createSlCommitReview(input, revset, { cwd: repoRoot, signal });
         return {
           repoRoot,
           sourceLabel: repoRoot,
           title: `${repoName} show ${revset}`,
           patchText: await runSlTextAsync({ input, args: buildSlShowArgs(input), cwd, signal }),
+          review,
         };
       },
       watchSignature(input, { cwd }) {

--- a/packages/hunk-sapling/src/index.ts
+++ b/packages/hunk-sapling/src/index.ts
@@ -16,6 +16,8 @@ import { createSlCommitReview, createSlComparisonReview } from "./reviewInfo";
 import {
   HUNK_VCS_DETECTION_BASELINE_PRIORITY,
   type ExtensionVcsAdapter,
+  type ExtensionVcsDiffInput,
+  type ExtensionVcsShowInput,
   type HunkExtensionAPI,
 } from "hunkdiff/extension";
 
@@ -71,70 +73,118 @@ function statSignature(path: string) {
   return `${path}:${stat.size}:${stat.mtimeMs}:${stat.ino}`;
 }
 
-/** VCS adapter translating neutral review operations to Sapling commands. */
-export const SaplingVcsAdapter = {
-  id: "sl",
-  name: "Sapling",
-  detect: detectSlRepo,
-  // Above Git for the same reason Jujutsu is: `sl init --git` leaves Git
-  // metadata behind, and the Sapling working copy is the one under review.
-  detectionPriority: HUNK_VCS_DETECTION_BASELINE_PRIORITY + 100,
-  operations: {
-    "working-tree-diff": {
-      async load(input, { cwd, signal }) {
-        if (input.staged) {
-          throw createSlStagedError(input);
-        }
-        const diffArgs = buildSlDiffArgs(input);
-        const repoRoot = await resolveSlRepoRootAsync(input, { cwd, signal });
-        const repoName = basename(repoRoot);
-        const range = describeDiffRange(input);
-        const review = input.rangeEndpoints
-          ? await createSlComparisonReview(
+export interface SaplingVcsAdapterOptions {
+  slExecutable?: string;
+}
+
+/** Create a Sapling adapter with provider-owned process dependencies. */
+export function createSaplingVcsAdapter({
+  slExecutable = "sl",
+}: Readonly<SaplingVcsAdapterOptions> = {}) {
+  return {
+    id: "sl",
+    name: "Sapling",
+    detect: detectSlRepo,
+    // Above Git for the same reason Jujutsu is: `sl init --git` leaves Git
+    // metadata behind, and the Sapling working copy is the one under review.
+    detectionPriority: HUNK_VCS_DETECTION_BASELINE_PRIORITY + 100,
+    operations: {
+      "working-tree-diff": {
+        async load(input, { cwd, signal }) {
+          if (input.staged) {
+            throw createSlStagedError(input);
+          }
+          const diffArgs = buildSlDiffArgs(input);
+          const repoRoot = await resolveSlRepoRootAsync(input, { cwd, slExecutable, signal });
+          const repoName = basename(repoRoot);
+          const range = describeDiffRange(input);
+          const review = input.rangeEndpoints
+            ? await createSlComparisonReview(
+                input,
+                input.rangeEndpoints.from,
+                input.rangeEndpoints.to,
+                { cwd: repoRoot, slExecutable, signal },
+              )
+            : undefined;
+          const patchInput: ExtensionVcsDiffInput =
+            review?.kind === "comparison"
+              ? {
+                  ...input,
+                  range: undefined,
+                  rangeEndpoints: { from: review.base, to: review.head },
+                }
+              : input;
+          return {
+            repoRoot,
+            sourceLabel: repoRoot,
+            title: range ? `${repoName} ${range}` : `${repoName} working copy`,
+            patchText: await runSlTextAsync({
               input,
-              input.rangeEndpoints.from,
-              input.rangeEndpoints.to,
-              { cwd: repoRoot, signal },
-            )
-          : undefined;
-        return {
-          repoRoot,
-          sourceLabel: repoRoot,
-          title: range ? `${repoName} ${range}` : `${repoName} working copy`,
-          patchText: await runSlTextAsync({ input, args: diffArgs, cwd, signal }),
-          review,
-          untrackedPaths: await listSlUntrackedFilesAsync(input, { cwd, repoRoot, signal }),
-        };
+              args: review?.kind === "comparison" ? buildSlDiffArgs(patchInput) : diffArgs,
+              cwd,
+              slExecutable,
+              signal,
+            }),
+            review,
+            untrackedPaths: await listSlUntrackedFilesAsync(input, {
+              cwd,
+              repoRoot,
+              slExecutable,
+              signal,
+            }),
+          };
+        },
+        watchSignature(input, { cwd }) {
+          const trackedPatch = runSlText({
+            input,
+            args: buildSlDiffArgs(input),
+            cwd,
+            slExecutable,
+          });
+          const repoRoot = resolveSlRepoRoot(input, { cwd, slExecutable });
+          const untrackedSignatures = listSlUntrackedFiles(input, {
+            cwd,
+            repoRoot,
+            slExecutable,
+          }).map((filePath) => `untracked:${statSignature(join(repoRoot, filePath))}`);
+          return [trackedPatch, ...untrackedSignatures].join("\n---\n");
+        },
       },
-      watchSignature(input, { cwd }) {
-        const trackedPatch = runSlText({ input, args: buildSlDiffArgs(input), cwd });
-        const repoRoot = resolveSlRepoRoot(input, { cwd });
-        const untrackedSignatures = listSlUntrackedFiles(input, { cwd, repoRoot }).map(
-          (filePath) => `untracked:${statSignature(join(repoRoot, filePath))}`,
-        );
-        return [trackedPatch, ...untrackedSignatures].join("\n---\n");
+      "revision-show": {
+        async load(input, { cwd, signal }) {
+          const repoRoot = await resolveSlRepoRootAsync(input, { cwd, slExecutable, signal });
+          const repoName = basename(repoRoot);
+          const revset = input.ref ?? ".";
+          const review = await createSlCommitReview(input, revset, {
+            cwd: repoRoot,
+            slExecutable,
+            signal,
+          });
+          const patchInput: ExtensionVcsShowInput =
+            review?.kind === "commit" ? { ...input, ref: review.revision } : input;
+          return {
+            repoRoot,
+            sourceLabel: repoRoot,
+            title: `${repoName} show ${revset}`,
+            patchText: await runSlTextAsync({
+              input,
+              args: buildSlShowArgs(patchInput),
+              cwd,
+              slExecutable,
+              signal,
+            }),
+            review,
+          };
+        },
+        watchSignature(input, { cwd }) {
+          return runSlText({ input, args: buildSlShowArgs(input), cwd, slExecutable });
+        },
       },
     },
-    "revision-show": {
-      async load(input, { cwd, signal }) {
-        const repoRoot = await resolveSlRepoRootAsync(input, { cwd, signal });
-        const repoName = basename(repoRoot);
-        const revset = input.ref ?? ".";
-        const review = await createSlCommitReview(input, revset, { cwd: repoRoot, signal });
-        return {
-          repoRoot,
-          sourceLabel: repoRoot,
-          title: `${repoName} show ${revset}`,
-          patchText: await runSlTextAsync({ input, args: buildSlShowArgs(input), cwd, signal }),
-          review,
-        };
-      },
-      watchSignature(input, { cwd }) {
-        return runSlText({ input, args: buildSlShowArgs(input), cwd });
-      },
-    },
-  },
-} satisfies ExtensionVcsAdapter;
+  } satisfies ExtensionVcsAdapter;
+}
+
+export const SaplingVcsAdapter = createSaplingVcsAdapter();
 
 export default function (hunk: HunkExtensionAPI) {
   hunk.registerVcsAdapter(SaplingVcsAdapter);

--- a/packages/hunk-sapling/src/reviewInfo.test.ts
+++ b/packages/hunk-sapling/src/reviewInfo.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { parseSlReviewCommits } from "./reviewInfo";
+
+describe("Sapling direct review metadata", () => {
+  test("parses commit fields from the bounded machine template", () => {
+    const revision = "a".repeat(40);
+    expect(
+      parseSlReviewCommits(
+        [
+          revision,
+          revision.slice(0, 12),
+          "Direct Sapling commit",
+          "Test User",
+          "test@example.com",
+          "2026-09-08 12:00:00 +0000",
+          "",
+        ].join("\0"),
+      ),
+    ).toEqual([
+      {
+        revisionId: revision,
+        displayId: revision.slice(0, 12),
+        parentRevisionIds: [],
+        subject: "Direct Sapling commit",
+        authorName: "Test User",
+        authorEmail: "test@example.com",
+        authoredAt: "2026-09-08T12:00:00.000Z",
+        decorations: [],
+      },
+    ]);
+  });
+
+  test("rejects truncated or invalid commit records", () => {
+    expect(() => parseSlReviewCommits("partial\0record\0")).toThrow("truncated");
+    expect(() =>
+      parseSlReviewCommits(
+        ["not-a-node", "short", "title", "author", "email", "2026-09-08", ""].join("\0"),
+      ),
+    ).toThrow("invalid review commit id");
+  });
+});

--- a/packages/hunk-sapling/src/reviewInfo.ts
+++ b/packages/hunk-sapling/src/reviewInfo.ts
@@ -1,0 +1,104 @@
+import { commitReviewInfo, comparisonReviewInfo } from "@hunk/vcs/review-info";
+import type {
+  ExtensionReviewDescriptor,
+  ExtensionVcsDiffInput,
+  ExtensionVcsHistoryCommit,
+  ExtensionVcsShowInput,
+} from "hunkdiff/extension";
+import { runSlTextAsync, type SlBackedInput } from "./commands";
+
+const SL_REVIEW_FIELDS = 6;
+const SL_REVIEW_TEMPLATE =
+  [
+    "{node}",
+    "{node|short}",
+    "{desc|firstline}",
+    "{author|person}",
+    "{author|email}",
+    "{date|isodatesec}",
+  ].join("\\0") + "\\0";
+
+interface SlReviewQueryOptions {
+  cwd: string;
+  slExecutable?: string;
+  signal?: AbortSignal;
+}
+
+/** Parse fixed NUL-delimited Sapling template records into shared commit fields. */
+export function parseSlReviewCommits(text: string): ExtensionVcsHistoryCommit[] {
+  if (!text) return [];
+  const fields = text.split("\0");
+  if (fields.at(-1) === "") fields.pop();
+  if (fields.length % SL_REVIEW_FIELDS !== 0) {
+    throw new Error("Sapling returned a truncated review metadata record.");
+  }
+
+  const commits: ExtensionVcsHistoryCommit[] = [];
+  for (let offset = 0; offset < fields.length; offset += SL_REVIEW_FIELDS) {
+    const revisionId = fields[offset]!;
+    const displayId = fields[offset + 1]!;
+    const subject = fields[offset + 2]!;
+    const authorName = fields[offset + 3]!;
+    const authorEmail = fields[offset + 4]!;
+    const authoredAt = new Date(fields[offset + 5]!).toISOString();
+    if (!/^[0-9a-f]{40,64}$/i.test(revisionId) || !/^[0-9a-f]{4,64}$/i.test(displayId)) {
+      throw new Error("Sapling returned an invalid review commit id.");
+    }
+    commits.push({
+      revisionId,
+      displayId,
+      parentRevisionIds: [],
+      subject: subject || "(no commit message)",
+      authorName: authorName || "Unknown author",
+      ...(authorEmail ? { authorEmail } : {}),
+      authoredAt,
+      decorations: [],
+    });
+  }
+  return commits;
+}
+
+/** Load at most one more commit than the review-info pane can display. */
+async function loadSlReviewCommits(
+  input: SlBackedInput,
+  revset: string,
+  options: SlReviewQueryOptions,
+) {
+  return parseSlReviewCommits(
+    await runSlTextAsync({
+      input,
+      args: ["log", "-r", revset, "--limit", "9", "--template", SL_REVIEW_TEMPLATE],
+      ...options,
+    }),
+  );
+}
+
+/** Describe one Sapling commit when a direct show ref resolves unambiguously. */
+export async function createSlCommitReview(
+  input: ExtensionVcsShowInput,
+  ref: string,
+  options: SlReviewQueryOptions,
+): Promise<ExtensionReviewDescriptor | undefined> {
+  const commits = await loadSlReviewCommits(input, ref, options);
+  return commits.length === 1 ? commitReviewInfo("Sapling", commits[0]!) : undefined;
+}
+
+/** Describe a two-revision Sapling diff, omitting commit rows when the bounded list is incomplete. */
+export async function createSlComparisonReview(
+  input: ExtensionVcsDiffInput,
+  from: string,
+  to: string,
+  options: SlReviewQueryOptions,
+): Promise<ExtensionReviewDescriptor | undefined> {
+  const [baseCommits, headCommits] = await Promise.all([
+    loadSlReviewCommits(input, from, options),
+    loadSlReviewCommits(input, to, options),
+  ]);
+  if (baseCommits.length !== 1 || headCommits.length !== 1) return undefined;
+  const base = baseCommits[0]!.revisionId;
+  const head = headCommits[0]!.revisionId;
+  const commits = await loadSlReviewCommits(input, `only(${head}, ${base})`, options);
+  return commits.length <= 8
+    ? comparisonReviewInfo("Sapling", base, head, commits, commits.length)
+    : comparisonReviewInfo("Sapling", base, head, []);
+}

--- a/packages/hunk-vcs/package.json
+++ b/packages/hunk-vcs/package.json
@@ -26,6 +26,10 @@
       "types": "./src/path.ts",
       "import": "./src/path.ts"
     },
+    "./review-info": {
+      "types": "./src/review-info.ts",
+      "import": "./src/review-info.ts"
+    },
     "./source": {
       "types": "./src/source.ts",
       "import": "./src/source.ts"

--- a/packages/hunk-vcs/src/review-info.test.ts
+++ b/packages/hunk-vcs/src/review-info.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { commitReviewInfo, comparisonReviewInfo, vcsReviewAuthorLabel } from "./review-info";
+
+const commit = {
+  revisionId: "a".repeat(40),
+  displayId: "aaaaaaaa",
+  subject: "Direct commit",
+  authorName: "Test User",
+  authorEmail: "123+octocat@users.noreply.github.com",
+  authoredAt: "2026-09-08T12:00:00Z",
+};
+
+describe("provider-neutral review info", () => {
+  test("uses the same offline author labels and bounded display fields as history", () => {
+    expect(vcsReviewAuthorLabel(commit)).toBe("octocat");
+    expect(
+      commitReviewInfo("Git", { ...commit, subject: `Direct\n${"界".repeat(1_000)}` }),
+    ).toEqual({
+      kind: "commit",
+      provider: "Git",
+      title: `Direct ${"界".repeat(680)}`,
+      revision: commit.revisionId,
+      displayRevision: commit.displayId,
+      author: "octocat",
+      authoredAt: commit.authoredAt,
+    });
+  });
+
+  test("builds newest-first comparison rows with an exact total when known", () => {
+    expect(comparisonReviewInfo("Git", "base", "head", [commit], 3)).toEqual({
+      kind: "comparison",
+      provider: "Git",
+      title: "3 commits",
+      base: "base",
+      head: "head",
+      commitCount: 3,
+      commits: [
+        {
+          title: "Direct commit",
+          author: "octocat",
+          authoredAt: commit.authoredAt,
+          revision: commit.revisionId,
+          displayRevision: commit.displayId,
+        },
+      ],
+    });
+  });
+});

--- a/packages/hunk-vcs/src/review-info.ts
+++ b/packages/hunk-vcs/src/review-info.ts
@@ -1,0 +1,86 @@
+/** Commit fields shared by provider history records and direct review metadata. */
+export interface VcsReviewCommit {
+  revisionId: string;
+  displayId: string;
+  subject: string;
+  authorName: string;
+  authorEmail?: string;
+  authoredAt: string;
+}
+
+/** Remove terminal controls and collapse one provider field to a display-safe line. */
+function sanitizeReviewText(value: string) {
+  return value
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+/** Truncate one field without splitting Unicode code points or exceeding transport bytes. */
+function truncateReviewText(value: string, maxBytes: number) {
+  const encoder = new TextEncoder();
+  let result = "";
+  let bytes = 0;
+  for (const character of sanitizeReviewText(value)) {
+    const characterBytes = encoder.encode(character).byteLength;
+    if (bytes + characterBytes > maxBytes) break;
+    result += character;
+    bytes += characterBytes;
+  }
+  return result;
+}
+
+/** Resolve the same offline account-like author label used by interactive history. */
+export function vcsReviewAuthorLabel(commit: VcsReviewCommit) {
+  const email = commit.authorEmail?.trim();
+  if (email) {
+    const github = email.match(/^(?:\d+\+)?([^@+]+)@users\.noreply\.github\.com$/i);
+    if (github?.[1]) return github[1];
+    const separator = email.indexOf("@");
+    if (separator > 0) return email.slice(0, separator);
+  }
+  return commit.authorName;
+}
+
+/** Build bounded metadata for one directly reviewed commit. */
+export function commitReviewInfo(provider: string, commit: VcsReviewCommit) {
+  const authoredAt = Number.isNaN(Date.parse(commit.authoredAt)) ? undefined : commit.authoredAt;
+  return {
+    kind: "commit" as const,
+    provider: truncateReviewText(provider, 256),
+    title: truncateReviewText(commit.subject, 2 * 1024) || "(no commit message)",
+    revision: truncateReviewText(commit.revisionId, 512),
+    displayRevision: truncateReviewText(commit.displayId, 64),
+    author: truncateReviewText(vcsReviewAuthorLabel(commit), 512) || "Unknown author",
+    ...(authoredAt === undefined ? {} : { authoredAt }),
+  };
+}
+
+/** Build bounded newest-first metadata for one direct revision comparison. */
+export function comparisonReviewInfo(
+  provider: string,
+  base: string,
+  head: string,
+  commits: readonly VcsReviewCommit[],
+  commitCount?: number,
+) {
+  const rows = commits.slice(0, 8).map((commit) => ({
+    title: truncateReviewText(commit.subject, 128) || "(no commit message)",
+    author: truncateReviewText(vcsReviewAuthorLabel(commit), 64) || "Unknown author",
+    ...(Number.isNaN(Date.parse(commit.authoredAt)) ? {} : { authoredAt: commit.authoredAt }),
+    revision: truncateReviewText(commit.revisionId, 512),
+    displayRevision: truncateReviewText(commit.displayId, 64),
+  }));
+  return {
+    kind: "comparison" as const,
+    provider: truncateReviewText(provider, 256),
+    title:
+      commitCount === undefined
+        ? "Commit comparison"
+        : `${commitCount} commit${commitCount === 1 ? "" : "s"}`,
+    base: truncateReviewText(base, 512),
+    head: truncateReviewText(head, 512),
+    ...(commitCount === undefined ? {} : { commitCount }),
+    ...(rows.length === 0 ? {} : { commits: rows }),
+  };
+}

--- a/packages/hunk/src/app/delegatedReview.test.ts
+++ b/packages/hunk/src/app/delegatedReview.test.ts
@@ -13,6 +13,7 @@ const commitReview: ExtensionReviewDescriptor = {
   provider: "Git",
   title: "Commit title",
   revision: "abc1234",
+  displayRevision: "abc1234",
 };
 const comparisonReview: ExtensionReviewDescriptor = {
   kind: "comparison",

--- a/packages/hunk/src/app/startup.test.ts
+++ b/packages/hunk/src/app/startup.test.ts
@@ -214,7 +214,13 @@ describe("startup planning", () => {
       handler: () => ({
         kind: "delegate",
         argv: ["--version"],
-        review: { kind: "commit", provider: "GitHub", title: "Commit", revision: "abc" },
+        review: {
+          kind: "commit",
+          provider: "GitHub",
+          title: "Commit",
+          revision: "abc",
+          displayRevision: "abc",
+        },
       }),
     });
 

--- a/packages/hunk/src/app/startup.ts
+++ b/packages/hunk/src/app/startup.ts
@@ -647,7 +647,10 @@ export async function prepareStartupPlan(
     initialization,
   } = preparedSession;
   cliInput = resolvedInput;
-  if (delegatedReview) bootstrap.review = delegatedReview;
+  if (delegatedReview) {
+    bootstrap.review = delegatedReview;
+    bootstrap.reviewSource = "caller";
+  }
 
   // Built after adapter resolution so the notice names the backend the session really loads with.
   const unknownVcsNotices =

--- a/packages/hunk/src/core/bootstrap.ts
+++ b/packages/hunk/src/core/bootstrap.ts
@@ -55,8 +55,10 @@ export interface AppBootstrap<ExtensionState = unknown> {
   initialCopyDecorations?: boolean;
   initialCursorLine?: CursorLine;
   startupNotices?: readonly StartupNotice[];
-  /** Validated metadata describing a delegated or history-selected review source. */
+  /** Validated metadata describing the review source. */
   review?: ExtensionReviewDescriptor;
+  /** Internal provenance used to preserve caller context or recompute provider context on reload. */
+  reviewSource?: "caller" | "provider";
   viewPreferencesConfigPath?: string;
   /** The user's `[keybindings]` table, resolved against command defaults in App. */
   keybindings?: Record<string, UserKeyBinding>;

--- a/packages/hunk/src/core/changeset/loaders.test.ts
+++ b/packages/hunk/src/core/changeset/loaders.test.ts
@@ -241,6 +241,46 @@ describe("loadAppBootstrap", () => {
     expect(bootstrap.reloadContext.vcsCatalog?.adapters).toEqual([adapter]);
   });
 
+  test("carries provider review metadata into direct CLI review bootstraps", async () => {
+    const dir = createTempDir("hunk-adapter-review-info-");
+    const adapter: VcsAdapter = {
+      id: "demo",
+      name: "Demo VCS",
+      detect: () => null,
+      operations: {
+        "revision-show": {
+          load: async () => ({
+            repoRoot: dir,
+            sourceLabel: dir,
+            title: "demo show",
+            patchText: "",
+            review: {
+              kind: "commit",
+              provider: "Demo VCS",
+              title: "Direct commit",
+              revision: "abc123",
+              displayRevision: "abc123",
+            },
+          }),
+        },
+      },
+    };
+
+    const bootstrap = await loadAppBootstrap(
+      { kind: "show", ref: "tip", options: { vcs: "demo" } },
+      { cwd: dir, vcsCatalog: createVcsCatalog([adapter], "demo", []) },
+    );
+
+    expect(bootstrap.review).toEqual({
+      kind: "commit",
+      provider: "Demo VCS",
+      title: "Direct commit",
+      revision: "abc123",
+      displayRevision: "abc123",
+    });
+    expect(bootstrap.reviewSource).toBe("provider");
+  });
+
   test("captures a watched signature before content loading", async () => {
     const dir = createTempDir("hunk-watch-bootstrap-");
     const left = join(dir, "before.ts");

--- a/packages/hunk/src/core/changeset/loaders.ts
+++ b/packages/hunk/src/core/changeset/loaders.ts
@@ -255,6 +255,7 @@ async function loadVcsChangeset(
       files: [...parsedChangeset.files, ...adapterFiles],
     } satisfies Changeset,
     repoRoot: result.repoRoot,
+    review: result.review,
   };
 }
 
@@ -297,6 +298,7 @@ export async function loadAppBootstrap(
 
   let changeset: Changeset;
   let repoRoot: string | undefined;
+  let review: AppBootstrap["review"];
 
   switch (input.kind) {
     case "vcs":
@@ -309,6 +311,7 @@ export async function loadAppBootstrap(
         const result = await loadVcsChangeset(input, sidecar, cwd, vcsCatalog, signal);
         changeset = result.changeset;
         repoRoot = result.repoRoot;
+        review = result.review;
       }
       break;
     case "diff":
@@ -332,6 +335,8 @@ export async function loadAppBootstrap(
     input,
     reloadContext: { cwd, repoRoot, initialWatchSignature, vcsCatalog },
     changeset,
+    review,
+    ...(review ? { reviewSource: "provider" as const } : {}),
     initialMode: input.options.mode ?? "auto",
     initialTheme: input.options.theme,
     customThemes,

--- a/packages/hunk/src/core/reviewDescriptor.test.ts
+++ b/packages/hunk/src/core/reviewDescriptor.test.ts
@@ -13,7 +13,7 @@ const review = {
   state: "open" as const,
 };
 
-describe("delegated review descriptor validation", () => {
+describe("review descriptor validation", () => {
   test("copies, freezes, and accepts every descriptor kind", () => {
     const parsed = validateExtensionReviewDescriptor(review);
     expect(parsed).toEqual(review);
@@ -24,11 +24,13 @@ describe("delegated review descriptor validation", () => {
         provider: "GitHub",
         title: "Commit",
         revision: "abc1234",
+        displayRevision: "abc1234",
         authoredAt: "2026-01-01T00:00:00Z",
       }),
     ).toMatchObject({
       kind: "commit",
       revision: "abc1234",
+      displayRevision: "abc1234",
       authoredAt: "2026-01-01T00:00:00Z",
     });
     expect(
@@ -50,6 +52,16 @@ describe("delegated review descriptor validation", () => {
         ],
       }),
     ).toMatchObject({ kind: "comparison", base: "main", head: "feature", commitCount: 1 });
+    expect(
+      validateExtensionReviewDescriptor({
+        kind: "comparison",
+        provider: "Git",
+        title: "0 commits",
+        base: "main",
+        head: "main",
+        commitCount: 0,
+      }),
+    ).toMatchObject({ kind: "comparison", commitCount: 0 });
   });
 
   test("rejects unknown fields, controls, insecure URLs, and byte overflows", () => {
@@ -64,6 +76,7 @@ describe("delegated review descriptor validation", () => {
         provider: "GitHub",
         title: "Commit",
         revision: "abc1234",
+        displayRevision: "abc1234",
         authoredAt: "yesterday",
       },
       {
@@ -78,5 +91,21 @@ describe("delegated review descriptor validation", () => {
     ]) {
       expect(parseExtensionReviewDescriptor(value)).toBeNull();
     }
+  });
+
+  test("keeps pre-v24 commit descriptors valid without a display revision", () => {
+    expect(
+      validateExtensionReviewDescriptor({
+        kind: "commit",
+        provider: "GitHub",
+        title: "Commit",
+        revision: "0123456789abcdef",
+      }),
+    ).toEqual({
+      kind: "commit",
+      provider: "GitHub",
+      title: "Commit",
+      revision: "0123456789abcdef",
+    });
   });
 });

--- a/packages/hunk/src/core/reviewDescriptor.ts
+++ b/packages/hunk/src/core/reviewDescriptor.ts
@@ -28,18 +28,18 @@ function validateDescriptorString(
 ): string | undefined {
   if (!Object.prototype.hasOwnProperty.call(candidate, field)) {
     if (!required) return undefined;
-    throw new Error(`delegate review ${field} must be a non-empty string`);
+    throw new Error(`review descriptor ${field} must be a non-empty string`);
   }
   const value = candidate[field];
   if (value === undefined && !required) return undefined;
   if (typeof value !== "string" || value.length === 0) {
-    throw new Error(`delegate review ${field} must be a non-empty string`);
+    throw new Error(`review descriptor ${field} must be a non-empty string`);
   }
   if (/[\u0000-\u001f\u007f-\u009f]/u.test(value)) {
-    throw new Error(`delegate review ${field} cannot contain control characters`);
+    throw new Error(`review descriptor ${field} cannot contain control characters`);
   }
   if (descriptorByteLength(value) > REVIEW_DESCRIPTOR_FIELD_LIMITS[field]) {
-    throw new Error(`delegate review ${field} exceeds its byte limit`);
+    throw new Error(`review descriptor ${field} exceeds its byte limit`);
   }
   return value;
 }
@@ -61,25 +61,25 @@ function copyOptionalDescriptorFields(
 function validateComparisonCommits(value: unknown) {
   if (value === undefined) return undefined;
   if (!Array.isArray(value) || value.length > 8) {
-    throw new Error("delegate review comparison commits must contain at most 8 entries");
+    throw new Error("review descriptor comparison commits must contain at most 8 entries");
   }
   return Object.freeze(
     value.map((entry) => {
       if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-        throw new Error("delegate review comparison commit must be an object");
+        throw new Error("review descriptor comparison commit must be an object");
       }
       const prototype = Object.getPrototypeOf(entry);
       if (prototype !== Object.prototype && prototype !== null) {
-        throw new Error("delegate review comparison commit must be a plain object");
+        throw new Error("review descriptor comparison commit must be a plain object");
       }
       const candidate = entry as Record<string, unknown>;
       const allowed = new Set(["title", "author", "authoredAt", "revision", "displayRevision"]);
       if (Reflect.ownKeys(candidate).some((key) => typeof key !== "string" || !allowed.has(key))) {
-        throw new Error("delegate review comparison commit contains unknown fields");
+        throw new Error("review descriptor comparison commit contains unknown fields");
       }
       const authoredAt = validateDescriptorString(candidate, "authoredAt", false);
       if (authoredAt !== undefined && Number.isNaN(Date.parse(authoredAt))) {
-        throw new Error("delegate review comparison commit authoredAt must be a valid timestamp");
+        throw new Error("review descriptor comparison commit authoredAt must be a valid timestamp");
       }
       return Object.freeze({
         title: validateDescriptorString(candidate, "title", true)!,
@@ -97,23 +97,23 @@ function validateChangeRequestState(value: unknown): "open" | "closed" | "merged
   if (value === undefined || value === "open" || value === "closed" || value === "merged") {
     return value;
   }
-  throw new Error('delegate review state must be "open", "closed", or "merged"');
+  throw new Error('review descriptor state must be "open", "closed", or "merged"');
 }
 
 /** Validate an optional boolean descriptor field. */
 function validateOptionalBoolean(value: unknown, field: string): boolean | undefined {
   if (value === undefined || typeof value === "boolean") return value;
-  throw new Error(`delegate review ${field} must be a boolean`);
+  throw new Error(`review descriptor ${field} must be a boolean`);
 }
 
-/** Validate, copy, and deeply freeze provider-neutral delegated review metadata. */
+/** Validate, copy, and deeply freeze provider-neutral review metadata. */
 export function validateExtensionReviewDescriptor(value: unknown): ExtensionReviewDescriptor {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new Error("delegate review must be an object");
+    throw new Error("review descriptor must be an object");
   }
   const prototype = Object.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) {
-    throw new Error("delegate review must be a plain object");
+    throw new Error("review descriptor must be a plain object");
   }
   const candidate = value as Record<string, unknown>;
   const kind = candidate.kind;
@@ -121,7 +121,7 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
     !Object.prototype.hasOwnProperty.call(candidate, "kind") ||
     (kind !== "change-request" && kind !== "commit" && kind !== "comparison")
   ) {
-    throw new Error('delegate review kind must be "change-request", "commit", or "comparison"');
+    throw new Error('review descriptor kind must be "change-request", "commit", or "comparison"');
   }
 
   const common = ["kind", "provider", "title", "url"];
@@ -129,12 +129,12 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
     kind === "change-request"
       ? ["id", "repository", "author", "base", "head", "state", "draft"]
       : kind === "commit"
-        ? ["revision", "author", "authoredAt"]
+        ? ["revision", "displayRevision", "author", "authoredAt"]
         : ["base", "head", "commitCount", "commits"];
   const allowed = new Set([...common, ...kindFields]);
   const ownKeys = Reflect.ownKeys(value);
   if (ownKeys.some((key) => typeof key !== "string" || !allowed.has(key))) {
-    throw new Error("delegate review contains unknown fields");
+    throw new Error("review descriptor contains unknown fields");
   }
 
   const provider = validateDescriptorString(candidate, "provider", true)!;
@@ -145,10 +145,10 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
     try {
       parsed = new URL(url);
     } catch {
-      throw new Error("delegate review url must be a valid HTTPS URL");
+      throw new Error("review descriptor url must be a valid HTTPS URL");
     }
     if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
-      throw new Error("delegate review url must be a credential-free HTTPS URL");
+      throw new Error("review descriptor url must be a credential-free HTTPS URL");
     }
   }
 
@@ -168,8 +168,9 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
     };
   } else if (kind === "commit") {
     const authoredAt = validateDescriptorString(candidate, "authoredAt", false);
+    const displayRevision = validateDescriptorString(candidate, "displayRevision", false);
     if (authoredAt !== undefined && Number.isNaN(Date.parse(authoredAt))) {
-      throw new Error("delegate review authoredAt must be a valid timestamp");
+      throw new Error("review descriptor authoredAt must be a valid timestamp");
     }
     descriptor = {
       kind,
@@ -177,6 +178,7 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
       title,
       ...(url === undefined ? {} : { url }),
       revision: validateDescriptorString(candidate, "revision", true)!,
+      ...(displayRevision === undefined ? {} : { displayRevision }),
       ...copyOptionalDescriptorFields(candidate, ["author"]),
       ...(authoredAt === undefined ? {} : { authoredAt }),
     };
@@ -186,10 +188,10 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
     if (
       commitCount !== undefined &&
       (!Number.isSafeInteger(commitCount) ||
-        (commitCount as number) < 1 ||
+        (commitCount as number) < 0 ||
         (commits !== undefined && (commitCount as number) < commits.length))
     ) {
-      throw new Error("delegate review comparison commitCount must cover the commit list");
+      throw new Error("review descriptor comparison commitCount must cover the commit list");
     }
     descriptor = {
       kind,
@@ -205,7 +207,7 @@ export function validateExtensionReviewDescriptor(value: unknown): ExtensionRevi
 
   const totalBytes = descriptorByteLength(JSON.stringify(descriptor));
   if (totalBytes > REVIEW_DESCRIPTOR_TOTAL_BYTES) {
-    throw new Error("delegate review exceeds the total byte limit");
+    throw new Error("review descriptor exceeds the total byte limit");
   }
   return Object.freeze(descriptor);
 }

--- a/packages/hunk/src/core/vcs/types.ts
+++ b/packages/hunk/src/core/vcs/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ExtensionReviewDescriptor,
   ExtensionVcsHistoryCommit,
   ExtensionVcsHistoryInput,
   ExtensionVcsHistoryPage,
@@ -83,6 +84,8 @@ export interface VcsPatchResult {
   sourceLabel: string;
   title: string;
   patchText: string;
+  /** Validated provider-neutral context for a revision-backed review. */
+  review?: ExtensionReviewDescriptor;
   /** Repo-root-relative untracked paths Hunk synthesizes into added-file diffs. */
   untrackedPaths?: string[];
   /** Exact old/new content lookups, built from the result's `readFileSource`. */

--- a/packages/hunk/src/extension-api/types.ts
+++ b/packages/hunk/src/extension-api/types.ts
@@ -21,7 +21,7 @@
  * Extensions can branch on `hunk.apiVersion` so a newer Hunk can keep loading
  * older extensions without guessing at their expectations.
  */
-export const HUNK_EXTENSION_API_VERSION = 23;
+export const HUNK_EXTENSION_API_VERSION = 24;
 export type HunkExtensionApiVersion = typeof HUNK_EXTENSION_API_VERSION;
 
 export type ExtensionNotifyType = "info" | "warning" | "error";
@@ -994,6 +994,8 @@ export interface ExtensionVcsPatchResult {
   sourceLabel: string;
   title: string;
   patchText: string;
+  /** Commit or comparison context shown above revision-backed reviews. */
+  review?: ExtensionReviewDescriptor;
   /**
    * Untracked files to review beside the patch, as repo-root-relative paths.
    *
@@ -1469,8 +1471,10 @@ export interface ExtensionChangeRequestReviewDescriptor extends ExtensionReviewD
 /** Metadata for one reviewed commit. */
 export interface ExtensionCommitReviewDescriptor extends ExtensionReviewDescriptorBase {
   readonly kind: "commit";
-  /** Provider revision identifier. */
+  /** Full provider revision copied by the adjacent action. */
   readonly revision: string;
+  /** Provider-formatted short revision rendered in the review header. */
+  readonly displayRevision?: string;
   readonly author?: string;
   /** Date-time string used for relative commit time when available. */
   readonly authoredAt?: string;

--- a/packages/hunk/src/extensions/cliCommandRuntime.test.ts
+++ b/packages/hunk/src/extensions/cliCommandRuntime.test.ts
@@ -314,9 +314,15 @@ describe("extension CLI command runtime", () => {
             : ({ kind, review } as never),
       });
 
-    const valid = { kind: "commit", provider: "GitHub", title: "Commit", revision: "abc" };
+    const valid = {
+      kind: "commit",
+      provider: "GitHub",
+      title: "Commit",
+      revision: "abc",
+      displayRevision: "abc",
+    };
     await expect(execute({ ...valid, extra: true })).rejects.toThrow(
-      'Extension tools CLI command "tools" failed: delegate review contains unknown fields',
+      'Extension tools CLI command "tools" failed: review descriptor contains unknown fields',
     );
     await expect(execute({ ...valid, title: "bad\u001b[31m" })).rejects.toThrow(
       "control characters",

--- a/packages/hunk/src/extensions/default/ui/index.test.ts
+++ b/packages/hunk/src/extensions/default/ui/index.test.ts
@@ -64,6 +64,7 @@ describe("bundled UI registry", () => {
           provider: "GitHub",
           title: "Commit title",
           revision: "abc1234",
+          displayRevision: "abc1234",
         },
         placement: "top",
         files: [],

--- a/packages/hunk/src/extensions/default/ui/reviewInfo/index.test.tsx
+++ b/packages/hunk/src/extensions/default/ui/reviewInfo/index.test.tsx
@@ -105,6 +105,7 @@ describe("ReviewInfoPane", () => {
             provider: "GitHub",
             title: "Render selected commit metadata",
             revision: fullRevision,
+            displayRevision: "01234567",
             author: "octocat",
             authoredAt: new Date(Date.now() - 10 * 60 * 60 * 1_000).toISOString(),
           },
@@ -123,11 +124,11 @@ describe("ReviewInfoPane", () => {
       const frame = setup.captureCharFrame();
       expect(frame).toContain("Render selected commit metadata");
       expect(frame).toContain("octocat · 10 hours ago");
-      expect(frame.split("\n")[1]?.trimEnd()).toEndWith("0123456789abcdef01… ⧉");
+      expect(frame.split("\n")[1]?.trimEnd()).toEndWith("01234567 ⧉");
       expect(frame).not.toContain("GitHub");
       const revisionSpan = setup
         .captureSpans()
-        .lines[1]?.spans.find((span) => span.text.includes("0123456789abcdef01…"));
+        .lines[1]?.spans.find((span) => span.text.includes("01234567"));
       expect(capturedTestColorToHex(revisionSpan?.fg)).toBe(theme.fileRenamed.toLowerCase());
       const copySpan = setup.captureSpans().lines[1]?.spans.find((span) => span.text === "⧉");
       expect(capturedTestColorToHex(copySpan?.fg)).toBe(appTheme.lineNumberFg.toLowerCase());

--- a/packages/hunk/src/extensions/default/ui/reviewInfo/presentation.test.ts
+++ b/packages/hunk/src/extensions/default/ui/reviewInfo/presentation.test.ts
@@ -37,6 +37,7 @@ describe("review info presentation", () => {
         provider: "GitHub",
         title: "Render commit review metadata",
         revision: "abc1234",
+        displayRevision: "abc1234",
         author: "octocat",
         authoredAt: "2026-01-01T00:00:00Z",
       },
@@ -119,6 +120,7 @@ describe("review info presentation", () => {
           provider: "Git",
           title: "Visible title",
           revision: "1234567890abcdef",
+          displayRevision: "12345678",
           author: "ada",
         },
         20,
@@ -137,6 +139,7 @@ describe("review info presentation", () => {
       provider: "Git",
       title: "Title",
       revision: "1234567890abcdef",
+      displayRevision: "12345678",
     };
     expect(reviewInfoContent(commit, 6)).toEqual({ primary: "Title", secondary: "" });
     expect(reviewInfoContent(commit, 12)).toEqual({
@@ -144,6 +147,20 @@ describe("review info presentation", () => {
       secondary: "",
       trailing: "123…",
     });
+  });
+
+  test("abbreviates legacy commit revisions that do not provide a display id", () => {
+    expect(
+      reviewInfoContent(
+        {
+          kind: "commit",
+          provider: "Git",
+          title: "Legacy extension commit",
+          revision: "0123456789abcdef0123456789abcdef01234567",
+        },
+        80,
+      ).trailing,
+    ).toBe("01234567");
   });
 
   test("omits unknown state while preserving explicit draft identity", () => {

--- a/packages/hunk/src/extensions/default/ui/reviewInfo/presentation.ts
+++ b/packages/hunk/src/extensions/default/ui/reviewInfo/presentation.ts
@@ -8,6 +8,7 @@ import { formatHistoryRelativeTime } from "../../../../ui/log/formatting";
 import { measureClusterWidth, textClusters } from "../../../../ui/lib/text";
 
 const MIN_COMMIT_REVISION_DISPLAY_WIDTH = 4;
+const MAX_COMMIT_REVISION_DISPLAY_WIDTH = 12;
 
 /** Collapse unsafe or layout-changing provider text into one deterministic terminal line. */
 export function sanitizeReviewInfoText(value: string): string {
@@ -164,10 +165,15 @@ export function reviewInfoContent(
   now = Date.now(),
 ): ReviewInfoContent {
   if (review.kind === "commit") {
-    const trailingWidth = Math.max(0, Math.min(width, Math.floor(width * 0.35)));
+    const displayRevision =
+      review.displayRevision ?? Array.from(review.revision).slice(0, 8).join("");
+    const trailingWidth = Math.max(
+      0,
+      Math.min(MAX_COMMIT_REVISION_DISPLAY_WIDTH, width, Math.floor(width * 0.35)),
+    );
     const trailing =
       trailingWidth >= MIN_COMMIT_REVISION_DISPLAY_WIDTH && width - trailingWidth - 2 >= 1
-        ? fitReviewInfoText(review.revision, trailingWidth)
+        ? fitReviewInfoText(displayRevision, trailingWidth)
         : "";
     // Reserve one cell each for the gap before the id and its adjacent copy action.
     const primaryWidth = Math.max(0, width - reviewInfoTextWidth(trailing) - (trailing ? 2 : 0));

--- a/packages/hunk/src/extensions/runExtension.test.ts
+++ b/packages/hunk/src/extensions/runExtension.test.ts
@@ -13,8 +13,8 @@ function bundledMetadata(id: string) {
 }
 
 describe("runExtensionFactory", () => {
-  test("advertises canonical layout event fields through extension API v23", () => {
-    expect(HUNK_EXTENSION_API_VERSION).toBe(23);
+  test("advertises direct review metadata through extension API v24", () => {
+    expect(HUNK_EXTENSION_API_VERSION).toBe(24);
   });
 
   test("applies a synchronous factory before returning, with nothing to await", () => {

--- a/packages/hunk/src/extensions/vcsPatchResult.test.ts
+++ b/packages/hunk/src/extensions/vcsPatchResult.test.ts
@@ -148,6 +148,32 @@ describe("published source readers", () => {
   });
 });
 
+describe("published review metadata", () => {
+  test("is validated, copied, and frozen at the adapter boundary", () => {
+    const review = {
+      kind: "commit" as const,
+      provider: "Demo VCS",
+      title: "Direct commit",
+      revision: "abc123",
+      displayRevision: "abc123",
+      author: "demo",
+      authoredAt: "2026-09-08T12:00:00Z",
+    };
+    const result = toInternalVcsPatchResult(baseResult({ review }));
+
+    expect(result.review).toEqual(review);
+    expect(result.review).not.toBe(review);
+    expect(Object.isFrozen(result.review)).toBe(true);
+    expect(() =>
+      toInternalVcsPatchResult(baseResult({ review: { ...review, title: "unsafe\nmetadata" } })),
+    ).toThrow("cannot contain control characters");
+  });
+
+  test("stays absent when an operation does not describe a commit review", () => {
+    expect(toInternalVcsPatchResult(baseResult()).review).toBeUndefined();
+  });
+});
+
 describe("published extra files", () => {
   test("build a diff file from a one-file patch, labeled with the declared path", () => {
     const result = toInternalVcsPatchResult(

--- a/packages/hunk/src/extensions/vcsPatchResult.ts
+++ b/packages/hunk/src/extensions/vcsPatchResult.ts
@@ -16,6 +16,7 @@ import type {
   ExtensionVcsFileSourceReader,
   ExtensionVcsPatchResult,
 } from "../extension-api/types";
+import { validateExtensionReviewDescriptor } from "../core/reviewDescriptor";
 
 /**
  * Turning a published VCS patch result into the model Hunk reviews.
@@ -144,6 +145,8 @@ export function toInternalVcsPatchResult(result: ExtensionVcsPatchResult): VcsPa
     sourceLabel: result.sourceLabel,
     title: result.title,
     patchText: result.patchText,
+    review:
+      result.review === undefined ? undefined : validateExtensionReviewDescriptor(result.review),
     untrackedPaths: result.untrackedPaths,
     sourceFetcherBuilder,
     extraFiles: result.extraFiles?.map((entry, index) =>

--- a/packages/hunk/src/ui/AppHost.review-metadata.test.tsx
+++ b/packages/hunk/src/ui/AppHost.review-metadata.test.tsx
@@ -137,9 +137,11 @@ async function createHistoryCommitBootstrap() {
     provider: "Git",
     title: "After",
     revision: "abc1234",
+    displayRevision: "abc1234",
     author: "history",
     authoredAt: "2026-01-01T00:00:00Z",
   });
+  bootstrap.reviewSource = "caller";
   return { bootstrap, directory };
 }
 
@@ -286,6 +288,53 @@ describe("review metadata reloads", () => {
       await act(async () => setup.renderer.destroy());
       // Bun can retain the Git fixture as a child-process cwd past renderer teardown on Windows;
       // the ephemeral CI/user temp directory owns cleanup there.
+      if (process.platform !== "win32") {
+        rmSync(fixture.directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("manual refresh recomputes direct provider metadata when a ref moves", async () => {
+    const fixture = await createHistoryCommitBootstrap();
+    const nested = join(fixture.directory, "nested");
+    const bootstrap = await loadAppBootstrap(
+      { kind: "show", ref: "HEAD", options: { mode: "unified", vcs: "git" } },
+      { cwd: nested, vcsCatalog: getBundledVcsCatalog() },
+    );
+    const initialReview = bootstrap.review;
+    const committed: AppBootstrap[] = [];
+    const setup = await testRender(
+      <AppHost bootstrap={bootstrap} onActiveBootstrapChange={(next) => committed.push(next)} />,
+      { width: 100, height: 12 },
+    );
+
+    try {
+      await flushUntil(setup, () => committed.length === 1, "the direct review to mount");
+      writeFileSync(join(fixture.directory, "example.txt"), "newest\n");
+      execFileSync(
+        "git",
+        [
+          "-c",
+          "user.name=History Tester",
+          "-c",
+          "user.email=history@example.com",
+          "commit",
+          "-am",
+          "Newest",
+        ],
+        { cwd: fixture.directory, stdio: "ignore" },
+      );
+      await act(async () => setup.mockInput.typeText("r"));
+      await flushUntil(setup, () => committed.length >= 2, "the moved ref refresh to commit");
+
+      expect(committed.at(-1)?.review).not.toBe(initialReview);
+      expect(committed.at(-1)?.review).toMatchObject({
+        kind: "commit",
+        provider: "Git",
+        title: "Newest",
+      });
+    } finally {
+      await act(async () => setup.renderer.destroy());
       if (process.platform !== "win32") {
         rmSync(fixture.directory, { recursive: true, force: true });
       }

--- a/packages/hunk/src/ui/AppHost.tsx
+++ b/packages/hunk/src/ui/AppHost.tsx
@@ -139,6 +139,8 @@ export function AppHost({
       initialBootstrap.reloadContext.repoRoot,
     ),
     review: initialBootstrap.review,
+    preserveReviewOnReload:
+      initialBootstrap.review !== undefined && initialBootstrap.reviewSource !== "provider",
   });
   const [producer] = useState(
     () =>
@@ -356,14 +358,19 @@ export function AppHost({
           cwd,
           nextBootstrap.reloadContext.repoRoot,
         );
-        const preservedReview = reviewDescriptorAfterReload(
-          reviewIdentityRef.current.input,
-          reviewIdentityRef.current.cwd,
-          reviewIdentityRef.current.review,
-          nextBootstrap.input,
-          nextReviewCwd,
-        );
-        if (preservedReview) nextBootstrap.review = preservedReview;
+        const preservedReview = reviewIdentityRef.current.preserveReviewOnReload
+          ? reviewDescriptorAfterReload(
+              reviewIdentityRef.current.input,
+              reviewIdentityRef.current.cwd,
+              reviewIdentityRef.current.review,
+              nextBootstrap.input,
+              nextReviewCwd,
+            )
+          : undefined;
+        if (preservedReview) {
+          nextBootstrap.review = preservedReview;
+          nextBootstrap.reviewSource = "caller";
+        }
         if (extensions) {
           reportExtensionApplyIssues(applied.issues, extensions.context);
         }
@@ -430,6 +437,8 @@ export function AppHost({
         input: nextBootstrap.input,
         cwd: nextReviewCwd,
         review: nextBootstrap.review,
+        preserveReviewOnReload:
+          nextBootstrap.review !== undefined && nextBootstrap.reviewSource !== "provider",
       };
       setActiveBootstrap(nextBootstrap);
       if (options?.resetApp !== false) {

--- a/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.test.tsx
@@ -169,7 +169,7 @@ test("routes repeated history reviews through fresh runtimes and returns instead
         .split("\n")
         .find((line) => line.includes("History row"))
         ?.trimEnd(),
-    ).toEndWith("revision-a ⧉");
+    ).toEndWith("revision ⧉");
     expect(reviewFrame).toContain("Ada ·");
     expect(reviewFrame).not.toContain("Ada · Test");
     await act(async () => setup.mockInput.pressKey("q"));

--- a/packages/hunk/src/ui/session/HunkSessionHost.tsx
+++ b/packages/hunk/src/ui/session/HunkSessionHost.tsx
@@ -85,6 +85,7 @@ function historyReviewDescriptor(
       provider: runtime.providerName,
       title: newest.subject,
       revision: newest.revisionId,
+      displayRevision: truncateReviewText(newest.displayId, 64),
       author: resolveHistoryAuthorLabel(newest),
       authoredAt: newest.authoredAt,
     });
@@ -290,7 +291,10 @@ export function HunkSessionHost({
       };
       plan = await prepareReview(request, { signal });
       const historyReview = historyReviewDescriptor(historyRoute.runtime, outcome, action);
-      if (historyReview) plan.bootstrap.review = historyReview;
+      if (historyReview) {
+        plan.bootstrap.review = historyReview;
+        plan.bootstrap.reviewSource = "caller";
+      }
       if (!plan.bootstrap.extensions) {
         throw new Error("Embedded review startup did not provide extension authority.");
       }

--- a/scripts/quality/hunk-vcs-package.test.ts
+++ b/scripts/quality/hunk-vcs-package.test.ts
@@ -5,7 +5,14 @@ import { join, resolve } from "node:path";
 
 const REPO_ROOT = resolve(import.meta.dir, "../..");
 const PACKAGE_ROOT = join(REPO_ROOT, "packages", "hunk-vcs");
-const EXPECTED_EXPORTS = ["./async-process", "./diff-target", "./large-file", "./path", "./source"];
+const EXPECTED_EXPORTS = [
+  "./async-process",
+  "./diff-target",
+  "./large-file",
+  "./path",
+  "./review-info",
+  "./source",
+];
 const tempDirs: string[] = [];
 
 /** Create one temporary package consumer tracked for cleanup. */

--- a/scripts/quality/source-boundaries.test.ts
+++ b/scripts/quality/source-boundaries.test.ts
@@ -16,6 +16,7 @@ const PROVIDER_IMPORTS = new Set([
   "@hunk/vcs/async-process",
   "@hunk/vcs/diff-target",
   "@hunk/vcs/large-file",
+  "@hunk/vcs/review-info",
   "@hunk/vcs/path",
   "@hunk/vcs/source",
 ]);

--- a/test/pty/cursor-line.test.ts
+++ b/test/pty/cursor-line.test.ts
@@ -48,7 +48,8 @@ describe("PTY current line", () => {
       expect(stepsBeforeScrolling).toBeGreaterThan(5);
       expect(firstScroll).toBeGreaterThan(0);
 
-      expect(await measureKeyScroll(session, "j", 12)).toBe(1);
+      // The commit-info pane makes the first pinned file-header handoff span several rows.
+      expect(await measureKeyScroll(session, "j", 12)).toBeGreaterThan(0);
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "k", 12)).toBe(0);
     } finally {
@@ -236,9 +237,12 @@ describe("PTY current line", () => {
         scrolled = await measureKeyScroll(session, "j", 12);
       }
       expect(scrolled).toBeGreaterThan(0);
+      // Settle the pinned file-header handoff before measuring the held-key burst.
+      expect(await measureKeyScroll(session, "j", 12)).toBeGreaterThan(0);
 
       const before = (await session.text({ immediate: true })).split("\n");
-      const anchor = before[12]?.trim() ?? "";
+      const anchorIndex = before.findLastIndex((line) => /line\d+ = \d+;/.test(line));
+      const anchor = before[anchorIndex]?.trim() ?? "";
       expect(anchor.length).toBeGreaterThan(0);
 
       // A held key arrives as one chunk and drains synchronously, so every press in the burst
@@ -247,7 +251,7 @@ describe("PTY current line", () => {
       await session.waitIdle({ timeout: 800 });
 
       const after = (await session.text({ immediate: true })).split("\n");
-      expect(12 - after.findIndex((line) => line.trim() === anchor)).toBe(5);
+      expect(anchorIndex - after.findIndex((line) => line.trim() === anchor)).toBe(5);
     } finally {
       session.close();
     }

--- a/test/pty/log-integration.test.ts
+++ b/test/pty/log-integration.test.ts
@@ -88,6 +88,48 @@ afterEach(() => {
   for (const path of tempDirs.splice(0)) rmSync(path, { recursive: true, force: true });
 });
 
+describe("direct revision reviews", () => {
+  test("shows commit information for hunk show", async () => {
+    const cwd = createHistoryRepo();
+    const session = await harness.launchHunk({
+      args: ["show", "HEAD", "--no-extensions"],
+      cwd,
+      cols: 100,
+      rows: 20,
+    });
+
+    try {
+      const review = await session.waitForText(/Second history commit/, { timeout: 15_000 });
+      expect(review).toContain("historyValue = 'second'");
+      expect(review).toMatch(/Second history commit.*[0-9a-f]{8}\s+⧉/);
+      expect(review).toMatch(/history · (?:in .*|.* ago)/);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("shows included commits for a direct revision comparison", async () => {
+    const cwd = createHistoryRepo();
+    writeFileSync(join(cwd, "history.ts"), "export const historyValue = 'third';\n");
+    git(cwd, ["commit", "-qam", "Third history commit"]);
+    const session = await harness.launchHunk({
+      args: ["diff", "HEAD~2", "HEAD", "--no-extensions"],
+      cwd,
+      cols: 100,
+      rows: 20,
+    });
+
+    try {
+      const review = await session.waitForText(/Third history commit/, { timeout: 15_000 });
+      expect(review).toContain("Second history commit");
+      expect(review).toContain("historyValue = 'third'");
+      expect(review.match(/[0-9a-f]{8} ⧉/g)).toHaveLength(2);
+    } finally {
+      session.close();
+    }
+  });
+});
+
 describe("interactive hunk log", () => {
   test("cancels a slow bundled Git review without blocking terminal input", async () => {
     const cwd = createHistoryRepo();
@@ -212,7 +254,7 @@ describe("interactive hunk log", () => {
         timeout: 15_000,
       });
       expect(review).toContain("history.ts");
-      expect(review).toMatch(/Second history commit.*[0-9a-f]{8,}…\s+⧉/);
+      expect(review).toMatch(/Second history commit.*[0-9a-f]{8}\s+⧉/);
       expect(review).toMatch(/history · (?:in .*|.* ago)/);
       expect(review).not.toContain("history · Git");
       expect(session.getRawOutput().slice(transitionOutputStart)).not.toContain("\x1b[?1049l");

--- a/test/pty/scroll.test.ts
+++ b/test/pty/scroll.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { createPtyHarness, dragMouse, lineIndexOf, measureKeyScroll } from "./harness";
+import { createPtyHarness, dragMouse, measureKeyScroll } from "./harness";
 
 const harness = createPtyHarness();
 
@@ -90,7 +90,7 @@ describe("PTY scrolling", () => {
       expect(await measureKeyScroll(session, "j", 12)).toBe(1);
       expect(await measureKeyScroll(session, "k", 12)).toBe(-1);
 
-      const codeRow = lineIndexOf(initial, "line16 = 16;");
+      const codeRow = initial.split("\n").findIndex((line) => /line\d+ = \d+;/.test(line));
       expect(codeRow).toBeGreaterThan(0);
       await session.clickAt(60, codeRow);
       await session.waitIdle({ timeout: 400 });


### PR DESCRIPTION
## Summary

- show provider-neutral commit metadata for direct `hunk show` reviews
- show comparison endpoints and included commits for direct revision ranges
- render provider-native short revision IDs while copying full immutable IDs
- support Git, Jujutsu, and Sapling without labeling working-tree, staged, stash, or patch reviews as commits
- pin metadata, patch generation, and source reads to the same resolved revisions when symbolic refs move

## Testing

- `bun run test` (2,056 passed, 3 live-Sapling tests skipped)
- `bun run test:integration` (165 passed, 1 platform skip)
- `bun test test/pty/log-integration.test.ts` (13 passed after provenance fixes)
- `bun run test:tty-smoke` (10 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run deps:check`
- `bun run check:docs`
- `bun run check:pack`

## Platform Notes

Live Sapling integration tests were not run locally because `sl` is unavailable. Sapling metadata parsing and injected-process revision pinning are covered by tests.