### PR TITLE
fix(watch): check Git signatures asynchronously

### DIFF
--- a/.changeset/async-watch-signatures.md
+++ b/.changeset/async-watch-signatures.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Watch mode no longer freezes the review while checking Git for changes, and extension API generation 25 adds Promise-returning, cancellable `watchSignature` hooks.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -302,8 +302,9 @@ and retires the replaced instance at that explicit ownership boundary.
 
 ### `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `24`). Branch on it if you want
-one file to support several Hunk versions. Version 24 adds review metadata to VCS patch results and
+The API generation this Hunk speaks (currently `25`). Branch on it if you want
+one file to support several Hunk versions. Version 25 adds Promise-returning watch signatures and
+watch cancellation; version 24 adds review metadata to VCS patch results and
 short display revisions to commit descriptors; version 23 adds canonical unified-layout fields
 while preserving the previous event vocabulary; version 22 adds frame-derived pane preferred sizing,
 non-resizable dynamic panes, and commit-history paint tokens; version 21 adds optional inclusive history-range review
@@ -605,11 +606,10 @@ reports it as unsupported. Jujutsu supplies commit/change identities, bookmarks,
 and native merge-review semantics without routing through a colocated Git repository. Third-party
 adapters use exactly the same contract.
 
-Every operation `load` receives `context.signal`. Use asynchronous subprocess
-APIs, pass cancellation through, and terminate plus reap provider processes when
-it aborts; a synchronous spawn blocks Hunk's renderer and prevents the abort
-handler from running. Watch signatures remain synchronous because the watch
-runtime calls them as short, noninteractive probes.
+Every operation `load` and `watchSignature` receives optional `context.signal`.
+Use asynchronous subprocess APIs, pass cancellation through, and terminate plus
+reap provider processes when it aborts; a synchronous spawn blocks Hunk's renderer
+and prevents the abort handler from running.
 
 A `load` result is patch text plus how to label it. Everything else on it is
 optional, and each optional field buys one thing. API version 24 adds `review`:
@@ -694,10 +694,16 @@ factory config, Hunk sends that provisional instance `shutdown` before rebuildin
 
 #### Watch support
 
+Promise-returning `watchSignature` hooks and watch cancellation require API version 25.
+Declare `"hunk": { "apiVersion": 25 }` in the extension manifest so older hosts refuse to
+load it, or branch on `hunk.apiVersion` and keep a synchronous hook on older hosts.
+Existing synchronous hooks remain supported.
+
 `--watch` works through extension adapters. Each operation may add:
 
-- `watchSignature(input, ctx)` — a cheap fingerprint of the reviewed state.
-  Hunk polls it and reloads when it changes.
+- `watchSignature(input, ctx)` — a fingerprint of the reviewed state, returning
+  `string | Promise<string>`. Hunk awaits it and reloads when it changes. Prefer
+  async I/O and honor `ctx.signal`, which aborts when observation closes.
 - `watchPlan(input, ctx)` — the filesystem targets that cover that state, so
   Hunk reacts to events instead of polling on a timer.
 

--- a/packages/hunk-git/src/index.test.ts
+++ b/packages/hunk-git/src/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterEach, describe, expect, setDefaultTimeout, spyOn, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { platform, tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
@@ -476,7 +476,53 @@ describe("GitVcsAdapter", () => {
     ]);
   });
 
