### PR TITLE
fix(ui): keep the selected file visible in the sidebar during held navigation

### DIFF
--- a/.changeset/steady-sidebar-follow.md
+++ b/.changeset/steady-sidebar-follow.md
@@ -1,0 +1,5 @@
+---
+"hunkdiff": patch
+---
+
+Keep the selected file visible in the sidebar while holding down next-file or previous-file navigation, instead of snapping the list back to the top.

--- a/packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.test.tsx
+++ b/packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { act, forwardRef, useImperativeHandle, useState } from "react";
+import { createTestDiffFile } from "../../../../../../../test/helpers/diff-helpers";
+import { resolveTheme } from "../../../../ui/themes";
+import { toReadOnlyFileViews } from "../../../events";
+import { FlexFileSidebar } from "./FileSidebars";
+
+const FILE_COUNT = 40;
+const FRAME_ROWS = 8;
+
+const fileId = (index: number) => `file-${String(index).padStart(2, "0")}`;
+
+const files = toReadOnlyFileViews(
+  Array.from({ length: FILE_COUNT }, (_, index) =>
+    createTestDiffFile({
+      id: fileId(index),
+      path: `src/${fileId(index)}.ts`,
+      before: "export const value = 1;\n",
+      after: "export const value = 2;\n",
+    }),
+  ),
+);
+
+interface SidebarSelectionHandle {
+  select(id: string): void;
+}
+
+/** Host the bundled sidebar behind a selection setter so tests drive it like the review does. */
+const SidebarSelectionHarness = forwardRef<SidebarSelectionHandle, { initialFileId: string }>(
+  function SidebarSelectionHarness({ initialFileId }, ref) {
+    const [selectedFileId, setSelectedFileId] = useState(initialFileId);
+    useImperativeHandle(ref, () => ({ select: setSelectedFileId }), []);
+    return (
+      <FlexFileSidebar
+        files={files}
+        selectedFileId={selectedFileId}
+        selectedHunkIndex={0}
+        theme={resolveTheme("github-dark-default", null)}
+        width={30}
+        keybindings={{ matches: () => false, getKeys: () => [] }}
+        actions={{
+          copyText: () => false,
+          selectFile: () => {},
+          selectHunk: () => {},
+          revealLine: () => {},
+          notify: () => {},
+        }}
+      />
+    );
+  },
+);
+
+/** Return the sidebar row carrying the selected-file marker, if one is on screen. */
+function selectedRow(frame: string) {
+  return frame.split("\n").find((line) => line.includes("▌"));
+}
+
+async function renderSidebar(initialFileId: string) {
+  const handle: { current: SidebarSelectionHandle | null } = { current: null };
+  const setup = await testRender(
+    <SidebarSelectionHarness
+      ref={(value) => {
+        handle.current = value;
+      }}
+      initialFileId={initialFileId}
+    />,
+    { width: 36, height: FRAME_ROWS },
+  );
+  await act(async () => {
+    await setup.renderOnce();
+  });
+
+  /** Change the selection without letting a frame lay the new row out first. */
+  const selectWithoutFrame = async (id: string) => {
+    await act(async () => {
+      handle.current?.select(id);
+    });
+  };
+
+  /** Change the selection and let one frame settle, the way an unhurried key press does. */
+  const selectAndSettle = async (id: string) => {
+    await selectWithoutFrame(id);
+    await act(async () => {
+      await setup.renderOnce();
+    });
+  };
+
+  const frame = async () => {
+    await act(async () => {
+      await setup.renderOnce();
+    });
+    return setup.captureCharFrame();
+  };
+
+  const destroy = async () => {
+    await act(async () => {
+      setup.renderer.destroy();
+    });
+  };
+
+  return { selectWithoutFrame, selectAndSettle, frame, destroy };
+}
+
+describe("FlexFileSidebar selected-row reveal", () => {
+  test("follows an unhurried walk down the list", async () => {
+    const sidebar = await renderSidebar(fileId(0));
+    try {
+      for (let index = 1; index <= 12; index += 1) {
+        await sidebar.selectAndSettle(fileId(index));
+      }
+      const frame = await sidebar.frame();
+      expect(selectedRow(frame)).toContain(`${fileId(12)}.ts`);
+      expect(frame).not.toContain(`${fileId(0)}.ts`);
+    } finally {
+      await sidebar.destroy();
+    }
+  });
+
+  test("keeps following when selection outruns the laid-out rows", async () => {
+    // Held-down file navigation lands several commits between two frames. Rows the render
+    // window mounts for those commits have no layout yet, so a reveal that reads their
+    // geometry either scrolls back to the top or does nothing.
+    const sidebar = await renderSidebar(fileId(0));
+    try {
+      for (let index = 1; index <= 12; index += 1) {
+        await sidebar.selectWithoutFrame(fileId(index));
+      }
+      const frame = await sidebar.frame();
+      expect(selectedRow(frame)).toContain(`${fileId(12)}.ts`);
+      expect(frame).not.toContain(`${fileId(0)}.ts`);
+    } finally {
+      await sidebar.destroy();
+    }
+  });
+
+  test("does not scroll back to the top when a far row mounts fresh", async () => {
+    const sidebar = await renderSidebar(fileId(0));
+    try {
+      for (let index = 1; index <= 20; index += 1) {
+        await sidebar.selectAndSettle(fileId(index));
+      }
+      expect(selectedRow(await sidebar.frame())).toContain(`${fileId(20)}.ts`);
+
+      await sidebar.selectWithoutFrame(fileId(30));
+      const frame = await sidebar.frame();
+      expect(selectedRow(frame)).toContain(`${fileId(30)}.ts`);
+      expect(frame).not.toContain(`${fileId(0)}.ts`);
+
+      // Stepping onward from the stuck state must keep revealing too.
+      await sidebar.selectWithoutFrame(fileId(31));
+      expect(selectedRow(await sidebar.frame())).toContain(`${fileId(31)}.ts`);
+    } finally {
+      await sidebar.destroy();
+    }
+  });
+
+  test("reveals a selection that starts outside the first viewport", async () => {
+    const sidebar = await renderSidebar(fileId(25));
+    try {
+      const frame = await sidebar.frame();
+      expect(selectedRow(frame)).toContain(`${fileId(25)}.ts`);
+    } finally {
+      await sidebar.destroy();
+    }
+  });
+
+  test("walks back up after the list has scrolled", async () => {
+    const sidebar = await renderSidebar(fileId(0));
+    try {
+      for (let index = 1; index <= 20; index += 1) {
+        await sidebar.selectAndSettle(fileId(index));
+      }
+      for (let index = 19; index >= 5; index -= 1) {
+        await sidebar.selectWithoutFrame(fileId(index));
+      }
+      const frame = await sidebar.frame();
+      expect(selectedRow(frame)).toContain(`${fileId(5)}.ts`);
+    } finally {
+      await sidebar.destroy();
+    }
+  });
+});

