### PR TITLE
perf(highlight): load Shiki WASM bytes without base64 decoding

### DIFF
--- a/.changeset/tidy-shiki-bytes.md
+++ b/.changeset/tidy-shiki-bytes.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Reduce startup input stalls by loading syntax-highlighting WASM without synchronous base64 decoding.

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -27,6 +27,9 @@ const UI_SESSION_ADAPTERS = [
 const PRODUCTION_ENTRY_POINTS = [
   "^packages/hunk/src/main\\.tsx$",
   "^packages/hunk/src/highlightWorkerEntry\\.ts$",
+  // Account for Pierre's shiki/wasm alias from untraversed node_modules and its ambient asset types.
+  "^packages/hunk/src/lib/shikiWasm\\.ts$",
+  "^packages/hunk/src/lib/shikiWasmAssets\\.d\\.ts$",
   "^packages/hunk/src/opentui/index\\.ts$",
   "^packages/hunk/src/extension-api/index\\.ts$",
   "^packages/hunk/src/hunk-review/skillDocument\\.ts$",

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "oxfmt": "^0.41.0",
         "oxlint": "^1.56.0",
         "react": "^19.2.4",
+        "shiki": "3.23.0",
         "simple-git-hooks": "^2.14.0",
         "string-width": "^8.2.1",
         "tuistory": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",
     "react": "^19.2.4",
+    "shiki": "3.23.0",
     "simple-git-hooks": "^2.14.0",
     "string-width": "^8.2.1",
     "tuistory": "^0.11.0",

--- a/packages/hunk/src/lib/shikiWasm.test.ts
+++ b/packages/hunk/src/lib/shikiWasm.test.ts
@@ -5,12 +5,15 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { REPO_ROOT } from "../../../../scripts/build/package-paths";
 
-// Exercise Pierre's actual import, not just the adapter, in fresh processes: Shiki caches its engine.
-const highlightTestProgram = `
+// Install the main-thread counter before Pierre evaluates its static imports.
+const highlightDecodeTestPreload = `
   const originalAtob = globalThis.atob;
-  let decodes = 0;
-  globalThis.atob = (value) => { decodes++; return originalAtob(value); };
-  const { getSharedHighlighter } = await import("@pierre/diffs");
+  globalThis.shikiTestDecodes = 0;
+  globalThis.atob = (value) => { globalThis.shikiTestDecodes++; return originalAtob(value); };
+`;
+
+// Exercise Pierre's actual import, not just the adapter, in fresh processes: Shiki caches its engine.
+const highlightTestBody = `
   const highlighter = await getSharedHighlighter({
     langs: ["typescript", "elixir"], themes: ["github-dark-default"],
     preferredHighlighter: "shiki-wasm",
@@ -19,7 +22,19 @@ const highlightTestProgram = `
     highlighter.codeToTokens("export const answer: number = 42;", { lang: "typescript", theme: "github-dark-default" }),
     highlighter.codeToTokens('def hello, do: "world"', { lang: "elixir", theme: "github-dark-default" }),
   ];
-  console.log(JSON.stringify({ decodes, tokens, assets: Bun.embeddedFiles.map(file => file.size) }));
+  console.log(JSON.stringify({ decodes: globalThis.shikiTestDecodes, tokens, assets: Bun.embeddedFiles.map(file => file.size) }));
+`;
+
+const highlightTestProgram = `
+  import { getSharedHighlighter } from "@pierre/diffs";
+  ${highlightTestBody}
+`;
+
+// Compiled executables have no runtime --preload; instrument before the dynamic import instead.
+const compiledHighlightTestProgram = `
+  ${highlightDecodeTestPreload}
+  const { getSharedHighlighter } = await import("@pierre/diffs");
+  ${highlightTestBody}
 `;
 
 // Install counters in the worker realm before its real entry imports Pierre or Shiki.
@@ -45,7 +60,7 @@ const workerDecodeTestPreload = `
 function workerHighlightTestProgram(preload: string) {
   const entry = pathToFileURL(join(REPO_ROOT, "packages/hunk/src/highlightWorkerEntry.ts"));
   return `
-    const { parseDiffFromFile } = await import("@pierre/diffs");
+    import { parseDiffFromFile } from "@pierre/diffs";
     const worker = new Worker(${JSON.stringify(entry.href)}, { preload: [${JSON.stringify(preload)}] });
     try {
       const result = await new Promise((resolve, reject) => {
@@ -82,8 +97,12 @@ test("Pierre avoids base64 decoding in source, workers, bundles, and binaries wi
   try {
     const config = join(temporary, "tsconfig.json");
     writeFileSync(config, JSON.stringify({ compilerOptions: { target: "ESNext" } }));
+    const mainPreload = join(temporary, "main-preload.ts");
+    writeFileSync(mainPreload, highlightDecodeTestPreload);
     const stock = runHighlightTestProcess([
       process.execPath,
+      "--preload",
+      mainPreload,
       "--tsconfig-override",
       config,
       "--eval",
@@ -91,7 +110,13 @@ test("Pierre avoids base64 decoding in source, workers, bundles, and binaries wi
     ]);
     expect(stock.decodes).toBe(1);
 
-    const source = runHighlightTestProcess([process.execPath, "--eval", highlightTestProgram]);
+    const source = runHighlightTestProcess([
+      process.execPath,
+      "--preload",
+      mainPreload,
+      "--eval",
+      highlightTestProgram,
+    ]);
     expect(source.decodes).toBe(0);
     expect(source.tokens).toEqual(stock.tokens);
 
@@ -111,7 +136,7 @@ test("Pierre avoids base64 decoding in source, workers, bundles, and binaries wi
 
     const entry = join(sourceDir, "highlight.ts");
     const binary = join(temporary, process.platform === "win32" ? "highlight.exe" : "highlight");
-    writeFileSync(entry, highlightTestProgram);
+    writeFileSync(entry, compiledHighlightTestProgram);
     const build = Bun.spawnSync(
       [
         process.execPath,
@@ -125,6 +150,7 @@ test("Pierre avoids base64 decoding in source, workers, bundles, and binaries wi
       { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe", timeout: 30_000 },
     );
     expect(build.exitCode, build.stderr.toString()).toBe(0);
+    writeFileSync(entry, highlightTestProgram);
     const bundleDir = join(temporary, "bundle");
     const bundle = Bun.spawnSync(
       [process.execPath, "build", "--target=bun", entry, "--outdir", bundleDir],
@@ -135,7 +161,7 @@ test("Pierre avoids base64 decoding in source, workers, bundles, and binaries wi
 
     // npm consumers launch from arbitrary repositories, not the directory containing the asset.
     const bundled = runHighlightTestProcess(
-      [process.execPath, join(bundleDir, "highlight.js")],
+      [process.execPath, "--preload", mainPreload, join(bundleDir, "highlight.js")],
       temporary,
     );
     expect(bundled.decodes).toBe(0);

--- a/packages/hunk/src/lib/shikiWasm.test.ts
+++ b/packages/hunk/src/lib/shikiWasm.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { REPO_ROOT } from "../../../../scripts/build/package-paths";
+
+// Exercise Pierre's actual import, not just the adapter, in fresh processes: Shiki caches its engine.
+const highlightTestProgram = `
+  const originalAtob = globalThis.atob;
+  let decodes = 0;
+  globalThis.atob = (value) => { decodes++; return originalAtob(value); };
+  const { getSharedHighlighter } = await import("@pierre/diffs");
+  const highlighter = await getSharedHighlighter({
+    langs: ["typescript", "elixir"], themes: ["github-dark-default"],
+    preferredHighlighter: "shiki-wasm",
+  });
+  const tokens = [
+    highlighter.codeToTokens("export const answer: number = 42;", { lang: "typescript", theme: "github-dark-default" }),
+    highlighter.codeToTokens('def hello, do: "world"', { lang: "elixir", theme: "github-dark-default" }),
+  ];
+  console.log(JSON.stringify({ decodes, tokens, assets: Bun.embeddedFiles.map(file => file.size) }));
+`;
+
+// Install counters in the worker realm before its real entry imports Pierre or Shiki.
+const workerDecodeTestPreload = `
+  let atobCalls = 0, stringCopies = 0;
+  const originalAtob = globalThis.atob;
+  globalThis.atob = (value) => {
+    if (value.length >= 600_000) atobCalls++;
+    return originalAtob(value);
+  };
+  const originalFrom = Uint8Array.from;
+  Uint8Array.from = function(value, ...rest) {
+    if (typeof value === "string" && value.length >= 400_000) stringCopies++;
+    return Reflect.apply(originalFrom, this, [value, ...rest]);
+  };
+  const originalPost = globalThis.postMessage;
+  globalThis.postMessage = function(value, ...rest) {
+    return Reflect.apply(originalPost, this, [{ ...value, atobCalls, stringCopies }, ...rest]);
+  };
+`;
+
+/** Drive the production worker from a fresh process and report its worker-local decode counters. */
+function workerHighlightTestProgram(preload: string) {
+  const entry = pathToFileURL(join(REPO_ROOT, "packages/hunk/src/highlightWorkerEntry.ts"));
+  return `
+    const { parseDiffFromFile } = await import("@pierre/diffs");
+    const worker = new Worker(${JSON.stringify(entry.href)}, { preload: [${JSON.stringify(preload)}] });
+    try {
+      const result = await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error("Highlight worker timed out")), 3_000);
+        worker.onerror = (event) => { clearTimeout(timeout); reject(new Error(event.message)); };
+        worker.onmessage = ({ data }) => { clearTimeout(timeout); resolve(data); };
+        worker.postMessage({
+          version: 3, id: 1, aliasContext: false, appearance: "dark",
+          language: "typescript", theme: "github-dark-default",
+          metadata: parseDiffFromFile(
+            { name: "example.ts", contents: "" },
+            { name: "example.ts", contents: "export const answer = 42;\\n" },
+            { context: 3 }, true,
+          ),
+        });
+      });
+      console.log(JSON.stringify({ ok: result.ok, message: result.message,
+        atobCalls: result.atobCalls, stringCopies: result.stringCopies }));
+    } finally { worker.terminate(); }
+  `;
+}
+
+/** Run a fresh source or compiled highlighter and surface child-process failures. */
+function runHighlightTestProcess(args: string[], cwd = REPO_ROOT) {
+  const result = Bun.spawnSync(args, { cwd, stdout: "pipe", stderr: "pipe", timeout: 30_000 });
+  expect(result.exitCode, result.stderr.toString()).toBe(0);
+  return JSON.parse(result.stdout.toString());
+}
+
+test("Pierre avoids base64 decoding in source, workers, bundles, and binaries with identical tokens", () => {
+  const temporary = mkdtempSync(join(tmpdir(), "hunk-shiki-test-"));
+  // Keep the compile entry under the repository so its package imports resolve normally.
+  const sourceDir = mkdtempSync(join(REPO_ROOT, ".shiki-test-"));
+  try {
+    const config = join(temporary, "tsconfig.json");
+    writeFileSync(config, JSON.stringify({ compilerOptions: { target: "ESNext" } }));
+    const stock = runHighlightTestProcess([
+      process.execPath,
+      "--tsconfig-override",
+      config,
+      "--eval",
+      highlightTestProgram,
+    ]);
+    expect(stock.decodes).toBe(1);
+
+    const source = runHighlightTestProcess([process.execPath, "--eval", highlightTestProgram]);
+    expect(source.decodes).toBe(0);
+    expect(source.tokens).toEqual(stock.tokens);
+
+    const preload = join(temporary, "worker-preload.ts");
+    writeFileSync(preload, workerDecodeTestPreload);
+    const workerProgram = workerHighlightTestProgram(preload);
+    const stockWorker = runHighlightTestProcess([
+      process.execPath,
+      "--tsconfig-override",
+      config,
+      "--eval",
+      workerProgram,
+    ]);
+    expect(stockWorker).toEqual({ ok: true, atobCalls: 1, stringCopies: 1 });
+    const worker = runHighlightTestProcess([process.execPath, "--eval", workerProgram]);
+    expect(worker).toEqual({ ok: true, atobCalls: 0, stringCopies: 0 });
+
+    const entry = join(sourceDir, "highlight.ts");
+    const binary = join(temporary, process.platform === "win32" ? "highlight.exe" : "highlight");
+    writeFileSync(entry, highlightTestProgram);
+    const build = Bun.spawnSync(
+      [
+        process.execPath,
+        "build",
+        "--compile",
+        "--no-compile-autoload-bunfig",
+        entry,
+        "--outfile",
+        binary,
+      ],
+      { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe", timeout: 30_000 },
+    );
+    expect(build.exitCode, build.stderr.toString()).toBe(0);
+    const bundleDir = join(temporary, "bundle");
+    const bundle = Bun.spawnSync(
+      [process.execPath, "build", "--target=bun", entry, "--outdir", bundleDir],
+      { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe", timeout: 30_000 },
+    );
+    expect(bundle.exitCode, bundle.stderr.toString()).toBe(0);
+    rmSync(sourceDir, { recursive: true, force: true });
+
+    // npm consumers launch from arbitrary repositories, not the directory containing the asset.
+    const bundled = runHighlightTestProcess(
+      [process.execPath, join(bundleDir, "highlight.js")],
+      temporary,
+    );
+    expect(bundled.decodes).toBe(0);
+    expect(bundled.tokens).toEqual(stock.tokens);
+
+    const compiled = runHighlightTestProcess([binary], temporary);
+    expect(compiled.decodes).toBe(0);
+    expect(compiled.tokens).toEqual(stock.tokens);
+    expect(compiled.assets).toContain(466_610);
+  } finally {
+    rmSync(sourceDir, { recursive: true, force: true });
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/packages/hunk/src/lib/shikiWasm.ts
+++ b/packages/hunk/src/lib/shikiWasm.ts
@@ -1,0 +1,15 @@
+/**
+ * Load Shiki's original WASM bytes for the terminal and highlight worker without base64 decoding.
+ * Pierre reaches this Bun runtime adapter through the `shiki/wasm` tsconfig alias in source and builds.
+ */
+import { resolve } from "node:path";
+import wasmPath from "shiki/onig.wasm" with { type: "file" };
+
+/** Read the asset asynchronously; Bun embeds this file when compiling the standalone executable. */
+export default async function instantiate(imports: WebAssembly.Imports) {
+  // Source and compiled paths are absolute; npm bundles emit a path beside the JS entry, not cwd.
+  return WebAssembly.instantiate(
+    await Bun.file(resolve(import.meta.dir, wasmPath)).arrayBuffer(),
+    imports,
+  );
+}

--- a/packages/hunk/src/lib/shikiWasmAssets.d.ts
+++ b/packages/hunk/src/lib/shikiWasmAssets.d.ts
@@ -1,0 +1,4 @@
+declare module "shiki/onig.wasm" {
+  const path: string;
+  export default path;
+}

--- a/test/pty/highlighting.test.ts
+++ b/test/pty/highlighting.test.ts
@@ -13,13 +13,13 @@ afterEach(() => {
   harness.cleanup();
 });
 
-/** Create a contiguous added TypeScript file large enough to use the highlight worker. */
-function createLargeHighlightTestFiles() {
+/** Create contiguous added TypeScript lines for main-thread or worker highlighting. */
+function createHighlightTestFiles(lineCount: number) {
   const dir = mkdtempSync(join(tmpdir(), "hunk-highlight-worker-"));
   const before = join(dir, "before.ts");
   const after = join(dir, "after.ts");
   const contents = Array.from(
-    { length: 8_000 },
+    { length: lineCount },
     (_, index) => `export const workerLine${index} = ${index};`,
   ).join("\n");
   writeFileSync(before, "");
@@ -33,8 +33,31 @@ function visibleWorkerLineIndexes(snapshot: string) {
 }
 
 describe("PTY syntax highlighting", () => {
+  test("highlights a small diff using the main-thread WASM engine", async () => {
+    const fixture = createHighlightTestFiles(2);
+    try {
+      const session = await harness.launchHunk({
+        args: ["diff", "--files", fixture.before, fixture.after, "--mode", "unified"],
+        cwd: fixture.dir,
+        cols: 100,
+        rows: 24,
+      });
+      await session.waitForText("export const workerLine0 = 0;");
+      let keywords = "";
+      for (let iteration = 0; iteration < 200; iteration += 1) {
+        await session.waitIdle({ timeout: 50 });
+        keywords = await session.text({ immediate: true, only: { foreground: "#ff7b72" } });
+        if (keywords.includes("export")) break;
+      }
+      expect(keywords).toContain("export");
+      session.close();
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
   test("keeps key input responsive while a large added file highlights", async () => {
-    const fixture = createLargeHighlightTestFiles();
+    const fixture = createHighlightTestFiles(8_000);
     const session = await harness.launchHunk({
       args: ["diff", "--files", fixture.before, fixture.after, "--fast", "--mode", "unified"],
       cwd: fixture.dir,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "types": ["bun", "react"],
     "baseUrl": ".",
     "paths": {
+      "shiki/wasm": ["packages/hunk/src/lib/shikiWasm.ts"],
       "@hunk/git": ["packages/hunk-git/src/index.ts"],
       "@hunk/jj": ["packages/hunk-jj/src/index.ts"],
       "@hunk/sapling": ["packages/hunk-sapling/src/index.ts"],


### PR DESCRIPTION
Follow-up to #1063. Second of two first-interaction fixes; independent of the help/menu overlay PR.

## Problem

Pierre requests the Oniguruma engine via `import("shiki/wasm")`, which resolves to `@shikijs/engine-oniguruma/wasm-inlined`: a 622 KB base64 literal decoded with `Uint8Array.from(atob(...))` on the main thread the first time a highlighter is prepared. That runs right after the first frame, so it lands between the user's first keypress and its render. Measured (n=5, median / max):

| | Linux 4 vCPU | macOS M-series |
|---|---:|---:|
| synchronous string→bytes | 29.2 / 33.6 ms | 5.9 / 7.3 ms |
| first highlighter prep, wall | 51.9 / 56.2 ms | 12.5 / 16.7 ms |
| largest event-loop gap during prep | 33.9 / 38.5 ms | 6.7 / 8.6 ms |

## Approach

A `tsconfig` `paths` alias maps `shiki/wasm` → `packages/hunk/src/lib/shikiWasm.ts`, which reads Shiki's public `shiki/onig.wasm` asset through Bun's file loader and calls `WebAssembly.instantiate`. Same bytes, engine, grammars, themes and Pierre lifecycle; token output is byte-identical (SHA-256 checked in tests). No dependency patching or vendoring. `shiki@3.23.0` becomes an explicit root devDependency (already present transitively at that version).

After: string→bytes conversions 1 → 0; Linux prep 51.9 → 20.0 ms, largest gap 33.9 → 12.9 ms; macOS prep 12.5 → 5.8 ms.

The alias applies to source runs, `build:bin` (asset embedded — verified `/$bunfs/root/onig-*.wasm`, and `B:/~BUN/root/...` on a Windows cross-compile), `build:npm` (asset emitted beside `main.js`, resolved against the module directory, not cwd), the highlight worker, and `bun test`. The OpenTUI Node facade externalizes `@pierre/diffs`, so downstream Node consumers keep upstream Shiki behaviour — this adapter is Bun-only by design.

## Tests / checks

- `packages/hunk/src/lib/shikiWasm.test.ts`: fresh-process zero-decode assertions for a source entry, the real highlight worker entry, a relocated JS bundle, and a compiled executable; stock-engine vs adapter token parity (TypeScript + Elixir); exact asset size so an upstream change forces review.
- `test/pty/highlighting.test.ts`: new small-diff (main-thread) highlighting case alongside the existing worker/Elixir cases; passes for source, compiled binary and npm main on macOS and Linux.
- `bun run typecheck`, `deps:check` (alias-only entry accounted for in `.dependency-cruiser.cjs`), `lint`, `format:check`, `build:bin`, `build:npm` — pass.
- `bun run test` — same 6 pre-existing failures as `main`; 1 remaining (`jj` not installed) with isolated config.
- `bun run test:integration` — the 5 failures reproduce on `main` (macOS `/var` vs `/private/var` TMPDIR trust-state cases; 3 signal-lifecycle cases).
- `bun run test:tty-smoke` — Linux 10/10; macOS skipped (no util-linux `script`).
- `bench:highlight-prefetch` / `bench:interaction-latency`: no material change; macOS `next_file_ready_ms` is bimodal (10 / 50 ms) in both stock and candidate runs with `adjacent_ready_before_move=1` throughout, so it is measuring act/render settling rather than highlighting.
- Not run on Windows (path handling inspected via cross-compile only).

## Pre-existing, not addressed

`build:npm` does not emit `highlightWorkerEntry.js`, so the npm large-file worker PTY test fails on `main` and here identically.
