### PR TITLE
feat(ui): add support line number in "Open file in editor" for zed

### DIFF
--- a/.changeset/zed-editor-line.md
+++ b/.changeset/zed-editor-line.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Pass the selected line to Zed (`zed` and `zeditor`) when opening a file with `e`, matching the existing Helix support.

--- a/packages/hunk/src/ui/lib/openInEditor.test.ts
+++ b/packages/hunk/src/ui/lib/openInEditor.test.ts
@@ -95,16 +95,39 @@ describe("open in editor helpers", () => {
     });
   });
 
+  test("builds path:line targets for zed and zeditor", () => {
+    expect(
+      buildEditorCommand({
+        editor: "zed --wait",
+        filePath: "/tmp/project/file.ts",
+        line: 123,
+      }),
+    ).toEqual({
+      command: "zed",
+      args: ["--wait", "/tmp/project/file.ts:123"],
+    });
+    expect(
+      buildEditorCommand({
+        editor: "zeditor",
+        filePath: "/tmp/project/file.ts",
+        line: 123,
+      }),
+    ).toEqual({
+      command: "zeditor",
+      args: ["/tmp/project/file.ts:123"],
+    });
+  });
+
   test("defaults unknown editors to opening the file path only", () => {
     expect(
       buildEditorCommand({
-        editor: "zed --new-window",
+        editor: "unknown-editor --flag",
         filePath: "/tmp/project/example.ts",
         line: 4,
       }),
     ).toEqual({
-      command: "zed",
-      args: ["--new-window", "/tmp/project/example.ts"],
+      command: "unknown-editor",
+      args: ["--flag", "/tmp/project/example.ts"],
     });
   });
 

--- a/packages/hunk/src/ui/lib/openInEditor.ts
+++ b/packages/hunk/src/ui/lib/openInEditor.ts
@@ -131,6 +131,10 @@ export function buildEditorCommand({
     return { command, args: [...editorArgs, `${filePath}:${line}`] };
   }
 
+  if (program === "zed" || program === "zeditor") {
+    return { command, args: [...editorArgs, `${filePath}:${line}`] };
+  }
+
   return { command, args: [...editorArgs, filePath] };
 }
 


### PR DESCRIPTION
## Summary
When `$EDITOR` is Zed, pressing `e` opens the correct file but does not jump to the selected line.
Zed accepts `path:line` (its CLI help documents `path:line:column`), so this passes the line number the same way #496 did for Helix.

## Changes
- `buildEditorCommand()`: handle `zed` and `zeditor` (Linux distro package CLI name) with `${filePath}:${line}`
- One test covering `zed --wait` (path:line plus preserved flags) and `zeditor`; the existing "unknown editor" test example moves from `zed --new-window` to a neutral placeholder since Zed is no longer unknown
- Changeset entry (`patch`)

## Verification
- `bun test packages/hunk/src/ui/lib/openInEditor.test.ts` (19 pass), `bun run typecheck`, `bun run lint`, `bun run format:check`, `bun run deps:check` all pass
- `bun run test`: 4 failures remain in `test/cli` (`HUNK_NODE_ADAPTER_BUNDLE` not built, `--watch` from local user config, local `git log` date format). They reproduce identically on `main` with `bun test test/cli test/session` and are unrelated to this change.
- `zed --help` (Linux, Zed CLI) confirms `[PATHS_WITH_POSITION]...` with `path:line:column` syntax. Not manually exercised in the TUI.

Related: #310 (original `e` shortcut), #496 (Helix line support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