-  test("computes watch signatures for each review operation", () => {
+  test("watch probes spawn asynchronously without optional locks and honor cancellation", async () => {
+    const repo = createTempRepo("hunk-git-async-watch-");
+    writeFileSync(join(repo, "file.txt"), "one\n");
+    git(repo, "add", "file.txt");
+    git(repo, "commit", "-m", "initial");
+    writeFileSync(join(repo, "file.txt"), "two\n");
+    git(repo, "stash", "push", "-m", "watch");
+    writeFileSync(join(repo, "untracked.txt"), "fresh\n");
+
+    const syncSpawn = spyOn(Bun, "spawnSync");
+    const asyncSpawn = spyOn(Bun, "spawn");
+    const abort = new AbortController();
+    const probes = [
+      () =>
+        GitVcsAdapter.operations["working-tree-diff"].watchSignature(
+          { kind: "vcs", staged: false, range: "HEAD", options: {} },
+          { cwd: repo, signal: abort.signal },
+        ),
+      () =>
+        GitVcsAdapter.operations["revision-show"].watchSignature(
+          { kind: "show", ref: "HEAD", options: {} },
+          { cwd: repo, signal: abort.signal },
+        ),
+      () =>
+        GitVcsAdapter.operations["stash-show"].watchSignature(
+          { kind: "stash-show", options: {} },
+          { cwd: repo, signal: abort.signal },
+        ),
+    ];
+    try {
+      for (const probe of probes) await probe();
+      expect(syncSpawn).not.toHaveBeenCalled();
+      // Diff, root, range classification, status, show, and stash show all suppress index writes.
+      expect(asyncSpawn.mock.calls).toHaveLength(6);
+      for (const call of asyncSpawn.mock.calls) {
+        expect(call[1]?.env?.GIT_OPTIONAL_LOCKS).toBe("0");
+      }
+      abort.abort(new Error("watch closed"));
+      for (const probe of probes) await expect(probe()).rejects.toThrow("watch closed");
+      expect(asyncSpawn.mock.calls).toHaveLength(6);
+    } finally {
+      syncSpawn.mockRestore();
+      asyncSpawn.mockRestore();
+    }
+  });
+
+  test("computes watch signatures for each review operation", async () => {
     const repo = createTempRepo("hunk-git-adapter-watch-");
     writeFileSync(join(repo, "file.txt"), "one\n");
     git(repo, "add", "file.txt");
@@ -486,14 +532,14 @@ describe("GitVcsAdapter", () => {
 
     // Measure the working-tree signature while the tree is actually dirty, so the assertion is
     // meaningful: it must carry the tracked diff and an untracked-file stat signature.
-    const diffSignature = GitVcsAdapter.operations["working-tree-diff"]!.watchSignature!(
+    const diffSignature = await GitVcsAdapter.operations["working-tree-diff"]!.watchSignature!(
       { kind: "vcs", staged: false, options: {} },
       { cwd: repo },
     );
     expect(diffSignature).toContain("diff --git a/file.txt b/file.txt");
     expect(diffSignature).toContain("untracked:");
 
-    const showSignature = GitVcsAdapter.operations["revision-show"]!.watchSignature!(
+    const showSignature = await GitVcsAdapter.operations["revision-show"]!.watchSignature!(
       { kind: "show", ref: "HEAD", options: {} },
       { cwd: repo },
     );
@@ -501,7 +547,7 @@ describe("GitVcsAdapter", () => {
 
     // Stash the dirty state so a stash entry exists for the stash-show signature.
     git(repo, "stash", "push", "--include-untracked", "-m", "watch stash");
-    const stashSignature = GitVcsAdapter.operations["stash-show"]!.watchSignature!(
+    const stashSignature = await GitVcsAdapter.operations["stash-show"]!.watchSignature!(
       { kind: "stash-show", options: {} },
       { cwd: repo },
     );

--- a/packages/hunk-git/src/index.ts
+++ b/packages/hunk-git/src/index.ts
@@ -7,7 +7,6 @@ import {
   buildGitShowArgs,
   buildGitStashShowArgs,
   listGitIgnoredDirectoryRoots,
-  listGitUntrackedFiles,
   listGitUntrackedFilesAsync,
   parseGitNumstat,
   resolveGitColorMovedOptionsAsync,
@@ -16,9 +15,7 @@ import {
   resolveGitDiffEndpoints,
   resolveGitDiffEndpointsAsync,
   resolveGitMetadata,
-  resolveGitRepoRoot,
   resolveGitRepoRootAsync,
-  runGitText,
   runGitTextAsync,
   shouldSkipLargeTrackedDiff,
   type GitBackedInput,
@@ -476,25 +473,31 @@ export function createGitVcsAdapter({
         watchPlan(input, { cwd }) {
           return buildGitWatchPlan(input, cwd, gitExecutable);
         },
-        watchSignature(input, { cwd }) {
-          const trackedPatch = runGitText({
+        async watchSignature(input, { cwd, signal }) {
+          const trackedPatch = await runGitTextAsync({
             input,
             args: buildGitDiffArgs(input),
             cwd,
             gitExecutable,
             preventOptionalLocks: true,
+            signal,
           });
-          const repoRoot = resolveGitRepoRoot(input, {
+          const repoRoot = await resolveGitRepoRootAsync(input, {
             cwd,
             gitExecutable,
             preventOptionalLocks: true,
+            signal,
           });
-          const untrackedSignatures = listGitUntrackedFiles(input, {
+          const untrackedPaths = await listGitUntrackedFilesAsync(input, {
             cwd,
             repoRoot,
             gitExecutable,
             preventOptionalLocks: true,
-          }).map((filePath) => `untracked:${statSignature(join(repoRoot, filePath))}`);
+            signal,
+          });
+          const untrackedSignatures = untrackedPaths.map(
+            (filePath) => `untracked:${statSignature(join(repoRoot, filePath))}`,
+          );
           return [trackedPatch, ...untrackedSignatures].join("\n---\n");
         },
       },
@@ -543,13 +546,14 @@ export function createGitVcsAdapter({
         watchPlan(input, { cwd }) {
           return buildGitWatchPlan(input, cwd, gitExecutable);
         },
-        watchSignature(input, { cwd }) {
-          return runGitText({
+        watchSignature(input, { cwd, signal }) {
+          return runGitTextAsync({
             input,
             args: buildGitShowArgs(input),
             cwd,
             gitExecutable,
             preventOptionalLocks: true,
+            signal,
           });
         },
       },
@@ -586,13 +590,14 @@ export function createGitVcsAdapter({
         watchPlan(input, { cwd }) {
           return buildGitWatchPlan(input, cwd, gitExecutable);
         },
-        watchSignature(input, { cwd }) {
-          return runGitText({
+        watchSignature(input, { cwd, signal }) {
+          return runGitTextAsync({
             input,
             args: buildGitStashShowArgs(input),
             cwd,
             gitExecutable,
             preventOptionalLocks: true,
+            signal,
           });
         },
       },

--- a/packages/hunk/skills/hunk-extensions/SKILL.md
+++ b/packages/hunk/skills/hunk-extensions/SKILL.md
@@ -111,10 +111,15 @@ bad or duplicate id is skipped with a startup notice.
 | Reload after an external agent changes reviewed inputs   | `ctx.review.requestReload()` in an event     |
 | Read user-supplied settings                              | `hunk.config` (`[extension.<id>]` table)     |
 | Snapshot stable files and every saved review note        | `ctx.review.snapshot()` in a command         |
-| Branch on the API generation (currently `21`)            | `hunk.apiVersion`                            |
+| Branch on the API generation (currently `25`)            | `hunk.apiVersion`                            |
 
 Registration is only valid while the factory runs — Hunk seals the API object
 afterwards.
+
+Promise-returning VCS `watchSignature` hooks and watch cancellation require API
+version 25. Declare `{"hunk": {"apiVersion": 25}}` in the manifest, or branch on
+`hunk.apiVersion` and return signatures synchronously on older hosts. Use async
+I/O and honor `ctx.signal` on API 25; existing synchronous hooks remain supported.
 
 ### Generic CLI handlers
 

--- a/packages/hunk/src/core/changeset/loaders.test.ts
+++ b/packages/hunk/src/core/changeset/loaders.test.ts
@@ -310,12 +310,42 @@ describe("loadAppBootstrap", () => {
 
       expect(bootstrap.reloadContext.cwd).toBe(dir);
       expect(bootstrap.reloadContext.initialWatchSignature).toBeDefined();
-      expect(computeWatchSignature(bootstrap.input, bootstrap.reloadContext)).not.toBe(
+      expect(await computeWatchSignature(bootstrap.input, bootstrap.reloadContext)).not.toBe(
         bootstrap.reloadContext.initialWatchSignature,
       );
     } finally {
       Bun.file = originalBunFile;
     }
+  });
+
+  test("awaits the initial provider signature before loading content", async () => {
+    const order: string[] = [];
+    const abort = new AbortController();
+    const adapter: VcsAdapter = {
+      id: "demo",
+      name: "Demo",
+      detect: () => null,
+      operations: {
+        "working-tree-diff": {
+          async watchSignature(_input, { signal }) {
+            expect(signal).toBe(abort.signal);
+            await Promise.resolve();
+            order.push("signature");
+            return "before-load";
+          },
+          async load() {
+            order.push("load");
+            return { repoRoot: process.cwd(), sourceLabel: "demo", title: "demo", patchText: "" };
+          },
+        },
+      },
+    };
+    const bootstrap = await loadAppBootstrap(
+      { kind: "vcs", staged: false, options: { watch: true, vcs: "demo" } },
+      { vcsCatalog: createVcsCatalog([adapter], "demo", []), signal: abort.signal },
+    );
+    expect(order).toEqual(["signature", "load"]);
+    expect(bootstrap.reloadContext.initialWatchSignature).toBe("vcs\n---\nbefore-load");
   });
 
   test("does not fail a valid initial load when best-effort watch signing fails", async () => {
@@ -417,7 +447,7 @@ describe("loadAppBootstrap", () => {
     );
     expect(bootstrap.changeset.files[0]?.path).toBe("example.ts");
     expect(bootstrap.changeset.files[0]?.agent?.annotations).toHaveLength(1);
-    expect(computeWatchSignature(bootstrap.input, bootstrap.reloadContext)).toBe(
+    expect(await computeWatchSignature(bootstrap.input, bootstrap.reloadContext)).toBe(
       bootstrap.reloadContext.initialWatchSignature!,
     );
   });

--- a/packages/hunk/src/core/changeset/loaders.ts
+++ b/packages/hunk/src/core/changeset/loaders.ts
@@ -286,13 +286,14 @@ export async function loadAppBootstrap(
   if (input.options.watch) {
     try {
       if (vcsCatalog || !isVcsReviewInput(input)) {
-        initialWatchSignature = computeWatchSignature(input, { cwd, vcsCatalog });
+        initialWatchSignature = await computeWatchSignature(input, { cwd, vcsCatalog, signal });
       }
     } catch {
       // A transient signature failure must not prevent an otherwise valid initial review.
     }
   }
 
+  signal?.throwIfAborted();
   const sidecar = await loadSidecarContext(input.options.agentContext, { cwd });
   signal?.throwIfAborted();
 

--- a/packages/hunk/src/core/vcs/types.ts
+++ b/packages/hunk/src/core/vcs/types.ts
@@ -40,7 +40,7 @@ export type VcsReviewOperationKind = VcsReviewOperation["kind"];
 
 export interface VcsOperation<Input extends VcsReviewInput> {
   load(input: Input, context: VcsLoadContext): Promise<VcsPatchResult>;
-  watchSignature?: (input: Input, context: VcsLoadContext) => string;
+  watchSignature?: (input: Input, context: VcsLoadContext) => string | Promise<string>;
   watchPlan?: (input: Input, context: VcsLoadContext) => ExtensionVcsWatchPlan;
 }
 

--- a/packages/hunk/src/core/watch/controller.test.ts
+++ b/packages/hunk/src/core/watch/controller.test.ts
@@ -330,21 +330,27 @@ describe("createWatchController", () => {
     expect(refreshes).toBe(1);
   });
 
-  test("checks the bootstrap signature immediately after source readiness", async () => {
+  test("checks an unchanged bootstrap signature on readiness without refreshing", async () => {
     const clock = new FakeWatchClock();
     const source = fakeSource();
     let checks = 0;
-    createWatchController({
+    let refreshes = 0;
+    const controller = createWatchController({
       initialSignature: "same",
       clock,
       createEventSource: source.create,
       getSignature: () => (++checks, "same"),
-      refresh: () => {},
+      refresh: () => {
+        refreshes++;
+      },
     });
 
     source.ready();
     await settle();
     expect(checks).toBe(1);
+    expect(refreshes).toBe(0);
+    expect(controller.getState().appliedSignature).toBe("same");
+    controller.close();
   });
 
   test("degrades a stalled source after the default startup deadline", async () => {
@@ -572,6 +578,107 @@ describe("createWatchController", () => {
     await settle();
     expect(checks).toBe(1);
   });
+
+  test("refreshes a change before readiness when the bootstrap baseline is missing", async () => {
+    const clock = new FakeWatchClock();
+    const source = fakeSource();
+    const pendingRefresh = deferred<void>();
+    let signature = "initial";
+    let refreshes = 0;
+    const controller = createWatchController({
+      // A failed bootstrap probe leaves the loaded content without a baseline.
+      initialSignature: undefined,
+      clock,
+      createEventSource: source.create,
+      getSignature: async () => signature,
+      refresh: () => {
+        refreshes++;
+        return pendingRefresh.promise;
+      },
+    });
+    signature = "changed";
+    source.ready();
+    await settle();
+    expect(refreshes).toBe(1);
+    expect(controller.getState().appliedSignature).toBeUndefined();
+    expect(controller.getState().phase).toBe("refreshing");
+
+    pendingRefresh.resolve();
+    await settle();
+    expect(controller.getState().appliedSignature).toBe("changed");
+    source.event();
+    clock.advance(200);
+    await settle();
+    clock.advance(10_000);
+    await settle();
+    expect(refreshes).toBe(1);
+    controller.close();
+  });
+
+  test("retries a missing baseline after the readiness refresh rejects", async () => {
+    const clock = new FakeWatchClock();
+    const source = fakeSource();
+    const failure = new Error("reload failed");
+    const errors: unknown[] = [];
+    let attempts = 0;
+    const controller = createWatchController({
+      clock,
+      createEventSource: source.create,
+      getSignature: async () => "changed",
+      refresh: async () => {
+        if (++attempts === 1) throw failure;
+      },
+      reportError: (error) => errors.push(error),
+    });
+
+    source.ready();
+    await settle();
+    expect(attempts).toBe(1);
+    expect(controller.getState().appliedSignature).toBeUndefined();
+    expect(errors).toEqual([failure]);
+
+    clock.advance(10_000);
+    await settle();
+    expect(attempts).toBe(2);
+    expect(controller.getState().appliedSignature).toBe("changed");
+    controller.close();
+  });
+
+  test.each(["resolve", "reject"] as const)(
+    "close aborts an in-flight signature and ignores late %s",
+    async (completion) => {
+      const clock = new FakeWatchClock();
+      const source = fakeSource();
+      const pending = deferred<string>();
+      let signal: AbortSignal | undefined;
+      let refreshes = 0;
+      const errors: unknown[] = [];
+      const controller = createWatchController({
+        initialSignature: "old",
+        clock,
+        createEventSource: source.create,
+        getSignature: (nextSignal) => {
+          signal = nextSignal;
+          return pending.promise;
+        },
+        refresh: () => {
+          refreshes++;
+        },
+        reportError: (error) => errors.push(error),
+      });
+      source.ready();
+      expect(signal?.aborted).toBe(false);
+      controller.close();
+      expect(signal?.aborted).toBe(true);
+      if (completion === "resolve") pending.resolve("new");
+      else pending.reject(signal?.reason);
+      await settle();
+      expect(refreshes).toBe(0);
+      expect(errors).toEqual([]);
+      expect(clock.timers.size).toBe(0);
+      expect(controller.getState().appliedSignature).toBe("old");
+    },
+  );
 
   test("close is idempotent, cancels timers, and ignores late completion", async () => {
     const clock = new FakeWatchClock();

--- a/packages/hunk/src/core/watch/controller.ts
+++ b/packages/hunk/src/core/watch/controller.ts
@@ -26,8 +26,9 @@ export const DEFAULT_WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_MS = 2_000;
 export const WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_CODE = "HUNK_WATCH_EVENT_SOURCE_STARTUP_TIMEOUT";
 
 export interface WatchControllerOptions {
-  initialSignature: string;
-  getSignature: () => string | Promise<string>;
+  /** Baseline captured before content loading; if absent, the first check must refresh. */
+  initialSignature?: string;
+  getSignature: (signal: AbortSignal) => string | Promise<string>;
   refresh: () => void | Promise<void>;
   /** A source event arrived and a debounced signature check is now pending. */
   onReloadPending?: () => void;
@@ -47,7 +48,7 @@ export interface WatchControllerState {
   phase: WatchControllerPhase;
   dirty: boolean;
   degraded: boolean;
-  appliedSignature: string;
+  appliedSignature: string | undefined;
 }
 
 export interface WatchController {
@@ -112,6 +113,7 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
   let maximumDeadline: number | undefined;
   let safetyDeadline: number | undefined;
   const reportedAt = new Map<string, number>();
+  const signatureAbort = new AbortController();
 
   /** Report an error at most once per configured interval for the same error key. */
   const reportError = (error: unknown) => {
@@ -177,7 +179,7 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
     schedule();
   };
 
-  /** Run one serialized signature check and refresh only when it changed. */
+  /** Run one serialized signature check and refresh changed or unverified content. */
   const beginCheck = async () => {
     if (state.phase === "closed" || state.phase === "checking" || state.phase === "refreshing") {
       return;
@@ -190,7 +192,7 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
 
     let signature: string;
     try {
-      signature = await options.getSignature();
+      signature = await options.getSignature(signatureAbort.signal);
     } catch (error) {
       if (isClosed()) return;
       reportError(error);
@@ -198,6 +200,7 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
       return;
     }
     if (isClosed()) return;
+    // Without a pre-load baseline, readiness cannot attest that the loaded content is current.
     if (signature === state.appliedSignature) {
       finishCheck();
       return;
@@ -330,6 +333,7 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
     close() {
       if (state.phase === "closed") return;
       state.phase = "closed";
+      signatureAbort.abort();
       state.dirty = false;
       quietDeadline = undefined;
       maximumDeadline = undefined;

--- a/packages/hunk/src/core/watch/signature.test.ts
+++ b/packages/hunk/src/core/watch/signature.test.ts
@@ -80,14 +80,14 @@ afterEach(() => {
 });
 
 describe("computeWatchSignature", () => {
-  test("resolves direct files, patch files, and agent sidecars against the supplied cwd", () => {
+  test("resolves direct files, patch files, and agent sidecars against the supplied cwd", async () => {
     const dir = createTempRepo("hunk-watch-files-cwd-");
     writeFileSync(join(dir, "left.ts"), "one\n");
     writeFileSync(join(dir, "right.ts"), "two\n");
     writeFileSync(join(dir, "review.patch"), "patch\n");
     writeFileSync(join(dir, "agent.json"), "{}\n");
 
-    const direct = computeWatchSignature(
+    const direct = await computeWatchSignature(
       {
         kind: "diff",
         left: "left.ts",
@@ -96,7 +96,7 @@ describe("computeWatchSignature", () => {
       },
       { cwd: dir },
     );
-    const patch = computeWatchSignature(
+    const patch = await computeWatchSignature(
       { kind: "patch", file: "review.patch", options: {} },
       { cwd: dir },
     );
@@ -107,7 +107,7 @@ describe("computeWatchSignature", () => {
     expect(patch).toContain(join(dir, "review.patch"));
   });
 
-  test("does not embed full untracked file contents in git watch signatures", () => {
+  test("does not embed full untracked file contents in git watch signatures", async () => {
     const dir = createTempRepo("hunk-watch-untracked-");
 
     writeFileSync(join(dir, "tracked.ts"), "export const tracked = 1;\n");
@@ -118,16 +118,16 @@ describe("computeWatchSignature", () => {
     const untrackedPath = join(dir, "large-untracked.txt");
     writeFileSync(untrackedPath, largeMarker);
 
-    const initialSignature = computeWatchSignature(createGitInput(), { cwd: dir });
+    const initialSignature = await computeWatchSignature(createGitInput(), { cwd: dir });
     writeFileSync(untrackedPath, `${largeMarker}changed`);
-    const changedSignature = computeWatchSignature(createGitInput(), { cwd: dir });
+    const changedSignature = await computeWatchSignature(createGitInput(), { cwd: dir });
 
     expect(initialSignature).not.toContain(largeMarker);
     expect(changedSignature).not.toContain(largeMarker);
     expect(changedSignature).not.toEqual(initialSignature);
   });
 
-  test("ignores untracked file changes when the git input excludes them", () => {
+  test("ignores untracked file changes when the git input excludes them", async () => {
     const dir = createTempRepo("hunk-watch-exclude-untracked-");
 
     writeFileSync(join(dir, "tracked.ts"), "export const tracked = 1;\n");
@@ -137,12 +137,12 @@ describe("computeWatchSignature", () => {
     const untrackedPath = join(dir, "note.txt");
     writeFileSync(untrackedPath, "first\n");
 
-    const initialSignature = computeWatchSignature(
+    const initialSignature = await computeWatchSignature(
       createGitInput({ options: { excludeUntracked: true } }),
       { cwd: dir },
     );
     writeFileSync(untrackedPath, "second\n");
-    const changedSignature = computeWatchSignature(
+    const changedSignature = await computeWatchSignature(
       createGitInput({ options: { excludeUntracked: true } }),
       { cwd: dir },
     );
@@ -150,7 +150,8 @@ describe("computeWatchSignature", () => {
     expect(changedSignature).toEqual(initialSignature);
   });
 
-  test("signs a review through an extension adapter threaded into the context", () => {
+  test("signs a review through an async extension adapter and forwards cancellation", async () => {
+    const abort = new AbortController();
     const adapter: VcsAdapter = {
       id: "hg",
       name: "Mercurial",
@@ -163,7 +164,11 @@ describe("computeWatchSignature", () => {
             title: "hg",
             patchText: "",
           }),
-          watchSignature: (input) => `hg:${input.range ?? "working-copy"}`,
+          watchSignature: async (input, { signal }) => {
+            expect(signal).toBe(abort.signal);
+            await Promise.resolve();
+            return `hg:${input.range ?? "working-copy"}`;
+          },
         },
       },
     };
@@ -174,15 +179,16 @@ describe("computeWatchSignature", () => {
     } satisfies CliInput;
 
     expect(
-      computeWatchSignature(input, {
+      await computeWatchSignature(input, {
         cwd: process.cwd(),
+        signal: abort.signal,
         vcsCatalog: createVcsCatalog([adapter], "demo", []),
       }),
     ).toBe("vcs\n---\nhg:working-copy");
   });
 
-  test("rejects unsupported watch operations before invoking adapter signatures", () => {
-    expect(() =>
+  test("rejects unsupported watch operations before invoking adapter signatures", async () => {
+    await expect(
       computeWatchSignature(
         {
           kind: "stash-show",
@@ -190,10 +196,10 @@ describe("computeWatchSignature", () => {
         },
         { cwd: process.cwd() },
       ),
-    ).toThrow("`hunk stash show` requires Git VCS mode.");
+    ).rejects.toThrow("`hunk stash show` requires Git VCS mode.");
   });
 
-  test("tracks untracked file changes when diff compares the working tree against one ref", () => {
+  test("tracks untracked file changes when diff compares the working tree against one ref", async () => {
     const dir = createTempRepo("hunk-watch-ref-untracked-");
 
     writeFileSync(join(dir, "tracked.ts"), "export const tracked = 1;\n");
@@ -208,11 +214,11 @@ describe("computeWatchSignature", () => {
     const untrackedPath = join(dir, "note.txt");
     writeFileSync(untrackedPath, "first\n");
 
-    const initialSignature = computeWatchSignature(createGitInput({ range: "main" }), {
+    const initialSignature = await computeWatchSignature(createGitInput({ range: "main" }), {
       cwd: dir,
     });
     writeFileSync(untrackedPath, "second\n");
-    const changedSignature = computeWatchSignature(createGitInput({ range: "main" }), {
+    const changedSignature = await computeWatchSignature(createGitInput({ range: "main" }), {
       cwd: dir,
     });
 

--- a/packages/hunk/src/core/watch/signature.ts
+++ b/packages/hunk/src/core/watch/signature.ts
@@ -24,17 +24,22 @@ function vcsPatchSignature(
   }
   const adapter = getConfiguredVcsAdapter(input.options.vcs, context.vcsCatalog);
   const operation = operationFromInput(input);
-  return createVcsWatchSignature(adapter, operation, { cwd: context.cwd }, context.vcsCatalog);
+  return createVcsWatchSignature(adapter, operation, context, context.vcsCatalog);
 }
 
 export interface WatchSignatureContext {
   cwd: string;
+  signal?: AbortSignal;
   /** Complete catalog retained from the review load. */
   vcsCatalog?: VcsCatalog;
 }
 
 /** Compute a change-detection signature relative to the source's stable load context. */
-export function computeWatchSignature(input: CliInput, context: WatchSignatureContext) {
+export async function computeWatchSignature(
+  input: CliInput,
+  context: WatchSignatureContext,
+): Promise<string> {
+  context.signal?.throwIfAborted();
   const parts: string[] = [input.kind];
   const resolveInputPath = (path: string) => resolve(context.cwd, path);
 
@@ -42,7 +47,7 @@ export function computeWatchSignature(input: CliInput, context: WatchSignatureCo
     case "vcs":
     case "show":
     case "stash-show":
-      parts.push(vcsPatchSignature(input, context));
+      parts.push(await vcsPatchSignature(input, context));
       break;
     case "diff":
     case "difftool":

--- a/packages/hunk/src/extension-api/types.ts
+++ b/packages/hunk/src/extension-api/types.ts
@@ -21,7 +21,7 @@
  * Extensions can branch on `hunk.apiVersion` so a newer Hunk can keep loading
  * older extensions without guessing at their expectations.
  */
-export const HUNK_EXTENSION_API_VERSION = 24;
+export const HUNK_EXTENSION_API_VERSION = 25;
 export type HunkExtensionApiVersion = typeof HUNK_EXTENSION_API_VERSION;
 
 export type ExtensionNotifyType = "info" | "warning" | "error";
@@ -1077,8 +1077,11 @@ export interface ExtensionVcsWatchPlan {
 /** One review operation an adapter implements. */
 export interface ExtensionVcsOperation<Input> {
   load(input: Input, context: ExtensionVcsLoadContext): Promise<ExtensionVcsPatchResult>;
-  /** Optional cheap fingerprint of the reviewed state, for `--watch`. */
-  watchSignature?: (input: Input, context: ExtensionVcsLoadContext) => string;
+  /**
+   * Optional fingerprint for `--watch`; use async I/O and honor context.signal.
+   * Promise returns and watch cancellation require extension API version 25.
+   */
+  watchSignature?: (input: Input, context: ExtensionVcsLoadContext) => string | Promise<string>;
   /**
    * Optional filesystem targets `--watch` observes instead of polling.
    *

--- a/packages/hunk/src/extensions/runExtension.test.ts
+++ b/packages/hunk/src/extensions/runExtension.test.ts
@@ -13,8 +13,8 @@ function bundledMetadata(id: string) {
 }
 
 describe("runExtensionFactory", () => {
-  test("advertises direct review metadata through extension API v24", () => {
-    expect(HUNK_EXTENSION_API_VERSION).toBe(24);
+  test("advertises async watch signatures through extension API v25", () => {
+    expect(HUNK_EXTENSION_API_VERSION).toBe(25);
   });
 
   test("applies a synchronous factory before returning, with nothing to await", () => {

--- a/packages/hunk/src/extensions/runExtension.ts
+++ b/packages/hunk/src/extensions/runExtension.ts
@@ -159,7 +159,12 @@ function toInternalVcsOperation(
     ...(watchSignature && {
       watchSignature(input, context) {
         try {
-          return watchSignature(input, context);
+          const signature = watchSignature(input, context);
+          return typeof signature === "string"
+            ? signature
+            : signature.catch((error) => {
+                throw toUserFacingError(error);
+              });
         } catch (error) {
           throw toUserFacingError(error);
         }

--- a/packages/hunk/src/extensions/vcsPatchResult.test.ts
+++ b/packages/hunk/src/extensions/vcsPatchResult.test.ts
@@ -313,6 +313,33 @@ describe("published user errors", () => {
     );
   });
 
+  test("normalizes rejected async watch signatures through the adapter boundary", async () => {
+    const adapter = toInternalVcsAdapter({
+      id: "demo",
+      name: "Demo VCS",
+      detect: () => null,
+      operations: {
+        "working-tree-diff": {
+          load: async () => ({
+            repoRoot: process.cwd(),
+            sourceLabel: "demo",
+            title: "demo",
+            patchText: "",
+          }),
+          watchSignature: async () => {
+            throw new HunkExtensionUserError("No signature available.");
+          },
+        },
+      },
+    });
+    await expect(
+      adapter.operations["working-tree-diff"]!.watchSignature!(
+        { kind: "vcs", staged: false, options: {} },
+        { cwd: process.cwd() },
+      ),
+    ).rejects.toBeInstanceOf(HunkUserError);
+  });
+
   test("drop an operation whose load is not callable rather than crashing mid-review", () => {
     const adapter = toInternalVcsAdapter({
       id: "bare",

--- a/packages/hunk/src/ui/hooks/useCurrentReviewRefreshController.test.tsx
+++ b/packages/hunk/src/ui/hooks/useCurrentReviewRefreshController.test.tsx
@@ -204,6 +204,12 @@ describe("useCurrentReviewRefreshController", () => {
 
     try {
       await act(async () => setup.renderOnce());
+      // Without a bootstrap signature, readiness must refresh before accepting a baseline.
+      await act(async () => {
+        watch.sources[0]?.callbacks.onReady?.();
+        await Promise.resolve();
+      });
+      expect(reloads.map((options) => options.reason)).toEqual(["watch"]);
       controller.triggerRefreshCurrentInput();
       await act(async () => {
         await Promise.resolve();
@@ -215,7 +221,7 @@ describe("useCurrentReviewRefreshController", () => {
       });
 
       expect(pendingCount).toBe(1);
-      expect(reloads.map((options) => options.reason)).toEqual(["manual", "watch"]);
+      expect(reloads.map((options) => options.reason)).toEqual(["watch", "manual", "watch"]);
       expect(reloads.every((options) => options.resetApp === false)).toBe(true);
     } finally {
       await act(async () => setup.renderer.destroy());

--- a/packages/hunk/src/ui/hooks/useWatchedInput.ts
+++ b/packages/hunk/src/ui/hooks/useWatchedInput.ts
@@ -12,7 +12,10 @@ import type { CliInput } from "../../core/run/commandInputs";
 
 export interface WatchedInputRuntime {
   clock?: WatchControllerClock;
-  getSignature?: (input: CliInput, context: ReloadContext) => string;
+  getSignature?: (
+    input: CliInput,
+    context: ReloadContext & { signal?: AbortSignal },
+  ) => string | Promise<string>;
   resolvePlan?: (input: CliInput, context: ReloadContext) => WatchPlan | null;
   createEventSource?: (plan: WatchPlan, callbacks: WatchEventSourceCallbacks) => { close(): void };
 }
@@ -53,14 +56,9 @@ export function useWatchedInput({
 
     const getSignature = runtime.getSignature ?? computeWatchSignature;
     let plan: WatchPlan | null;
-    let initialSignature: string;
     try {
       plan = (runtime.resolvePlan ?? resolveWatchPlan)(input, reloadContext);
       if (!plan) return;
-      initialSignature =
-        runtime.getSignature === undefined && reloadContext.initialWatchSignature !== undefined
-          ? reloadContext.initialWatchSignature
-          : getSignature(input, reloadContext);
     } catch (error) {
       console.error("Failed to initialize watch mode.", error);
       return;
@@ -72,9 +70,9 @@ export function useWatchedInput({
     const controller = createWatchController({
       clock: runtime.clock,
       createEventSource: eventSourceFactory,
-      getSignature: () => getSignature(input, reloadContext),
+      getSignature: (signal) => getSignature(input, { ...reloadContext, signal }),
       healthyCheckMs: hasDirectFileContent(plan) ? DIRECT_FILE_WATCH_SAFETY_CHECK_MS : undefined,
-      initialSignature,
+      initialSignature: reloadContext.initialWatchSignature,
       onReloadPending: () => pendingRef.current?.(),
       pollOnly: plan.coverage === "poll-only",
       refresh: () => refreshRef.current(),

--- a/website/src/content/docs/docs/extend/extension-api.md
+++ b/website/src/content/docs/docs/extend/extension-api.md
@@ -7,8 +7,8 @@ The extension factory receives one API object. Registration calls are only valid
 
 ## `hunk.apiVersion`
 
-The API generation this Hunk speaks (currently `23`). Branch on it if you want
-one file to support several Hunk versions. Version 23 adds canonical unified-layout fields while preserving the previous event vocabulary; version 22 adds frame-derived pane preferred sizing, non-resizable dynamic panes, and commit-history paint tokens; version 21 adds optional inclusive history-range review
+The API generation this Hunk speaks (currently `25`). Branch on it if you want
+one file to support several Hunk versions. Version 25 adds Promise-returning watch signatures and watch cancellation; version 24 adds review metadata to VCS patch results and short display revisions to commit descriptors; version 23 adds canonical unified-layout fields while preserving the previous event vocabulary; version 22 adds frame-derived pane preferred sizing, non-resizable dynamic panes, and commit-history paint tokens; version 21 adds optional inclusive history-range review
 planning and bounded comparison commit summaries; version 20 adds optional commit timestamps to review
 metadata, pane clipboard actions, and the `theme.copyAction` paint token; version 19 adds provider-owned history enumeration and review planning; version 18 lets
 lifecycle and custom-event handlers request a host-owned review reload; version 17 adds structured review metadata to delegated

--- a/website/src/content/docs/docs/extend/vcs-adapters.md
+++ b/website/src/content/docs/docs/extend/vcs-adapters.md
@@ -72,9 +72,11 @@ What detection never overrides is an explicit choice: a `vcs = "<id>"` in Hunk c
 
 ## Watch support
 
+Promise-returning `watchSignature` hooks and watch cancellation require API version 25. Declare `"hunk": { "apiVersion": 25 }` in the extension manifest so older hosts refuse to load it, or branch on `hunk.apiVersion` and keep a synchronous hook on older hosts. Existing synchronous hooks remain supported.
+
 `--watch` works through extension adapters. Each operation may add:
 
-- `watchSignature(input, ctx)` — a cheap fingerprint of the reviewed state. Hunk polls it and reloads when it changes.
+- `watchSignature(input, ctx)` — a fingerprint of the reviewed state, returning `string | Promise<string>`. Hunk awaits it and reloads when it changes. Prefer async I/O and honor optional `ctx.signal`, which aborts when observation closes.
 - `watchPlan(input, ctx)` — the filesystem targets that cover that state, so Hunk reacts to events instead of polling on a timer.
 
 ```ts


### PR DESCRIPTION
Part of #1063 (step 3). Fixes #543.

## Problem

Every watch-mode signature check (`git diff`, `git rev-parse --show-toplevel`, `git status --porcelain`) ran through the synchronous `spawnSync` runner. The check fires once on observer readiness and again on every filesystem event, so each one blocked the main thread for the full duration of three Git subprocesses. Measured on Linux (4 vCPU, source invocation): the sync signature starves timers/input for 14–46 ms depending on repo size, and up to ~210 ms when the Git index stat cache is stale. That is the steady-state freeze reported in #543 and part of the first-interaction stall in #1063.

## Approach

- `VcsAdapter.watchSignature` / the public extension `watchSignature` hook may now return `string | Promise<string>` and receive an `AbortSignal`. Synchronous adapters keep working unchanged (jj/Sapling untouched).
- The three Git watch signature implementations use the existing async runners (`runGitTextAsync`, `resolveGitRepoRootAsync`, `listGitUntrackedFilesAsync`). `--no-optional-locks` (#398) is preserved on every watch-time call.
- The watch controller aborts an in-flight signature on close and suppresses late results; signature checks remain serialized and burst-coalesced.
- The pre-content-load baseline signature (`initialWatchSignature`) is still captured before content loads so the startup race stays closed. If that baseline probe failed, readiness now refreshes once before adopting a baseline instead of silently accepting whatever it sees.
- Extension API generation bumped 24 → 25 so extensions can gate on Promise-returning hooks; an API-24 host would stringify a Promise and stop detecting changes.
- Async extension errors are normalized through the same path as sync ones.

Non-goals: the chokidar directory-walk cost on Linux (#1063 step 2) and deferring observer start (step 1) are separate PRs.

## Measurements (Linux, isolated observer probe, n=5)

| Fixture | sync signature timer gap max | async |
|---|---:|---:|
| hunk repo | 20.3 ms | 8.0 ms |
| 300 dirs | 14.9 ms | 2.5 ms |
| 2,000 dirs | 45.9 ms | 3.5 ms |

## Tests / checks

- `bun run typecheck`, `bun run deps:check` — pass
- `bun run test` — 4151 pass, 48 skip, 6 fail; the same 6 fail on `origin/main` @ `bc76a0bc` (jj diagnostic context, extension unavailable-file toast, AppHost file-view soft reload, two VM-shell staging cases, VM cleanup path validation)
- `bun run test:integration` — PTY watch tests pass; 3 pre-existing signal-shutdown failures also reproduce on main
- New coverage: controller abort-on-close, missing-baseline refresh-once / failure-retry / unchanged-baseline-zero-refresh, async git watch signatures, async extension error normalization, loader baseline ordering.
- Tested on macOS (unit) and Linux (measurements). Not run on Windows.

Docs updated: `docs/extensions.md`, `packages/hunk/skills/hunk-extensions/SKILL.md`, website extension-api / vcs-adapters pages. Changeset included.