--- a/packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.tsx
+++ b/packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.tsx
@@ -1,6 +1,6 @@
 import type { ScrollBoxRenderable } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { ExtensionPaneProps } from "../../../../extension-api/types";
 import {
   buildFlatSidebarEntries,
@@ -13,8 +13,10 @@ import {
   toggleCollapsedDirectoryPath,
   type SidebarEntry,
 } from "../../../../ui/lib/files";
-import { fileRowId } from "../../../../ui/lib/ids";
-import { buildSidebarRenderWindow } from "../../../../ui/lib/sidebarRenderWindow";
+import {
+  buildSidebarRenderWindow,
+  planSidebarRowReveal,
+} from "../../../../ui/lib/sidebarRenderWindow";
 import {
   FileDirectoryRow,
   FileGroupHeader,
@@ -27,24 +29,21 @@ export type BuiltInSidebarProps = Omit<
 > &
   Partial<Pick<ExtensionPaneProps, "placement" | "height" | "currentLine" | "review">>;
 
-type FileSidebarVariantProps = Pick<
-  BuiltInSidebarProps,
-  "actions" | "files" | "selectedFileId" | "theme"
-> & {
-  estimatedViewportRows: number;
-  scrollTop: number;
-  textWidth: number;
-  viewportHeight: number;
-};
-
 /** Ignore directory toggles for projections that cannot contain directory rows. */
 function ignoreDirectoryToggle() {}
 
-interface VirtualizedFileSidebarRowsProps extends Omit<FileSidebarVariantProps, "files"> {
+interface VirtualizedFileSidebarRowsProps extends Pick<
+  BuiltInSidebarProps,
+  "actions" | "selectedFileId" | "theme"
+> {
   collapsedDirectoryPaths?: ReadonlySet<string>;
   entries: SidebarEntry[];
+  estimatedViewportRows: number;
   onToggleDirectory?: (path: string) => void;
   paddingLeft?: number;
+  scrollTop: number;
+  textWidth: number;
+  viewportHeight: number;
 }
 
 /** Render one windowed sidebar projection with shared file selection and stats lanes. */
@@ -132,43 +131,15 @@ export function VirtualizedFileSidebarRows({
   );
 }
 
-/** Render the compact directory-group projection for a narrow file sidebar. */
-export function FlatFileSidebar({ files, ...props }: FileSidebarVariantProps): ReactNode {
-  const entries = useMemo(() => buildFlatSidebarEntries(files), [files]);
-  return <VirtualizedFileSidebarRows {...props} entries={entries} />;
-}
-
-/** Render the ordered hierarchy after applying the sidebar's collapsed directory paths. */
-export function TreeFileSidebar({
-  collapsedDirectoryPaths,
-  files,
-  onToggleDirectory,
-  ...props
-}: FileSidebarVariantProps & {
-  collapsedDirectoryPaths: ReadonlySet<string>;
-  onToggleDirectory: (path: string) => void;
-}): ReactNode {
-  const entries = useMemo(
-    () => collapseTreeSidebarEntries(buildTreeSidebarEntries(files), collapsedDirectoryPaths),
-    [collapsedDirectoryPaths, files],
-  );
-  return (
-    <VirtualizedFileSidebarRows
-      {...props}
-      collapsedDirectoryPaths={collapsedDirectoryPaths}
-      entries={entries}
-      onToggleDirectory={onToggleDirectory}
-      paddingLeft={0}
-    />
-  );
-}
-
 /**
- * Adapt the built-in file sidebar between compact and hierarchical projections.
+ * Render the built-in file sidebar, switching between the compact directory-group
+ * projection and the collapsible tree as the pane width changes.
  *
- * Resizing only replaces the rows inside one stable scrollbox. The sidebar keeps
- * file navigation and selected-row reveal shared so both projections preserve
- * the same review-stream behavior.
+ * Resizing only replaces the rows inside one stable scrollbox. File navigation, a
+ * projection change, and a reload all reveal the selected row through the same
+ * fixed-row geometry the render window uses, so the reveal never depends on a row
+ * having been laid out: rows mounted since the last frame carry no position yet, and
+ * held-down navigation lands several commits between frames.
  */
 export function FlexFileSidebar({
   files,
@@ -180,6 +151,10 @@ export function FlexFileSidebar({
   const scrollRef = useRef<ScrollBoxRenderable | null>(null);
   const previousSelectedFileIdRef = useRef(selectedFileId);
   const skipSelectedFileRevealRef = useRef(false);
+  // The file whose row still has to be brought on screen. It stays set until a measured
+  // viewport confirms the row is visible, so a reveal that ran before the first layout or
+  // against a content height the next layout will grow retries once geometry settles.
+  const pendingRevealFileIdRef = useRef<string | null>(null);
   const [collapsedDirectoryPaths, setCollapsedDirectoryPaths] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -188,22 +163,67 @@ export function FlexFileSidebar({
   // Mirrors the host layout: one column of row highlight plus row padding.
   const textWidth = Math.max(8, width - 2);
   const mode = resolveFileSidebarMode(textWidth);
-  const variantProps: FileSidebarVariantProps = {
-    actions,
-    estimatedViewportRows: terminal.height,
-    files,
-    scrollTop: scrollViewport.top,
-    selectedFileId,
-    textWidth,
-    theme,
-    viewportHeight: scrollViewport.height,
-  };
+  const entries = useMemo(
+    () =>
+      mode === "tree"
+        ? collapseTreeSidebarEntries(buildTreeSidebarEntries(files), collapsedDirectoryPaths)
+        : buildFlatSidebarEntries(files),
+    [collapsedDirectoryPaths, files, mode],
+  );
 
   /** Toggle one logical directory everywhere it appears in the ordered tree projection. */
   const toggleDirectory = (path: string) => {
     skipSelectedFileRevealRef.current = true;
     setCollapsedDirectoryPaths((current) => toggleCollapsedDirectoryPath(current, path));
   };
+
+  /**
+   * Scroll the pending file's row into the viewport and clear the request once it is visible.
+   *
+   * Works from the row's entry index rather than its rendered position, so it is correct
+   * for rows the render window mounted in this very commit. A viewport that has not been
+   * measured yet, or a scroll the scrollbox clamped against a stale content height, leaves
+   * the request pending for the next viewport event.
+   */
+  const revealPendingRow = useCallback(() => {
+    const scrollBox = scrollRef.current;
+    const fileId = pendingRevealFileIdRef.current;
+    if (!scrollBox || !fileId) {
+      return;
+    }
+
+    const entryIndex = entries.findIndex((entry) => entry.kind === "file" && entry.id === fileId);
+    if (entryIndex < 0) {
+      pendingRevealFileIdRef.current = null;
+      return;
+    }
+
+    const viewportHeight = scrollBox.viewport.height ?? 0;
+    if (viewportHeight <= 0) {
+      return;
+    }
+
+    const target = planSidebarRowReveal({
+      entryIndex,
+      scrollTop: scrollBox.scrollTop ?? 0,
+      viewportHeight,
+    });
+    if (target !== null) {
+      scrollBox.scrollTo(target);
+    }
+
+    const stillHidden =
+      planSidebarRowReveal({
+        entryIndex,
+        scrollTop: scrollBox.scrollTop ?? 0,
+        viewportHeight,
+      }) !== null;
+    if (!stillHidden) {
+      pendingRevealFileIdRef.current = null;
+    }
+  }, [entries]);
+  const revealPendingRowRef = useRef(revealPendingRow);
+  revealPendingRowRef.current = revealPendingRow;
 
   useEffect(() => {
     const previousSelectedFileId = previousSelectedFileIdRef.current;
@@ -241,6 +261,8 @@ export function FlexFileSidebar({
       );
     };
 
+    // OpenTUI emits these from its own layout and slider work; one microtask per burst
+    // reads the settled geometry and gives a pending reveal its retry.
     const handleViewportChange = () => {
       if (scheduled) {
         return;
@@ -254,6 +276,7 @@ export function FlexFileSidebar({
 
         try {
           readViewport();
+          revealPendingRowRef.current();
         } finally {
           scheduled = false;
         }
@@ -262,19 +285,19 @@ export function FlexFileSidebar({
 
     readViewport();
     scrollBox.verticalScrollBar.on("change", handleViewportChange);
-    scrollBox.viewport.on("layout-changed", handleViewportChange);
-    scrollBox.viewport.on("resized", handleViewportChange);
+    scrollBox.viewport.on("resize", handleViewportChange);
+    scrollBox.content.on("resize", handleViewportChange);
 
     return () => {
       cancelled = true;
       scrollBox.verticalScrollBar.off("change", handleViewportChange);
-      scrollBox.viewport.off("layout-changed", handleViewportChange);
-      scrollBox.viewport.off("resized", handleViewportChange);
+      scrollBox.viewport.off("resize", handleViewportChange);
+      scrollBox.content.off("resize", handleViewportChange);
     };
   }, [files, mode]);
 
-  // Selection and projection changes can both move the target row, so follow
-  // the stable file id after either event instead of only after navigation.
+  // Selection and projection changes can both move the target row, so follow the stable
+  // file id after either event instead of only after navigation.
   useEffect(() => {
     if (skipSelectedFileRevealRef.current) {
       skipSelectedFileRevealRef.current = false;
@@ -284,8 +307,9 @@ export function FlexFileSidebar({
       return;
     }
 
-    scrollRef.current?.scrollChildIntoView(fileRowId(selectedFileId));
-  }, [collapsedDirectoryPaths, files, mode, selectedFileId]);
+    pendingRevealFileIdRef.current = selectedFileId;
+    revealPendingRow();
+  }, [revealPendingRow, selectedFileId]);
 
   return (
     <scrollbox
@@ -302,15 +326,19 @@ export function FlexFileSidebar({
       verticalScrollbarOptions={{ visible: false }}
       horizontalScrollbarOptions={{ visible: false }}
     >
-      {mode === "tree" ? (
-        <TreeFileSidebar
-          {...variantProps}
-          collapsedDirectoryPaths={collapsedDirectoryPaths}
-          onToggleDirectory={toggleDirectory}
-        />
-      ) : (
-        <FlatFileSidebar {...variantProps} />
-      )}
+      <VirtualizedFileSidebarRows
+        actions={actions}
+        collapsedDirectoryPaths={mode === "tree" ? collapsedDirectoryPaths : undefined}
+        entries={entries}
+        estimatedViewportRows={terminal.height}
+        onToggleDirectory={mode === "tree" ? toggleDirectory : undefined}
+        paddingLeft={mode === "tree" ? 0 : 1}
+        scrollTop={scrollViewport.top}
+        selectedFileId={selectedFileId}
+        textWidth={textWidth}
+        theme={theme}
+        viewportHeight={scrollViewport.height}
+      />
     </scrollbox>
   );
 }

--- a/packages/hunk/src/extensions/default/ui/sidebar/index.tsx
+++ b/packages/hunk/src/extensions/default/ui/sidebar/index.tsx
@@ -22,7 +22,7 @@ import { FlexFileSidebar } from "./FileSidebars";
 export const BUNDLED_SIDEBAR_EXTENSION_ID = HUNK_VENDOR_EXTENSION_ID;
 export const BUNDLED_SIDEBAR_VIEW_ID = "files";
 
-export { FlatFileSidebar, FlexFileSidebar, TreeFileSidebar } from "./FileSidebars";
+export { FlexFileSidebar } from "./FileSidebars";
 
 /** Register the responsive built-in file navigation pane. */
 const registerBundledSidebar: ExtensionFactory = (hunk) => {

--- a/packages/hunk/src/ui/lib/sidebarRenderWindow.test.ts
+++ b/packages/hunk/src/ui/lib/sidebarRenderWindow.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { SidebarEntry } from "./files";
-import { buildSidebarRenderWindow, type SidebarRenderWindowItem } from "./sidebarRenderWindow";
+import {
+  buildSidebarRenderWindow,
+  planSidebarRowReveal,
+  type SidebarRenderWindowItem,
+} from "./sidebarRenderWindow";
 
 /** Build fixed-height sidebar rows with occasional group headers. */
 function createEntries(ids: string[]): SidebarEntry[] {
@@ -200,5 +204,28 @@ describe("buildSidebarRenderWindow", () => {
     expect(plan.topSpacerHeight).toBe(2);
     expect(plan.bottomSpacerHeight).toBe(2);
     expect(renderedHeight(plan.items)).toBe(entries.length);
+  });
+});
+
+describe("planSidebarRowReveal", () => {
+  test("leaves a row that is already inside the viewport alone", () => {
+    expect(planSidebarRowReveal({ entryIndex: 3, scrollTop: 0, viewportHeight: 8 })).toBeNull();
+    expect(planSidebarRowReveal({ entryIndex: 7, scrollTop: 0, viewportHeight: 8 })).toBeNull();
+    expect(planSidebarRowReveal({ entryIndex: 12, scrollTop: 12, viewportHeight: 8 })).toBeNull();
+  });
+
+  test("scrolls a row below the viewport onto its bottom edge", () => {
+    expect(planSidebarRowReveal({ entryIndex: 8, scrollTop: 0, viewportHeight: 8 })).toBe(1);
+    expect(planSidebarRowReveal({ entryIndex: 30, scrollTop: 13, viewportHeight: 8 })).toBe(23);
+  });
+
+  test("scrolls a row above the viewport onto its top edge", () => {
+    expect(planSidebarRowReveal({ entryIndex: 4, scrollTop: 13, viewportHeight: 8 })).toBe(4);
+    expect(planSidebarRowReveal({ entryIndex: 0, scrollTop: 1, viewportHeight: 8 })).toBe(0);
+  });
+
+  test("refuses to plan without a measured viewport or a real row", () => {
+    expect(planSidebarRowReveal({ entryIndex: 5, scrollTop: 0, viewportHeight: 0 })).toBeNull();
+    expect(planSidebarRowReveal({ entryIndex: -1, scrollTop: 0, viewportHeight: 8 })).toBeNull();
   });
 });

--- a/packages/hunk/src/ui/lib/sidebarRenderWindow.ts
+++ b/packages/hunk/src/ui/lib/sidebarRenderWindow.ts
@@ -70,6 +70,39 @@ function entryRangeHeight(startIndex: number, endIndex: number) {
   return startIndex > endIndex ? 0 : (endIndex - startIndex + 1) * SIDEBAR_ROW_HEIGHT;
 }
 
+/**
+ * Return the scroll offset that brings one fixed-height sidebar row inside the viewport, or
+ * `null` when the row is already fully visible.
+ *
+ * Works from the entry index and row height alone so callers never read a row's rendered
+ * position: rows the render window mounted since the last frame carry no layout yet. Scrolls
+ * to the nearest edge, so a row above the viewport lands on its top and a row below lands on
+ * its bottom. Callers pass a measured, positive viewport height.
+ */
+export function planSidebarRowReveal({
+  entryIndex,
+  scrollTop,
+  viewportHeight,
+}: {
+  entryIndex: number;
+  scrollTop: number;
+  viewportHeight: number;
+}): number | null {
+  if (entryIndex < 0 || viewportHeight <= 0) {
+    return null;
+  }
+
+  const rowTop = entryIndex * SIDEBAR_ROW_HEIGHT;
+  const rowBottom = rowTop + SIDEBAR_ROW_HEIGHT;
+  if (rowTop < scrollTop) {
+    return rowTop;
+  }
+  if (rowBottom > scrollTop + viewportHeight) {
+    return rowBottom - viewportHeight;
+  }
+  return null;
+}
+
 /** Build a sparse sidebar render plan that preserves exact scroll height with spacers. */
 export function buildSidebarRenderWindow({
   entries,

--- a/test/pty/harness.ts
+++ b/test/pty/harness.ts
@@ -754,6 +754,20 @@ end
     );
   }
 
+  /** Build a repo with enough one-line files that the sidebar list overflows a short terminal. */
+  function createManyFileSidebarRepoFixture(count = 40) {
+    return createGitRepoFixture(
+      Array.from({ length: count }, (_, index) => {
+        const name = `file-${String(index).padStart(2, "0")}`;
+        return {
+          path: `src/${name}.ts`,
+          before: `export const ${name.replace("-", "")} = ${index};\n`,
+          after: `export const ${name.replace("-", "")} = ${index + 100};\n`,
+        };
+      }),
+    );
+  }
+
   function createPinnedHeaderRepoFixture() {
     return createGitRepoFixture([
       {
@@ -1125,6 +1139,7 @@ end
     createNarrowHeaderTestRepoFixture,
     createPagerPatchFixture,
     createManyShortFileRepoFixture,
+    createManyFileSidebarRepoFixture,
     createPinnedHeaderRepoFixture,
     createRapidThemePreviewTestRepoFixture,
     createScrollableFilePair,

--- a/test/pty/sidebar-follow-integration.test.ts
+++ b/test/pty/sidebar-follow-integration.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { createPtyHarness } from "./harness";
+
+const harness = createPtyHarness();
+
+/** Give PTY-backed startup and redraws enough headroom for slower CI machines. */
+setDefaultTimeout(20_000);
+
+afterEach(() => {
+  harness.cleanup();
+});
+
+/** Return the file named on the sidebar row that carries the selected-file marker. */
+function selectedSidebarFile(text: string) {
+  for (const line of text.split("\n")) {
+    const match = /^\s*▌\s+\S\s+(file-\d\d\.ts)/.exec(line);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+/** Report whether the sidebar lists a file row, selected or not. */
+function sidebarLists(text: string, file: string) {
+  return new RegExp(`^\\s*▌?\\s+\\S\\s+${file.replace(".", "\\.")}\\s`, "m").test(text);
+}
+
+describe("PTY sidebar selection follow", () => {
+  test("a burst of next-file presses keeps the selected file inside the sidebar viewport", async () => {
+    // Held-down `.` delivers key repeats faster than the renderer paints frames. The sidebar
+    // must keep the selected row on screen even when several selections land between two
+    // frames, on rows the render window has only just mounted.
+    const fixture = harness.createManyFileSidebarRepoFixture(60);
+    const session = await harness.launchHunk({
+      args: ["diff", "--mode", "split"],
+      cwd: fixture.dir,
+      cols: 160,
+      rows: 24,
+    });
+
+    try {
+      const initial = await session.waitForText(/View\s+Navigate\s+Agent\s+Help/, {
+        timeout: 15_000,
+      });
+      expect(selectedSidebarFile(initial)).toBe("file-00.ts");
+      expect(sidebarLists(initial, "file-40.ts")).toBe(false);
+
+      // One write carries the whole burst so every press is handled before the next frame.
+      session.writeRaw(".".repeat(40));
+      await harness.waitForSnapshot(session, (text) => text.includes("file40 = 140"), 5_000);
+      const revealed = await harness.waitForSnapshot(
+        session,
+        (text) => selectedSidebarFile(text) === "file-40.ts",
+        3_000,
+      );
+      expect(sidebarLists(revealed, "file-00.ts")).toBe(false);
+
+      // Stepping onward from a scrolled list must not snap the sidebar back to its top.
+      session.writeRaw(".".repeat(10));
+      await harness.waitForSnapshot(session, (text) => text.includes("file50 = 150"), 5_000);
+      const revealedAgain = await harness.waitForSnapshot(
+        session,
+        (text) => selectedSidebarFile(text) === "file-50.ts",
+        3_000,
+      );
+      expect(sidebarLists(revealedAgain, "file-00.ts")).toBe(false);
+      expect(sidebarLists(revealedAgain, "file-40.ts")).toBe(true);
+    } finally {
+      session.close();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1084.

## Problem

Holding `.` (or `,`) on a review with more files than the sidebar can show sometimes snaps the file list back to its top, and from then on the selected row stays out of view until the selection steps back onto a row that is still mounted. The review stream itself keeps navigating correctly; only the sidebar loses the selected file.

The sidebar revealed the selected row with `scrollChildIntoView(fileRowId(id))` from an effect. OpenTUI only syncs a renderable's `y`/`height` from Yoga during a frame's `updateFromLayout`, so a row the windowed list mounted since the last frame still reports `y = 0`. Held-down navigation delivers key repeats faster than frames, so several selection commits land between two layouts; once the selection reaches such a row, the reveal computes `childTop = viewportTop - scrollTop`, scrolls by `-scrollTop`, and lands on 0. Every later selection is again a fresh mount with `childTop == viewportTop`, so the reveal computes a delta of 0 and the list stays stuck.

## Approach

- Reveal from the fixed-row geometry the render window already owns. `planSidebarRowReveal` in `sidebarRenderWindow.ts` returns the nearest-edge scroll offset from the entry index and `SIDEBAR_ROW_HEIGHT`, so the reveal never reads a row's rendered position.
- Keep the reveal pending until a measured viewport confirms the row is visible. This also makes the first paint reveal a selection that starts outside the initial viewport, and retries a scroll the scrollbox clamped against a content height the next layout will grow.
- Subscribe to the events OpenTUI actually emits. The previous `viewport.on("layout-changed")` / `viewport.on("resized")` subscriptions never fired in 0.5.6 (per-node size changes emit `resize`; `layout-changed` is root-only), so the render window only learned its viewport height after the first scroll. The sidebar now listens to the scrollbar `change`, `viewport` `resize`, and `content` `resize`.
- Fold the flat and tree projections into one entry list computed in `FlexFileSidebar`, since the reveal needs the same entries the rows render. `FlatFileSidebar`/`TreeFileSidebar` had no consumers outside their re-export and are removed.

Non-goals: the extension-facing `scrollChildIntoView` recipe in `docs/extensions.md` has the same exposure for windowed lists in third-party sidebars; that is a documentation/API follow-up, not changed here.

## Why core

This is the bundled sidebar's own follow-selection behavior inside `packages/hunk/src/extensions/default/ui/sidebar`; no extension API changes.

## Tests

- `packages/hunk/src/extensions/default/ui/sidebar/FileSidebars.test.tsx` (new): drives `FlexFileSidebar` through a selection setter with `@opentui/react/test-utils` and changes the selection without rendering a frame in between. Three of the five cases fail on the old code (stuck at top after outrunning laid-out rows, snap back to top when a far row mounts fresh, no reveal of an initial off-screen selection).
- `packages/hunk/src/ui/lib/sidebarRenderWindow.test.ts`: cases for `planSidebarRowReveal`.
- `test/pty/sidebar-follow-integration.test.ts` (new) with the `createManyFileSidebarRepoFixture` harness fixture: writes a burst of 40 `.` presses in one chunk to a live 160×24 Hunk and asserts the sidebar's `▌` row follows to `file-40.ts`, then to `file-50.ts` without returning to the top. Fails on the old code.

## Validation

| Command | Result |
| --- | --- |
| `bun run typecheck` | pass |
| `bun run lint` | pass |
| `bun run format:check` | pass |
| `bun run deps:check` | pass |
| `bun run knip` | 5 pre-existing findings in `packages/term-video` and `packages/hunk-git`, none in touched files |
| `bun test packages/hunk/src/extensions/default/ui/sidebar packages/hunk/src/ui/lib/sidebarRenderWindow.test.ts` | 20 pass |
| `bun test packages/hunk/src/ui/AppHost.extension-sidebar.test.tsx AppHost.sidebar-*.test.tsx AppHost.responsive.test.tsx AppHost.extension-navigation.test.tsx components/ui-components.test.tsx` | 130 pass |
| `bun run test` | 4198 pass, 19 fail; all 19 also fail on `main` in this environment (git prints localized errors, `/var` vs `/private/var` install-VM path checks, jj-colocated checkout makes VCS detection return `jj`, and `AppHost.file-view-modes` soft-reload dialog timeout) |
| `bun run test:integration` | 163 pass, 5 fail; the 5 (`extensions-integration` trust prompts ×2, `lifecycle` SIGHUP/SIGQUIT/SIGPIPE ×3) fail identically on untouched code |
| `bun run test:tty-smoke` | all 10 skip on macOS: the suite needs util-linux `script -f -e -c`, which BSD `script` lacks; relies on Linux CI |

Platforms: macOS (Apple Silicon, iTerm2). Linux and Windows not tested; the change is React/OpenTUI-only with no platform-specific code.

## Reproduction at a real key-repeat rate

Beyond the single-chunk burst the PTY test uses, I drove a live 180×32 Hunk with one `.` every 30 ms (macOS's fastest Key Repeat setting) and every 90 ms (the default), on two diffs, checking whether the sidebar's `▌` row is on screen after 45 presses:

| Diff | 30 ms repeat, old code | 90 ms repeat, old code | 30 ms repeat, this branch |
| --- | --- | --- | --- |
| 60 one-line files | follows (3/3) | follows (3/3) | follows (3/3) |
| 60 files × 400 lines, split view | **stuck at top (2/2)** | follows (2/2) | follows (2/2) |

The heavier diff makes frames slower than the repeat interval, which is the condition the analysis predicts; the trivial diff keeps up at 30 ms and never hits it.

## Visual evidence

Recorded with `skills/hunk-launch-video`, so every terminal frame is the real TUI driven over a PTY: `hunk diff --mode split` on the 60 × 400-line repo at 180×32, github-dark-default, macOS/iTerm2. First half is `main`, second half this branch, with three unhurried `.` presses followed by `.` held at a 30 ms repeat for 45 presses.

The hold is captured press by press rather than as two stills. Grabbing the terminal grid costs ~0.3 ms, so the 30 ms cadence survives capture, and consecutive identical grids collapse into one keyframe. That collapse is itself the measurement: **45 presses painted 16 frames**, about three presses per painted frame, which is the condition the analysis needs.

- Before: the list tracks for a while, then drops the selected row entirely — the review reaches `file-48.ts` while the pane sits at `file-00.ts`, and later presses never bring it back.
- After: the same hold keeps `▌ file-48.ts` on the pane's bottom edge.

The main pane renders only the file header during the hold in both halves. That is ordinary behaviour when navigation outruns the diff body, unchanged by this PR, and the callout marks the files pane as the subject.


https://github.com/user-attachments/assets/0870cc8c-7431-4f79-a947-19d6a362f0e7


