### PR TITLE
fix(extensions): reject non-callable VCS operation watch hooks

### DIFF
--- a/.changeset/reject-malformed-vcs-watch-hooks.md
+++ b/.changeset/reject-malformed-vcs-watch-hooks.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Extension VCS operation registration now requires `watchSignature` and `watchPlan` to be absent or callable. A non-callable hook is dropped along with its operation at registration instead of throwing a `TypeError` the first time watch planning invokes it.

--- a/packages/hunk/src/extensions/publicApiRobustness.test.ts
+++ b/packages/hunk/src/extensions/publicApiRobustness.test.ts
@@ -352,6 +352,36 @@ describe("registerVcsAdapter with junk", () => {
     expect(registry.vcsAdapters[0]?.adapter.operations).toEqual({});
   });
 
+  test("an operation with a non-callable watch hook is dropped, not wrapped", () => {
+    const { registry, issues } = loadFactory(
+      (hunk: { registerVcsAdapter: (adapter: unknown) => void }) => {
+        hunk.registerVcsAdapter({
+          id: "hg",
+          name: "Mercurial",
+          detect: (cwd: string) => ({ id: "hg", repoRoot: cwd }),
+          operations: {
+            "working-tree-diff": {
+              load: async () => ({ files: [] }),
+              watchSignature: "not-a-function",
+            },
+            "revision-show": {
+              load: async () => ({ files: [] }),
+              watchPlan: 42,
+            },
+            "stash-show": { load: async () => ({ files: [] }) },
+          },
+        });
+      },
+    );
+
+    expect(issues).toEqual([]);
+    // Truthy-but-uncallable hooks would otherwise pass the `watchSignature &&`
+    // guard in toInternalVcsOperation and fail with a TypeError only once
+    // watch planning invokes them, well after registration.
+    const operations = registry.vcsAdapters[0]?.adapter.operations ?? {};
+    expect(Object.keys(operations)).toEqual(["stash-show"]);
+  });
+
   test("built-in ids stay reserved however an extension asks for them", () => {
     const { registry } = loadFactory((hunk: { registerVcsAdapter: (a: unknown) => void }) => {
       for (const id of ["git", "jj", "sl"]) {

--- a/packages/hunk/src/extensions/runExtension.ts
+++ b/packages/hunk/src/extensions/runExtension.ts
@@ -502,7 +502,12 @@ export function toInternalVcsAdapter(
 
   const internalOperations: Record<string, VcsOperation<VcsReviewInput>> = {};
   for (const [kind, operation] of Object.entries(operations ?? {})) {
-    if (isPlainObject(operation) && typeof operation.load === "function") {
+    if (
+      isPlainObject(operation) &&
+      typeof operation.load === "function" &&
+      (operation.watchSignature === undefined || typeof operation.watchSignature === "function") &&
+      (operation.watchPlan === undefined || typeof operation.watchPlan === "function")
+    ) {
       internalOperations[kind] = toInternalVcsOperation(
         operation as unknown as ExtensionVcsOperation<VcsReviewInput>,
       );


### PR DESCRIPTION
## Summary

`registerVcsAdapter` validates that an operation's `load` field is callable, but not the optional `watchSignature` / `watchPlan` hooks. An untyped extension can register:

```ts
{
  load: async () => result,
  watchSignature: "not a function",
}
```

Registration currently accepts this. The `watchSignature && {...}` spread guard in `toInternalVcsOperation` treats any truthy value as present, wraps it, and the resulting `TypeError` only surfaces once watch planning invokes the hook — well after registration.

## Fix

`toInternalVcsAdapter` now requires `watchSignature` and `watchPlan` to be absent or callable before accepting an operation, matching the existing behavior for a non-callable `load` (the whole operation entry is dropped, so lookups report "not supported" instead of failing mid-review).

## Test plan

- Added `an operation with a non-callable watch hook is dropped, not wrapped` to `publicApiRobustness.test.ts`, mirroring the existing `load` coverage.
- Confirmed the new test fails on current `main` (TypeError path) and passes with the fix.
- `bun test packages/hunk/src/extensions/runExtension.test.ts` — 51 pass, 0 fail.
- `bun run typecheck`, `oxfmt --check`, `oxlint --deny-warnings` all clean on the changed files.
- Added a patch changeset.

Fixes #763