### PR TITLE
fix(watch): register directory watchers in yielding batches on Linux

### DIFF
--- a/.changeset/quiet-trees-recover.md
+++ b/.changeset/quiet-trees-recover.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep automatic refresh working on Linux after deleting and recreating nested directories.

--- a/.changeset/quiet-watch-batches.md
+++ b/.changeset/quiet-watch-batches.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Watch mode registers directory watchers in small batches so large repositories stay responsive during the first interaction on Linux.

--- a/packages/hunk/src/core/watch/controller.test.ts
+++ b/packages/hunk/src/core/watch/controller.test.ts
@@ -87,6 +87,10 @@ function fakeSource() {
     ready() {
       callbacks.onReady?.();
     },
+    /** Report one chunk of startup progress from a still-registering source. */
+    progress() {
+      callbacks.onProgress?.();
+    },
     get closes() {
       return closes;
     },
@@ -378,6 +382,173 @@ describe("createWatchController", () => {
     clock.advance(2_000);
     await settle();
     expect(checks).toBe(2);
+  });
+
+  test("extends the startup deadline while a slow source keeps reporting progress", async () => {
+    const clock = new FakeWatchClock();
+    const source = fakeSource();
+    const errors: unknown[] = [];
+    let checks = 0;
+    const controller = createWatchController({
+      initialSignature: "same",
+      clock,
+      createEventSource: source.create,
+      getSignature: () => (++checks, "same"),
+      refresh: () => {},
+      reportError: (error) => errors.push(error),
+    });
+
+    // Six 1.5 s gaps carry startup past the original 2 s deadline without ever going silent.
+    for (let chunk = 0; chunk < 6; chunk += 1) {
+      clock.advance(1_500);
+      source.progress();
+      expect(controller.getState().degraded).toBe(false);
+      expect(source.closes).toBe(0);
+    }
+    expect(clock.now()).toBeGreaterThan(2_000);
+    expect(errors).toEqual([]);
+
+    source.ready();
+    await settle();
+    expect(checks).toBe(1);
+    clock.advance(2_000);
+    await settle();
+    expect(controller.getState().degraded).toBe(false);
+    expect(source.closes).toBe(0);
+    // Readiness stays a single signal even after a long progress-extended startup.
+    expect(checks).toBe(1);
+  });
+
+  test("degrades two seconds after the last startup progress report", async () => {
+    const clock = new FakeWatchClock();
+    const source = fakeSource();
+    const errors: unknown[] = [];
+    const controller = createWatchController({
+      initialSignature: "same",
+      clock,
+      createEventSource: source.create,
+      getSignature: () => "same",
+      refresh: () => {},
+      reportError: (error) => errors.push(error),
+    });
+
+    clock.advance(1_500);
+    source.progress();
+    clock.advance(1_500);
+    source.progress();
+    const stalledAt = clock.now();
+
+    clock.advance(1_999);
+    expect(controller.getState().degraded).toBe(false);
+    expect(source.closes).toBe(0);
+    clock.advance(1);
+    expect(clock.now()).toBe(stalledAt + 2_000);
+    expect(controller.getState().degraded).toBe(true);
+    expect(source.closes).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_CODE });
+  });
+
+  test("does not let ordinary filesystem events extend the startup deadline", async () => {
+    const clock = new FakeWatchClock();
+    const source = fakeSource();
+    const errors: unknown[] = [];
+    const controller = createWatchController({
+      initialSignature: "same",
+      clock,
+      createEventSource: source.create,
+      getSignature: () => "same",
+      refresh: () => {},
+      reportError: (error) => errors.push(error),
+    });
+
+    // Events are change hints, not evidence that registration is still advancing.
+    clock.advance(500);
+    source.event();
+    clock.advance(500);
+    source.event();
+    clock.advance(999);
+    await settle();
+    expect(controller.getState().degraded).toBe(false);
+    clock.advance(1);
+    await settle();
+    expect(clock.now()).toBe(2_000);
+    expect(controller.getState().degraded).toBe(true);
+    expect(source.closes).toBe(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_CODE });
+  });
+
+  test("ignores progress reported after degradation, readiness, or close", async () => {
+    const clock = new FakeWatchClock();
+    const degradedSource = fakeSource();
+    const degradedErrors: unknown[] = [];
+    const degraded = createWatchController({
+      initialSignature: "same",
+      clock,
+      createEventSource: degradedSource.create,
+      getSignature: () => "same",
+      refresh: () => {},
+      reportError: (error) => degradedErrors.push(error),
+      startupTimeoutMs: 500,
+    });
+
+    clock.advance(500);
+    expect(degraded.getState().degraded).toBe(true);
+    degradedSource.progress();
+    degradedSource.ready();
+    clock.advance(10_000);
+    await settle();
+    // Late progress cannot revive the closed source or clear the degraded fallback.
+    expect(degraded.getState().degraded).toBe(true);
+    expect(degradedSource.closes).toBe(1);
+    expect(degradedErrors).toHaveLength(1);
+    degraded.close();
+
+    const readyClock = new FakeWatchClock();
+    const readySource = fakeSource();
+    let readyChecks = 0;
+    const ready = createWatchController({
+      initialSignature: "same",
+      clock: readyClock,
+      createEventSource: readySource.create,
+      getSignature: () => (++readyChecks, "same"),
+      refresh: () => {},
+      startupTimeoutMs: 500,
+    });
+
+    readySource.ready();
+    await settle();
+    expect(readyChecks).toBe(1);
+    readySource.progress();
+    readyClock.advance(9_999);
+    await settle();
+    // Progress after readiness neither reopens startup nor forces an extra check.
+    expect(readyChecks).toBe(1);
+    expect(ready.getState().degraded).toBe(false);
+    expect(readySource.closes).toBe(0);
+    ready.close();
+
+    const closedClock = new FakeWatchClock();
+    const closedSource = fakeSource();
+    const closedErrors: unknown[] = [];
+    const closed = createWatchController({
+      initialSignature: "same",
+      clock: closedClock,
+      createEventSource: closedSource.create,
+      getSignature: () => "same",
+      refresh: () => {},
+      reportError: (error) => closedErrors.push(error),
+      startupTimeoutMs: 500,
+    });
+
+    closed.close();
+    closedSource.progress();
+    closedClock.advance(10_000);
+    await settle();
+    expect(closedErrors).toEqual([]);
+    expect(closedSource.closes).toBe(1);
+    expect(closedClock.timers.size).toBe(0);
   });
 
   test("accepts readiness just before an injected startup deadline", async () => {

--- a/packages/hunk/src/core/watch/controller.ts
+++ b/packages/hunk/src/core/watch/controller.ts
@@ -20,6 +20,12 @@ export interface WatchEventSourceCallbacks {
   onEvent(): void;
   onError(error: unknown): void;
   onReady?(): void;
+  /**
+   * Report that startup is still advancing (for example one more directory registered) so a
+   * large tree keeps its watcher instead of timing out on total startup duration. Progress only
+   * matters while the source is still starting; readiness is still signalled once via onReady.
+   */
+  onProgress?(): void;
 }
 
 export const DEFAULT_WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_MS = 2_000;
@@ -75,10 +81,15 @@ function getErrorKey(error: unknown) {
   return String(error);
 }
 
-/** Build the stable diagnostic reported when an event source cannot establish readiness. */
+/**
+ * Build the stable diagnostic reported when an event source stops making startup progress.
+ * The deadline measures the gap since the last progress report, not total startup duration.
+ */
 function createEventSourceStartupTimeoutError(timeoutMs: number) {
   return Object.assign(
-    new Error(`The watch event source did not become ready within ${timeoutMs} ms.`),
+    new Error(
+      `The watch event source made no startup progress for ${timeoutMs} ms and did not become ready.`,
+    ),
     {
       code: WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_CODE,
       name: "WatchEventSourceStartupTimeoutError",
@@ -283,6 +294,17 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
     void beginCheck();
   };
 
+  /**
+   * Extend the startup deadline while the source is still registering.
+   * Progress after readiness, closure, or degradation cannot revive a settled source, and it
+   * never substitutes for the single onReady signal that ends startup.
+   */
+  const onSourceProgress = () => {
+    if (state.phase === "closed" || sourceStatus !== "starting") return;
+    startupDeadline = clock.now() + startupTimeoutMs;
+    schedule();
+  };
+
   /** Degrade only for watcher resource exhaustion; other source errors stay nonfatal. */
   const onSourceError = (error: unknown) => {
     if (state.phase === "closed" || sourceStatus === "closed") return;
@@ -303,6 +325,8 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
   safetyDeadline = clock.now() + safetyInterval();
   if (options.createEventSource && !options.pollOnly) {
     sourceStatus = "starting";
+    // The deadline bounds silence, not total startup: each onProgress report pushes it forward so
+    // a deep tree that keeps registering directories is never mistaken for a stalled watcher.
     startupDeadline = clock.now() + startupTimeoutMs;
     // This JS timer is a secondary guard: FSEvents lock contention can also delay timers, so
     // bounded native registration remains the primary macOS protection.
@@ -312,6 +336,7 @@ export function createWatchController(options: WatchControllerOptions): WatchCon
         onEvent,
         onError: onSourceError,
         onReady: onSourceReady,
+        onProgress: onSourceProgress,
       });
       if (isSourceClosed()) createdSource.close();
       else eventSource = createdSource;

--- a/packages/hunk/src/core/watch/observer.fs.test.ts
+++ b/packages/hunk/src/core/watch/observer.fs.test.ts
@@ -245,6 +245,54 @@ describe("filesystem watch observer", () => {
     );
   });
 
+  // Exercise inotify re-registration rather than native recursive backends.
+  for (const scenario of ["initial", "runtime", "new-child", "rename"] as const) {
+    test.skipIf(process.platform !== "linux")(
+      `portable batches observe writes after intermediate directory recreation (${scenario})`,
+      async () => {
+        const parent = await temporaryDirectory();
+        const directory = join(parent, "root");
+        const intermediate = join(directory, "a");
+        const nested = join(intermediate, "b");
+        await mkdir(directory);
+        if (scenario !== "runtime") {
+          await mkdir(nested, { recursive: true });
+          await writeFile(join(nested, "file"), "before");
+        }
+        const source = await startObserver({
+          coverage: "hybrid",
+          targets: [{ kind: "directory-tree", directory, ignoredRoots: [], sources: ["worktree"] }],
+        });
+        if (scenario === "runtime") {
+          await mkdir(nested, { recursive: true });
+          await writeFile(join(nested, "file"), "before");
+          await new Promise((resolve) => setTimeout(resolve, ABSENCE_MS));
+        }
+        const moved = join(parent, "moved");
+        if (scenario === "rename") await rename(intermediate, moved);
+        else await rm(intermediate, { recursive: true });
+        // Let unlinkDir retire the old inode before recreating the same pathname.
+        await new Promise((resolve) => setTimeout(resolve, ABSENCE_MS));
+        if (scenario === "rename") await rename(moved, intermediate);
+        else await mkdir(nested, { recursive: true });
+        const destination = scenario === "new-child" ? join(intermediate, "c") : nested;
+        await mkdir(destination, { recursive: true });
+        // Discard earlier hints: both the subtree and intermediate inode must recover.
+        for (const file of [join(destination, "new-file"), join(intermediate, "direct-file")]) {
+          await new Promise((resolve) => setTimeout(resolve, ABSENCE_MS));
+          const beforeWrite = source.eventCount;
+          await writeFile(file, "after");
+          await bounded(
+            (async () => {
+              while (source.eventCount === beforeWrite)
+                await new Promise((resolve) => setTimeout(resolve, 5));
+            })(),
+          );
+        }
+      },
+    );
+  }
+
   test("does not refresh for excluded worktree metadata churn", async () => {
     const directory = await temporaryDirectory();
     const metadataDirectory = join(directory, ".git");

--- a/packages/hunk/src/core/watch/observer.fs.test.ts
+++ b/packages/hunk/src/core/watch/observer.fs.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { mkdtemp, mkdir, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { watch as chokidarWatch } from "chokidar";
 
 import { createWatchController } from "./controller";
 import { createWatchEventSource, createWatchObserver, type WatchObserver } from "./observer";
 import type { WatchPlan } from "./plan";
+import { createChunkedTreeWatcher } from "./portableTree";
 
 const WAIT_MS = 3_000;
 const ABSENCE_MS = 250;
@@ -47,21 +49,25 @@ function entriesPlan(directory: string, entries: string[]): WatchPlan {
 }
 
 /** Start an observer and expose queued events so mutations cannot race test listeners. */
-async function startObserver(plan: WatchPlan) {
+async function startObserver(plan: WatchPlan, platform = process.platform) {
   let eventCount = 0;
   let pendingEvents = 0;
   const waiters: Array<() => void> = [];
-  const observer = createWatchObserver(plan, {
-    onEvent() {
-      eventCount++;
-      const waiter = waiters.shift();
-      if (waiter) waiter();
-      else pendingEvents++;
+  const observer = createWatchObserver(
+    plan,
+    {
+      onEvent() {
+        eventCount++;
+        const waiter = waiters.shift();
+        if (waiter) waiter();
+        else pendingEvents++;
+      },
+      onError(error) {
+        throw error;
+      },
     },
-    onError(error) {
-      throw error;
-    },
-  });
+    { platform },
+  );
   cleanups.push(async () => {
     observer.close();
     await bounded(observer.closed);
@@ -266,6 +272,121 @@ describe("filesystem watch observer", () => {
       () => readFileSync(worktreeFile, "utf8"),
       () => writeFile(metadata, "after"),
     );
+  });
+
+  // Creating directory symlinks requires privileges not guaranteed on Windows CI.
+  test.skipIf(process.platform === "win32")(
+    "portable batches prune ignored and symlinked trees",
+    async () => {
+      const parent = await temporaryDirectory();
+      const directory = join(parent, "worktree");
+      const ignored = join(directory, "node_modules");
+      const external = join(parent, "external");
+      await mkdir(ignored, { recursive: true });
+      await mkdir(external);
+      await writeFile(join(ignored, "dependency.ts"), "before");
+      await writeFile(join(external, "external.ts"), "before");
+      await symlink(external, join(directory, "linked"), "dir");
+      const source = await startObserver(
+        {
+          coverage: "hybrid",
+          targets: [
+            { kind: "directory-tree", directory, ignoredRoots: [ignored], sources: ["worktree"] },
+          ],
+        },
+        "linux",
+      );
+      const initialEvents = source.eventCount;
+      await writeFile(join(ignored, "dependency.ts"), "after");
+      await writeFile(join(external, "external.ts"), "after");
+      await new Promise((resolve) => setTimeout(resolve, ABSENCE_MS));
+      expect(source.eventCount).toBe(initialEvents);
+      await mkdir(join(directory, "new", "nested"), { recursive: true });
+      await bounded(source.nextEvent());
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const afterCreation = source.eventCount;
+      await writeFile(join(directory, "new", "nested", "file.ts"), "after");
+      await bounded(
+        (async () => {
+          while (source.eventCount === afterCreation)
+            await new Promise((resolve) => setTimeout(resolve, 5));
+        })(),
+      );
+    },
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "a portable symlink root does not traverse its referent",
+    async () => {
+      const parent = await temporaryDirectory();
+      const external = join(parent, "external");
+      const directory = join(parent, "linked");
+      await mkdir(join(external, "nested"), { recursive: true });
+      const file = join(external, "nested", "file.ts");
+      await writeFile(file, "before");
+      await symlink(external, directory, "dir");
+      const admitted: string[] = [];
+      const source = createChunkedTreeWatcher(
+        directory,
+        () => false,
+        () => {},
+        {
+          watch(paths, options) {
+            admitted.push(...(typeof paths === "string" ? [paths] : paths));
+            return chokidarWatch(paths, options);
+          },
+        },
+      );
+      cleanups.push(() => bounded(source.close()));
+      await bounded(new Promise<void>((resolveReady) => source.whenReady(resolveReady)));
+      await writeFile(file, "after");
+      await new Promise((resolve) => setTimeout(resolve, ABSENCE_MS));
+      // A symlink-root watcher can emit conservative hints from its parent. Assert the
+      // traversal boundary, not absence of hints from that public Chokidar fallback.
+      expect(admitted).toEqual([directory]);
+    },
+  );
+
+  test("portable observation recovers a missing root without recursively watching its parent", async () => {
+    const parent = await temporaryDirectory();
+    const directory = join(parent, "missing");
+    const errors: unknown[] = [];
+    let events = 0;
+    const observer = createWatchObserver(
+      {
+        coverage: "hybrid",
+        targets: [{ kind: "directory-tree", directory, ignoredRoots: [], sources: ["worktree"] }],
+      },
+      {
+        onEvent() {
+          events++;
+        },
+        onError(error) {
+          errors.push(error);
+        },
+      },
+      { platform: "linux" },
+    );
+    cleanups.push(async () => {
+      observer.close();
+      await bounded(observer.closed);
+    });
+    await bounded(observer.ready);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: "ENOENT" });
+    for (let index = 0; index < 2; index++) {
+      await mkdir(join(directory, "nested"), { recursive: true });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const beforeWrite = events;
+      await writeFile(join(directory, "nested", "file.ts"), "content");
+      await bounded(
+        (async () => {
+          while (events === beforeWrite) await new Promise((resolve) => setTimeout(resolve, 5));
+        })(),
+      );
+      await rm(directory, { recursive: true });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
   });
 
   test("close releases handles and suppresses later events", async () => {

--- a/packages/hunk/src/core/watch/observer.test.ts
+++ b/packages/hunk/src/core/watch/observer.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { join } from "node:path";
+import { statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { FSWatcher, type ChokidarOptions } from "chokidar";
 
 import { createWatchTestClock } from "../../../../../test/helpers/watchTest";
 import { createWatchController, WATCH_EVENT_SOURCE_STARTUP_TIMEOUT_CODE } from "./controller";
@@ -10,6 +12,11 @@ import {
   type WatchTreeBackend,
 } from "./observer";
 import type { DirectoryTreeWatchTarget, WatchPlan } from "./plan";
+import {
+  createChunkedTreeWatcher,
+  PORTABLE_TREE_BATCH_SIZE,
+  type PortableTreeRuntime,
+} from "./portableTree";
 
 /** Build one neutral recursive target for backend and event-filter tests. */
 function treeTarget(directory = "/repo"): DirectoryTreeWatchTarget {
@@ -188,6 +195,25 @@ describe("native recursive tree watcher", () => {
     expect(events).toBe(4);
   });
 
+  test("cached ancestor decisions preserve ignored boundaries after bounded-cache eviction", () => {
+    const directory = resolve("watch-test-root");
+    let emit!: (filename: string | Buffer | null) => void;
+    let events = 0;
+    const source = createNativeTreeWatcher(
+      { ...treeTarget(directory), ignoredRoots: [join(directory, "src", "ignored")] },
+      () => events++,
+      (_directory, onChange) => {
+        emit = onChange;
+        return { close() {}, onError() {} };
+      },
+    );
+    for (let index = 0; index < 8_200; index++) emit(join("src", `file-${index}.ts`));
+    emit(join("src", "ignored", "file.ts"));
+    emit(join("src", "ignored-sibling", "file.ts"));
+    expect(events).toBe(8_201);
+    source.close();
+  });
+
   test("forwards errors and releases its native handle", () => {
     let reportError!: (error: unknown) => void;
     let closes = 0;
@@ -212,5 +238,361 @@ describe("native recursive tree watcher", () => {
 
     expect(errors).toEqual([error]);
     expect(closes).toBe(1);
+  });
+});
+
+/** Drain the bounded promise chain of one batch without advancing its admission timer. */
+async function settleTestBatch() {
+  for (let index = 0; index < 24; index++) await Promise.resolve();
+}
+
+/** Control public Chokidar events, directory reads, and individual admission macrotasks. */
+function createTestPortableTree() {
+  const root = resolve("watch-test-root");
+  const directories = new Map<string, string[]>();
+  const tasks = new Set<() => void>();
+  const batches: Array<{
+    paths: string[];
+    watcher: FSWatcher;
+    options?: ChokidarOptions;
+    closes: number;
+  }> = [];
+  const reads: string[] = [];
+  const runtime: PortableTreeRuntime = {
+    watch(paths, options) {
+      // Empty FSWatcher instances exercise only public events and never register real paths.
+      const watcher = new FSWatcher(options);
+      const batch = {
+        paths: typeof paths === "string" ? [paths] : paths,
+        watcher,
+        options,
+        closes: 0,
+      };
+      const close = watcher.close.bind(watcher);
+      watcher.close = () => {
+        batch.closes++;
+        return close();
+      };
+      batches.push(batch);
+      return watcher;
+    },
+    async readDirectories(path) {
+      reads.push(path);
+      return directories.get(path) ?? [];
+    },
+    schedule(callback) {
+      tasks.add(callback);
+      return () => {
+        tasks.delete(callback);
+      };
+    },
+  };
+  return {
+    root,
+    directories,
+    tasks,
+    batches,
+    reads,
+    runtime,
+    async advanceBatch() {
+      const callback = tasks.values().next().value;
+      if (!callback) throw new Error("No queued test batch");
+      tasks.delete(callback);
+      callback();
+      await settleTestBatch();
+    },
+    async ready(index: number) {
+      batches[index]!.watcher.emit("ready");
+      await settleTestBatch();
+    },
+  };
+}
+
+describe("portable tree batches", () => {
+  test("yields between bounded shallow batches and reports ready only after nested discovery", async () => {
+    const fixture = createTestPortableTree();
+    const children = Array.from({ length: PORTABLE_TREE_BATCH_SIZE + 1 }, (_, index) =>
+      join(fixture.root, `d${index}`),
+    );
+    const nested = join(children[0]!, "nested");
+    const ignored = join(fixture.root, "ignored");
+    fixture.directories.set(fixture.root, [...children, ignored]);
+    fixture.directories.set(children[0]!, [nested]);
+    let ready = 0;
+    let progress = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      (path) => path === ignored,
+      () => {},
+      fixture.runtime,
+    );
+    source.whenReady(() => ready++);
+    source.onProgress(() => progress++);
+    try {
+      expect(fixture.batches).toHaveLength(0);
+      await fixture.advanceBatch();
+      expect(fixture.batches[0]!.paths).toEqual([fixture.root]);
+      expect(fixture.batches[0]!.options).toMatchObject({
+        depth: 0,
+        followSymlinks: false,
+        ignoreInitial: true,
+      });
+      await fixture.ready(0);
+      expect(progress).toBe(1);
+      expect(ready).toBe(0);
+      expect(fixture.batches).toHaveLength(1);
+      await fixture.advanceBatch();
+      expect(fixture.batches[1]!.paths).toEqual(children.slice(0, PORTABLE_TREE_BATCH_SIZE));
+      await fixture.ready(1);
+      expect(ready).toBe(0);
+      await fixture.advanceBatch();
+      expect(fixture.batches[2]!.paths).toEqual([children.at(-1)!, nested]);
+      await fixture.ready(2);
+      expect(ready).toBe(1);
+      expect(progress).toBe(3);
+      expect(fixture.tasks.size).toBe(0);
+      expect(fixture.reads).not.toContain(ignored);
+    } finally {
+      await source.close();
+    }
+    expect(fixture.batches.map((batch) => batch.closes)).toEqual([1, 1, 1]);
+  });
+
+  test("a wholly ignored root reaches ready without creating a watcher", async () => {
+    const fixture = createTestPortableTree();
+    let ready = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => true,
+      () => {},
+      fixture.runtime,
+    );
+    source.whenReady(() => ready++);
+    await fixture.advanceBatch();
+    expect(ready).toBe(1);
+    expect(fixture.batches).toHaveLength(0);
+    expect(fixture.reads).toHaveLength(0);
+    await source.close();
+    source.whenReady(() => ready++);
+    await settleTestBatch();
+    expect(ready).toBe(1);
+  });
+
+  test("close cancels queued admission before any watcher exists", async () => {
+    const fixture = createTestPortableTree();
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => {},
+      fixture.runtime,
+    );
+    const closing = source.close();
+    expect(source.close()).toBe(closing);
+    await closing;
+    expect(fixture.tasks.size).toBe(0);
+    expect(fixture.batches).toHaveLength(0);
+  });
+
+  test("close settles a drain awaiting batch ready and suppresses late callbacks", async () => {
+    const fixture = createTestPortableTree();
+    let callbacks = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => callbacks++,
+      fixture.runtime,
+    );
+    source.whenReady(() => callbacks++);
+    source.onProgress(() => callbacks++);
+    await fixture.advanceBatch();
+    const watcher = fixture.batches[0]!.watcher;
+    expect(watcher.listenerCount("ready")).toBe(1);
+    await source.close();
+    watcher.emit("ready");
+    watcher.emit("all", "addDir", join(fixture.root, "late"));
+    await settleTestBatch();
+    expect(watcher.listenerCount("ready")).toBe(0);
+    expect(callbacks).toBe(0);
+    expect(fixture.reads).toHaveLength(0);
+    expect(fixture.tasks.size).toBe(0);
+    expect(fixture.batches[0]!.closes).toBe(1);
+  });
+
+  test("close does not wait for an outstanding directory read or admit its late children", async () => {
+    const fixture = createTestPortableTree();
+    let finishRead!: (children: string[]) => void;
+    fixture.runtime.readDirectories = () =>
+      new Promise((resolveRead) => {
+        finishRead = resolveRead;
+      });
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => {},
+      fixture.runtime,
+    );
+    await fixture.advanceBatch();
+    await fixture.ready(0);
+    await source.close();
+    finishRead([join(fixture.root, "late")]);
+    await settleTestBatch();
+    expect(fixture.tasks.size).toBe(0);
+    expect(fixture.batches).toHaveLength(1);
+    expect(fixture.batches[0]!.closes).toBe(1);
+  });
+
+  test("an enumeration error is reported without stranding final readiness", async () => {
+    const fixture = createTestPortableTree();
+    const error = Object.assign(new Error("read failed"), { code: "EACCES" });
+    fixture.runtime.readDirectories = async () => {
+      throw error;
+    };
+    const errors: unknown[] = [];
+    let ready = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => {},
+      fixture.runtime,
+    );
+    source.onError((error) => errors.push(error));
+    source.whenReady(() => ready++);
+    await fixture.advanceBatch();
+    await fixture.ready(0);
+    expect(errors).toEqual([error]);
+    expect(ready).toBe(1);
+    await source.close();
+  });
+
+  test.each(["ENOSPC", "EMFILE", "EACCES"])(
+    "a mid-batch %s error reaches polling fallback and cancels the drain",
+    async (code) => {
+      const fixture = createTestPortableTree();
+      const clock = createWatchTestClock();
+      let source!: ReturnType<typeof createChunkedTreeWatcher>;
+      let observer!: ReturnType<typeof createWatchObserver>;
+      const backend: WatchTreeBackend = (_target, onEvent) => {
+        source = createChunkedTreeWatcher(fixture.root, () => false, onEvent, fixture.runtime);
+        return source;
+      };
+      const errors: unknown[] = [];
+      const controller = createWatchController({
+        initialSignature: "same",
+        getSignature: () => "same",
+        refresh() {},
+        clock: clock.clock,
+        reportError: (error) => errors.push(error),
+        createEventSource(callbacks) {
+          observer = createWatchObserver(
+            { coverage: "hybrid", targets: [treeTarget(fixture.root)] },
+            callbacks,
+            { platform: "linux", treeBackends: { native: backend, portable: backend } },
+          );
+          return observer;
+        },
+      });
+      await fixture.advanceBatch();
+      fixture.batches[0]!.watcher.emit("error", Object.assign(new Error("watch failed"), { code }));
+      // Non-resource errors retain the no-progress deadline rather than declaring partial ready.
+      if (code === "EACCES") {
+        expect(controller.getState().degraded).toBe(false);
+        clock.advanceBy(2_000);
+      }
+      await observer.closed;
+      await source.close();
+      expect(controller.getState().degraded).toBe(true);
+      expect(fixture.batches[0]!.closes).toBe(1);
+      expect(fixture.tasks.size).toBe(0);
+      expect(errors[0]).toMatchObject({ code });
+      controller.close();
+    },
+  );
+
+  test("runtime addDir duplicates share one admission and removed batches can be recreated", async () => {
+    const fixture = createTestPortableTree();
+    let events = 0;
+    let ready = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => events++,
+      fixture.runtime,
+    );
+    source.whenReady(() => ready++);
+    await fixture.advanceBatch();
+    await fixture.ready(0);
+    const parent = fixture.batches[0]!.watcher;
+    const child = join(fixture.root, "new");
+    parent.emit("all", "addDir", child);
+    parent.emit("all", "addDir", child);
+    await fixture.advanceBatch();
+    expect(fixture.batches[1]!.paths).toEqual([child]);
+    parent.emit("all", "addDir", child);
+    await fixture.ready(1);
+    expect(fixture.batches).toHaveLength(2);
+    expect(fixture.tasks.size).toBe(0);
+    expect(events).toBe(5); // Three events, one new admission, and the population-race hint.
+    expect(ready).toBe(1);
+    fixture.batches[1]!.watcher.emit("all", "unlinkDir", child);
+    await settleTestBatch();
+    expect(fixture.batches[1]!.closes).toBe(1);
+    parent.emit("all", "addDir", child);
+    await fixture.advanceBatch();
+    await fixture.ready(2);
+    expect(fixture.batches[2]!.paths).toEqual([child]);
+    await source.close();
+    expect(fixture.batches.map((batch) => batch.closes)).toEqual([1, 1, 1]);
+  });
+
+  test("the public directory filter queues runtime children once without admitting ignored or outside paths", async () => {
+    const fixture = createTestPortableTree();
+    const ignored = join(fixture.root, "ignored");
+    let events = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      (path) => path === ignored,
+      () => events++,
+      fixture.runtime,
+    );
+    await fixture.advanceBatch();
+    await fixture.ready(0);
+    const filter = fixture.batches[0]!.options!.ignored;
+    if (typeof filter !== "function") throw new Error("Expected a public ignored predicate");
+    const stats = statSync(process.cwd());
+    const child = join(fixture.root, "new");
+    expect(filter(child, stats)).toBe(true);
+    expect(filter(child, stats)).toBe(true);
+    expect(filter(ignored, stats)).toBe(true);
+    // Missing-root fallback can inspect its parent, but must never recursively queue it.
+    expect(filter(dirname(fixture.root), stats)).toBe(false);
+    fixture.batches[0]!.watcher.emit("all", "addDir", dirname(fixture.root));
+    expect(fixture.tasks.size).toBe(1);
+    expect(events).toBe(2);
+    await fixture.advanceBatch();
+    expect(fixture.batches[1]!.paths).toEqual([child]);
+    await fixture.ready(1);
+    await source.close();
+  });
+
+  test("removing a batch before ready unblocks its drain and releases it once", async () => {
+    const fixture = createTestPortableTree();
+    fixture.runtime.readDirectories = async () => {
+      throw Object.assign(new Error("removed"), { code: "ENOENT" });
+    };
+    let ready = 0;
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => {},
+      fixture.runtime,
+    );
+    source.onError(() => {});
+    source.whenReady(() => ready++);
+    await fixture.advanceBatch();
+    fixture.batches[0]!.watcher.emit("all", "unlinkDir", fixture.root);
+    await settleTestBatch();
+    expect(ready).toBe(1);
+    await source.close();
+    expect(fixture.batches[0]!.closes).toBe(1);
   });
 });

--- a/packages/hunk/src/core/watch/observer.test.ts
+++ b/packages/hunk/src/core/watch/observer.test.ts
@@ -544,6 +544,120 @@ describe("portable tree batches", () => {
     expect(fixture.batches.map((batch) => batch.closes)).toEqual([1, 1, 1]);
   });
 
+  test.each(["parent", "owner"] as const)(
+    "%s unlinkDir invalidates descendant batches and queued children without reusing stale owners",
+    async (origin) => {
+      const fixture = createTestPortableTree();
+      const child = join(fixture.root, "a");
+      const nested = join(child, "b");
+      const queued = join(nested, "queued");
+      const sibling = join(fixture.root, "ab");
+      fixture.directories.set(fixture.root, [child, sibling]);
+      fixture.directories.set(child, [nested]);
+      let events = 0;
+      const source = createChunkedTreeWatcher(
+        fixture.root,
+        () => false,
+        () => events++,
+        fixture.runtime,
+      );
+      try {
+        await fixture.advanceBatch();
+        await fixture.ready(0);
+        await fixture.advanceBatch();
+        await fixture.ready(1);
+        await fixture.advanceBatch();
+        await fixture.ready(2);
+        fixture.batches[2]!.watcher.emit("all", "addDir", queued);
+        // No descendant unlinkDir events are required to invalidate their ownership.
+        fixture.batches[origin === "parent" ? 0 : 1]!.watcher.emit("all", "unlinkDir", child);
+        await settleTestBatch();
+        expect(fixture.batches.map((batch) => batch.closes)).toEqual([0, 1, 1]);
+        const afterRemoval = events;
+        fixture.batches[2]!.watcher.emit("all", "addDir", queued);
+        const retiredFilter = fixture.batches[2]!.options!.ignored;
+        if (typeof retiredFilter !== "function") throw new Error("Expected an ignored predicate");
+        expect(retiredFilter(queued, statSync(process.cwd()))).toBe(true);
+        expect(events).toBe(afterRemoval);
+        await fixture.advanceBatch();
+        expect(fixture.batches[3]!.paths).toEqual([sibling]);
+        await fixture.ready(3);
+        fixture.batches[0]!.watcher.emit("all", "addDir", child);
+        fixture.batches[0]!.watcher.emit("all", "addDir", child);
+        await fixture.advanceBatch();
+        expect(fixture.batches[4]!.paths).toEqual([child]);
+        await fixture.ready(4);
+        await fixture.advanceBatch();
+        expect(fixture.batches[5]!.paths).toEqual([nested]);
+        await fixture.ready(5);
+        expect(fixture.tasks.size).toBe(0);
+      } finally {
+        await source.close();
+      }
+      expect(fixture.batches.every((batch) => batch.closes === 1)).toBe(true);
+    },
+  );
+
+  test("a removed anchor discovers the replacement root without owning its new inode", async () => {
+    const fixture = createTestPortableTree();
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => {},
+      fixture.runtime,
+    );
+    try {
+      await fixture.advanceBatch();
+      await fixture.ready(0);
+      const anchor = fixture.batches[0]!;
+      anchor.watcher.emit("all", "unlinkDir", fixture.root);
+      const filter = anchor.options!.ignored;
+      if (typeof filter !== "function") throw new Error("Expected an ignored predicate");
+      expect(filter(fixture.root, statSync(process.cwd()))).toBe(true);
+      anchor.watcher.emit("all", "addDir", fixture.root);
+      await fixture.advanceBatch();
+      await fixture.ready(1);
+      expect(fixture.batches[1]!.paths).toEqual([fixture.root]);
+      expect(filter(fixture.root, statSync(process.cwd()))).toBe(true);
+      expect(fixture.tasks.size).toBe(0);
+      expect(anchor.closes).toBe(0);
+    } finally {
+      await source.close();
+    }
+    expect(fixture.batches.map((batch) => batch.closes)).toEqual([1, 1]);
+  });
+
+  test("subtree invalidation discards an outstanding enumeration's late children", async () => {
+    const fixture = createTestPortableTree();
+    const child = join(fixture.root, "a");
+    let finishRead!: (children: string[]) => void;
+    fixture.runtime.readDirectories = async (path) =>
+      path === fixture.root
+        ? [child]
+        : new Promise((resolveRead) => {
+            finishRead = resolveRead;
+          });
+    const source = createChunkedTreeWatcher(
+      fixture.root,
+      () => false,
+      () => {},
+      fixture.runtime,
+    );
+    try {
+      await fixture.advanceBatch();
+      await fixture.ready(0);
+      await fixture.advanceBatch();
+      await fixture.ready(1);
+      fixture.batches[0]!.watcher.emit("all", "unlinkDir", child);
+      finishRead([join(child, "late")]);
+      await settleTestBatch();
+      expect(fixture.tasks.size).toBe(0);
+      expect(fixture.batches[1]!.closes).toBe(1);
+    } finally {
+      await source.close();
+    }
+  });
+
   test("the public directory filter queues runtime children once without admitting ignored or outside paths", async () => {
     const fixture = createTestPortableTree();
     const ignored = join(fixture.root, "ignored");
@@ -560,8 +674,8 @@ describe("portable tree batches", () => {
     if (typeof filter !== "function") throw new Error("Expected a public ignored predicate");
     const stats = statSync(process.cwd());
     const child = join(fixture.root, "new");
-    expect(filter(child, stats)).toBe(true);
-    expect(filter(child, stats)).toBe(true);
+    expect(filter(child, stats)).toBe(false);
+    expect(filter(child, stats)).toBe(false);
     expect(filter(ignored, stats)).toBe(true);
     // Missing-root fallback can inspect its parent, but must never recursively queue it.
     expect(filter(dirname(fixture.root), stats)).toBe(false);

--- a/packages/hunk/src/core/watch/observer.ts
+++ b/packages/hunk/src/core/watch/observer.ts
@@ -1,9 +1,15 @@
+/**
+ * Observe review inputs and forward event hints, startup progress, and final readiness.
+ * Native recursive paths remain platform-owned. Portable trees use separate depth-zero
+ * Chokidar batches for public ready boundaries; one wide directory's scan remains indivisible.
+ */
 import { watch as nativeFsWatch } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { watch as chokidarWatch, type ChokidarOptions, type FSWatcher } from "chokidar";
 
 import type { WatchEventSource, WatchEventSourceCallbacks } from "./controller";
 import type { DirectoryTreeWatchTarget, WatchPlan, WatchTarget } from "./plan";
+import { createChunkedTreeWatcher } from "./portableTree";
 
 export interface WatchObserver extends WatchEventSource {
   ready: Promise<void>;
@@ -14,6 +20,7 @@ export interface WatchRegistration {
   close(): void | Promise<void>;
   onError(callback: (error: unknown) => void): void;
   whenReady(callback: () => void): void;
+  onProgress?(callback: () => void): void;
 }
 
 export type WatchTreeBackend = (
@@ -53,17 +60,34 @@ function normalizedPath(path: string) {
   return process.platform === "win32" ? absolute.toLowerCase() : absolute;
 }
 
-/** Build an ancestor-set matcher whose cost depends on path depth, not ignored-root count. */
+/** Match immutable ignored roots without repeatedly walking shared ancestors during a scan. */
 function createIgnoredRootMatcher(ignoredRoots: string[]) {
   const roots = new Set(ignoredRoots.map(normalizedPath));
+  const decisions = new Map<string, boolean>();
   return (path: string) => {
     let current = normalizedPath(path);
+    const ancestors: string[] = [];
+    let ignored = false;
     for (;;) {
-      if (roots.has(current)) return true;
+      if (roots.has(current)) {
+        ignored = true;
+        break;
+      }
+      const cached = decisions.get(current);
+      if (cached !== undefined) {
+        ignored = cached;
+        break;
+      }
+      ancestors.push(current);
       const parent = dirname(current);
-      if (parent === current) return false;
+      if (parent === current) break;
       current = parent;
     }
+    // Root membership cannot change within a plan. Bound memoization so runtime file churn
+    // cannot retain every path ever observed; clearing it changes cost, never pruning policy.
+    if (decisions.size + ancestors.length > 8_192) decisions.clear();
+    for (const ancestor of ancestors) decisions.set(ancestor, ignored);
+    return ignored;
   };
 }
 
@@ -123,12 +147,7 @@ function createPortableTreeWatcher(
   onEvent: () => void,
 ): WatchRegistration {
   const isIgnored = createIgnoredRootMatcher(target.ignoredRoots);
-  const watcher = chokidarWatch(target.directory, {
-    ...WATCH_OPTIONS,
-    ignored: (path) => isIgnored(path),
-  });
-  watcher.on("all", onEvent);
-  return chokidarRegistration(watcher);
+  return createChunkedTreeWatcher(target.directory, isIgnored, onEvent);
 }
 
 const DEFAULT_TREE_BACKENDS = {
@@ -199,6 +218,7 @@ export function createWatchObserver(
   const markReady = () => {
     if (isClosed) return;
     remainingReady--;
+    callbacks.onProgress?.();
     if (remainingReady === 0) {
       resolveReady();
       callbacks.onReady?.();
@@ -211,6 +231,9 @@ export function createWatchObserver(
       registrations.push(registration);
       registration.onError((error) => {
         if (!isClosed) callbacks.onError(error);
+      });
+      registration.onProgress?.(() => {
+        if (!isClosed) callbacks.onProgress?.();
       });
       registration.whenReady(markReady);
     }

--- a/packages/hunk/src/core/watch/portableTree.ts
+++ b/packages/hunk/src/core/watch/portableTree.ts
@@ -1,0 +1,241 @@
+/**
+ * Observe portable trees in yielding batches while Chokidar normalizes file events and saves.
+ * Separate depth-zero watchers expose a public ready boundary for each batch; adding paths to
+ * an already-ready watcher does not. Depth zero bounds recursion, not a wide directory's own
+ * readdir/stat work: that remaining flat-directory burst is the accepted batching floor.
+ */
+import { lstat, readdir } from "node:fs/promises";
+import { join, resolve, sep } from "node:path";
+import { watch, type FSWatcher } from "chokidar";
+
+export const PORTABLE_TREE_BATCH_SIZE = 32;
+
+export interface PortableTreeRuntime {
+  watch: typeof watch;
+  readDirectories(directory: string): Promise<string[]>;
+  /** Schedule one macrotask and return its cancellation function. */
+  schedule(callback: () => void): () => void;
+}
+
+const defaultRuntime: PortableTreeRuntime = {
+  watch,
+  async readDirectories(directory) {
+    // Explicit roots and directories replaced during admission can themselves be symlinks.
+    // Match Chokidar's followSymlinks:false policy before enumerating their referents.
+    if (!(await lstat(directory)).isDirectory()) return [];
+    const entries = await readdir(directory, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(directory, entry.name));
+  },
+  schedule(callback) {
+    const timer = setTimeout(callback, 0);
+    return () => clearTimeout(timer);
+  },
+};
+
+/** Register existing and newly created directories without recursively admitting a subtree. */
+export function createChunkedTreeWatcher(
+  directory: string,
+  isIgnored: (path: string) => boolean,
+  onEvent: () => void,
+  runtimeOverrides: Partial<PortableTreeRuntime> = {},
+) {
+  const runtime = { ...defaultRuntime, ...runtimeOverrides };
+  const root = resolve(directory);
+  const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`;
+  const watchers = new Set<FSWatcher>();
+  const retiring = new Set<Promise<void>>();
+  const queued = new Set<string>();
+  const known = new Set<string>();
+  let anchor: FSWatcher | undefined;
+  let closed = false;
+  let ready = false;
+  let draining: Promise<void> | undefined;
+  let closing: Promise<void> | undefined;
+  let cancelTimer: (() => void) | undefined;
+  let cancelWork!: () => void;
+  const cancelled = new Promise<void>((resolveCancelled) => {
+    cancelWork = resolveCancelled;
+  });
+  let readyCallback: (() => void) | undefined;
+  let errorCallback: ((error: unknown) => void) | undefined;
+  let progressCallback: (() => void) | undefined;
+
+  /** Deduplicate parent enumeration and repeated runtime addDir discovery. */
+  function enqueue(path: string) {
+    path = resolve(path);
+    // Chokidar may observe a missing root's parent until the root is recreated. Never
+    // turn that conservative fallback into recursive coverage outside this target.
+    if (path !== root && !path.startsWith(rootPrefix)) return;
+    if (closed || isIgnored(path) || known.has(path)) return;
+    known.add(path);
+    queued.add(path);
+    schedule();
+    if (ready) onEvent();
+  }
+
+  /** Yield between batches instead of chaining directory traversal through microtasks. */
+  function schedule() {
+    if (closed || draining || cancelTimer) return;
+    cancelTimer = runtime.schedule(() => {
+      cancelTimer = undefined;
+      draining = drain()
+        .catch(reportError)
+        .finally(() => {
+          draining = undefined;
+          if (!closed && queued.size) schedule();
+        });
+    });
+  }
+
+  /** Forward errors without treating a partial or failed registration as scan completion. */
+  function reportError(error: unknown) {
+    if (!closed) errorCallback?.(error);
+  }
+
+  /** Complete one shallow scan, then enumerate its children for a later macrotask. */
+  async function drain() {
+    if (closed) return;
+    const paths: string[] = [];
+    for (const path of queued) {
+      queued.delete(path);
+      paths.push(path);
+      if (paths.length === PORTABLE_TREE_BATCH_SIZE) break;
+    }
+    if (paths.length) {
+      let watcher: FSWatcher;
+      const roots = new Set(paths);
+      try {
+        watcher = runtime.watch(paths, {
+          depth: 0,
+          ignoreInitial: true,
+          persistent: true,
+          followSymlinks: false,
+          usePolling: false,
+          awaitWriteFinish: false,
+          ignored(path, stats) {
+            if (isIgnored(path)) return true;
+            const normalized = resolve(path);
+            if (
+              stats?.isDirectory() &&
+              normalized.startsWith(rootPrefix) &&
+              !roots.has(normalized)
+            ) {
+              // Depth zero still stats each child twice unless it is pruned. Discover
+              // non-root directories through the public filter and admit them in a later
+              // batch instead; this also catches runtime creation without a raw-event hook.
+              enqueue(normalized);
+              return true;
+            }
+            return false;
+          },
+        });
+      } catch (error) {
+        // Without a registered batch there is no progress to report. The controller's
+        // inactivity deadline (or resource-exhaustion error) closes this partial observer.
+        queued.clear();
+        reportError(error);
+        return;
+      }
+      watchers.add(watcher);
+      anchor ??= watcher;
+      let markReady!: () => void;
+      const batchReady = new Promise<void>((resolveReady) => {
+        markReady = resolveReady;
+      });
+      watcher.once("ready", markReady);
+      watcher.on("error", reportError);
+      watcher.on("all", (event, path) => {
+        if (closed) return;
+        if (event === "addDir") enqueue(path);
+        if (event === "unlinkDir") {
+          known.delete(resolve(path));
+          queued.delete(resolve(path));
+          roots.delete(resolve(path));
+          if (roots.size === 0) {
+            // Keep the initial anchor: Chokidar may be watching a missing root's parent
+            // there. Retire later empty batches so runtime churn does not retain instances.
+            if (watcher !== anchor) {
+              watchers.delete(watcher);
+              const released = Promise.resolve()
+                .then(() => watcher.close())
+                .catch(reportError);
+              retiring.add(released);
+              void released.then(() => retiring.delete(released));
+            }
+            // Removal can race the initial scan. Enumeration reconciles missing paths;
+            // do not await a ready event from a batch whose roots have all disappeared.
+            markReady();
+          }
+        }
+        onEvent();
+      });
+      await Promise.race([batchReady, cancelled]);
+      watcher.off("ready", markReady);
+      if (closed) return;
+      if (!ready) progressCallback?.();
+      await Promise.race([
+        Promise.all(
+          paths.map(async (path) => {
+            try {
+              const children = await runtime.readDirectories(path);
+              for (const child of children) enqueue(child);
+            } catch (error) {
+              // A directory may disappear between Chokidar's scan and enumeration. Allow a
+              // later addDir to rediscover it; report other filesystem failures the same way.
+              known.delete(path);
+              reportError(error);
+            }
+          }),
+        ),
+        cancelled,
+      ]);
+    }
+    if (closed || queued.size) return;
+    if (!ready) {
+      ready = true;
+      readyCallback?.();
+    } else {
+      // Population can race queued registration; reconcile even if its first event was early.
+      onEvent();
+    }
+  }
+
+  enqueue(directory);
+  // A wholly ignored root still establishes an empty, ready registration.
+  schedule();
+  return {
+    /** Cancel queued/in-flight work before closing every constructed handle exactly once. */
+    close(): Promise<void> {
+      if (closing) return closing;
+      closed = true;
+      cancelTimer?.();
+      cancelTimer = undefined;
+      queued.clear();
+      known.clear();
+      cancelWork();
+      closing = Promise.all([
+        draining,
+        ...retiring,
+        ...[...watchers].map((watcher) => Promise.resolve().then(() => watcher.close())),
+      ]).then(() => {
+        watchers.clear();
+      });
+      return closing;
+    },
+    onError(callback: (error: unknown) => void) {
+      errorCallback = callback;
+    },
+    onProgress(callback: () => void) {
+      progressCallback = callback;
+    },
+    whenReady(callback: () => void) {
+      readyCallback = callback;
+      if (ready)
+        queueMicrotask(() => {
+          if (!closed) callback();
+        });
+    },
+  };
+}

--- a/packages/hunk/src/core/watch/portableTree.ts
+++ b/packages/hunk/src/core/watch/portableTree.ts
@@ -44,7 +44,10 @@ export function createChunkedTreeWatcher(
   const runtime = { ...defaultRuntime, ...runtimeOverrides };
   const root = resolve(directory);
   const rootPrefix = root.endsWith(sep) ? root : `${root}${sep}`;
-  const watchers = new Set<FSWatcher>();
+  const watchers = new Map<
+    FSWatcher,
+    { roots: Set<string>; markReady: () => void; active: boolean }
+  >();
   const retiring = new Set<Promise<void>>();
   const queued = new Set<string>();
   const known = new Set<string>();
@@ -73,6 +76,46 @@ export function createChunkedTreeWatcher(
     queued.add(path);
     schedule();
     if (ready) onEvent();
+  }
+
+  /** Forget a removed subtree and retire its owners before admitting replacement inodes. */
+  function invalidate(path: string) {
+    path = resolve(path);
+    const prefix = path.endsWith(sep) ? path : `${path}${sep}`;
+    const contains = (candidate: string) => candidate === path || candidate.startsWith(prefix);
+    for (const candidate of known) {
+      if (contains(candidate)) {
+        known.delete(candidate);
+        queued.delete(candidate);
+      }
+    }
+    for (const [watcher, batch] of watchers) {
+      if (![...batch.roots].some(contains)) continue;
+      if (watcher === anchor) {
+        // Preserve the missing-root parent fallback, but turn its old root into discovery
+        // only. A replacement batch owns the new inode and its file events.
+        batch.roots.clear();
+        batch.markReady();
+        continue;
+      }
+      watchers.delete(watcher);
+      batch.active = false;
+      batch.markReady();
+      // Chokidar unwatch(root) does not recursively close file handles. Retire the whole
+      // bounded batch, then re-admit surviving siblings instead of retaining stale owners.
+      for (const candidate of batch.roots) {
+        if (!contains(candidate)) {
+          known.delete(candidate);
+          enqueue(candidate);
+        }
+      }
+      batch.roots.clear();
+      const released = Promise.resolve()
+        .then(() => watcher.close())
+        .catch(reportError);
+      retiring.add(released);
+      void released.then(() => retiring.delete(released));
+    }
   }
 
   /** Yield between batches instead of chaining directory traversal through microtasks. */
@@ -106,6 +149,7 @@ export function createChunkedTreeWatcher(
     if (paths.length) {
       let watcher: FSWatcher;
       const roots = new Set(paths);
+      const batch = { roots, markReady: () => {}, active: true };
       try {
         watcher = runtime.watch(paths, {
           depth: 0,
@@ -115,18 +159,18 @@ export function createChunkedTreeWatcher(
           usePolling: false,
           awaitWriteFinish: false,
           ignored(path, stats) {
-            if (isIgnored(path)) return true;
+            if (closed || !batch.active || isIgnored(path)) return true;
             const normalized = resolve(path);
             if (
               stats?.isDirectory() &&
-              normalized.startsWith(rootPrefix) &&
+              (normalized === root || normalized.startsWith(rootPrefix)) &&
               !roots.has(normalized)
             ) {
-              // Depth zero still stats each child twice unless it is pruned. Discover
-              // non-root directories through the public filter and admit them in a later
-              // batch instead; this also catches runtime creation without a raw-event hook.
               enqueue(normalized);
-              return true;
+              // Keep child directory entries visible to depth-zero Chokidar so removing
+              // an intermediate directory emits unlinkDir, even when it contains no files.
+              // A removed anchor root only discovers replacements; it must not own them.
+              return paths.includes(normalized);
             }
             return false;
           },
@@ -138,37 +182,19 @@ export function createChunkedTreeWatcher(
         reportError(error);
         return;
       }
-      watchers.add(watcher);
       anchor ??= watcher;
       let markReady!: () => void;
       const batchReady = new Promise<void>((resolveReady) => {
         markReady = resolveReady;
       });
+      batch.markReady = markReady;
+      watchers.set(watcher, batch);
       watcher.once("ready", markReady);
       watcher.on("error", reportError);
       watcher.on("all", (event, path) => {
-        if (closed) return;
+        if (closed || !watchers.has(watcher)) return;
         if (event === "addDir") enqueue(path);
-        if (event === "unlinkDir") {
-          known.delete(resolve(path));
-          queued.delete(resolve(path));
-          roots.delete(resolve(path));
-          if (roots.size === 0) {
-            // Keep the initial anchor: Chokidar may be watching a missing root's parent
-            // there. Retire later empty batches so runtime churn does not retain instances.
-            if (watcher !== anchor) {
-              watchers.delete(watcher);
-              const released = Promise.resolve()
-                .then(() => watcher.close())
-                .catch(reportError);
-              retiring.add(released);
-              void released.then(() => retiring.delete(released));
-            }
-            // Removal can race the initial scan. Enumeration reconciles missing paths;
-            // do not await a ready event from a batch whose roots have all disappeared.
-            markReady();
-          }
-        }
+        if (event === "unlinkDir") invalidate(path);
         onEvent();
       });
       await Promise.race([batchReady, cancelled]);
@@ -178,13 +204,16 @@ export function createChunkedTreeWatcher(
       await Promise.race([
         Promise.all(
           paths.map(async (path) => {
+            if (!roots.has(path)) return;
             try {
               const children = await runtime.readDirectories(path);
+              if (!roots.has(path)) return;
               for (const child of children) enqueue(child);
             } catch (error) {
+              if (!roots.has(path)) return;
               // A directory may disappear between Chokidar's scan and enumeration. Allow a
               // later addDir to rediscover it; report other filesystem failures the same way.
-              known.delete(path);
+              invalidate(path);
               reportError(error);
             }
           }),
@@ -218,7 +247,7 @@ export function createChunkedTreeWatcher(
       closing = Promise.all([
         draining,
         ...retiring,
-        ...[...watchers].map((watcher) => Promise.resolve().then(() => watcher.close())),
+        ...[...watchers.keys()].map((watcher) => Promise.resolve().then(() => watcher.close())),
       ]).then(() => {
         watchers.clear();
       });

--- a/test/pty/watch-start-integration.test.ts
+++ b/test/pty/watch-start-integration.test.ts
@@ -1,0 +1,183 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { stripVTControlCharacters } from "node:util";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const acknowledgement = "\x1b]777;hunk-watch-first-key-ack\x07";
+
+/** Build a warm-index checkout without hiding watcher cost behind a large dirty diff. */
+function createTestFirstInteractionWatchFixture(directory: string) {
+  const git = (args: string[], allowed = [0]) => {
+    const result = spawnSync("git", args, {
+      cwd: directory,
+      encoding: "utf8",
+      timeout: 2_000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: "0", GIT_EDITOR: "true" },
+    });
+    if (!allowed.includes(result.status ?? -1)) throw new Error(result.stderr);
+  };
+  git(["init", "-q"]);
+  writeFileSync(join(directory, ".gitignore"), "node_modules/\n");
+  for (let branch = 0; branch < 20; branch++) {
+    let child = join(directory, `b${branch}`);
+    for (let depth = 0; depth < 100; depth++) {
+      mkdirSync(child);
+      writeFileSync(join(child, "file.txt"), "before\n");
+      child = join(child, "d");
+    }
+  }
+  git(["add", "."]);
+  git([
+    "-c",
+    "user.name=Hunk Test",
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "-qm",
+    "fixture",
+  ]);
+  writeFileSync(join(directory, "b0", "file.txt"), "after\n");
+  git(["update-index", "--refresh"], [0, 1]);
+}
+
+// Bun's PTY API is Unix-only. In particular, this exercises Linux's portable watcher backend.
+test.skipIf(process.platform === "win32")(
+  "answers the first painted frame's key while starting a deeply nested watch",
+  async () => {
+    const temporary = mkdtempSync(join(tmpdir(), "hunk-watch-first-key-"));
+    const fixture = join(temporary, "repo");
+    const config = join(temporary, "config");
+    mkdirSync(fixture);
+    mkdirSync(join(config, "hunk"), { recursive: true });
+    let terminal: Bun.Terminal | undefined;
+    let child: ReturnType<typeof Bun.spawn> | undefined;
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    try {
+      createTestFirstInteractionWatchFixture(fixture);
+      writeFileSync(join(config, "hunk", "config.toml"), "watch = true\n");
+      const extension = join(temporary, "first-key.ts");
+      // Explicit --extension consent loads only test-owned code. writeSync bypasses the TUI's
+      // stdout interception; the OSC acknowledgement originates inside real command dispatch.
+      writeFileSync(
+        extension,
+        `import { writeSync } from "node:fs";
+export default function (hunk) {
+  hunk.registerCommand({ id: "ack", title: "Acknowledge test input", key: "f9" }, (ctx) => {
+    writeSync(1, ${JSON.stringify(acknowledgement)});
+    ctx.commands.execute("hunk.app.toggleHelp");
+  });
+}\n`,
+      );
+      let output = "";
+      let sentAt: number | undefined;
+      let latency: number | undefined;
+      let visibleLatency: number | undefined;
+      let resolveInteraction!: () => void;
+      let rejectInteraction!: (error: Error) => void;
+      const interaction = new Promise<void>((resolvePromise, reject) => {
+        resolveInteraction = resolvePromise;
+        rejectInteraction = reject;
+      });
+      watchdog = setTimeout(() => rejectInteraction(new Error("No first frame within 3 s")), 3_000);
+      terminal = new Bun.Terminal({
+        cols: 120,
+        rows: 30,
+        name: "xterm-truecolor",
+        data(pty, bytes) {
+          output += Buffer.from(bytes).toString();
+          const text = stripVTControlCharacters(output);
+          if (sentAt === undefined && text.includes("File  View")) {
+            sentAt = performance.now();
+            // No idle wait, warmup, retry, or second key before the dispatch acknowledgement.
+            pty.write("\x1b[20~");
+            clearTimeout(watchdog);
+            watchdog = setTimeout(
+              () => rejectInteraction(new Error("No first-key ACK within 1 s")),
+              1_000,
+            );
+          }
+          if (sentAt !== undefined && latency === undefined && output.includes(acknowledgement)) {
+            latency = performance.now() - sentAt;
+            console.log(`first-key dispatch ACK: ${latency.toFixed(1)} ms (${process.platform})`);
+            clearTimeout(watchdog);
+            watchdog = setTimeout(
+              () => rejectInteraction(new Error("No ordinary help response within 2 s")),
+              2_000,
+            );
+          }
+          if (
+            latency !== undefined &&
+            visibleLatency === undefined &&
+            text.includes("Controls help")
+          ) {
+            visibleLatency = performance.now() - sentAt!;
+            resolveInteraction();
+          }
+        },
+      });
+      child = Bun.spawn(
+        [
+          process.execPath,
+          join(root, "packages/hunk/src/main.tsx"),
+          "diff",
+          "--theme",
+          "github-dark-default",
+          "--extension",
+          extension,
+        ],
+        {
+          cwd: fixture,
+          terminal,
+          env: {
+            ...process.env,
+            XDG_CONFIG_HOME: config,
+            HUNK_MCP_DISABLE: "1",
+            HUNK_DISABLE_UPDATE_NOTICE: "1",
+            TERM: "xterm-truecolor",
+            NO_COLOR: undefined,
+          },
+        },
+      );
+      await interaction;
+      expect(output.split(acknowledgement)).toHaveLength(2);
+      console.log(`first-key visible help: ${visibleLatency!.toFixed(1)} ms (${process.platform})`);
+      expect(latency).toBeLessThanOrEqual(250);
+      // Dispatch can beat the initial traversal even on main; bound the first key's actual
+      // UI response too, or an early ACK would hide starvation of the requested render.
+      expect(visibleLatency).toBeLessThanOrEqual(750);
+    } finally {
+      clearTimeout(watchdog);
+      try {
+        if (child) {
+          // The PTY child owns its process group. Also kill surviving group members after
+          // the leader exits, so an assertion failure cannot leave a Git subprocess behind.
+          if (child.exitCode === null) {
+            try {
+              process.kill(-child.pid, "SIGTERM");
+            } catch {
+              child.kill("SIGTERM");
+            }
+            await Promise.race([child.exited, Bun.sleep(500)]);
+          }
+          try {
+            process.kill(-child.pid, "SIGKILL");
+          } catch {
+            if (child.exitCode === null) child.kill("SIGKILL");
+          }
+          await Promise.race([child.exited, Bun.sleep(500)]);
+          expect(child.exitCode).not.toBeNull();
+        }
+      } finally {
+        terminal?.close();
+        rmSync(temporary, { recursive: true, force: true });
+      }
+    }
+  },
+  10_000,
+);


### PR DESCRIPTION
Part of #1063 (step 2 + step 5). Independent of #1075; either can land first.

## Problem

With `watch = true` on Linux, chokidar's initial directory traversal runs as one long chain of callbacks/microtasks that Bun does not interrupt for timers, input, or rendering. It starts right after the first frame, so the first keypress waits for the whole walk. Measured on a 4-vCPU Linux host (key sent at first paint → visible response; watch-off floor is ~370 ms):

| Fixture | main | this branch |
|---|---:|---:|
| 300 flat dirs | 479 / 525 ms | 394 / 425 ms |
| 2,000 flat dirs | 825 / 896 ms | 389 / 402 ms |
| 2,000 dirs, 100 deep | 1,219 / 1,741 ms | 403 / 413 ms |
| hunk repo + ignored `node_modules` | 601 / 773 ms | 412 / 539 ms |

(median / max, n=5). Worst main-thread gap during observer setup drops from 300–1,100 ms to ≤30 ms, except for one indivisible readdir of a very wide directory (documented floor).

## Approach

- `portableTree.ts`: enumerate directories ourselves (async, non-following, Git-ignored-root aware) and register them with chokidar in batches of 32 using separate depth-0 watcher instances, yielding a macrotask between batches. Separate instances are used because that is the only public boundary that tells us a batch has finished scanning; `add()` on a ready watcher has no completion signal. Runtime `addDir` goes through the same queue. Chokidar still owns file events and atomic-save normalization.
- Removed subtrees are invalidated (queued/known/batch owners), so delete-and-recreate re-registers the directory.
- Controller: the 2 s startup deadline now measures time *without a completed batch* rather than total time, because batched registration roughly doubles total time-to-ready (2k flat 330 → 720 ms; 10k deep 7.1 → 8.8 s) and a fixed 2 s ceiling would push ~3k-directory repos into polling fallback where main today handles ~10k. A wedged backend still trips the deadline; ordinary events do not extend it; the ENOSPC/EMFILE polling fallback is unchanged.
- Constraints kept: chokidar on Linux with Git-derived pruning (#531) — verified 0 of 18,826 ignored inodes watched, watch counts identical to main, 0 watches after close; `--no-optional-locks` (#398) and the Bun ≥1.3.14 guard (#902) untouched; macOS/Windows native paths unchanged.
- Batch size 32 chosen by measurement: 8 → 32 cut time-to-ready without raising the worst gap (dominated by the widest single directory, not batch size).

Non-goals: async Git signatures (#1075), deferring observer start (measured ineffective on its own — dropped), worker-thread enumeration (not justified by the numbers).

## Tests / checks

- New `test/pty/watch-start-integration.test.ts`: nested fixture, one key sent in the first PTY frame callback with no warmup; asserts a test-extension dispatch ACK ≤250 ms and visible response ≤750 ms. Fails on main 5/5 (visible ~1,170 ms), passes 5/5 here (Linux) and on macOS.
- Unit: `observer.test.ts` (injected runtime: batch cadence, cancel mid-drain, error mid-batch, ignored root, queued dedupe, invalidation), `observer.fs.test.ts` (real fs, Linux: recreation of initial/runtime/new-child dirs, rename out/back), `controller.test.ts` (fake clock: progress extends deadline, no-progress still times out, fallback intact).
- `bun run typecheck`, `bun run deps:check` — pass. `bun test packages/hunk/src/core/watch` — 96 pass Linux, 92 pass + 4 Linux-only skips macOS.
- `bun run test:integration` on Linux — 165 pass, 1 skip, 1 `highlighting` timeout that also reproduces on `main` @ `bc76a0bc`.
- Full `bun run test` failures are the same 6 as on main (see #1075 for the list).
- Not tested on Windows (native path unchanged).

## Known limitations

- One very wide directory is still a single chokidar scan (~15–40 ms for 2,000 siblings).
- Deleting the watched root itself, or recreating a directory within ~1 ms of deleting it, can lose observation — reproduced identically on main; not addressed here.
- Total time-to-ready is longer on very large repos (see deadline note); changes made during that window are still caught by the readiness signature check.
